### PR TITLE
split semigroup from monoid

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/hkt/Kind.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/Kind.java
@@ -2,23 +2,22 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
- * Represents a simulated Higher-Kinded Type (HKT) in Java.
+ * The core of the Higher-Kinded Type (HKT) simulation.
  *
- * <p>Java's type system does not natively support type constructors like {@code F<_>} (e.g., {@code
- * List<_>}, {@code Optional<_>}) as first-class type parameters. This interface serves as a marker
- * or bridge to simulate the concept of applying a type constructor {@code F} to a type argument
- * {@code A}, conceptually representing {@code F<A>}.
+ * <p>{@code Kind<F, A>} is a type that represents the application of a type constructor {@code F}
+ * to a type argument {@code A}. Since Java's type system does not natively support type
+ * constructors as parameters (like F&lt;_&gt;), we use a "witness type" for {@code F} to stand in
+ * for the constructor.
  *
- * <p>Concrete 'kinds' (like ListKind, OptionalKind) implement this interface to participate in the
- * simulation, typically using a pattern like: {@code interface ListKind<T> extends
- * Kind<ListKind<?>, T> {}} where {@code ListKind<?>} acts as the witness type {@code F}.
+ * <p>For example, a {@code java.util.List<String>} would be represented as {@code
+ * Kind<ListKind.Witness, String>}, where {@code ListKind.Witness} is the marker type that
+ * represents the {@code List} type constructor.
  *
- * <p>Interfaces like {@link Functor} and {@code Monad} operate on instances of {@code Kind<F, A>}.
- *
- * @param <F> The witness type representing the type constructor (e.g., {@code ListKind<?>}, {@code
- *     OptionalKind<?>}). This acts as the 'F' in the conceptual type {@code F<A>}.
- * @param <A> The type argument applied to the type constructor F (e.g., {@code Integer} in {@code
- *     List<Integer>}). This acts as the 'A' in the conceptual type {@code F<A>}.
+ * @param <F> The witness type for the type constructor.
+ * @param <A> The type of the value contained within the context.
  */
+@NullMarked
 public interface Kind<F, A> {}

--- a/hkj-api/src/main/java/org/higherkindedj/hkt/MonadZero.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/MonadZero.java
@@ -2,20 +2,30 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
- * An interface for monads that have a "zero" or "empty" element. This is crucial for filtering
- * operations, where a failing predicate results in the zero element.
+ * A Monad that also has a "zero" or "empty" element, which allows it to represent failure or an
+ * empty result.
  *
- * @param <M> The witness type for the Monad.
+ * <p>This is useful for monads that can be filtered, such as {@code List}, {@code Optional}, or
+ * {@code Maybe}. The {@code zero()} method provides the empty value for that monad (e.g., an empty
+ * list or {@code Optional.empty()}).
+ *
+ * <p>This interface is particularly important for enabling the {@code when()} (filtering) clause in
+ * for-comprehensions, allowing computations to be short-circuited.
+ *
+ * @param <F> The witness type of the Monad.
+ * @see Monad
  */
-public interface MonadZero<M> extends Monad<M> {
+@NullMarked
+public interface MonadZero<F> extends Monad<F> {
 
   /**
-   * Returns the zero element for this monad. The result is polymorphic and can be safely cast to
-   * any Kind&lt;M, T&gt;. For example, for List it is an empty list, for Maybe it is Nothing.
+   * Returns the "zero" or "empty" value for this Monad.
    *
-   * @param <T> The desired inner type of the zero value.
-   * @return The zero or empty value for the monad.
+   * @param <A> The type parameter of the Kind, which will not be present.
+   * @return The empty value for the monad (non-null), e.g., {@code Optional.empty()}.
    */
-  <T> Kind<M, T> zero();
+  <A> Kind<F, A> zero();
 }

--- a/hkj-api/src/main/java/org/higherkindedj/hkt/Monoid.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/Monoid.java
@@ -2,100 +2,41 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt;
 
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
- * Represents the Monoid type class, a fundamental concept in abstract algebra and functional
- * programming. A Monoid defines a structure for a specific type {@code A} that allows elements of
- * that type to be combined, and it includes a special "identity" element for this combination.
+ * A Monoid is a Semigroup that also has an "identity" or "empty" element.
  *
- * <p>A Monoid consists of:
- *
- * <ol>
- *   <li>A set of elements of type {@code A}.
- *   <li>A binary operation ({@link #combine(Object, Object)}) that takes two elements of type
- *       {@code A} and returns another element of type {@code A}.
- *   <li>An identity element ({@link #empty()}) of type {@code A} which, when combined with any
- *       element using the binary operation, yields that same element.
- * </ol>
- *
- * <p><b>Monoid Laws:</b> For an implementation to be a valid Monoid, it must satisfy the following
- * laws:
- *
- * <ol>
- *   <li><b>Associativity:</b> The {@code combine} operation must be associative. For any elements
- *       {@code x}, {@code y}, {@code z} of type {@code A}: <br>
- *       {@code monoid.combine(x, monoid.combine(y, z))} must be equal to {@code
- *       monoid.combine(monoid.combine(x, y), z)}. <br>
- *       This means the order in which combinations are grouped does not affect the final result.
- *   <li><b>Identity Element (Left Identity):</b> The {@code empty} element must act as a left
- *       identity for the {@code combine} operation. For any element {@code x} of type {@code A}:
- *       <br>
- *       {@code monoid.combine(monoid.empty(), x)} must be equal to {@code x}.
- *   <li><b>Identity Element (Right Identity):</b> The {@code empty} element must act as a right
- *       identity for the {@code combine} operation. For any element {@code x} of type {@code A}:
- *       <br>
- *       {@code monoid.combine(x, monoid.empty())} must be equal to {@code x}.
- * </ol>
- *
- * <p><b>Common Examples of Monoids:</b>
+ * <p>In addition to the associative law from Semigroup, a Monoid must satisfy the identity laws:
  *
  * <ul>
- *   <li>Integers with addition: {@code empty = 0}, {@code combine(x, y) = x + y}
- *   <li>Integers with multiplication: {@code empty = 1}, {@code combine(x, y) = x * y}
- *   <li>Strings with concatenation: {@code empty = ""}, {@code combine(x, y) = x + y}
- *   <li>Lists with concatenation: {@code empty = Collections.emptyList()}, {@code combine(x, y) =
- *       newList.addAll(x); newList.addAll(y);}
- *   <li>Booleans with conjunction (AND): {@code empty = true}, {@code combine(x, y) = x && y}
- *   <li>Booleans with disjunction (OR): {@code empty = false}, {@code combine(x, y) = x || y}
- *   <li>Functions {@code A -> A} with function composition: {@code empty = a -> a} (identity
- *       function), {@code combine(f, g) = f.compose(g)} or {@code f.andThen(g)} (depending on
- *       composition order preference).
+ *   <li><b>Left identity:</b> {@code combine(empty(), a)} is equivalent to {@code a}.
+ *   <li><b>Right identity:</b> {@code combine(a, empty())} is equivalent to {@code a}.
  * </ul>
  *
- * <p>Monoids are particularly useful for aggregating data, folding collections, and defining
- * operations that can be parallelized due to the associativity law.
+ * <p><b>Example:</b> A Monoid for {@code Integer} with addition:
  *
- * @param <A> The type for which the Monoid instance is defined. This type must adhere to the Monoid
- *     laws.
+ * <pre>{@code
+ * Monoid<Integer> integerAddition = new Monoid<>() {
+ *  public Integer combine(Integer i1, Integer i2) {
+ *    return i1 + i2;
+ *  }
+ *  public Integer empty() {
+ *    return 0;
+ *  }
+ * };
+ * }</pre>
+ *
+ * @param <A> The type of the values.
+ * @see Semigroup
  */
-public interface Monoid<A> {
+@NullMarked
+public interface Monoid<A> extends Semigroup<A> {
 
   /**
-   * Provides the identity element for the Monoid's {@code combine} operation.
+   * Returns the identity or "empty" value for this Monoid.
    *
-   * <p>The identity element {@code e} must satisfy the following for all {@code x} of type {@code
-   * A}:
-   *
-   * <ul>
-   *   <li>{@code combine(empty(), x) == x} (Left identity)
-   *   <li>{@code combine(x, empty()) == x} (Right identity)
-   * </ul>
-   *
-   * This element is often the "zero" or "neutral" element for the operation, such as {@code 0} for
-   * addition, {@code 1} for multiplication, or an empty string/list for concatenation.
-   *
-   * @return The non-null identity element of type {@code A}. While conceptually the identity
-   *     element can sometimes be represented by {@code null} in certain contexts (e.g., a nullable
-   *     wrapper type), for this interface, a non-null value is generally expected for common Monoid
-   *     instances like numbers, strings, and collections.
+   * @return The empty value (non-null).
    */
-  @NonNull A empty();
-
-  /**
-   * Combines two elements of type {@code A} into a single element of type {@code A}.
-   *
-   * <p>This operation must be associative: {@code combine(x, combine(y, z)) == combine(combine(x,
-   * y), z)} for all {@code x, y, z} of type {@code A}.
-   *
-   * <p>Associativity allows for flexible grouping of operations, which is crucial for tasks like
-   * parallel processing or efficient folding of data structures.
-   *
-   * @param x The first non-null element of type {@code A}.
-   * @param y The second non-null element of type {@code A}.
-   * @return The non-null result of combining {@code x} and {@code y}, also of type {@code A}. The
-   *     non-null annotation implies that combining two non-null values should typically result in a
-   *     non-null value, fitting most common Monoid definitions.
-   */
-  @NonNull A combine(@NonNull A x, @NonNull A y);
+  A empty();
 }

--- a/hkj-api/src/main/java/org/higherkindedj/hkt/Semigroup.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/Semigroup.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A Semigroup is a type {@code A} that has an associative {@code combine} operation.
+ *
+ * <p>The combine operation must satisfy the following law:
+ *
+ * <ul>
+ *   <li><b>Associativity:</b> {@code combine(a, combine(b, c))} is equivalent to {@code
+ *       combine(combine(a, b), c)} for all values a, b, and c.
+ * </ul>
+ *
+ * <p><b>Example:</b> A Semigroup for {@code String} with concatenation:
+ *
+ * <pre>{@code
+ * Semigroup<String> stringSemigroup = (s1, s2) -> s1 + s2;
+ * stringSemigroup.combine("hello", " world"); // "hello world"
+ * }</pre>
+ *
+ * @param <A> The type of the values to be combined.
+ * @see Monoid
+ */
+@NullMarked
+public interface Semigroup<A> {
+
+  /**
+   * Combines two values of type {@code A} into one.
+   *
+   * @param a1 The first value (non-null).
+   * @param a2 The second value (non-null).
+   * @return The combined value (non-null).
+   */
+  A combine(A a1, A a2);
+}

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Extending](hkts/extending-simulation.md)
 - [For Comprehension](functional/for_comprehension.md)
 - [Monads](monads/supported-types.md)
+  - [Semigroup and Monoid](monads/semigroup_and_monoid.md)
   - [CompletableFuture](monads/cf_monad.md)
   - [Either](monads/either_monad.md)
   - [Identity](monads/identity.md)

--- a/hkj-book/src/hkts/core-concepts.md
+++ b/hkj-book/src/hkts/core-concepts.md
@@ -10,6 +10,11 @@ Higher-Kinded-J employs several key components to emulate Higher-Kinded Types (H
 
 As we have already discussed, Java's type system lacks native Higher-Kinded Types. We can easily parametrise a type by another type (like `List<String>`), but we cannot easily parametrise a type or method by a *type constructor* itself (like `F<_>`). We can't write `void process<F<_>>(F<Integer> data)` to mean "process any container F of Integers".
 
+~~~ admonish warning
+You will often see Higher-Kinded Types represented with an underscore, like `F<_>` (e.g., `List<_>`, `Optional<_>`). This notation, borrowed from languages like Scala, represents a "type constructor"—a type that is waiting for a type parameter. It's important to note that this underscore is a conceptual placeholder and is not the same as Java's `?` wildcard, which is used for instantiated types. Our library provides a way to simulate this `F<_>` concept in Java.
+
+~~~
+
 ## 2. The `Kind<F, A>` Bridge
 
 ![defunctionalisation_internal.svg](../images/puml/defunctionalisation_internal.svg)
@@ -21,7 +26,9 @@ As we have already discussed, Java's type system lacks native Higher-Kinded Type
   * `EitherKind.Witness<L>` represents the `Either<L, _>` type constructor (where `L` is fixed).
   * `IOKind<IOKind.Witness>` represents the `IO` type constructor.
 * **`A` (Type Argument):** The concrete type contained within or parameterised by the constructor (e.g., `Integer` in `List<Integer>`).
-* **How it Works:** An actual object, like a `java.util.List<Integer>`, is wrapped in a helper class (e.g., `ListHolder`) which implements `Kind<ListKind<?>, Integer>`. This `Kind` object can then be passed to generic functions that expect `Kind<F, A>`.
+* **How it Works:** The library provides a seamless bridge between a standard java type, like a `java.util.List<Integer>`and its `Kind` representation `Kind<ListKind.Witness, Integer>`. Instead of requiring you to manually wrap objects, this conversion is handled by static helper methods, typically `widen` and `narrow`.
+  * To treat a `List<Integer>` as a `Kind`, you use a helper function like `LIST.widen()`.
+  * This `Kind` object can then be passed to generic functions (such as `map` or `flatMap` from a `Functor` or `Monad` instance) that expect `Kind<F, A>`.
 * **Reference:** [`Kind.java`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-api/src/main/java/org/higherkindedj/hkt/Kind.java)
 
 ## 3. Type Classes (`Functor`, `Applicative`, `Monad`, `MonadError`)

--- a/hkj-book/src/monads/cf_monad.md
+++ b/hkj-book/src/monads/cf_monad.md
@@ -1,4 +1,4 @@
-# CompletableFutureMonad: 
+# The CompletableFutureMonad: 
 ## _Asynchronous Computations with `CompletableFuture`_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/either_monad.md
+++ b/hkj-book/src/monads/either_monad.md
@@ -1,4 +1,4 @@
-# EitherMonad: 
+#The EitherMonad: 
 ## _Typed Error Handling_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/io_monad.md
+++ b/hkj-book/src/monads/io_monad.md
@@ -1,4 +1,4 @@
-# IOMonad: 
+#The IOMonad: 
 ## _Managing Side Effects with `IO`_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/lazy_monad.md
+++ b/hkj-book/src/monads/lazy_monad.md
@@ -1,4 +1,4 @@
-# Lazy Monad: 
+#The Lazy Monad: 
 ## _Lazy Evaluation with `Lazy`_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/list_monad.md
+++ b/hkj-book/src/monads/list_monad.md
@@ -1,4 +1,4 @@
-# ListMonad:
+#The ListMonad:
 ## _Monadic Operations on Java Lists_
 
 ~~~ admonish example title="See Example Code:"
@@ -15,7 +15,7 @@ Key benefits include:
 * **HKT Integration:** `ListKind` (the higher-kinded wrapper for `List`) and `ListMonad` allow `List` to be used with generic functions and type classes expecting `Kind<F, A>`, `Functor<F>`, `Applicative<F>`, or `Monad<F>`.
 * **Standard List Behavior:** Leverages the familiar behavior of Java lists, such as non-uniqueness of elements and order preservation. `flatMap` corresponds to applying a function that returns a list to each element and then concatenating the results.
 
-It implements `Monad<ListKind<?>>`, inheriting from `Functor<ListKind<?>>` and `Applicative<ListKind<?>>`.
+It implements `Monad<ListKind<A>>`, inheriting from `Functor<ListKind<A>>` and `Applicative<ListKind<A>>`.
 
 ## Structure
 

--- a/hkj-book/src/monads/maybe_monad.md
+++ b/hkj-book/src/monads/maybe_monad.md
@@ -1,4 +1,4 @@
-# MaybeMonad:
+#The MaybeMonad:
 ## _Handling Optional Values with Non-Null Guarantee_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/monad_zero.md
+++ b/hkj-book/src/monads/monad_zero.md
@@ -1,14 +1,24 @@
 # MonadZero
 
-The `MonadZero` type class extends the `Monad` interface to include the concept of a "zero" or "empty" element. It is designed for monads that can represent failure, absence, or emptiness, allowing them to be used in filtering operations.
+The `MonadZero` is a more advanced type class extends the `Monad` interface to include the concept of a "zero" or "empty" element. It is designed for monads that can represent failure, absence, or emptiness, allowing them to be used in filtering operations.
 
-### Purpose and Concept
+The interface for MonadZero in hkj-api extends Monad:
+
+```java
+public interface MonadZero<F> extends Monad<F> {
+    <A> Kind<F, A> zero();
+}
+```
+
+### Why is it useful?
 
 A `Monad` provides a way to sequence computations within a context (`flatMap`, `map`, `of`). A `MonadZero` adds one critical operation to this structure:
 
 * `zero()`: Returns the "empty" or "zero" element for the monad.
 
 This `zero` element acts as an absorbing element in a monadic sequence, similar to how multiplying by zero results in zero. If a computation results in a `zero`, subsequent operations in the chain are typically skipped.
+
+`MonadZero` is particularly useful for making for-comprehensions more powerful. When you are working with a monad that has a `MonadZero` instance, you can use a `when()` clause to filter results within the comprehension.
 
 **Key Implementations in this Project:**
 
@@ -22,7 +32,7 @@ The main purpose of `MonadZero` is to enable filtering within monadic comprehens
 
 #### 1. Filtering in For-Comprehensions
 
-The most powerful application in this codebase is within the **`For` comprehension builder**. The builder has two entry points:
+As already mentioned the most powerful application in this codebase is within the **`For` comprehension builder**. The builder has two entry points:
 
 * `For.from(monad, ...)`: For any standard `Monad`.
 * `For.from(monadZero, ...)`: An overloaded version specifically for a `MonadZero`.

--- a/hkj-book/src/monads/optional_monad.md
+++ b/hkj-book/src/monads/optional_monad.md
@@ -1,4 +1,4 @@
-# OptionalMonad:
+# The OptionalMonad:
 ## _Monadic Operations for Java Optional_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/reader_monad.md
+++ b/hkj-book/src/monads/reader_monad.md
@@ -1,4 +1,4 @@
-# Reader Monad:
+# The Reader Monad:
 ## _Managed Dependencies and Configuration_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/semigroup_and_monoid.md
+++ b/hkj-book/src/monads/semigroup_and_monoid.md
@@ -1,0 +1,77 @@
+# _Semigroup and  Monoid_:
+## Foundational Type Classes
+In functional programming, we often use "type classes" to define common behaviors that can be applied to a wide range of data types. These act as interfaces that allow us to write more abstract and reusable code. In `higher-kinded-j`, we provide a number of these type classes to enable powerful functional patterns.
+
+This document will cover three foundational type classes: `Semigroup`,and  `Monoid`. Understanding these will give you a solid foundation for many of the more advanced concepts in the library.
+
+## **`Semigroup<A>`**
+
+A **`Semigroup`** is one of the simplest and most fundamental type classes. It provides a blueprint for types that have a single, associative way of being combined.
+
+### What is it?
+
+A `Semigroup` is a type class for any data type that has a `combine` operation. This operation takes two values of the same type and merges them into a single value of that type. The only rule is that this operation must be **associative**.
+
+This means that for any values `a`, `b`, and `c`:
+
+`(a.combine(b)).combine(c)` must be equal to `a.combine(b.combine(c))`
+
+The interface for `Semigroup` in `hkj-api` is as follows:
+
+``` java
+public interface Semigroup<A> {
+    A combine(A a1, A a2);
+}
+```
+
+### Why is it useful?
+
+The `Semigroup` type class is useful whenever you have a data type that can be combined. By abstracting this `combine` operation into a type class, we can write generic functions that can combine any two values of a `Semigroup` type, without needing to know the specific type.
+
+Some common examples of semigroups include:
+
+* **String Concatenation**: `"hello" + " " + "world"`
+* **List Concatenation**: `[1, 2] + [3, 4]`
+* **Integer Addition**: `1 + 2 + 3`
+
+### Where is it used in `higher-kinded-j`?
+
+A key use case for `Semigroup` is in the **`Writer`** monad. The `Writer` monad allows you to accumulate a log value alongside a computation. To combine these log values at each step, we need a `Semigroup` for the log type. For example, if you are logging strings, you would use a `Semigroup<String>` to concatenate them.
+
+<hr>
+
+## **`Monoid<A>`**
+
+A **`Monoid`** is a `Semigroup` with a special "identity" or "empty" element. This makes it even more powerful, as it provides a way to have a "starting" or "default" value.
+
+### What is it?
+
+A `Monoid` is a type class for any data type that has an associative `combine` operation (from `Semigroup`) and an `empty` value. This `empty` value is a special element that, when combined with any other value, returns that other value.
+
+This is known as the **identity law**. For any value `a`:
+
+`a.combine(empty())` must be equal to `a``empty().combine(a)` must be equal to `a`
+
+The interface for `Monoid` in `hkj-api` extends `Semigroup`:
+
+
+``` java
+public interface Monoid<A> extends Semigroup<A> {
+    A empty();
+}
+```
+
+### Why is it useful?
+
+The `Monoid` type class is useful when you need to combine a collection of values into a single value. The `empty` element gives you a starting point. For example, if you have a list of numbers and want to sum them, you can start with `0` (the `empty` value for addition) and combine each number in the list.
+
+Some common examples of monoids include:
+
+* **Integer Addition**, where `empty` is `0`.
+* **String Concatenation**, where `empty` is `""`.
+* **List Concatenation**, where `empty` is an empty list.
+
+### Where is it used in `higher-kinded-j`?
+
+Just like `Semigroup`, the **`Monoid`** type class is essential for the **`Writer`** monad. When you start a `Writer` computation, you need an initial log value. The `empty` value from the `Monoid` provides this starting point. For example, a `Writer<String, A>` would start with an empty string `""` as its initial log.
+

--- a/hkj-book/src/monads/state_monad.md
+++ b/hkj-book/src/monads/state_monad.md
@@ -1,4 +1,4 @@
-# State Monad:
+# The State Monad:
 ## _Managing State Functionally_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/try_monad.md
+++ b/hkj-book/src/monads/try_monad.md
@@ -1,4 +1,4 @@
-# TryMonad:
+# The TryMonad:
 ## _Typed Error Handling_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/validated_monad.md
+++ b/hkj-book/src/monads/validated_monad.md
@@ -1,4 +1,4 @@
-# ValidatedMonad:
+#The ValidatedMonad:
 ## _Handling Valid or Invalid Operations_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/monads/writer_monad.md
+++ b/hkj-book/src/monads/writer_monad.md
@@ -1,4 +1,4 @@
-# WriterMonad:
+# The WriterMonad:
 ## _Accumulating Output Alongside Computations_
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/transformers/eithert_transformer.md
+++ b/hkj-book/src/transformers/eithert_transformer.md
@@ -1,4 +1,5 @@
-# EitherT: _Combining Monadic Effects_
+# The EitherT Transformer: 
+## _Combining Monadic Effects_
 
 ~~~ admonish example title="See Example Code:"
 [EitherTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java)

--- a/hkj-book/src/transformers/maybet_transformer.md
+++ b/hkj-book/src/transformers/maybet_transformer.md
@@ -1,4 +1,5 @@
-# MaybeT: _Combining Monadic Effects with Optionality_
+# The MaybeT Transformer:
+## _Combining Monadic Effects with Optionality_
 
 ~~~ admonish example title="See Example Code:"
 [MaybeTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/maybe_t/MaybeTExample.java)

--- a/hkj-book/src/transformers/optionalt_transformer.md
+++ b/hkj-book/src/transformers/optionalt_transformer.md
@@ -1,4 +1,5 @@
-# OptionalT: _Combining Monadic Effects with `java.util.Optional`_
+# The OptionalT Transformer: 
+## _Combining Monadic Effects with `java.util.Optional`_
 
 
 ~~~ admonish example title="See Example Code:"

--- a/hkj-book/src/transformers/readert_transformer.md
+++ b/hkj-book/src/transformers/readert_transformer.md
@@ -1,4 +1,5 @@
-# ReaderT: _Combining Monadic Effects with a Read-Only Environment_
+# The ReaderT Transformer: 
+## _Combining Monadic Effects with a Read-Only Environment_
 
 ~~~ admonish example title="See Example Code:"
 - [ReaderTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTExample.java)

--- a/hkj-book/src/transformers/statet_transformer.md
+++ b/hkj-book/src/transformers/statet_transformer.md
@@ -1,4 +1,5 @@
-# StateT:  _Monad Transformer_
+# The StateT Transformer:  
+## _Monad Transformer_
 
 ~~~ admonish example title="See Example Code:"
 - [StateTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTExample.java)

--- a/hkj-book/src/transformers/transformers.md
+++ b/hkj-book/src/transformers/transformers.md
@@ -1,4 +1,5 @@
-# Transformers:  _Combining Monadic Effects_
+# The Transformers:  
+_Combining Monadic Effects_
 
 ![stand_back_monad_transformers.jpg](../images/stand_back_monad_transformers.jpg)
 

--- a/hkj-book/theme/additional-hkj.css
+++ b/hkj-book/theme/additional-hkj.css
@@ -6,3 +6,8 @@ li:not(:last-of-type) {
 li :is(ul, ol) {
     margin-block-start: 0.5em;
 }
+
+/* Reduces the top margin of an H2 that directly follows an H1 */
+h1 + h2 {
+    margin-top: -2.0rem;
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer/WriterExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer/WriterExample.java
@@ -11,6 +11,7 @@ import org.higherkindedj.hkt.unit.Unit;
 import org.higherkindedj.hkt.writer.Writer;
 import org.higherkindedj.hkt.writer.WriterKind;
 import org.higherkindedj.hkt.writer.WriterMonad;
+import org.jspecify.annotations.NonNull;
 
 /** see {<a href="https://higher-kinded-j.github.io/writer_monad.html">Writer Monad</a>} */
 public class WriterExample {
@@ -83,12 +84,12 @@ public class WriterExample {
 
 class StringMonoid implements Monoid<String> {
   @Override
-  public String empty() {
+  public @NonNull String empty() {
     return "";
   }
 
   @Override
-  public String combine(String x, String y) {
+  public @NonNull String combine(@NonNull String x, @NonNull String y) {
     return x + y;
   }
 }


### PR DESCRIPTION
## Description
Create a Semigroup that has combine operation and make Monoid extend this with empty

Fixes #99 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring/Code cleanup
- [ ] Test addition/update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] `./gradlew test` passes locally
- [ ] New unit tests added/updated
- [ ] Relevant examples in `MonadSimulation.java` or `OrderWorkflowRunner.java` updated/tested (if applicable)


## Checklist:

- [ ] My code follows the style guidelines of this project (Standard Google Java Conventions)[**See Google Java Style Guide**](https://google.github.io/styleguide/javaguide.html)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g., README.md, Javadoc)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`./gradlew test`)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)
- [ ] I have checked that the GitHub Actions CI build passes with my changes

## Additional Comments (Optional)

Add any other comments here.