### PR TITLE
Now using NullMarked on package-info to remove NonNull boilerplate

### DIFF
--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.either;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -27,7 +26,7 @@ public interface EitherConverterOps {
    *     Either}.
    * @throws NullPointerException if {@code either} is {@code null}.
    */
-  <L, R> @NonNull Kind<EitherKind.Witness<L>, R> widen(@NonNull Either<L, R> either);
+  <L, R> Kind<EitherKind.Witness<L>, R> widen(Either<L, R> either);
 
   /**
    * Narrows a {@code Kind<EitherKind.Witness<L>, R>} back to its concrete {@code Either<L, R>}
@@ -40,5 +39,5 @@ public interface EitherConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null} or not a representation
    *     of an {@code Either<L,R>}.
    */
-  <L, R> @NonNull Either<L, R> narrow(@Nullable Kind<EitherKind.Witness<L>, R> kind);
+  <L, R> Either<L, R> narrow(@Nullable Kind<EitherKind.Witness<L>, R> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherFunctor.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Functor} interface for the {@link Either} type, biased towards the "Right"
@@ -39,8 +38,8 @@ public class EitherFunctor<L> implements Functor<EitherKind.Witness<L>> {
    *     Either<L, B>}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<EitherKind.Witness<L>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<EitherKind.Witness<L>, A> ma) {
+  public <A, B> Kind<EitherKind.Witness<L>, B> map(
+      Function<? super A, ? extends B> f, Kind<EitherKind.Witness<L>, A> ma) {
     Either<L, A> eitherA = EITHER.narrow(ma);
     Either<L, B> resultEither = eitherA.map(f); // Delegates to Either's right-biased map
     return EITHER.widen(resultEither);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherMonad.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.function.Function3;
 import org.higherkindedj.hkt.function.Function4;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -49,7 +48,7 @@ public class EitherMonad<L> extends EitherFunctor<L>
    * @return A {@code Kind<EitherKind.Witness<L>, R>} representing {@code Right(value)}. Never null.
    */
   @Override
-  public <R> @NonNull Kind<EitherKind.Witness<L>, R> of(@Nullable R value) {
+  public <R> Kind<EitherKind.Witness<L>, R> of(@Nullable R value) {
     return EITHER.widen(Either.right(value));
   }
 
@@ -67,9 +66,9 @@ public class EitherMonad<L> extends EitherFunctor<L>
    *     original "Left" propagated. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<EitherKind.Witness<L>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<EitherKind.Witness<L>, B>> f,
-      @NonNull Kind<EitherKind.Witness<L>, A> ma) {
+  public <A, B> Kind<EitherKind.Witness<L>, B> flatMap(
+      Function<? super A, ? extends Kind<EitherKind.Witness<L>, B>> f,
+      Kind<EitherKind.Witness<L>, A> ma) {
     Either<L, A> eitherA = EITHER.narrow(ma);
     Either<L, B> resultEither =
         eitherA.flatMap(
@@ -95,9 +94,9 @@ public class EitherMonad<L> extends EitherFunctor<L>
    * @return A {@code Kind<EitherKind.Witness<L>, B>} representing the result. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<EitherKind.Witness<L>, B> ap(
-      @NonNull Kind<EitherKind.Witness<L>, ? extends Function<A, B>> ffKind,
-      @NonNull Kind<EitherKind.Witness<L>, A> faKind) {
+  public <A, B> Kind<EitherKind.Witness<L>, B> ap(
+      Kind<EitherKind.Witness<L>, ? extends Function<A, B>> ffKind,
+      Kind<EitherKind.Witness<L>, A> faKind) {
     Either<L, ? extends Function<A, B>> eitherF = EITHER.narrow(ffKind);
     Either<L, A> eitherA = EITHER.narrow(faKind);
 
@@ -111,11 +110,11 @@ public class EitherMonad<L> extends EitherFunctor<L>
   // map is inherited from EitherFunctor and is correct.
 
   @Override
-  public <A, B, C, R_TYPE> @NonNull Kind<EitherKind.Witness<L>, R_TYPE> map3(
-      @NonNull Kind<EitherKind.Witness<L>, A> faKind,
-      @NonNull Kind<EitherKind.Witness<L>, B> fbKind,
-      @NonNull Kind<EitherKind.Witness<L>, C> fcKind,
-      @NonNull Function3<? super A, ? super B, ? super C, ? extends R_TYPE> f) {
+  public <A, B, C, R_TYPE> Kind<EitherKind.Witness<L>, R_TYPE> map3(
+      Kind<EitherKind.Witness<L>, A> faKind,
+      Kind<EitherKind.Witness<L>, B> fbKind,
+      Kind<EitherKind.Witness<L>, C> fcKind,
+      Function3<? super A, ? super B, ? super C, ? extends R_TYPE> f) {
     // Monad.flatMap(Function<T, Kind<F, U>> func, Kind<F, T> kind)
     // Monad.map(Function<T, U> func, Kind<F, T> kind)
     return this.flatMap(
@@ -123,12 +122,12 @@ public class EitherMonad<L> extends EitherFunctor<L>
   }
 
   @Override
-  public <A, B, C, D, R_TYPE> @NonNull Kind<EitherKind.Witness<L>, R_TYPE> map4(
-      @NonNull Kind<EitherKind.Witness<L>, A> faKind,
-      @NonNull Kind<EitherKind.Witness<L>, B> fbKind,
-      @NonNull Kind<EitherKind.Witness<L>, C> fcKind,
-      @NonNull Kind<EitherKind.Witness<L>, D> fdKind,
-      @NonNull Function4<? super A, ? super B, ? super C, ? super D, ? extends R_TYPE> f) {
+  public <A, B, C, D, R_TYPE> Kind<EitherKind.Witness<L>, R_TYPE> map4(
+      Kind<EitherKind.Witness<L>, A> faKind,
+      Kind<EitherKind.Witness<L>, B> fbKind,
+      Kind<EitherKind.Witness<L>, C> fcKind,
+      Kind<EitherKind.Witness<L>, D> fdKind,
+      Function4<? super A, ? super B, ? super C, ? super D, ? extends R_TYPE> f) {
     return this.flatMap(
         a ->
             this.flatMap(
@@ -137,14 +136,14 @@ public class EitherMonad<L> extends EitherFunctor<L>
   }
 
   @Override
-  public <A> @NonNull Kind<EitherKind.Witness<L>, A> raiseError(@Nullable L error) {
+  public <A> Kind<EitherKind.Witness<L>, A> raiseError(@Nullable L error) {
     return EITHER.widen(Either.left(error));
   }
 
   @Override
-  public <A> @NonNull Kind<EitherKind.Witness<L>, A> handleErrorWith(
-      @NonNull Kind<EitherKind.Witness<L>, A> ma,
-      @NonNull Function<? super L, ? extends Kind<EitherKind.Witness<L>, A>> handler) {
+  public <A> Kind<EitherKind.Witness<L>, A> handleErrorWith(
+      Kind<EitherKind.Witness<L>, A> ma,
+      Function<? super L, ? extends Kind<EitherKind.Witness<L>, A>> handler) {
     Either<L, A> either = EITHER.narrow(ma);
     return either.fold(handler, rightValue -> ma);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherTraverse.java
@@ -10,7 +10,6 @@ import org.higherkindedj.hkt.Foldable;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.Traverse;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Traverse} and {@link Foldable} typeclasses for {@link Either}, using {@link
@@ -33,16 +32,16 @@ public final class EitherTraverse<E> implements Traverse<EitherKind.Witness<E>> 
   }
 
   @Override
-  public <A, B> @NonNull Kind<EitherKind.Witness<E>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<EitherKind.Witness<E>, A> fa) {
+  public <A, B> Kind<EitherKind.Witness<E>, B> map(
+      Function<? super A, ? extends B> f, Kind<EitherKind.Witness<E>, A> fa) {
     return EITHER.widen(EITHER.narrow(fa).map(f));
   }
 
   @Override
-  public <G, A, B> @NonNull Kind<G, Kind<EitherKind.Witness<E>, B>> traverse(
-      @NonNull Applicative<G> applicative,
-      @NonNull Function<? super A, ? extends Kind<G, ? extends B>> f,
-      @NonNull Kind<EitherKind.Witness<E>, A> ta) {
+  public <G, A, B> Kind<G, Kind<EitherKind.Witness<E>, B>> traverse(
+      Applicative<G> applicative,
+      Function<? super A, ? extends Kind<G, ? extends B>> f,
+      Kind<EitherKind.Witness<E>, A> ta) {
 
     return EITHER
         .narrow(ta)
@@ -58,9 +57,7 @@ public final class EitherTraverse<E> implements Traverse<EitherKind.Witness<E>> 
 
   @Override
   public <A, M> M foldMap(
-      @NonNull Monoid<M> monoid,
-      @NonNull Function<? super A, ? extends M> f,
-      @NonNull Kind<EitherKind.Witness<E>, A> fa) {
+      Monoid<M> monoid, Function<? super A, ? extends M> f, Kind<EitherKind.Witness<E>, A> fa) {
     return EITHER.narrow(fa).fold(left -> monoid.empty(), f);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.either_t;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -30,7 +29,7 @@ public interface EitherTConverterOps {
    * @return The {@code Kind} representation.
    * @throws NullPointerException if {@code eitherT} is {@code null}.
    */
-  <F, L, R> @NonNull Kind<EitherTKind.Witness<F, L>, R> widen(@NonNull EitherT<F, L, R> eitherT);
+  <F, L, R> Kind<EitherTKind.Witness<F, L>, R> widen(EitherT<F, L, R> eitherT);
 
   /**
    * Narrows a {@code Kind<EitherTKind.Witness<F, L>, R>} back to its concrete {@link EitherT
@@ -45,5 +44,5 @@ public interface EitherTConverterOps {
    * @return The unwrapped, non-null {@link EitherT EitherT&lt;F, L, R&gt;} instance.
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link EitherT} instance.
    */
-  <F, L, R> @NonNull EitherT<F, L, R> narrow(@Nullable Kind<EitherTKind.Witness<F, L>, R> kind);
+  <F, L, R> EitherT<F, L, R> narrow(@Nullable Kind<EitherTKind.Witness<F, L>, R> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTKindHelper.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -43,8 +42,7 @@ public enum EitherTKindHelper implements EitherTConverterOps {
    * @throws NullPointerException if {@code eitherT} is null.
    */
   @Override
-  public <F, L, R> @NonNull Kind<EitherTKind.Witness<F, L>, R> widen(
-      @NonNull EitherT<F, L, R> eitherT) {
+  public <F, L, R> Kind<EitherTKind.Witness<F, L>, R> widen(EitherT<F, L, R> eitherT) {
     requireNonNull(eitherT, INVALID_KIND_TYPE_NULL_MSG);
     return (EitherTKind<F, L, R>) eitherT;
   }
@@ -61,8 +59,7 @@ public enum EitherTKindHelper implements EitherTConverterOps {
    * @throws KindUnwrapException if {@code kind} is null or not an {@link EitherT} instance.
    */
   @Override
-  public <F, L, R> @NonNull EitherT<F, L, R> narrow(
-      @Nullable Kind<EitherTKind.Witness<F, L>, R> kind) {
+  public <F, L, R> EitherT<F, L, R> narrow(@Nullable Kind<EitherTKind.Witness<F, L>, R> kind) {
     if (kind == null) {
       throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
     }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTMonad.java
@@ -10,7 +10,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.either.Either;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -32,7 +31,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>, L> {
 
-  private final @NonNull Monad<F> outerMonad;
+  private final Monad<F> outerMonad;
 
   /**
    * Constructs an {@code EitherTMonad} instance.
@@ -40,7 +39,7 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    * @param outerMonad The {@link Monad} instance for the outer monad {@code F}. Must not be null.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public EitherTMonad(@NonNull Monad<F> outerMonad) {
+  public EitherTMonad(Monad<F> outerMonad) {
     this.outerMonad =
         Objects.requireNonNull(outerMonad, "Outer Monad instance cannot be null for EitherTMonad");
   }
@@ -54,7 +53,7 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    * @return A {@code Kind<EitherTKind.Witness<F, L>, R>} representing the lifted 'right' value.
    */
   @Override
-  public <R> @NonNull Kind<EitherTKind.Witness<F, L>, R> of(@Nullable R r) {
+  public <R> Kind<EitherTKind.Witness<F, L>, R> of(@Nullable R r) {
     EitherT<F, L, R> concreteEitherT = EitherT.right(outerMonad, r);
     return EITHER_T.widen(concreteEitherT);
   }
@@ -71,9 +70,8 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    * @return A new {@code Kind<EitherTKind.Witness<F, L>, R_OUT>} with the function applied.
    */
   @Override
-  public <R_IN, R_OUT> @NonNull Kind<EitherTKind.Witness<F, L>, R_OUT> map(
-      @NonNull Function<? super R_IN, ? extends R_OUT> f,
-      @NonNull Kind<EitherTKind.Witness<F, L>, R_IN> fa) {
+  public <R_IN, R_OUT> Kind<EitherTKind.Witness<F, L>, R_OUT> map(
+      Function<? super R_IN, ? extends R_OUT> f, Kind<EitherTKind.Witness<F, L>, R_IN> fa) {
     Objects.requireNonNull(f, "Function f cannot be null for map");
     Objects.requireNonNull(fa, "Kind fa cannot be null for map");
 
@@ -94,9 +92,9 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    * @return A new {@code Kind<EitherTKind.Witness<F, L>, R_OUT>} representing the application.
    */
   @Override
-  public <R_IN, R_OUT> @NonNull Kind<EitherTKind.Witness<F, L>, R_OUT> ap(
-      @NonNull Kind<EitherTKind.Witness<F, L>, ? extends Function<R_IN, R_OUT>> ff,
-      @NonNull Kind<EitherTKind.Witness<F, L>, R_IN> fa) {
+  public <R_IN, R_OUT> Kind<EitherTKind.Witness<F, L>, R_OUT> ap(
+      Kind<EitherTKind.Witness<F, L>, ? extends Function<R_IN, R_OUT>> ff,
+      Kind<EitherTKind.Witness<F, L>, R_IN> fa) {
     Objects.requireNonNull(ff, "Kind ff cannot be null for ap");
     Objects.requireNonNull(fa, "Kind fa cannot be null for ap");
 
@@ -128,9 +126,9 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    * @return A new {@code Kind<EitherTKind.Witness<F, L>, R_OUT>}.
    */
   @Override
-  public <R_IN, R_OUT> @NonNull Kind<EitherTKind.Witness<F, L>, R_OUT> flatMap(
-      @NonNull Function<? super R_IN, ? extends Kind<EitherTKind.Witness<F, L>, R_OUT>> f,
-      @NonNull Kind<EitherTKind.Witness<F, L>, R_IN> ma) {
+  public <R_IN, R_OUT> Kind<EitherTKind.Witness<F, L>, R_OUT> flatMap(
+      Function<? super R_IN, ? extends Kind<EitherTKind.Witness<F, L>, R_OUT>> f,
+      Kind<EitherTKind.Witness<F, L>, R_IN> ma) {
     Objects.requireNonNull(f, "Function f cannot be null for flatMap");
     Objects.requireNonNull(ma, "Kind ma cannot be null for flatMap");
 
@@ -166,7 +164,7 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    * @return A {@code Kind<EitherTKind.Witness<F, L>, R>} representing {@code F<Left(error)>}.
    */
   @Override
-  public <R> @NonNull Kind<EitherTKind.Witness<F, L>, R> raiseError(@Nullable L error) {
+  public <R> Kind<EitherTKind.Witness<F, L>, R> raiseError(@Nullable L error) {
     EitherT<F, L, R> concreteEitherT = EitherT.left(outerMonad, error);
     return EITHER_T.widen(concreteEitherT);
   }
@@ -186,9 +184,9 @@ public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>,
    *     handler.
    */
   @Override
-  public <R> @NonNull Kind<EitherTKind.Witness<F, L>, R> handleErrorWith(
-      @NonNull Kind<EitherTKind.Witness<F, L>, R> ma,
-      @NonNull Function<? super L, ? extends Kind<EitherTKind.Witness<F, L>, R>> handler) {
+  public <R> Kind<EitherTKind.Witness<F, L>, R> handleErrorWith(
+      Kind<EitherTKind.Witness<F, L>, R> ma,
+      Function<? super L, ? extends Kind<EitherTKind.Witness<F, L>, R>> handler) {
     Objects.requireNonNull(ma, "Kind ma cannot be null for handleErrorWith");
     Objects.requireNonNull(handler, "Function handler cannot be null for handleErrorWith");
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureApplicative.java
@@ -10,7 +10,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -60,7 +59,7 @@ public class CompletableFutureApplicative extends CompletableFutureFunctor
    *     {@code CompletableFuture.completedFuture(value)}.
    */
   @Override
-  public <A> @NonNull Kind<CompletableFutureKind.Witness, A> of(@Nullable A value) {
+  public <A> Kind<CompletableFutureKind.Witness, A> of(@Nullable A value) {
     return FUTURE.widen(CompletableFuture.completedFuture(value));
   }
 
@@ -95,9 +94,9 @@ public class CompletableFutureApplicative extends CompletableFutureFunctor
    *     be unwrapped.
    */
   @Override
-  public <A, B> @NonNull Kind<CompletableFutureKind.Witness, B> ap(
-      @NonNull Kind<CompletableFutureKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<CompletableFutureKind.Witness, A> fa) {
+  public <A, B> Kind<CompletableFutureKind.Witness, B> ap(
+      Kind<CompletableFutureKind.Witness, ? extends Function<A, B>> ff,
+      Kind<CompletableFutureKind.Witness, A> fa) {
     CompletableFuture<? extends Function<A, B>> futureF = FUTURE.narrow(ff);
     CompletableFuture<A> futureA = FUTURE.narrow(fa);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureConverterOps.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.future;
 import java.util.concurrent.CompletableFuture;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -27,7 +26,7 @@ public interface CompletableFutureConverterOps {
    *     future.
    * @throws NullPointerException if {@code future} is {@code null}.
    */
-  <A> @NonNull Kind<CompletableFutureKind.Witness, A> widen(@NonNull CompletableFuture<A> future);
+  <A> Kind<CompletableFutureKind.Witness, A> widen(CompletableFuture<A> future);
 
   /**
    * Narrows a {@code Kind<CompletableFutureKind.Witness, A>} back to its concrete {@link
@@ -41,5 +40,5 @@ public interface CompletableFutureConverterOps {
    *     expected underlying holder type, or if the holder internally contains a {@code null}
    *     future.
    */
-  <A> @NonNull CompletableFuture<A> narrow(@Nullable Kind<CompletableFutureKind.Witness, A> kind);
+  <A> CompletableFuture<A> narrow(@Nullable Kind<CompletableFutureKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureFunctor.java
@@ -8,7 +8,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -67,9 +66,9 @@ public class CompletableFutureFunctor implements Functor<CompletableFutureKind.W
    * @throws NullPointerException if {@code f} or {@code fa} is null.
    */
   @Override
-  public <A, B> @NonNull Kind<CompletableFutureKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends @Nullable B> f, // Function A -> B, where B can be null
-      @NonNull Kind<CompletableFutureKind.Witness, A> fa) {
+  public <A, B> Kind<CompletableFutureKind.Witness, B> map(
+      Function<? super A, ? extends @Nullable B> f, // Function A -> B, where B can be null
+      Kind<CompletableFutureKind.Witness, A> fa) {
     CompletableFuture<A> futureA = FUTURE.narrow(fa);
     CompletableFuture<B> futureB = futureA.thenApply(f);
     return FUTURE.widen(futureB);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureKindHelper.java
@@ -7,7 +7,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -59,8 +58,7 @@ public enum CompletableFutureKindHelper implements CompletableFutureConverterOps
    * @throws NullPointerException if {@code future} is {@code null}.
    */
   @Override
-  public <A> @NonNull Kind<CompletableFutureKind.Witness, A> widen(
-      @NonNull CompletableFuture<A> future) {
+  public <A> Kind<CompletableFutureKind.Witness, A> widen(CompletableFuture<A> future) {
     Objects.requireNonNull(future, INVALID_KIND_TYPE_NULL_MSG);
     return new CompletableFutureHolder<>(future);
   }
@@ -79,8 +77,7 @@ public enum CompletableFutureKindHelper implements CompletableFutureConverterOps
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <A> @NonNull CompletableFuture<A> narrow(
-      @Nullable Kind<CompletableFutureKind.Witness, A> kind) {
+  public <A> CompletableFuture<A> narrow(@Nullable Kind<CompletableFutureKind.Witness, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
       case CompletableFutureKindHelper.CompletableFutureHolder<?> holder -> {
@@ -107,7 +104,7 @@ public enum CompletableFutureKindHelper implements CompletableFutureConverterOps
    * @throws CompletionException if the future completed exceptionally.
    * @throws java.util.concurrent.CancellationException if the future was cancelled.
    */
-  public <A> @NonNull A join(@NonNull Kind<CompletableFutureKind.Witness, A> kind) {
+  public <A> A join(Kind<CompletableFutureKind.Witness, A> kind) {
     CompletableFuture<A> future = this.narrow(kind); // Uses instance method narrow
     try {
       return future.join();

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureMonad.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -76,11 +75,9 @@ public class CompletableFutureMonad extends CompletableFutureApplicative
    * @throws NullPointerException if {@code f} is null, or if {@code f} returns a null {@code Kind}.
    */
   @Override
-  public <A, B> @NonNull Kind<CompletableFutureKind.Witness, B> flatMap(
-      @NonNull
-          Function<? super @Nullable A, ? extends @NonNull Kind<CompletableFutureKind.Witness, B>>
-          f,
-      @NonNull Kind<CompletableFutureKind.Witness, A> ma) {
+  public <A, B> Kind<CompletableFutureKind.Witness, B> flatMap(
+      Function<? super @Nullable A, ? extends Kind<CompletableFutureKind.Witness, B>> f,
+      Kind<CompletableFutureKind.Witness, A> ma) {
     CompletableFuture<A> futureA = FUTURE.narrow(ma);
     CompletableFuture<B> futureB =
         futureA.thenCompose(
@@ -101,7 +98,7 @@ public class CompletableFutureMonad extends CompletableFutureApplicative
    *     CompletableFuture.failedFuture(error)}.
    */
   @Override
-  public <A> @NonNull Kind<CompletableFutureKind.Witness, A> raiseError(@NonNull Throwable error) {
+  public <A> Kind<CompletableFutureKind.Witness, A> raiseError(Throwable error) {
     return FUTURE.widen(CompletableFuture.failedFuture(error));
   }
 
@@ -125,10 +122,9 @@ public class CompletableFutureMonad extends CompletableFutureApplicative
    *     successful, or the result from the {@code handler}.
    */
   @Override
-  public <A> @NonNull Kind<CompletableFutureKind.Witness, A> handleErrorWith(
-      @NonNull Kind<CompletableFutureKind.Witness, A> ma,
-      @NonNull Function<? super Throwable, ? extends Kind<CompletableFutureKind.Witness, A>>
-          handler) {
+  public <A> Kind<CompletableFutureKind.Witness, A> handleErrorWith(
+      Kind<CompletableFutureKind.Witness, A> ma,
+      Function<? super Throwable, ? extends Kind<CompletableFutureKind.Witness, A>> handler) {
     CompletableFuture<A> futureA = FUTURE.narrow(ma);
 
     // Optimization: If already successfully completed, no need to attach handler.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdConverterOps.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.id;
 
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Defines conversion operations (widen and narrow) specific to Id types and their Kind
@@ -21,7 +20,7 @@ public interface IdConverterOps {
    * @param <A> The type of the value.
    * @return The {@link Kind} representation.
    */
-  <A> @NonNull Kind<Id.Witness, A> widen(@NonNull Id<A> id);
+  <A> Kind<Id.Witness, A> widen(Id<A> id);
 
   /**
    * Narrows a {@link Kind} representation to an {@link Id}.
@@ -31,5 +30,5 @@ public interface IdConverterOps {
    * @return The {@link Id} instance.
    * @throws ClassCastException if the kind is not an Id instance of the expected type.
    */
-  <A> @NonNull Id<A> narrow(@NonNull Kind<Id.Witness, A> kind);
+  <A> Id<A> narrow(Kind<Id.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdKindHelper.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.id;
 
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -30,7 +29,7 @@ public enum IdKindHelper implements IdConverterOps {
    * @throws NullPointerException if id is null.
    */
   @Override
-  public <A> @NonNull Kind<Id.Witness, A> widen(@NonNull Id<A> id) {
+  public <A> Kind<Id.Witness, A> widen(Id<A> id) {
     Objects.requireNonNull(id, "Id cannot be null");
     return id;
   }
@@ -45,7 +44,7 @@ public enum IdKindHelper implements IdConverterOps {
    * @throws NullPointerException if kind is null.
    */
   @Override
-  public <A> @NonNull Id<A> narrow(@NonNull Kind<Id.Witness, A> kind) {
+  public <A> Id<A> narrow(Kind<Id.Witness, A> kind) {
     Objects.requireNonNull(kind, "Kind cannot be null");
     return (Id<A>) kind;
   }
@@ -58,7 +57,7 @@ public enum IdKindHelper implements IdConverterOps {
    * @param <A> The type of the value.
    * @return The underlying value. Can be null if the {@link Id} wrapped a null.
    */
-  public <A> @Nullable A unwrap(@NonNull Kind<Id.Witness, A> kind) {
+  public <A> @Nullable A unwrap(Kind<Id.Witness, A> kind) {
     return this.narrow(kind).value();
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdentityMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdentityMonad.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -44,7 +43,7 @@ public final class IdentityMonad implements Monad<Id.Witness> {
    *
    * @return The singleton {@code IdentityMonad} instance.
    */
-  public static @NonNull IdentityMonad instance() {
+  public static IdentityMonad instance() {
     return INSTANCE;
   }
 
@@ -58,7 +57,7 @@ public final class IdentityMonad implements Monad<Id.Witness> {
    *     {@link Kind} is guaranteed non-null, even if {@code a} is null.
    */
   @Override
-  public <A> @NonNull Kind<Id.Witness, A> of(@Nullable A a) {
+  public <A> Kind<Id.Witness, A> of(@Nullable A a) {
     return Id.of(a);
   }
 
@@ -83,8 +82,8 @@ public final class IdentityMonad implements Monad<Id.Witness> {
    * @throws NullPointerException if {@code fn} or {@code fa} is null.
    */
   @Override
-  public <A, B> @NonNull Kind<Id.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> fn, @NonNull Kind<Id.Witness, A> fa) {
+  public <A, B> Kind<Id.Witness, B> map(
+      Function<? super A, ? extends B> fn, Kind<Id.Witness, A> fa) {
     Objects.requireNonNull(fn, "Function cannot be null");
     Objects.requireNonNull(fa, "Kind fa cannot be null");
     // Delegate to Id.map for directness. Id.map handles null values wrapped in Id correctly.
@@ -111,8 +110,8 @@ public final class IdentityMonad implements Monad<Id.Witness> {
    *     is null.
    */
   @Override
-  public <A, B> @NonNull Kind<Id.Witness, B> ap(
-      @NonNull Kind<Id.Witness, ? extends Function<A, B>> ff, @NonNull Kind<Id.Witness, A> fa) {
+  public <A, B> Kind<Id.Witness, B> ap(
+      Kind<Id.Witness, ? extends Function<A, B>> ff, Kind<Id.Witness, A> fa) {
     Objects.requireNonNull(ff, "Kind ff cannot be null");
     Objects.requireNonNull(fa, "Kind fa cannot be null");
     Function<A, B> function = ID.narrow(ff).value();
@@ -147,9 +146,8 @@ public final class IdentityMonad implements Monad<Id.Witness> {
    *     {@link Kind}.
    */
   @Override
-  public <A, B> @NonNull Kind<Id.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<Id.Witness, B>> fn,
-      @NonNull Kind<Id.Witness, A> fa) {
+  public <A, B> Kind<Id.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<Id.Witness, B>> fn, Kind<Id.Witness, A> fa) {
     Objects.requireNonNull(fn, "Function cannot be null");
     Objects.requireNonNull(fa, "Kind fa cannot be null");
     A valueInA = ID.narrow(fa).value();

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOApplicative.java
@@ -7,20 +7,18 @@ import static org.higherkindedj.hkt.io.IOKindHelper.IO_OP;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 public class IOApplicative extends IOFunctor implements Applicative<IOKind.Witness> {
   @Override
-  public <A> @NonNull Kind<IOKind.Witness, A> of(A value) {
+  public <A> Kind<IOKind.Witness, A> of(A value) {
     // 'of'/'pure' typically captures a pure value, delaying its evaluation
     // until unsafeRunSync. Contrast with delay() which takes a Supplier.
     return IO_OP.widen(IO.delay(() -> value));
   }
 
   @Override
-  public <A, B> @NonNull Kind<IOKind.Witness, B> ap(
-      @NonNull Kind<IOKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<IOKind.Witness, A> fa) {
+  public <A, B> Kind<IOKind.Witness, B> ap(
+      Kind<IOKind.Witness, ? extends Function<A, B>> ff, Kind<IOKind.Witness, A> fa) {
     IO<? extends Function<A, B>> ioF = IO_OP.narrow(ff);
     IO<A> ioA = IO_OP.narrow(fa);
     // IO<B> ioB = IO { ioF.unsafeRunSync().apply(ioA.unsafeRunSync()) }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.io;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +25,7 @@ public interface IOConverterOps {
    *     computation.
    * @throws NullPointerException if {@code io} is {@code null}.
    */
-  <A> @NonNull Kind<IOKind.Witness, A> widen(@NonNull IO<A> io);
+  <A> Kind<IOKind.Witness, A> widen(IO<A> io);
 
   /**
    * Narrows a {@code Kind<IOKind.Witness, A>} back to its concrete {@link IO<A>} type.
@@ -37,5 +36,5 @@ public interface IOConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null}, or not an instance of
    *     the expected underlying holder type for IO.
    */
-  <A> @NonNull IO<A> narrow(@Nullable Kind<IOKind.Witness, A> kind);
+  <A> IO<A> narrow(@Nullable Kind<IOKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOFunctor.java
@@ -6,12 +6,11 @@ import static org.higherkindedj.hkt.io.IOKindHelper.*;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.*;
-import org.jspecify.annotations.NonNull;
 
 public class IOFunctor implements Functor<IOKind.Witness> {
   @Override
-  public <A, B> @NonNull Kind<IOKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<IOKind.Witness, A> fa) {
+  public <A, B> Kind<IOKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<IOKind.Witness, A> fa) {
     IO<A> ioA = IO_OP.narrow(fa);
     IO<B> ioB = ioA.map(f); // Use IO's own map
     return IO_OP.widen(ioB);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOKindHelper.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -30,7 +29,7 @@ public enum IOKindHelper implements IOConverterOps {
   /**
    * Error message for when the internal holder in {@link #narrow(Kind)} contains a {@code null} IO
    * instance. This should ideally not occur if {@link #widen(IO)} enforces non-null IO instances
-   * and IOHolder guarantees its content via @NonNull.
+   * and IOHolder guarantees its content via .
    */
   public static final String INVALID_HOLDER_STATE_MSG = "IOHolder contained null IO instance";
 
@@ -41,7 +40,7 @@ public enum IOKindHelper implements IOConverterOps {
    * @param <A> The result type of the IO computation.
    * @param ioInstance The non-null, actual {@link IO} instance.
    */
-  record IOHolder<A>(@NonNull IO<A> ioInstance) implements IOKind<A> {}
+  record IOHolder<A>(IO<A> ioInstance) implements IOKind<A> {}
 
   /**
    * Widens a concrete {@link IO<A>} instance into its higher-kinded representation, {@code
@@ -54,7 +53,7 @@ public enum IOKindHelper implements IOConverterOps {
    * @throws NullPointerException if {@code io} is {@code null}.
    */
   @Override
-  public <A> @NonNull Kind<IOKind.Witness, A> widen(@NonNull IO<A> io) {
+  public <A> Kind<IOKind.Witness, A> widen(IO<A> io) {
     Objects.requireNonNull(io, "Input IO cannot be null for widen");
     return new IOHolder<>(io);
   }
@@ -72,10 +71,10 @@ public enum IOKindHelper implements IOConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked") // For casting holder.ioInstance()
-  public <A> @NonNull IO<A> narrow(@Nullable Kind<IOKind.Witness, A> kind) {
+  public <A> IO<A> narrow(@Nullable Kind<IOKind.Witness, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
-      // IOHolder's record component ioInstance is @NonNull, so no further null check needed here.
+      // IOHolder's record component ioInstance is , so no further null check needed here.
       case IOKindHelper.IOHolder<?> holder -> (IO<A>) holder.ioInstance();
       default -> throw new KindUnwrapException(INVALID_KIND_TYPE_MSG + kind.getClass().getName());
     };
@@ -91,7 +90,7 @@ public enum IOKindHelper implements IOConverterOps {
    *     computation.
    * @throws NullPointerException if {@code thunk} is {@code null}.
    */
-  public <A> @NonNull Kind<IOKind.Witness, A> delay(@NonNull Supplier<A> thunk) {
+  public <A> Kind<IOKind.Witness, A> delay(Supplier<A> thunk) {
     return this.widen(IO.delay(thunk));
   }
 
@@ -105,7 +104,7 @@ public enum IOKindHelper implements IOConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is invalid. Any exceptions from the
    *     {@code IO} computation propagate.
    */
-  public <A> @NonNull A unsafeRunSync(@NonNull Kind<IOKind.Witness, A> kind) {
+  public <A> A unsafeRunSync(Kind<IOKind.Witness, A> kind) {
     return this.narrow(kind).unsafeRunSync();
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOMonad.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.io.IOKindHelper.IO_OP;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 
 public class IOMonad extends IOApplicative implements Monad<IOKind.Witness> {
   /** Singleton instance of {@code MaybeMonad}. */
@@ -19,9 +18,8 @@ public class IOMonad extends IOApplicative implements Monad<IOKind.Witness> {
   }
 
   @Override
-  public <A, B> @NonNull Kind<IOKind.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<IOKind.Witness, B>> f,
-      @NonNull Kind<IOKind.Witness, A> ma) {
+  public <A, B> Kind<IOKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<IOKind.Witness, B>> f, Kind<IOKind.Witness, A> ma) {
     IO<A> ioA = IO_OP.narrow(ma);
     // Need to adapt f: A -> Kind<IO.Witness, B> to A -> IO<B> for IO's flatMap
     IO<B> ioB = ioA.flatMap(a -> IO_OP.narrow(f.apply(a)));

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/Lazy.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/Lazy.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.lazy;
 
 import java.util.Objects;
 import java.util.function.Function;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -18,9 +17,9 @@ public final class Lazy<A> {
   private transient volatile boolean evaluated = false;
   private @Nullable A value;
   private @Nullable Throwable exception;
-  private final @NonNull ThrowableSupplier<? extends A> computation;
+  private final ThrowableSupplier<? extends A> computation;
 
-  private Lazy(@NonNull ThrowableSupplier<? extends A> computation) {
+  private Lazy(ThrowableSupplier<? extends A> computation) {
     this.computation = Objects.requireNonNull(computation, "Lazy computation cannot be null");
   }
 
@@ -31,7 +30,7 @@ public final class Lazy<A> {
    * @param <A> The value type.
    * @return A new Lazy instance. (NonNull)
    */
-  public static <A> @NonNull Lazy<A> defer(@NonNull ThrowableSupplier<? extends A> computation) {
+  public static <A> Lazy<A> defer(ThrowableSupplier<? extends A> computation) {
     return new Lazy<>(computation);
   }
 
@@ -42,7 +41,7 @@ public final class Lazy<A> {
    * @param <A> The value type.
    * @return A new Lazy instance holding the pre-computed value. (NonNull)
    */
-  public static <A> @NonNull Lazy<A> now(@Nullable A value) {
+  public static <A> Lazy<A> now(@Nullable A value) {
     Lazy<A> lazy = new Lazy<>(() -> value);
     lazy.value = value;
     lazy.exception = null;
@@ -89,7 +88,7 @@ public final class Lazy<A> {
    * @param <B> The result type of the mapping function.
    * @return A new Lazy computation for the mapped value. (NonNull)
    */
-  public <B> @NonNull Lazy<B> map(@NonNull Function<? super A, ? extends B> f) {
+  public <B> Lazy<B> map(Function<? super A, ? extends B> f) {
     Objects.requireNonNull(f, "mapper function cannot be null");
     return Lazy.defer(() -> f.apply(this.force()));
   }
@@ -103,8 +102,7 @@ public final class Lazy<A> {
    * @param <B> The value type of the returned Lazy computation.
    * @return A new Lazy computation representing the sequenced operation. (NonNull)
    */
-  public <B> @NonNull Lazy<B> flatMap(
-      @NonNull Function<? super A, ? extends @NonNull Lazy<? extends B>> f) {
+  public <B> Lazy<B> flatMap(Function<? super A, ? extends Lazy<? extends B>> f) {
     Objects.requireNonNull(f, "flatMap mapper function cannot be null");
     return Lazy.defer(
         () -> {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.lazy;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +25,7 @@ public interface LazyConverterOps {
    *     computation.
    * @throws NullPointerException if {@code lazy} is {@code null}.
    */
-  <A> @NonNull Kind<LazyKind.Witness, A> widen(@NonNull Lazy<A> lazy);
+  <A> Kind<LazyKind.Witness, A> widen(Lazy<A> lazy);
 
   /**
    * Narrows a {@code Kind<LazyKind.Witness, A>} back to its concrete {@link Lazy<A>} type.
@@ -37,5 +36,5 @@ public interface LazyConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null}, or not an instance of
    *     the expected underlying holder type for Lazy.
    */
-  <A> @NonNull Lazy<A> narrow(@Nullable Kind<LazyKind.Witness, A> kind);
+  <A> Lazy<A> narrow(@Nullable Kind<LazyKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyKindHelper.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.lazy;
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -34,7 +33,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    * Internal record implementing {@link LazyKind} to hold the concrete {@link Lazy} instance.
    * Changed to package-private for potential test access.
    */
-  record LazyHolder<A>(@NonNull Lazy<A> lazyInstance) implements LazyKind<A> {}
+  record LazyHolder<A>(Lazy<A> lazyInstance) implements LazyKind<A> {}
 
   /**
    * Widens a concrete {@link Lazy<A>} instance into its higher-kinded representation, {@code
@@ -47,7 +46,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    * @throws NullPointerException if {@code lazy} is {@code null}.
    */
   @Override
-  public <A> @NonNull Kind<LazyKind.Witness, A> widen(@NonNull Lazy<A> lazy) {
+  public <A> Kind<LazyKind.Witness, A> widen(Lazy<A> lazy) {
     Objects.requireNonNull(lazy, "Input Lazy cannot be null for widen");
     return new LazyHolder<>(lazy);
   }
@@ -64,7 +63,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <A> @NonNull Lazy<A> narrow(@Nullable Kind<LazyKind.Witness, A> kind) {
+  public <A> Lazy<A> narrow(@Nullable Kind<LazyKind.Witness, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
       case LazyKindHelper.LazyHolder<?> holder -> (Lazy<A>) holder.lazyInstance();
@@ -82,7 +81,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    * @return A new, non-null {@code Kind<LazyKind.Witness, A>} representing the deferred {@code
    *     Lazy} computation.
    */
-  public <A> @NonNull Kind<LazyKind.Witness, A> defer(@NonNull ThrowableSupplier<A> computation) {
+  public <A> Kind<LazyKind.Witness, A> defer(ThrowableSupplier<A> computation) {
     return this.widen(Lazy.defer(computation));
   }
 
@@ -94,7 +93,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    * @return A new, non-null {@code Kind<LazyKind.Witness, A>} representing an already evaluated
    *     {@code Lazy} computation.
    */
-  public <A> @NonNull Kind<LazyKind.Witness, A> now(@Nullable A value) {
+  public <A> Kind<LazyKind.Witness, A> now(@Nullable A value) {
     return this.widen(Lazy.now(value));
   }
 
@@ -109,7 +108,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is invalid.
    * @throws Throwable if the underlying {@link ThrowableSupplier} throws an exception.
    */
-  public <A> @Nullable A force(@NonNull Kind<LazyKind.Witness, A> kind) throws Throwable {
+  public <A> @Nullable A force(Kind<LazyKind.Witness, A> kind) throws Throwable {
     return this.narrow(kind).force();
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyMonad.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,8 +45,8 @@ public class LazyMonad
    * @return A new {@code Kind<LazyKind.Witness, B>} containing the result of applying the function.
    */
   @Override
-  public <A, B> @NonNull Kind<LazyKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<LazyKind.Witness, A> fa) {
+  public <A, B> Kind<LazyKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<LazyKind.Witness, A> fa) {
     Lazy<A> lazyA = LAZY.narrow(fa);
     Lazy<B> lazyB = lazyA.map(f); // Use Lazy's map
     return LAZY.widen(lazyB);
@@ -62,7 +61,7 @@ public class LazyMonad
    * @return A {@code Kind<LazyKind.Witness, A>} containing the value.
    */
   @Override
-  public <A> @NonNull Kind<LazyKind.Witness, A> of(@Nullable A value) {
+  public <A> Kind<LazyKind.Witness, A> of(@Nullable A value) {
     // 'of'/'pure' creates a Lazy that is already evaluated
     return LAZY.widen(Lazy.now(value));
   }
@@ -78,9 +77,8 @@ public class LazyMonad
    * @return A new {@code Kind<LazyKind.Witness, B>} containing the result.
    */
   @Override
-  public <A, B> @NonNull Kind<LazyKind.Witness, B> ap(
-      @NonNull Kind<LazyKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<LazyKind.Witness, A> fa) {
+  public <A, B> Kind<LazyKind.Witness, B> ap(
+      Kind<LazyKind.Witness, ? extends Function<A, B>> ff, Kind<LazyKind.Witness, A> fa) {
     Lazy<? extends Function<A, B>> lazyF = LAZY.narrow(ff);
     Lazy<A> lazyA = LAZY.narrow(fa);
 
@@ -101,9 +99,8 @@ public class LazyMonad
    * @return A new {@code Kind<LazyKind.Witness, B>} representing the composed action.
    */
   @Override
-  public <A, B> @NonNull Kind<LazyKind.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<LazyKind.Witness, B>> f,
-      @NonNull Kind<LazyKind.Witness, A> ma) {
+  public <A, B> Kind<LazyKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<LazyKind.Witness, B>> f, Kind<LazyKind.Witness, A> ma) {
     Lazy<A> lazyA = LAZY.narrow(ma);
 
     // Adapt the function for Lazy's flatMap

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.list;
 
 import java.util.List;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -24,7 +23,7 @@ public interface ListConverterOps {
    * @param <A> The element type of the list.
    * @return The higher-kinded representation of the list.
    */
-  <A> @NonNull Kind<ListKind.Witness, A> widen(@NonNull List<A> list);
+  <A> Kind<ListKind.Witness, A> widen(List<A> list);
 
   /**
    * Narrows a higher-kinded representation of a list, {@code Kind<ListKind.Witness, A>}, back to a
@@ -36,5 +35,5 @@ public interface ListConverterOps {
    * @throws ClassCastException if the provided {@code kind} is not actually a representation of a
    *     List.
    */
-  <A> @NonNull List<A> narrow(@Nullable Kind<ListKind.Witness, A> kind);
+  <A> List<A> narrow(@Nullable Kind<ListKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListFunctor.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Functor} type class for {@link java.util.List}, using {@link
@@ -66,8 +65,8 @@ class ListFunctor implements Functor<ListKind.Witness> {
    * @throws NullPointerException if {@code f} or {@code fa} is null.
    */
   @Override
-  public <A, B> @NonNull Kind<ListKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<ListKind.Witness, A> fa) {
+  public <A, B> Kind<ListKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<ListKind.Witness, A> fa) {
     // Narrow to ListKind<A> to call unwrap, or directly to ListView<A>
     // ListKind.narrow ensures fa is not null and is of the correct type.
     List<A> listA = ListKind.narrow(fa).unwrap();

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKind.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKind.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.list; // Assuming a package structure
 
 import java.util.List;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents {@link java.util.List} as a Higher-Kinded Type. This interface, {@code ListKind<A>},
@@ -28,7 +27,7 @@ public interface ListKind<A> extends Kind<ListKind.Witness, A> {
    *
    * @return The underlying {@link java.util.List<A>}.
    */
-  @NonNull List<A> unwrap();
+  List<A> unwrap();
 
   /**
    * Narrows a {@code Kind<ListKind.Witness, A>} to a {@code ListKind<A>}. This is a safe cast when
@@ -38,7 +37,7 @@ public interface ListKind<A> extends Kind<ListKind.Witness, A> {
    * @param <A> The element type.
    * @return The {@code ListKind<A>} instance.
    */
-  static <A> @NonNull ListKind<A> narrow(@NonNull Kind<Witness, A> kind) {
+  static <A> ListKind<A> narrow(Kind<Witness, A> kind) {
     return (ListKind<A>) kind;
   }
 
@@ -50,7 +49,7 @@ public interface ListKind<A> extends Kind<ListKind.Witness, A> {
    * @param <A> The element type.
    * @return A new {@code ListKind<A>} instance.
    */
-  static <A> @NonNull ListKind<A> of(@NonNull List<A> list) {
+  static <A> ListKind<A> of(List<A> list) {
     return new ListView<>(list);
   }
 
@@ -61,9 +60,9 @@ public interface ListKind<A> extends Kind<ListKind.Witness, A> {
    * @param <A> The element type of the list.
    * @param list The list.
    */
-  record ListView<A>(@NonNull List<A> list) implements ListKind<A> {
+  record ListView<A>(List<A> list) implements ListKind<A> {
     @Override
-    public @NonNull List<A> unwrap() {
+    public List<A> unwrap() {
       return list;
     }
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKindHelper.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,7 +32,7 @@ public enum ListKindHelper implements ListConverterOps {
    * @return The higher-kinded representation of the list.
    */
   @Override
-  public <A> @NonNull Kind<ListKind.Witness, A> widen(@NonNull List<A> list) {
+  public <A> Kind<ListKind.Witness, A> widen(List<A> list) {
     Objects.requireNonNull(list, INVALID_KIND_TYPE_NULL_MSG);
     return ListKind.of(list);
   }
@@ -50,7 +49,7 @@ public enum ListKindHelper implements ListConverterOps {
    * @throws ClassCastException if the provided {@code kind} is not actually a {@code ListKind}.
    */
   @Override
-  public <A> @NonNull List<A> narrow(@Nullable Kind<ListKind.Witness, A> kind) {
+  public <A> List<A> narrow(@Nullable Kind<ListKind.Witness, A> kind) {
     if (kind == null) {
       return Collections.emptyList();
     }
@@ -69,8 +68,7 @@ public enum ListKindHelper implements ListConverterOps {
    * @return The unwrapped list, or {@code defaultValue} if {@code kind} is null.
    * @throws ClassCastException if the provided {@code kind} is not actually a {@code ListKind}.
    */
-  public <A> @NonNull List<A> unwrapOr(
-      @Nullable Kind<ListKind.Witness, A> kind, @NonNull List<A> defaultValue) {
+  public <A> List<A> unwrapOr(@Nullable Kind<ListKind.Witness, A> kind, List<A> defaultValue) {
     Objects.requireNonNull(defaultValue, "defaultValue cannot be null");
     if (kind == null) {
       return defaultValue;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadZero;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -34,7 +33,7 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
    *     empty list; otherwise, a list containing the single value.
    */
   @Override
-  public <A> @NonNull Kind<ListKind.Witness, A> of(@Nullable A value) {
+  public <A> Kind<ListKind.Witness, A> of(@Nullable A value) {
     if (value == null) {
       return ListKind.of(Collections.emptyList()); // Create an empty list for null input
     }
@@ -55,9 +54,8 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
    *     {@code ff} to each value in {@code fa}.
    */
   @Override
-  public <A, B> @NonNull Kind<ListKind.Witness, B> ap(
-      @NonNull Kind<ListKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<ListKind.Witness, A> fa) {
+  public <A, B> Kind<ListKind.Witness, B> ap(
+      Kind<ListKind.Witness, ? extends Function<A, B>> ff, Kind<ListKind.Witness, A> fa) {
 
     List<? extends Function<A, B>> functions = ListKind.narrow(ff).unwrap();
     List<A> values = ListKind.narrow(fa).unwrap();
@@ -87,8 +85,8 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
    *     each element.
    */
   @Override
-  public <A, B> @NonNull Kind<ListKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<ListKind.Witness, A> fa) {
+  public <A, B> Kind<ListKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<ListKind.Witness, A> fa) {
     return ListFunctor.INSTANCE.map(f, fa);
   }
 
@@ -104,9 +102,8 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
    * @return A {@code Kind<ListKind.Witness, B>} which is the flattened list of all results.
    */
   @Override
-  public <A, B> @NonNull Kind<ListKind.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<ListKind.Witness, B>> f,
-      @NonNull Kind<ListKind.Witness, A> ma) {
+  public <A, B> Kind<ListKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<ListKind.Witness, B>> f, Kind<ListKind.Witness, A> ma) {
 
     List<A> inputList = ListKind.narrow(ma).unwrap();
     List<B> resultList = new ArrayList<>();

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListTraverse.java
@@ -13,7 +13,6 @@ import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.Traverse;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -57,7 +56,7 @@ public enum ListTraverse implements Traverse<ListKind.Witness> {
    *     applying the function {@code f}.
    */
   @Override
-  public <A, B> @NonNull Kind<ListKind.Witness, B> map(
+  public <A, B> Kind<ListKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<ListKind.Witness, A> fa) {
     // For lists, mapping is equivalent to the Functor implementation.
     return ListFunctor.INSTANCE.map(f, fa);
@@ -83,7 +82,7 @@ public enum ListTraverse implements Traverse<ListKind.Witness> {
    *     applicative context {@code G}.
    */
   @Override
-  public <G, A, B> @NonNull Kind<G, Kind<ListKind.Witness, B>> traverse(
+  public <G, A, B> Kind<G, Kind<ListKind.Witness, B>> traverse(
       Applicative<G> applicative,
       Function<? super A, ? extends Kind<G, ? extends B>> f,
       Kind<ListKind.Witness, A> ta) {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
@@ -5,12 +5,11 @@ package org.higherkindedj.hkt.maybe;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /** Concrete implementation of Maybe representing the presence of a value. */
 // Value must be NonNull because Maybe.just requires it
-record Just<T extends @NonNull Object>(@NonNull T value) implements Maybe<T> {
+record Just<T extends Object>(T value) implements Maybe<T> {
   // Constructor implicitly checks value is non-null via Maybe.just factory
 
   @Override
@@ -24,30 +23,29 @@ record Just<T extends @NonNull Object>(@NonNull T value) implements Maybe<T> {
   }
 
   @Override
-  public @NonNull T get() {
+  public T get() {
     return value;
   } // Value is guaranteed non-null
 
   @Override
-  public @NonNull T orElse(@NonNull T other) {
+  public T orElse(T other) {
     return value;
   }
 
   @Override
-  public @NonNull T orElseGet(@NonNull Supplier<? extends @NonNull T> other) {
+  public T orElseGet(Supplier<? extends T> other) {
     return value;
   }
 
   @Override
-  public @NonNull <U> Maybe<U> map(@NonNull Function<? super T, ? extends @Nullable U> mapper) {
+  public <U> Maybe<U> map(Function<? super T, ? extends @Nullable U> mapper) {
     Objects.requireNonNull(mapper, "mapper function cannot be null");
     // Use fromNullable to handle cases where the mapper might return null
     return Maybe.fromNullable(mapper.apply(value)); // Result of apply is Nullable
   }
 
   @Override
-  public @NonNull <U> Maybe<U> flatMap(
-      @NonNull Function<? super T, ? extends @NonNull Maybe<? extends U>> mapper) {
+  public <U> Maybe<U> flatMap(Function<? super T, ? extends Maybe<? extends U>> mapper) {
     Objects.requireNonNull(mapper, "mapper function cannot be null");
     Maybe<? extends U> result =
         mapper.apply(value); // apply expects NonNull T, returns NonNull Maybe
@@ -60,7 +58,7 @@ record Just<T extends @NonNull Object>(@NonNull T value) implements Maybe<T> {
   }
 
   @Override
-  public @NonNull String toString() {
+  public String toString() {
     return "Just(" + value + ")";
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Maybe.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Maybe.java
@@ -6,7 +6,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -36,7 +35,7 @@ public sealed interface Maybe<T> permits Just, Nothing {
    *     null}.
    * @throws NullPointerException if {@code value} is {@code null}.
    */
-  static <T> @NonNull Maybe<T> just(@NonNull T value) {
+  static <T> Maybe<T> just(T value) {
     Objects.requireNonNull(value, "Value for Just cannot be null");
     return new Just<>(value);
   }
@@ -47,7 +46,7 @@ public sealed interface Maybe<T> permits Just, Nothing {
    * @param <T> The type of the non-existent value. This is a phantom type parameter.
    * @return an empty {@code Maybe} instance. Will not be {@code null}.
    */
-  static <T> @NonNull Maybe<T> nothing() {
+  static <T> Maybe<T> nothing() {
     return Nothing.instance();
   }
 
@@ -60,7 +59,7 @@ public sealed interface Maybe<T> permits Just, Nothing {
    * @return a {@code Maybe} with the value present if the specified {@code value} is non-null,
    *     otherwise an empty {@code Maybe} (Nothing). Will not be {@code null}.
    */
-  static <T> @NonNull Maybe<T> fromNullable(@Nullable T value) {
+  static <T> Maybe<T> fromNullable(@Nullable T value) {
     return value == null ? nothing() : just(value);
   }
 
@@ -88,7 +87,7 @@ public sealed interface Maybe<T> permits Just, Nothing {
    * @return the non-null value held by this {@code Maybe}.
    * @throws NoSuchElementException if there is no value present (i.e., this is {@link Nothing}).
    */
-  @NonNull T get() throws NoSuchElementException;
+  T get() throws NoSuchElementException;
 
   /**
    * Returns the value if present (i.e., this is a {@link Just}), otherwise returns {@code other}.
@@ -98,7 +97,7 @@ public sealed interface Maybe<T> permits Just, Nothing {
    * @return the value, if present, otherwise {@code other}. The result is guaranteed to be
    *     non-null.
    */
-  @NonNull T orElse(@NonNull T other);
+  T orElse(T other);
 
   /**
    * Returns the value if present (i.e., this is a {@link Just}), otherwise invokes {@code
@@ -106,12 +105,12 @@ public sealed interface Maybe<T> permits Just, Nothing {
    * and must produce a non-null value.
    *
    * @param otherSupplier a {@link Supplier} whose result is returned if no value is present. Must
-   *     not be {@code null}. The supplier itself is {@code @NonNull}, and it's expected to produce
-   *     a {@code @NonNull T}.
+   *     not be {@code null}. The supplier itself is {@code }, and it's expected to produce a {@code
+   *     T}.
    * @return the value if present, otherwise the non-null result of {@code otherSupplier.get()}.
    * @throws NullPointerException if no value is present and {@code otherSupplier} is {@code null}.
    */
-  @NonNull T orElseGet(@NonNull Supplier<? extends @NonNull T> otherSupplier);
+  T orElseGet(Supplier<? extends T> otherSupplier);
 
   /**
    * If a value is present (i.e., this is a {@link Just}), returns a {@code Maybe} describing the
@@ -129,7 +128,7 @@ public sealed interface Maybe<T> permits Just, Nothing {
    *     this {@code Maybe}, if a value is present; otherwise, an empty {@code Maybe} (Nothing). The
    *     returned {@code Maybe} itself will not be {@code null}.
    */
-  @NonNull <U> Maybe<U> map(@NonNull Function<? super T, ? extends @Nullable U> mapper);
+  <U> Maybe<U> map(Function<? super T, ? extends @Nullable U> mapper);
 
   /**
    * If a value is present (i.e., this is a {@link Just}), returns the result of applying the given
@@ -143,14 +142,13 @@ public sealed interface Maybe<T> permits Just, Nothing {
    *
    * @param <U> The type parameter of the {@code Maybe} returned by the mapping function.
    * @param mapper the mapping function to apply to a value, if present. Must not be {@code null}.
-   *     The function takes the non-null value of type {@code T} and must return a {@code @NonNull
-   *     Maybe<? extends U>}.
+   *     The function takes the non-null value of type {@code T} and must return a {@code Maybe<?
+   *     extends U>}.
    * @return the result of applying a {@code Maybe}-bearing mapping function to the value of this
    *     {@code Maybe}, if a value is present; otherwise, an empty {@code Maybe} (Nothing). The
    *     returned {@code Maybe} itself will not be {@code null}.
    * @throws NullPointerException if {@code mapper} is {@code null}, or if a value is present and
    *     {@code mapper} returns a {@code null} {@code Maybe} instance.
    */
-  @NonNull <U> Maybe<U> flatMap(
-      @NonNull Function<? super T, ? extends @NonNull Maybe<? extends U>> mapper);
+  <U> Maybe<U> flatMap(Function<? super T, ? extends Maybe<? extends U>> mapper);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.maybe;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,7 +24,7 @@ public interface MaybeConverterOps {
    * @return A non-null {@link Kind<MaybeKind.Witness, A>} representing the wrapped {@code Maybe}.
    * @throws NullPointerException if {@code maybe} is {@code null}.
    */
-  <A> @NonNull Kind<MaybeKind.Witness, A> widen(@NonNull Maybe<A> maybe);
+  <A> Kind<MaybeKind.Witness, A> widen(Maybe<A> maybe);
 
   /**
    * Narrows a {@code Kind<MaybeKind.Witness, A>} back to its concrete {@link Maybe}&lt;A&gt; type.
@@ -36,5 +35,5 @@ public interface MaybeConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null}, not an instance of the
    *     expected underlying holder type, or if the holder contains a null Maybe instance.
    */
-  <A> @NonNull Maybe<A> narrow(@Nullable Kind<MaybeKind.Witness, A> kind);
+  <A> Maybe<A> narrow(@Nullable Kind<MaybeKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeFunctor.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -42,16 +41,15 @@ public class MaybeFunctor implements Functor<MaybeKind.Witness> {
    *     {@code A} and may return a {@code @Nullable B}. Must not be {@code null}.
    * @param ma The input {@code MaybeKind<A>} instance, which is a {@link Kind} representing a
    *     {@link Maybe}. Must not be {@code null}.
-   * @return A new {@code @NonNull MaybeKind<B>} containing the result of applying the function
-   *     {@code f} if {@code ma} contained a value and {@code f} produced a non-null result. Returns
-   *     a {@code MaybeKind} representing {@code Nothing} if {@code ma} was {@code Nothing} or if
-   *     {@code f} returned {@code null}.
+   * @return A new {@code MaybeKind<B>} containing the result of applying the function {@code f} if
+   *     {@code ma} contained a value and {@code f} produced a non-null result. Returns a {@code
+   *     MaybeKind} representing {@code Nothing} if {@code ma} was {@code Nothing} or if {@code f}
+   *     returned {@code null}.
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code ma} cannot be unwrapped.
    */
   @Override
-  public <A, B> @NonNull Kind<MaybeKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends @Nullable B> f,
-      @NonNull Kind<MaybeKind.Witness, A> ma) {
+  public <A, B> Kind<MaybeKind.Witness, B> map(
+      Function<? super A, ? extends @Nullable B> f, Kind<MaybeKind.Witness, A> ma) {
     // 1. Unwrap the Kind<MaybeKind.Witness, A> to get the concrete Maybe<A>.
     Maybe<A> maybeA = MAYBE.narrow(ma);
     // 2. Apply the function using Maybe's own map method.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeKindHelper.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.maybe;
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -47,7 +46,7 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    * @throws NullPointerException if {@code maybe} is {@code null}.
    */
   @Override
-  public <A> @NonNull Kind<MaybeKind.Witness, A> widen(@NonNull Maybe<A> maybe) {
+  public <A> Kind<MaybeKind.Witness, A> widen(Maybe<A> maybe) {
     Objects.requireNonNull(maybe, "Input Maybe cannot be null for widen");
     return new MaybeHolder<>(maybe);
   }
@@ -65,7 +64,7 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <A> @NonNull Maybe<A> narrow(@Nullable Kind<MaybeKind.Witness, A> kind) {
+  public <A> Maybe<A> narrow(@Nullable Kind<MaybeKind.Witness, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
       case MaybeKindHelper.MaybeHolder<?> holder -> {
@@ -91,7 +90,7 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    * @return A {@link Kind}&lt;{@link MaybeKind.Witness}, A&gt; representing {@code Just(value)}.
    * @throws NullPointerException if {@code value} is {@code null}.
    */
-  public <A> @NonNull Kind<MaybeKind.Witness, A> just(@NonNull A value) {
+  public <A> Kind<MaybeKind.Witness, A> just(A value) {
     return this.widen(Maybe.just(value));
   }
 
@@ -102,7 +101,7 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    * @param <A> The phantom element type for the {@code Nothing} state.
    * @return A {@link Kind}&lt;{@link MaybeKind.Witness}, A&gt; representing {@code Nothing}.
    */
-  public <A> @NonNull Kind<MaybeKind.Witness, A> nothing() {
+  public <A> Kind<MaybeKind.Witness, A> nothing() {
     return this.widen(Maybe.nothing());
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeMonad.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.MonadZero;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -29,14 +28,13 @@ public final class MaybeMonad extends MaybeFunctor
   }
 
   @Override
-  public <A> @NonNull Kind<MaybeKind.Witness, A> of(@Nullable A value) {
+  public <A> Kind<MaybeKind.Witness, A> of(@Nullable A value) {
     return MAYBE.widen(Maybe.fromNullable(value));
   }
 
   @Override
-  public <A, B> @NonNull Kind<MaybeKind.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<MaybeKind.Witness, B>> f,
-      @NonNull Kind<MaybeKind.Witness, A> ma) {
+  public <A, B> Kind<MaybeKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<MaybeKind.Witness, B>> f, Kind<MaybeKind.Witness, A> ma) {
     Maybe<A> maybeA = MAYBE.narrow(ma);
 
     Maybe<B> resultMaybe =
@@ -50,9 +48,8 @@ public final class MaybeMonad extends MaybeFunctor
   }
 
   @Override
-  public <A, B> @NonNull Kind<MaybeKind.Witness, B> ap(
-      @NonNull Kind<MaybeKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<MaybeKind.Witness, A> fa) {
+  public <A, B> Kind<MaybeKind.Witness, B> ap(
+      Kind<MaybeKind.Witness, ? extends Function<A, B>> ff, Kind<MaybeKind.Witness, A> fa) {
     Maybe<? extends Function<A, B>> maybeF = MAYBE.narrow(ff);
     Maybe<A> maybeA = MAYBE.narrow(fa);
 
@@ -72,7 +69,7 @@ public final class MaybeMonad extends MaybeFunctor
    * @return A MaybeKind representing Nothing. (NonNull)
    */
   @Override
-  public <A> @NonNull Kind<MaybeKind.Witness, A> raiseError(@NonNull Unit error) {
+  public <A> Kind<MaybeKind.Witness, A> raiseError(Unit error) {
     return MAYBE.nothing();
   }
 
@@ -88,9 +85,9 @@ public final class MaybeMonad extends MaybeFunctor
    * @return Original Kind if Just, or result of handler if Nothing. (NonNull)
    */
   @Override
-  public <A> @NonNull Kind<MaybeKind.Witness, A> handleErrorWith(
-      @NonNull Kind<MaybeKind.Witness, A> ma,
-      @NonNull Function<? super Unit, ? extends Kind<MaybeKind.Witness, A>> handler) {
+  public <A> Kind<MaybeKind.Witness, A> handleErrorWith(
+      Kind<MaybeKind.Witness, A> ma,
+      Function<? super Unit, ? extends Kind<MaybeKind.Witness, A>> handler) {
     return MAYBE.narrow(ma).isNothing() ? handler.apply(Unit.INSTANCE) : ma;
   }
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeTraverse.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.Traverse;
-import org.jspecify.annotations.NonNull;
 
 /**
  * The Traverse and Foldable instance for {@link Maybe}.
@@ -21,16 +20,16 @@ public enum MaybeTraverse implements Traverse<MaybeKind.Witness> {
   INSTANCE;
 
   @Override
-  public <A, B> @NonNull Kind<MaybeKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<MaybeKind.Witness, A> fa) {
+  public <A, B> Kind<MaybeKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<MaybeKind.Witness, A> fa) {
     return MAYBE.widen(MAYBE.narrow(fa).map(f));
   }
 
   @Override
-  public <G, A, B> @NonNull Kind<G, Kind<MaybeKind.Witness, B>> traverse(
-      @NonNull Applicative<G> applicative,
-      @NonNull Function<? super A, ? extends Kind<G, ? extends B>> f,
-      @NonNull Kind<MaybeKind.Witness, A> ta) {
+  public <G, A, B> Kind<G, Kind<MaybeKind.Witness, B>> traverse(
+      Applicative<G> applicative,
+      Function<? super A, ? extends Kind<G, ? extends B>> f,
+      Kind<MaybeKind.Witness, A> ta) {
 
     final Maybe<A> maybe = MAYBE.narrow(ta);
 
@@ -45,9 +44,7 @@ public enum MaybeTraverse implements Traverse<MaybeKind.Witness> {
 
   @Override
   public <A, M> M foldMap(
-      @NonNull Monoid<M> monoid,
-      @NonNull Function<? super A, ? extends M> f,
-      @NonNull Kind<MaybeKind.Witness, A> fa) {
+      Monoid<M> monoid, Function<? super A, ? extends M> f, Kind<MaybeKind.Witness, A> fa) {
     final Maybe<A> maybe = MAYBE.narrow(fa);
     // If Just, map the value. If Nothing, return the monoid's empty value.
     if (maybe.isJust()) {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Nothing.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Nothing.java
@@ -6,20 +6,19 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /** Concrete implementation of Maybe representing the absence of a value (singleton). */
 final class Nothing<T> implements Maybe<T> {
   // Singleton instance
-  private static final @NonNull Nothing<?> INSTANCE = new Nothing<>();
+  private static final Nothing<?> INSTANCE = new Nothing<>();
 
   // Private constructor to enforce singleton pattern
   private Nothing() {}
 
   /** Factory method to get the singleton instance */
   @SuppressWarnings("unchecked")
-  static <T> @NonNull Nothing<T> instance() {
+  static <T> Nothing<T> instance() {
     return (Nothing<T>) INSTANCE;
   }
 
@@ -35,36 +34,35 @@ final class Nothing<T> implements Maybe<T> {
 
   // get() throws, return type annotation isn't critical but technically should match Maybe<T>
   @Override
-  public @NonNull T get() {
+  public T get() {
     throw new NoSuchElementException("Cannot call get() on Nothing");
   }
 
   @Override
-  public @NonNull T orElse(@NonNull T other) {
+  public T orElse(T other) {
     return other;
   }
 
   @Override
-  public @NonNull T orElseGet(@NonNull Supplier<? extends @NonNull T> other) {
+  public T orElseGet(Supplier<? extends T> other) {
     Objects.requireNonNull(other, "orElseGet supplier cannot be null");
     return other.get(); // Supplier must return NonNull T
   }
 
   @Override
-  public @NonNull <U> Maybe<U> map(@NonNull Function<? super T, ? extends @Nullable U> mapper) {
+  public <U> Maybe<U> map(Function<? super T, ? extends @Nullable U> mapper) {
     Objects.requireNonNull(mapper, "mapper function cannot be null");
     return instance(); // Mapping Nothing always results in Nothing
   }
 
   @Override
-  public @NonNull <U> Maybe<U> flatMap(
-      @NonNull Function<? super T, ? extends @NonNull Maybe<? extends U>> mapper) {
+  public <U> Maybe<U> flatMap(Function<? super T, ? extends Maybe<? extends U>> mapper) {
     Objects.requireNonNull(mapper, "mapper function cannot be null");
     return instance(); // FlatMapping Nothing always results in Nothing
   }
 
   @Override
-  public @NonNull String toString() {
+  public String toString() {
     return "Nothing";
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeT.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.maybe.Maybe;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents the concrete implementation of the Maybe Transformer Monad (MaybeT). It wraps a
@@ -24,7 +23,7 @@ import org.jspecify.annotations.NonNull;
  * @see MaybeTMonad
  * @see MaybeTKindHelper
  */
-public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKind<F, A> {
+public record MaybeT<F, A>(Kind<F, Maybe<A>> value) implements MaybeTKind<F, A> {
 
   /**
    * Canonical constructor for {@code MaybeT}.
@@ -45,7 +44,7 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKi
    * @return A new {@code MaybeT} instance.
    * @throws NullPointerException if {@code value} is null.
    */
-  public static <F, A> @NonNull MaybeT<F, A> fromKind(@NonNull Kind<F, Maybe<A>> value) {
+  public static <F, A> MaybeT<F, A> fromKind(Kind<F, Maybe<A>> value) {
     return new MaybeT<>(value);
   }
 
@@ -59,8 +58,7 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKi
    * @return A new {@code MaybeT} instance representing {@code outerMonad.of(Maybe.just(a))}.
    * @throws NullPointerException if {@code outerMonad} or {@code a} is null.
    */
-  public static <F, A extends @NonNull Object> @NonNull MaybeT<F, A> just(
-      @NonNull Monad<F> outerMonad, @NonNull A a) {
+  public static <F, A extends Object> MaybeT<F, A> just(Monad<F> outerMonad, A a) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for just");
     // Maybe.just itself will throw if 'a' is null.
     Kind<F, Maybe<A>> lifted = outerMonad.of(Maybe.just(a));
@@ -77,7 +75,7 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKi
    * @return A new {@code MaybeT} instance representing {@code outerMonad.of(Maybe.nothing())}.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public static <F, A> @NonNull MaybeT<F, A> nothing(@NonNull Monad<F> outerMonad) {
+  public static <F, A> MaybeT<F, A> nothing(Monad<F> outerMonad) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for nothing");
     Kind<F, Maybe<A>> lifted = outerMonad.of(Maybe.nothing());
     return new MaybeT<>(lifted);
@@ -93,8 +91,7 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKi
    * @return A new {@code MaybeT} instance representing {@code outerMonad.of(maybe)}.
    * @throws NullPointerException if {@code outerMonad} or {@code maybe} is null.
    */
-  public static <F, A> @NonNull MaybeT<F, A> fromMaybe(
-      @NonNull Monad<F> outerMonad, @NonNull Maybe<A> maybe) {
+  public static <F, A> MaybeT<F, A> fromMaybe(Monad<F> outerMonad, Maybe<A> maybe) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for fromMaybe");
     Objects.requireNonNull(maybe, "Input Maybe cannot be null for fromMaybe");
     Kind<F, Maybe<A>> lifted = outerMonad.of(maybe);
@@ -114,8 +111,7 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKi
    *     fa)}.
    * @throws NullPointerException if {@code outerMonad} or {@code fa} is null.
    */
-  public static <F, A> @NonNull MaybeT<F, A> liftF(
-      @NonNull Monad<F> outerMonad, @NonNull Kind<F, A> fa) {
+  public static <F, A> MaybeT<F, A> liftF(Monad<F> outerMonad, Kind<F, A> fa) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for liftF");
     Objects.requireNonNull(fa, "Input Kind<F, A> cannot be null for liftF");
     // Use Maybe.fromNullable for safety when mapping the value inside F
@@ -126,10 +122,10 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) implements MaybeTKi
   /**
    * Accessor for the underlying monadic value.
    *
-   * @return The {@code @NonNull Kind<F, Maybe<A>>} wrapped by this {@code MaybeT}.
+   * @return The {@code Kind<F, Maybe<A>>} wrapped by this {@code MaybeT}.
    */
   @Override
-  public @NonNull Kind<F, Maybe<A>> value() {
+  public Kind<F, Maybe<A>> value() {
     return value;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.maybe_t;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +25,7 @@ public interface MaybeTConverterOps {
    * @return The {@code Kind} representation.
    * @throws NullPointerException if {@code maybeT} is {@code null}.
    */
-  <F, A> @NonNull Kind<MaybeTKind.Witness<F>, A> widen(@NonNull MaybeT<F, A> maybeT);
+  <F, A> Kind<MaybeTKind.Witness<F>, A> widen(MaybeT<F, A> maybeT);
 
   /**
    * Narrows a {@code Kind<MaybeTKind.Witness<F>, A>} back to its concrete {@link MaybeT
@@ -38,5 +37,5 @@ public interface MaybeTConverterOps {
    * @return The unwrapped, non-null {@link MaybeT MaybeT&lt;F, A&gt;} instance.
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link MaybeT} instance.
    */
-  <F, A> @NonNull MaybeT<F, A> narrow(@Nullable Kind<MaybeTKind.Witness<F>, A> kind);
+  <F, A> MaybeT<F, A> narrow(@Nullable Kind<MaybeTKind.Witness<F>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTKindHelper.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.maybe_t;
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -42,7 +41,7 @@ public enum MaybeTKindHelper implements MaybeTConverterOps {
    * @throws NullPointerException if {@code maybeT} is null.
    */
   @Override
-  public <F, A> @NonNull Kind<MaybeTKind.Witness<F>, A> widen(@NonNull MaybeT<F, A> maybeT) {
+  public <F, A> Kind<MaybeTKind.Witness<F>, A> widen(MaybeT<F, A> maybeT) {
     Objects.requireNonNull(maybeT, INVALID_KIND_TYPE_NULL_MSG);
     // maybeT is already a MaybeTKind<F, A>, which is a Kind<MaybeTKind.Witness<F>, A>.
     return maybeT;
@@ -59,7 +58,7 @@ public enum MaybeTKindHelper implements MaybeTConverterOps {
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link MaybeT} instance.
    */
   @Override
-  public <F, A> @NonNull MaybeT<F, A> narrow(@Nullable Kind<MaybeTKind.Witness<F>, A> kind) {
+  public <F, A> MaybeT<F, A> narrow(@Nullable Kind<MaybeTKind.Witness<F>, A> kind) {
     if (kind == null) {
       throw new KindUnwrapException(MaybeTKindHelper.INVALID_KIND_NULL_MSG);
     }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTMonad.java
@@ -11,7 +11,6 @@ import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -27,7 +26,7 @@ import org.jspecify.annotations.Nullable;
  * @param <F> The witness type of the outer monad (e.g., {@code OptionalKind.Witness}).
  */
 public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
-  private final @NonNull Monad<F> outerMonad;
+  private final Monad<F> outerMonad;
 
   /**
    * Constructs a {@code MaybeTMonad} instance.
@@ -35,7 +34,7 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    * @param outerMonad The {@link Monad} instance for the outer monad {@code F}. Must not be null.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public MaybeTMonad(@NonNull Monad<F> outerMonad) {
+  public MaybeTMonad(Monad<F> outerMonad) {
     this.outerMonad =
         Objects.requireNonNull(outerMonad, "Outer Monad instance cannot be null for MaybeTMonad");
   }
@@ -50,7 +49,7 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    * @return A {@code Kind<MaybeTKind.Witness<F>, A>} representing the lifted value.
    */
   @Override
-  public <A> @NonNull Kind<MaybeTKind.Witness<F>, A> of(@Nullable A value) {
+  public <A> Kind<MaybeTKind.Witness<F>, A> of(@Nullable A value) {
     Kind<F, Maybe<A>> lifted = outerMonad.of(Maybe.fromNullable(value));
     return MAYBE_T.widen(MaybeT.fromKind(lifted));
   }
@@ -69,8 +68,8 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    * @return A new {@code Kind<MaybeTKind.Witness<F>, B>} with the function applied.
    */
   @Override
-  public <A, B> @NonNull Kind<MaybeTKind.Witness<F>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<MaybeTKind.Witness<F>, A> fa) {
+  public <A, B> Kind<MaybeTKind.Witness<F>, B> map(
+      Function<? super A, ? extends B> f, Kind<MaybeTKind.Witness<F>, A> fa) {
     Objects.requireNonNull(f, "Function f cannot be null for map");
     Objects.requireNonNull(fa, "Kind fa cannot be null for map");
     MaybeT<F, A> maybeT = MAYBE_T.narrow(fa);
@@ -100,9 +99,8 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    * @return A new {@code Kind<MaybeTKind.Witness<F>, B>} representing the application.
    */
   @Override
-  public <A, B> @NonNull Kind<MaybeTKind.Witness<F>, B> ap(
-      @NonNull Kind<MaybeTKind.Witness<F>, ? extends Function<A, B>> ff,
-      @NonNull Kind<MaybeTKind.Witness<F>, A> fa) {
+  public <A, B> Kind<MaybeTKind.Witness<F>, B> ap(
+      Kind<MaybeTKind.Witness<F>, ? extends Function<A, B>> ff, Kind<MaybeTKind.Witness<F>, A> fa) {
     Objects.requireNonNull(ff, "Kind ff cannot be null for ap");
     Objects.requireNonNull(fa, "Kind fa cannot be null for ap");
     MaybeT<F, ? extends Function<A, B>> funcT = MAYBE_T.narrow(ff);
@@ -131,9 +129,9 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    * @return A new {@code Kind<MaybeTKind.Witness<F>, B>}.
    */
   @Override
-  public <A, B> @NonNull Kind<MaybeTKind.Witness<F>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<MaybeTKind.Witness<F>, B>> f,
-      @NonNull Kind<MaybeTKind.Witness<F>, A> ma) {
+  public <A, B> Kind<MaybeTKind.Witness<F>, B> flatMap(
+      Function<? super A, ? extends Kind<MaybeTKind.Witness<F>, B>> f,
+      Kind<MaybeTKind.Witness<F>, A> ma) {
     Objects.requireNonNull(f, "Function f cannot be null for flatMap");
     Objects.requireNonNull(ma, "Kind ma cannot be null for flatMap");
     MaybeT<F, A> maybeT = MAYBE_T.narrow(ma);
@@ -168,7 +166,7 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    * @return A {@code Kind<MaybeTKind.Witness<F>, A>} representing {@code F<Nothing>}.
    */
   @Override
-  public <A> @NonNull Kind<MaybeTKind.Witness<F>, A> raiseError(@NonNull Unit error) {
+  public <A> Kind<MaybeTKind.Witness<F>, A> raiseError(@Nullable Unit error) {
     return MAYBE_T.widen(MaybeT.nothing(outerMonad));
   }
 
@@ -188,9 +186,9 @@ public class MaybeTMonad<F> implements MonadError<MaybeTKind.Witness<F>, Unit> {
    *     handler.
    */
   @Override
-  public <A> @NonNull Kind<MaybeTKind.Witness<F>, A> handleErrorWith(
-      @NonNull Kind<MaybeTKind.Witness<F>, A> ma,
-      @NonNull Function<? super Unit, ? extends Kind<MaybeTKind.Witness<F>, A>> handler) {
+  public <A> Kind<MaybeTKind.Witness<F>, A> handleErrorWith(
+      Kind<MaybeTKind.Witness<F>, A> ma,
+      Function<? super Unit, ? extends Kind<MaybeTKind.Witness<F>, A>> handler) {
     Objects.requireNonNull(ma, "Kind ma cannot be null for handleErrorWith");
     Objects.requireNonNull(handler, "Function handler cannot be null for handleErrorWith");
     MaybeT<F, A> maybeT = MAYBE_T.narrow(ma);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalConverterOps.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.optional;
 import java.util.Optional;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +27,7 @@ public interface OptionalConverterOps {
    *     Optional}.
    * @throws NullPointerException if {@code optional} is {@code null}.
    */
-  <A> @NonNull Kind<OptionalKind.Witness, A> widen(@NonNull Optional<A> optional);
+  <A> Kind<OptionalKind.Witness, A> widen(Optional<A> optional);
 
   /**
    * Narrows a {@code Kind<OptionalKind.Witness, A>} back to its concrete {@link Optional}{@code
@@ -40,5 +39,5 @@ public interface OptionalConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null}, or not an instance of
    *     the expected underlying holder type for Optional.
    */
-  <A> @NonNull Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind);
+  <A> Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalFunctor.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -72,9 +71,8 @@ public class OptionalFunctor implements Functor<OptionalKind.Witness> {
    * @throws NullPointerException if {@code f} or {@code fa} is null.
    */
   @Override
-  public <A, B> @NonNull Kind<OptionalKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends @Nullable B> f,
-      @NonNull Kind<OptionalKind.Witness, A> fa) {
+  public <A, B> Kind<OptionalKind.Witness, B> map(
+      Function<? super A, ? extends @Nullable B> f, Kind<OptionalKind.Witness, A> fa) {
     Optional<A> optionalA = OPTIONAL.narrow(fa);
     // Optional.map correctly handles f returning null by creating Optional.empty()
     Optional<B> resultOptional = optionalA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalKindHelper.java
@@ -7,7 +7,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -47,7 +46,7 @@ public enum OptionalKindHelper implements OptionalConverterOps {
    * @param <A> The type of the value potentially held by the {@code Optional}.
    * @param optional The concrete {@link Optional} instance. Must not be {@code null} itself.
    */
-  record OptionalHolder<A>(@NonNull Optional<A> optional) implements OptionalKind<A> {
+  record OptionalHolder<A>(Optional<A> optional) implements OptionalKind<A> {
     /**
      * Constructs an {@code OptionalHolder}.
      *
@@ -71,7 +70,7 @@ public enum OptionalKindHelper implements OptionalConverterOps {
    * @throws NullPointerException if {@code optional} is {@code null}.
    */
   @Override
-  public <A> @NonNull Kind<OptionalKind.Witness, A> widen(@NonNull Optional<A> optional) {
+  public <A> Kind<OptionalKind.Witness, A> widen(Optional<A> optional) {
     requireNonNull(optional, INVALID_KIND_TYPE_NULL_MSG);
     return new OptionalHolder<>(optional);
   }
@@ -88,7 +87,7 @@ public enum OptionalKindHelper implements OptionalConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <A> @NonNull Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind) {
+  public <A> Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
       case OptionalKindHelper.OptionalHolder<?> holder -> (Optional<A>) holder.optional();

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalMonad.java
@@ -10,7 +10,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.MonadZero;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -75,7 +74,7 @@ public final class OptionalMonad extends OptionalFunctor
    *     Optional.ofNullable(value)}.
    */
   @Override
-  public <A> @NonNull Kind<OptionalKind.Witness, A> of(@Nullable A value) {
+  public <A> Kind<OptionalKind.Witness, A> of(@Nullable A value) {
     return OPTIONAL.widen(Optional.ofNullable(value));
   }
 
@@ -95,9 +94,9 @@ public final class OptionalMonad extends OptionalFunctor
    *     operation.
    */
   @Override
-  public <A, B> @NonNull Kind<OptionalKind.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<OptionalKind.Witness, B>> f,
-      @NonNull Kind<OptionalKind.Witness, A> ma) {
+  public <A, B> Kind<OptionalKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<OptionalKind.Witness, B>> f,
+      Kind<OptionalKind.Witness, A> ma) {
     Optional<A> optA = OPTIONAL.narrow(ma);
     Optional<B> resultOpt =
         optA.flatMap(
@@ -123,9 +122,8 @@ public final class OptionalMonad extends OptionalFunctor
    *     application.
    */
   @Override
-  public <A, B> @NonNull Kind<OptionalKind.Witness, B> ap(
-      @NonNull Kind<OptionalKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<OptionalKind.Witness, A> fa) {
+  public <A, B> Kind<OptionalKind.Witness, B> ap(
+      Kind<OptionalKind.Witness, ? extends Function<A, B>> ff, Kind<OptionalKind.Witness, A> fa) {
     Optional<? extends Function<A, B>> optF = OPTIONAL.narrow(ff);
     Optional<A> optA = OPTIONAL.narrow(fa);
     Optional<B> resultOpt = optF.flatMap(optA::map);
@@ -141,7 +139,7 @@ public final class OptionalMonad extends OptionalFunctor
    * @return A non-null {@code Kind<OptionalKind.Witness, A>} representing {@code Optional.empty()}.
    */
   @Override
-  public <A> @NonNull Kind<OptionalKind.Witness, A> raiseError(@NonNull Unit error) {
+  public <A> Kind<OptionalKind.Witness, A> raiseError(Unit error) {
     return OPTIONAL.widen(Optional.empty());
   }
 
@@ -159,9 +157,9 @@ public final class OptionalMonad extends OptionalFunctor
    *     the result of the handler if empty.
    */
   @Override
-  public <A> @NonNull Kind<OptionalKind.Witness, A> handleErrorWith(
-      @NonNull Kind<OptionalKind.Witness, A> ma,
-      @NonNull Function<? super Unit, ? extends Kind<OptionalKind.Witness, A>> handler) {
+  public <A> Kind<OptionalKind.Witness, A> handleErrorWith(
+      Kind<OptionalKind.Witness, A> ma,
+      Function<? super Unit, ? extends Kind<OptionalKind.Witness, A>> handler) {
     Optional<A> optional = OPTIONAL.narrow(ma);
     if (optional.isEmpty()) {
       return handler.apply(Unit.INSTANCE);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalTraverse.java
@@ -10,7 +10,6 @@ import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.Traverse;
-import org.jspecify.annotations.NonNull;
 
 /**
  * The Traverse and Foldable instance for {@link java.util.Optional}.
@@ -22,16 +21,16 @@ public enum OptionalTraverse implements Traverse<OptionalKind.Witness> {
   INSTANCE;
 
   @Override
-  public <A, B> @NonNull Kind<OptionalKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<OptionalKind.Witness, A> fa) {
+  public <A, B> Kind<OptionalKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<OptionalKind.Witness, A> fa) {
     return OPTIONAL.widen(OPTIONAL.narrow(fa).map(f));
   }
 
   @Override
-  public <G, A, B> @NonNull Kind<G, Kind<OptionalKind.Witness, B>> traverse(
-      @NonNull Applicative<G> applicative,
-      @NonNull Function<? super A, ? extends Kind<G, ? extends B>> f,
-      @NonNull Kind<OptionalKind.Witness, A> ta) {
+  public <G, A, B> Kind<G, Kind<OptionalKind.Witness, B>> traverse(
+      Applicative<G> applicative,
+      Function<? super A, ? extends Kind<G, ? extends B>> f,
+      Kind<OptionalKind.Witness, A> ta) {
 
     return OPTIONAL
         .narrow(ta)
@@ -42,9 +41,7 @@ public enum OptionalTraverse implements Traverse<OptionalKind.Witness> {
 
   @Override
   public <A, M> M foldMap(
-      @NonNull Monoid<M> monoid,
-      @NonNull Function<? super A, ? extends M> f,
-      @NonNull Kind<OptionalKind.Witness, A> fa) {
+      Monoid<M> monoid, Function<? super A, ? extends M> f, Kind<OptionalKind.Witness, A> fa) {
     Optional<A> optional = OPTIONAL.narrow(fa);
     // If present, map the value. If empty, return the monoid's empty value.
     if (optional.isPresent()) {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalT.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.Optional;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents the concrete implementation of the Optional Transformer Monad (OptionalT). It wraps a
@@ -27,7 +26,7 @@ import org.jspecify.annotations.NonNull;
  * @see OptionalTKindHelper
  * @see OptionalTMonad
  */
-public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements OptionalTKind<F, A> {
+public record OptionalT<F, A>(Kind<F, Optional<A>> value) implements OptionalTKind<F, A> {
 
   /**
    * Canonical constructor for {@code OptionalT}.
@@ -48,7 +47,7 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements Op
    * @return A new {@code OptionalT} instance.
    * @throws NullPointerException if {@code value} is null.
    */
-  public static <F, A> @NonNull OptionalT<F, A> fromKind(@NonNull Kind<F, Optional<A>> value) {
+  public static <F, A> OptionalT<F, A> fromKind(Kind<F, Optional<A>> value) {
     return new OptionalT<>(value);
   }
 
@@ -63,8 +62,7 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements Op
    * @return A new {@code OptionalT} instance representing {@code outerMonad.of(Optional.of(a))}.
    * @throws NullPointerException if {@code outerMonad} or {@code a} is null.
    */
-  public static <F, A extends @NonNull Object> @NonNull OptionalT<F, A> some(
-      @NonNull Monad<F> outerMonad, @NonNull A a) {
+  public static <F, A extends Object> OptionalT<F, A> some(Monad<F> outerMonad, A a) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for some");
     Kind<F, Optional<A>> lifted = outerMonad.of(Optional.of(a));
     return new OptionalT<>(lifted);
@@ -80,7 +78,7 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements Op
    * @return A new {@code OptionalT} instance representing {@code outerMonad.of(Optional.empty())}.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public static <F, A> @NonNull OptionalT<F, A> none(@NonNull Monad<F> outerMonad) {
+  public static <F, A> OptionalT<F, A> none(Monad<F> outerMonad) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for none");
     Kind<F, Optional<A>> lifted = outerMonad.of(Optional.empty());
     return new OptionalT<>(lifted);
@@ -97,8 +95,7 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements Op
    * @return A new {@code OptionalT} instance representing {@code outerMonad.of(optional)}.
    * @throws NullPointerException if {@code outerMonad} or {@code optional} is null.
    */
-  public static <F, A> @NonNull OptionalT<F, A> fromOptional(
-      @NonNull Monad<F> outerMonad, @NonNull Optional<A> optional) {
+  public static <F, A> OptionalT<F, A> fromOptional(Monad<F> outerMonad, Optional<A> optional) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for fromOptional");
     Objects.requireNonNull(optional, "Input Optional cannot be null for fromOptional");
     Kind<F, Optional<A>> lifted = outerMonad.of(optional);
@@ -118,8 +115,7 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements Op
    *     outerMonad.map(Optional::ofNullable, fa)}.
    * @throws NullPointerException if {@code outerMonad} or {@code fa} is null.
    */
-  public static <F, A> @NonNull OptionalT<F, A> liftF(
-      @NonNull Monad<F> outerMonad, @NonNull Kind<F, A> fa) {
+  public static <F, A> OptionalT<F, A> liftF(Monad<F> outerMonad, Kind<F, A> fa) {
     Objects.requireNonNull(outerMonad, "Outer Monad cannot be null for liftF");
     Objects.requireNonNull(fa, "Input Kind<F, A> cannot be null for liftF");
     Kind<F, Optional<A>> mapped = outerMonad.map(Optional::ofNullable, fa);
@@ -129,10 +125,10 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value) implements Op
   /**
    * Accessor for the underlying monadic value.
    *
-   * @return The {@code @NonNull Kind<F, Optional<A>>} wrapped by this {@code OptionalT}.
+   * @return The {@code Kind<F, Optional<A>>} wrapped by this {@code OptionalT}.
    */
   @Override
-  public @NonNull Kind<F, Optional<A>> value() {
+  public Kind<F, Optional<A>> value() {
     return value;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.optional_t;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +25,7 @@ public interface OptionalTConverterOps {
    * @return The {@code Kind} representation.
    * @throws NullPointerException if {@code optionalT} is {@code null}.
    */
-  <F, A> @NonNull Kind<OptionalTKind.Witness<F>, A> widen(@NonNull OptionalT<F, A> optionalT);
+  <F, A> Kind<OptionalTKind.Witness<F>, A> widen(OptionalT<F, A> optionalT);
 
   /**
    * Narrows a {@code Kind<OptionalTKind.Witness<F>, A>} back to its concrete {@link OptionalT
@@ -38,5 +37,5 @@ public interface OptionalTConverterOps {
    * @return The unwrapped, non-null {@link OptionalT OptionalT&lt;F, A&gt;} instance.
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link OptionalT} instance.
    */
-  <F, A> @NonNull OptionalT<F, A> narrow(@Nullable Kind<OptionalTKind.Witness<F>, A> kind);
+  <F, A> OptionalT<F, A> narrow(@Nullable Kind<OptionalTKind.Witness<F>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTKindHelper.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.optional_t;
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -42,8 +41,7 @@ public enum OptionalTKindHelper implements OptionalTConverterOps {
    * @throws NullPointerException if {@code optionalT} is null.
    */
   @Override
-  public <F, A> @NonNull Kind<OptionalTKind.Witness<F>, A> widen(
-      @NonNull OptionalT<F, A> optionalT) {
+  public <F, A> Kind<OptionalTKind.Witness<F>, A> widen(OptionalT<F, A> optionalT) {
     Objects.requireNonNull(optionalT, INVALID_KIND_TYPE_NULL_MSG);
     // optionalT is already an OptionalTKind<F, A>, which is a Kind<OptionalTKind.Witness<F>, A>.
     return optionalT;
@@ -60,7 +58,7 @@ public enum OptionalTKindHelper implements OptionalTConverterOps {
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link OptionalT} instance.
    */
   @Override
-  public <F, A> @NonNull OptionalT<F, A> narrow(@Nullable Kind<OptionalTKind.Witness<F>, A> kind) {
+  public <F, A> OptionalT<F, A> narrow(@Nullable Kind<OptionalTKind.Witness<F>, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(OptionalTKindHelper.INVALID_KIND_NULL_MSG);
       // Since OptionalT<F,A> implements OptionalTKind<F,A>,

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTMonad.java
@@ -11,7 +11,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +27,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, Unit> {
 
-  private final @NonNull Monad<F> outerMonad;
+  private final Monad<F> outerMonad;
 
   /**
    * Constructs an {@code OptionalTMonad} instance.
@@ -36,7 +35,7 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    * @param outerMonad The {@link Monad} instance for the outer monad {@code F}. Must not be null.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public OptionalTMonad(@NonNull Monad<F> outerMonad) {
+  public OptionalTMonad(Monad<F> outerMonad) {
     this.outerMonad =
         Objects.requireNonNull(
             outerMonad, "Outer Monad instance cannot be null for OptionalTMonad");
@@ -52,7 +51,7 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    * @return A {@code Kind<OptionalTKind.Witness<F>, A>} representing the lifted value.
    */
   @Override
-  public <A> @NonNull Kind<OptionalTKind.Witness<F>, A> of(@Nullable A value) {
+  public <A> Kind<OptionalTKind.Witness<F>, A> of(@Nullable A value) {
     Kind<F, Optional<A>> lifted = outerMonad.of(Optional.ofNullable(value));
     return OPTIONAL_T.widen(OptionalT.fromKind(lifted));
   }
@@ -71,9 +70,8 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    * @return A new {@code Kind<OptionalTKind.Witness<F>, B>} with the function applied.
    */
   @Override
-  public <A, B> @NonNull Kind<OptionalTKind.Witness<F>, B> map(
-      @NonNull Function<? super A, ? extends @Nullable B> f,
-      @NonNull Kind<OptionalTKind.Witness<F>, A> fa) {
+  public <A, B> Kind<OptionalTKind.Witness<F>, B> map(
+      Function<? super A, ? extends @Nullable B> f, Kind<OptionalTKind.Witness<F>, A> fa) {
     Objects.requireNonNull(f, "Function f cannot be null for map");
     Objects.requireNonNull(fa, "Kind fa cannot be null for map");
     OptionalT<F, A> optionalT = OPTIONAL_T.narrow(fa);
@@ -102,9 +100,9 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    * @return A new {@code Kind<OptionalTKind.Witness<F>, B>} representing the application.
    */
   @Override
-  public <A, B> @NonNull Kind<OptionalTKind.Witness<F>, B> ap(
-      @NonNull Kind<OptionalTKind.Witness<F>, ? extends Function<A, @Nullable B>> ff,
-      @NonNull Kind<OptionalTKind.Witness<F>, A> fa) {
+  public <A, B> Kind<OptionalTKind.Witness<F>, B> ap(
+      Kind<OptionalTKind.Witness<F>, ? extends Function<A, @Nullable B>> ff,
+      Kind<OptionalTKind.Witness<F>, A> fa) {
     Objects.requireNonNull(ff, "Kind ff cannot be null for ap");
     Objects.requireNonNull(fa, "Kind fa cannot be null for ap");
     OptionalT<F, ? extends Function<A, @Nullable B>> funcT = OPTIONAL_T.narrow(ff);
@@ -132,9 +130,9 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    * @return A new {@code Kind<OptionalTKind.Witness<F>, B>}.
    */
   @Override
-  public <A, B> @NonNull Kind<OptionalTKind.Witness<F>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<OptionalTKind.Witness<F>, B>> f,
-      @NonNull Kind<OptionalTKind.Witness<F>, A> ma) {
+  public <A, B> Kind<OptionalTKind.Witness<F>, B> flatMap(
+      Function<? super A, ? extends Kind<OptionalTKind.Witness<F>, B>> f,
+      Kind<OptionalTKind.Witness<F>, A> ma) {
     Objects.requireNonNull(f, "Function f cannot be null for flatMap");
     Objects.requireNonNull(ma, "Kind ma cannot be null for flatMap");
     OptionalT<F, A> optionalT = OPTIONAL_T.narrow(ma);
@@ -166,7 +164,7 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    * @return A {@code Kind<OptionalTKind.Witness<F>, A>} representing {@code F<Optional.empty()>}.
    */
   @Override
-  public <A> @NonNull Kind<OptionalTKind.Witness<F>, A> raiseError(@NonNull Unit error) {
+  public <A> Kind<OptionalTKind.Witness<F>, A> raiseError(Unit error) {
     return OPTIONAL_T.widen(OptionalT.none(outerMonad));
   }
 
@@ -186,9 +184,9 @@ public class OptionalTMonad<F> implements MonadError<OptionalTKind.Witness<F>, U
    *     handler.
    */
   @Override
-  public <A> @NonNull Kind<OptionalTKind.Witness<F>, A> handleErrorWith(
-      @NonNull Kind<OptionalTKind.Witness<F>, A> ma,
-      @NonNull Function<? super Unit, ? extends Kind<OptionalTKind.Witness<F>, A>> handler) {
+  public <A> Kind<OptionalTKind.Witness<F>, A> handleErrorWith(
+      Kind<OptionalTKind.Witness<F>, A> ma,
+      Function<? super Unit, ? extends Kind<OptionalTKind.Witness<F>, A>> handler) {
     Objects.requireNonNull(ma, "Kind ma cannot be null for handleErrorWith");
     Objects.requireNonNull(handler, "Function handler cannot be null for handleErrorWith");
     OptionalT<F, A> optionalT = OPTIONAL_T.narrow(ma);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/Reader.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/Reader.java
@@ -75,7 +75,7 @@ public interface Reader<R, A> {
    * Executes the computation encapsulated by this {@code Reader} using the provided environment.
    * This is the method that "runs" the reader, supplying the necessary context or dependencies.
    *
-   * @param r The environment of type {@code R}. While annotated as {@code @NonNull}, the specific
+   * @param r The environment of type {@code R}. While annotated as {@code }, the specific
    *     nullability contract for {@code r} depends on the design of the environment type {@code R}
    *     and how it's intended to be used. It's generally good practice for {@code R} to be
    *     non-null.
@@ -95,10 +95,10 @@ public interface Reader<R, A> {
    *     null.
    * @param <R> The type of the environment.
    * @param <A> The type of the value produced.
-   * @return A new {@code @NonNull Reader<R, A>} instance.
+   * @return A new {@code Reader<R, A>} instance.
    * @throws NullPointerException if {@code runFunction} is null.
    */
-  static <R, A> @NonNull Reader<R, A> of(@NonNull Function<R, A> runFunction) {
+  static <R, A> Reader<R, A> of(Function<R, A> runFunction) {
     Objects.requireNonNull(runFunction, "runFunction cannot be null");
     return runFunction::apply;
   }
@@ -117,11 +117,11 @@ public interface Reader<R, A> {
    *     of type {@code A} and returns a value of type {@code B}.
    * @param <B> The type of the value produced by the mapping function and thus by the new {@code
    *     Reader}.
-   * @return A new {@code @NonNull Reader<R, B>} that, when run, will execute this {@code Reader}
-   *     and then apply the mapping function {@code f} to its result.
+   * @return A new {@code Reader<R, B>} that, when run, will execute this {@code Reader} and then
+   *     apply the mapping function {@code f} to its result.
    * @throws NullPointerException if {@code f} is null.
    */
-  default <B> @NonNull Reader<R, B> map(@NonNull Function<? super A, ? extends B> f) {
+  default <B> Reader<R, B> map(Function<? super A, ? extends B> f) {
     Objects.requireNonNull(f, "mapper function cannot be null");
     return (R r) -> f.apply(this.run(r));
   }
@@ -141,17 +141,16 @@ public interface Reader<R, A> {
    *     of type {@code A} and returns a {@code Reader<R, ? extends B>}. The returned {@code Reader}
    *     must not be null.
    * @param <B> The type of the value produced by the {@code Reader} returned by function {@code f}.
-   * @return A new {@code @NonNull Reader<R, B>} that, when run, will execute this {@code Reader},
-   *     apply function {@code f} to its result to get a new {@code Reader}, and then run that new
-   *     {@code Reader} with the original environment.
+   * @return A new {@code Reader<R, B>} that, when run, will execute this {@code Reader}, apply
+   *     function {@code f} to its result to get a new {@code Reader}, and then run that new {@code
+   *     Reader} with the original environment.
    * @throws NullPointerException if {@code f} is null, or if {@code f} returns a null {@code
    *     Reader}.
    */
-  default <B> @NonNull Reader<R, B> flatMap(
-      @NonNull Function<? super A, ? extends Reader<R, ? extends B>> f) {
+  default <B> Reader<R, B> flatMap(Function<? super A, ? extends Reader<R, ? extends B>> f) {
     Objects.requireNonNull(f, "flatMap mapper function cannot be null");
     return (R r) -> {
-      @Nullable A a = this.run(r);
+      A a = this.run(r);
       Reader<R, ? extends B> readerB = f.apply(a);
       Objects.requireNonNull(readerB, "flatMap function returned null Reader");
       return readerB.run(r);
@@ -167,10 +166,10 @@ public interface Reader<R, A> {
    *     be {@code null} if {@code A} is a nullable type.
    * @param <R> The type of the environment (which will be ignored).
    * @param <A> The type of the constant value.
-   * @return A new {@code @NonNull Reader<R, A>} that always produces the given {@code value}
-   *     regardless of the environment it is run with.
+   * @return A new {@code Reader<R, A>} that always produces the given {@code value} regardless of
+   *     the environment it is run with.
    */
-  static <R, A> @NonNull Reader<R, A> constant(@Nullable A value) {
+  static <R, A> Reader<R, A> constant(@Nullable A value) {
     return r -> value;
   }
 
@@ -183,9 +182,9 @@ public interface Reader<R, A> {
    * <p>In Category Theory terms, this is often called {@code ask} (from the Reader Monad).
    *
    * @param <R> The type of the environment, which is also the type of the value produced.
-   * @return A new {@code @NonNull Reader<R, R>} that yields the environment it is run with.
+   * @return A new {@code Reader<R, R>} that yields the environment it is run with.
    */
-  static <R> @NonNull Reader<R, R> ask() {
+  static <R> Reader<R, R> ask() {
     return r -> r;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderApplicative.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.reader.ReaderKindHelper.READER;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -43,7 +42,7 @@ public class ReaderApplicative<R> extends ReaderFunctor<R>
    *     run, yields the given {@code value}. Never null.
    */
   @Override
-  public <A> @NonNull Kind<ReaderKind.Witness<R>, A> of(@Nullable A value) {
+  public <A> Kind<ReaderKind.Witness<R>, A> of(@Nullable A value) {
     // Reader.constant(value) creates a Reader that ignores the environment and returns the value.
     return READER.constant(value);
   }
@@ -67,9 +66,8 @@ public class ReaderApplicative<R> extends ReaderFunctor<R>
    *     results from applying the function. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<ReaderKind.Witness<R>, B> ap(
-      @NonNull Kind<ReaderKind.Witness<R>, ? extends Function<A, B>> ff,
-      @NonNull Kind<ReaderKind.Witness<R>, A> fa) {
+  public <A, B> Kind<ReaderKind.Witness<R>, B> ap(
+      Kind<ReaderKind.Witness<R>, ? extends Function<A, B>> ff, Kind<ReaderKind.Witness<R>, A> fa) {
 
     Reader<R, ? extends Function<A, B>> readerF = READER.narrow(ff);
     Reader<R, A> readerA = READER.narrow(fa);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.reader;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +27,7 @@ public interface ReaderConverterOps {
    *     Reader}.
    * @throws NullPointerException if {@code reader} is {@code null}.
    */
-  <R, A> @NonNull Kind<ReaderKind.Witness<R>, A> widen(@NonNull Reader<R, A> reader);
+  <R, A> Kind<ReaderKind.Witness<R>, A> widen(Reader<R, A> reader);
 
   /**
    * Narrows a {@code Kind<ReaderKind.Witness<R>, A>} back to its concrete {@link Reader
@@ -41,5 +40,5 @@ public interface ReaderConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null} or not an instance of the
    *     expected underlying holder type for Reader.
    */
-  <R, A> @NonNull Reader<R, A> narrow(@Nullable Kind<ReaderKind.Witness<R>, A> kind);
+  <R, A> Reader<R, A> narrow(@Nullable Kind<ReaderKind.Witness<R>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderFunctor.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.reader.ReaderKindHelper.READER;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Functor} interface for the {@link Reader} type, using {@link
@@ -43,8 +42,8 @@ public class ReaderFunctor<R> implements Functor<ReaderKind.Witness<R>> {
    *     Reader<R, B>}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<ReaderKind.Witness<R>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<ReaderKind.Witness<R>, A> fa) {
+  public <A, B> Kind<ReaderKind.Witness<R>, B> map(
+      Function<? super A, ? extends B> f, Kind<ReaderKind.Witness<R>, A> fa) {
     Reader<R, A> readerA = READER.narrow(fa);
     Reader<R, B> readerB = readerA.map(f); // Delegates to Reader's own map method
     return READER.widen(readerB);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderKindHelper.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,7 +45,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    * @param <A> The value type of the {@code Reader}.
    * @param reader The non-null, actual {@link Reader Reader&lt;R, A&gt;} instance.
    */
-  record ReaderHolder<R, A>(@NonNull Reader<R, A> reader) implements ReaderKind<R, A> {}
+  record ReaderHolder<R, A>(Reader<R, A> reader) implements ReaderKind<R, A> {}
 
   /**
    * Widens a concrete {@link Reader Reader&lt;R, A&gt;} instance into its higher-kinded
@@ -62,7 +61,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    * @throws NullPointerException if {@code reader} is {@code null}.
    */
   @Override
-  public <R, A> @NonNull Kind<ReaderKind.Witness<R>, A> widen(@NonNull Reader<R, A> reader) {
+  public <R, A> Kind<ReaderKind.Witness<R>, A> widen(Reader<R, A> reader) {
     Objects.requireNonNull(reader, INVALID_KIND_TYPE_NULL_MSG);
     return new ReaderHolder<>(reader);
   }
@@ -81,10 +80,10 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <R, A> @NonNull Reader<R, A> narrow(@Nullable Kind<ReaderKind.Witness<R>, A> kind) {
+  public <R, A> Reader<R, A> narrow(@Nullable Kind<ReaderKind.Witness<R>, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(ReaderKindHelper.INVALID_KIND_NULL_MSG);
-      // ReaderHolder's record component 'reader' is @NonNull.
+      // ReaderHolder's record component 'reader' is .
       case ReaderKindHelper.ReaderHolder<?, ?> holder -> (Reader<R, A>) holder.reader();
       default ->
           throw new KindUnwrapException(
@@ -101,8 +100,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    * @param runFunction The non-null function {@code (R -> A)} defining the reader's computation.
    * @return A new, non-null {@code Kind<ReaderKind.Witness<R>, A>} representing the {@code Reader}.
    */
-  public <R, A> @NonNull Kind<ReaderKind.Witness<R>, A> reader(
-      @NonNull Function<R, A> runFunction) {
+  public <R, A> Kind<ReaderKind.Witness<R>, A> reader(Function<R, A> runFunction) {
     return this.widen(Reader.of(runFunction));
   }
 
@@ -116,7 +114,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    * @return A new, non-null {@code Kind<ReaderKind.Witness<R>, A>} representing the constant {@code
    *     Reader}.
    */
-  public <R, A> @NonNull Kind<ReaderKind.Witness<R>, A> constant(@Nullable A value) {
+  public <R, A> Kind<ReaderKind.Witness<R>, A> constant(@Nullable A value) {
     return this.widen(Reader.constant(value));
   }
 
@@ -128,7 +126,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    * @return A new, non-null {@code Kind<ReaderKind.Witness<R>, R>} representing the "ask" {@code
    *     Reader}.
    */
-  public <R> @NonNull Kind<ReaderKind.Witness<R>, R> ask() {
+  public <R> Kind<ReaderKind.Witness<R>, R> ask() {
     return this.widen(Reader.ask());
   }
 
@@ -145,8 +143,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is invalid.
    * @throws NullPointerException if {@code environment} is {@code null}.
    */
-  public <R, A> @Nullable A runReader(
-      @NonNull Kind<ReaderKind.Witness<R>, A> kind, @NonNull R environment) {
+  public <R, A> @Nullable A runReader(Kind<ReaderKind.Witness<R>, A> kind, R environment) {
     return this.narrow(kind).run(environment);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderMonad.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.reader.ReaderKindHelper.*;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Monad} interface for the {@link Reader} monad.
@@ -74,9 +73,9 @@ public final class ReaderMonad<R> extends ReaderApplicative<R>
    *     {@code r}.
    */
   @Override
-  public <A, B> @NonNull Kind<ReaderKind.Witness<R>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<ReaderKind.Witness<R>, B>> f,
-      @NonNull Kind<ReaderKind.Witness<R>, A> ma) {
+  public <A, B> Kind<ReaderKind.Witness<R>, B> flatMap(
+      Function<? super A, ? extends Kind<ReaderKind.Witness<R>, B>> f,
+      Kind<ReaderKind.Witness<R>, A> ma) {
 
     Reader<R, A> readerA = READER.narrow(ma); // Convert Kind back to concrete Reader
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderT.java
@@ -7,7 +7,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents the Reader Transformer Monad, {@code ReaderT<F, R, A>}. It wraps a computation that
@@ -35,7 +34,7 @@ import org.jspecify.annotations.NonNull;
  * @see Monad
  * @see Kind
  */
-public record ReaderT<F, R_ENV, A>(@NonNull Function<R_ENV, Kind<F, A>> run)
+public record ReaderT<F, R_ENV, A>(Function<R_ENV, Kind<F, A>> run)
     implements ReaderTKind<F, R_ENV, A> {
 
   /**
@@ -60,8 +59,7 @@ public record ReaderT<F, R_ENV, A>(@NonNull Function<R_ENV, Kind<F, A>> run)
    * @return A new {@link ReaderT} instance. Never null.
    * @throws NullPointerException if {@code runFunction} is null.
    */
-  public static <F, R_ENV, A> @NonNull ReaderT<F, R_ENV, A> of(
-      @NonNull Function<R_ENV, Kind<F, A>> runFunction) {
+  public static <F, R_ENV, A> ReaderT<F, R_ENV, A> of(Function<R_ENV, Kind<F, A>> runFunction) {
     return new ReaderT<>(runFunction);
   }
 
@@ -79,8 +77,7 @@ public record ReaderT<F, R_ENV, A>(@NonNull Function<R_ENV, Kind<F, A>> run)
    * @return A new {@link ReaderT} that wraps {@code fa}. Never null.
    * @throws NullPointerException if {@code outerMonad} or {@code fa} is null.
    */
-  public static <F, R_ENV, A> @NonNull ReaderT<F, R_ENV, A> lift(
-      @NonNull Monad<F> outerMonad, @NonNull Kind<F, A> fa) {
+  public static <F, R_ENV, A> ReaderT<F, R_ENV, A> lift(Monad<F> outerMonad, Kind<F, A> fa) {
     requireNonNull(outerMonad, "Outer Monad cannot be null for lift");
     requireNonNull(fa, "Input Kind<F, A> cannot be null for lift");
     return new ReaderT<>(r -> fa);
@@ -99,8 +96,8 @@ public record ReaderT<F, R_ENV, A>(@NonNull Function<R_ENV, Kind<F, A>> run)
    * @return A new {@link ReaderT} instance. Never null.
    * @throws NullPointerException if {@code outerMonad} or {@code f} is null.
    */
-  public static <F, R_ENV, A> @NonNull ReaderT<F, R_ENV, A> reader(
-      @NonNull Monad<F> outerMonad, @NonNull Function<R_ENV, A> f) {
+  public static <F, R_ENV, A> ReaderT<F, R_ENV, A> reader(
+      Monad<F> outerMonad, Function<R_ENV, A> f) {
     requireNonNull(outerMonad, "Outer Monad cannot be null for reader");
     requireNonNull(f, "Function cannot be null for reader");
     return new ReaderT<>(r -> outerMonad.of(f.apply(r)));
@@ -116,7 +113,7 @@ public record ReaderT<F, R_ENV, A>(@NonNull Function<R_ENV, Kind<F, A>> run)
    * @return A new {@link ReaderT} that, when run, yields {@code outerMonad.of(r)}. Never null.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public static <F, R_ENV> @NonNull ReaderT<F, R_ENV, R_ENV> ask(@NonNull Monad<F> outerMonad) {
+  public static <F, R_ENV> ReaderT<F, R_ENV, R_ENV> ask(Monad<F> outerMonad) {
     requireNonNull(outerMonad, "Outer Monad cannot be null for ask");
     return new ReaderT<>(r -> outerMonad.of(r));
   }
@@ -127,7 +124,7 @@ public record ReaderT<F, R_ENV, A>(@NonNull Function<R_ENV, Kind<F, A>> run)
    * @return The function {@code R_ENV -> Kind<F, A>}. Never null.
    */
   @Override
-  public @NonNull Function<R_ENV, Kind<F, A>> run() {
+  public Function<R_ENV, Kind<F, A>> run() {
     return run;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.reader_t;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,8 +27,7 @@ public interface ReaderTConverterOps {
    * @return The {@code Kind} representation.
    * @throws NullPointerException if {@code readerT} is {@code null}.
    */
-  <F, R_ENV, A> @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, A> widen(
-      @NonNull ReaderT<F, R_ENV, A> readerT);
+  <F, R_ENV, A> Kind<ReaderTKind.Witness<F, R_ENV>, A> widen(ReaderT<F, R_ENV, A> readerT);
 
   /**
    * Narrows a {@code Kind<ReaderTKind.Witness<F, R_ENV>, A>} back to its concrete {@link ReaderT
@@ -42,6 +40,5 @@ public interface ReaderTConverterOps {
    * @return The unwrapped, non-null {@link ReaderT ReaderT&lt;F, R_ENV, A&gt;} instance.
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link ReaderT} instance.
    */
-  <F, R_ENV, A> @NonNull ReaderT<F, R_ENV, A> narrow(
-      @Nullable Kind<ReaderTKind.Witness<F, R_ENV>, A> kind);
+  <F, R_ENV, A> ReaderT<F, R_ENV, A> narrow(@Nullable Kind<ReaderTKind.Witness<F, R_ENV>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTKindHelper.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.reader_t;
 import java.util.Objects;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -40,14 +39,13 @@ public enum ReaderTKindHelper implements ReaderTConverterOps {
    * @param <R_ENV> The type of the environment required by the {@code ReaderT}.
    * @param <A> The type of the value produced by the {@code ReaderT}.
    * @param readerT The concrete {@link ReaderT ReaderT&lt;F, R_ENV, A&gt;} instance to widen. Must
-   *     be {@code @NonNull}.
+   *     be {@code }.
    * @return A non-null {@code Kind<ReaderTKind.Witness<F, R_ENV>, A>} representing the wrapped
    *     {@code readerT}.
    * @throws NullPointerException if {@code readerT} is {@code null}.
    */
   @Override
-  public <F, R_ENV, A> @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, A> widen(
-      @NonNull ReaderT<F, R_ENV, A> readerT) {
+  public <F, R_ENV, A> Kind<ReaderTKind.Witness<F, R_ENV>, A> widen(ReaderT<F, R_ENV, A> readerT) {
     Objects.requireNonNull(readerT, INVALID_KIND_TYPE_NULL_MSG);
     // ReaderT<F,R_ENV,A> is already a ReaderTKind<F,R_ENV,A>,
     // which is a Kind<ReaderTKind.Witness<F,R_ENV>,A>.
@@ -68,7 +66,7 @@ public enum ReaderTKindHelper implements ReaderTConverterOps {
    *     {@link ReaderT}.
    */
   @Override
-  public <F, R_ENV, A> @NonNull ReaderT<F, R_ENV, A> narrow(
+  public <F, R_ENV, A> ReaderT<F, R_ENV, A> narrow(
       @Nullable Kind<ReaderTKind.Witness<F, R_ENV>, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(ReaderTKindHelper.INVALID_KIND_NULL_MSG);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTMonad.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -35,7 +34,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class ReaderTMonad<F, R_ENV> implements Monad<ReaderTKind.Witness<F, R_ENV>> {
 
-  private final @NonNull Monad<F> outerMonad;
+  private final Monad<F> outerMonad;
 
   /**
    * Constructs a {@link ReaderTMonad} instance.
@@ -44,7 +43,7 @@ public class ReaderTMonad<F, R_ENV> implements Monad<ReaderTKind.Witness<F, R_EN
    *     crucial for defining the monadic operations of {@code ReaderT}. Must not be null.
    * @throws NullPointerException if {@code outerMonad} is null.
    */
-  public ReaderTMonad(@NonNull Monad<F> outerMonad) {
+  public ReaderTMonad(Monad<F> outerMonad) {
     this.outerMonad =
         Objects.requireNonNull(outerMonad, "Outer Monad instance cannot be null for ReaderTMonad");
   }
@@ -60,7 +59,7 @@ public class ReaderTMonad<F, R_ENV> implements Monad<ReaderTKind.Witness<F, R_EN
    *     Never null.
    */
   @Override
-  public <A> @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, A> of(@Nullable A value) {
+  public <A> Kind<ReaderTKind.Witness<F, R_ENV>, A> of(@Nullable A value) {
     ReaderT<F, R_ENV, A> readerT = new ReaderT<>(r -> outerMonad.of(value));
     return READER_T.widen(readerT);
   }
@@ -83,9 +82,9 @@ public class ReaderTMonad<F, R_ENV> implements Monad<ReaderTKind.Witness<F, R_EN
    *     ReaderT}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, B> ap(
-      @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, ? extends Function<A, B>> ff,
-      @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, A> fa) {
+  public <A, B> Kind<ReaderTKind.Witness<F, R_ENV>, B> ap(
+      Kind<ReaderTKind.Witness<F, R_ENV>, ? extends Function<A, B>> ff,
+      Kind<ReaderTKind.Witness<F, R_ENV>, A> fa) {
 
     ReaderT<F, R_ENV, ? extends Function<A, B>> ffT = READER_T.narrow(ff);
     ReaderT<F, R_ENV, A> faT = READER_T.narrow(fa);
@@ -118,9 +117,8 @@ public class ReaderTMonad<F, R_ENV> implements Monad<ReaderTKind.Witness<F, R_EN
    *     ReaderT}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, B> map(
-      @NonNull Function<? super A, ? extends B> f,
-      @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, A> fa) {
+  public <A, B> Kind<ReaderTKind.Witness<F, R_ENV>, B> map(
+      Function<? super A, ? extends B> f, Kind<ReaderTKind.Witness<F, R_ENV>, A> fa) {
 
     ReaderT<F, R_ENV, A> faT = READER_T.narrow(fa);
 
@@ -155,9 +153,9 @@ public class ReaderTMonad<F, R_ENV> implements Monad<ReaderTKind.Witness<F, R_EN
    *     {@code ReaderT}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<ReaderTKind.Witness<F, R_ENV>, B>> f,
-      @NonNull Kind<ReaderTKind.Witness<F, R_ENV>, A> ma) {
+  public <A, B> Kind<ReaderTKind.Witness<F, R_ENV>, B> flatMap(
+      Function<? super A, ? extends Kind<ReaderTKind.Witness<F, R_ENV>, B>> f,
+      Kind<ReaderTKind.Witness<F, R_ENV>, A> ma) {
 
     ReaderT<F, R_ENV, A> maT = READER_T.narrow(ma);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/State.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/State.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,7 +24,7 @@ public interface State<S, A> {
    * @param initialState The non-null initial state.
    * @return A non-null {@link StateTuple} containing the computed value and the final state.
    */
-  @NonNull StateTuple<S, A> run(@NonNull S initialState);
+  StateTuple<S, A> run(S initialState);
 
   /**
    * Creates a {@code State} instance from a function that performs the state transition. The
@@ -39,8 +38,7 @@ public interface State<S, A> {
    * @return A non-null {@code State<S, A>} instance.
    * @throws NullPointerException if {@code runFunction} is null.
    */
-  static <S, A> @NonNull State<S, A> of(
-      @NonNull Function<@NonNull S, @NonNull StateTuple<S, A>> runFunction) {
+  static <S, A> State<S, A> of(Function<S, StateTuple<S, A>> runFunction) {
     requireNonNull(runFunction, "runFunction cannot be null");
     return runFunction::apply;
   }
@@ -64,7 +62,7 @@ public interface State<S, A> {
    *     transition.
    * @throws NullPointerException if {@code f} is null.
    */
-  default <B> @NonNull State<S, B> map(@NonNull Function<? super A, ? extends B> f) {
+  default <B> State<S, B> map(Function<? super A, ? extends B> f) {
     requireNonNull(f, "mapper function cannot be null");
     return State.of(
         initialState -> {
@@ -96,8 +94,7 @@ public interface State<S, A> {
    * @throws NullPointerException if {@code f} is null or if the {@code State} returned by {@code f}
    *     is null.
    */
-  default <B> @NonNull State<S, B> flatMap(
-      @NonNull Function<? super A, ? extends State<S, ? extends B>> f) {
+  default <B> State<S, B> flatMap(Function<? super A, ? extends State<S, ? extends B>> f) {
     requireNonNull(f, "flatMap mapper function cannot be null");
     return State.of(
         initialState -> {
@@ -133,7 +130,7 @@ public interface State<S, A> {
    * @param value The value to be returned by the State computation. Can be {@code null}.
    * @return A non-null {@code State<S, A>} that always returns the given value and original state.
    */
-  static <S, A> @NonNull State<S, A> pure(@Nullable A value) {
+  static <S, A> State<S, A> pure(@Nullable A value) {
     return State.of(s -> new StateTuple<>(value, s));
   }
 
@@ -146,7 +143,7 @@ public interface State<S, A> {
    * @param <S> The type of the state.
    * @return A non-null {@code State<S, S>} that returns the current state as its value.
    */
-  static <S> @NonNull State<S, S> get() {
+  static <S> State<S, S> get() {
     return State.of(s -> new StateTuple<>(s, s));
   }
 
@@ -162,7 +159,7 @@ public interface State<S, A> {
    *     Unit#INSTANCE}.
    * @throws NullPointerException if {@code newState} is null.
    */
-  static <S> @NonNull State<S, Unit> set(@NonNull S newState) {
+  static <S> State<S, Unit> set(S newState) {
     requireNonNull(newState, "newState cannot be null");
     // The old state `s` is ignored here, as `newState` replaces it.
     return State.of(s -> new StateTuple<>(Unit.INSTANCE, newState));
@@ -181,7 +178,7 @@ public interface State<S, A> {
    *     Unit#INSTANCE}.
    * @throws NullPointerException if {@code f} is null.
    */
-  static <S> @NonNull State<S, Unit> modify(@NonNull Function<@NonNull S, @NonNull S> f) {
+  static <S> State<S, Unit> modify(Function<S, S> f) {
     requireNonNull(f, "state modification function cannot be null");
     return State.of(s -> new StateTuple<>(Unit.INSTANCE, f.apply(s)));
   }
@@ -199,7 +196,7 @@ public interface State<S, A> {
    * @return A non-null {@code State<S, A>} that returns the result of inspecting the state.
    * @throws NullPointerException if {@code f} is null.
    */
-  static <S, A> @NonNull State<S, A> inspect(@NonNull Function<@NonNull S, @Nullable A> f) {
+  static <S, A> State<S, A> inspect(Function<S, @Nullable A> f) {
     requireNonNull(f, "state inspection function cannot be null");
     return State.of(s -> new StateTuple<>(f.apply(s), s));
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateApplicative.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.state.StateKindHelper.STATE;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -31,7 +30,7 @@ public class StateApplicative<S> extends StateFunctor<S>
    * @return A {@code Kind<StateKind.Witness, A>} representing {@code State.pure(value)}.
    */
   @Override
-  public <A> @NonNull Kind<StateKind.Witness<S>, A> of(@Nullable A value) {
+  public <A> Kind<StateKind.Witness<S>, A> of(@Nullable A value) {
     return STATE.pure(value);
   }
 
@@ -47,9 +46,8 @@ public class StateApplicative<S> extends StateFunctor<S>
    * @return A new {@code Kind<StateKind.Witness, B>} resulting from the application.
    */
   @Override
-  public <A, B> @NonNull Kind<StateKind.Witness<S>, B> ap(
-      @NonNull Kind<StateKind.Witness<S>, ? extends Function<A, B>> ff,
-      @NonNull Kind<StateKind.Witness<S>, A> fa) {
+  public <A, B> Kind<StateKind.Witness<S>, B> ap(
+      Kind<StateKind.Witness<S>, ? extends Function<A, B>> ff, Kind<StateKind.Witness<S>, A> fa) {
 
     State<S, ? extends Function<A, B>> stateF = STATE.narrow(ff);
     State<S, A> stateA = STATE.narrow(fa);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.state;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -27,7 +26,7 @@ public interface StateConverterOps {
    *     State}.
    * @throws NullPointerException if {@code state} is {@code null}.
    */
-  <S, A> @NonNull Kind<StateKind.Witness<S>, A> widen(@NonNull State<S, A> state);
+  <S, A> Kind<StateKind.Witness<S>, A> widen(State<S, A> state);
 
   /**
    * Narrows a {@code Kind<StateKind.Witness<S>, A>} back to its concrete {@link State}{@code <S,
@@ -40,5 +39,5 @@ public interface StateConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is {@code null} or not an instance of the
    *     expected underlying holder type for State.
    */
-  <S, A> @NonNull State<S, A> narrow(@Nullable Kind<StateKind.Witness<S>, A> kind);
+  <S, A> State<S, A> narrow(@Nullable Kind<StateKind.Witness<S>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateFunctor.java
@@ -8,7 +8,6 @@ import static org.higherkindedj.hkt.state.StateKindHelper.STATE;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -60,9 +59,8 @@ public class StateFunctor<S> implements Functor<StateKind.Witness<S>> {
    * @throws NullPointerException if {@code f} is {@code null}.
    */
   @Override
-  public <A, B> @NonNull Kind<StateKind.Witness<S>, B> map(
-      @NonNull Function<? super A, ? extends @Nullable B> f,
-      @NonNull Kind<StateKind.Witness<S>, A> fa) {
+  public <A, B> Kind<StateKind.Witness<S>, B> map(
+      Function<? super A, ? extends @Nullable B> f, Kind<StateKind.Witness<S>, A> fa) {
     requireNonNull(f, "Mapping function cannot be null");
 
     // 1. Unwrap the Kind to get the concrete State<S, A>.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateKindHelper.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -44,7 +43,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @param <A> The type of the computed value.
    * @param stateInstance The non-null, actual {@link State}{@code <S, A>} instance being wrapped.
    */
-  record StateHolder<S, A>(@NonNull State<S, A> stateInstance) implements StateKind<S, A> {}
+  record StateHolder<S, A>(State<S, A> stateInstance) implements StateKind<S, A> {}
 
   /**
    * Widens a concrete {@link State}{@code <S, A>} instance into its higher-kinded representation,
@@ -58,7 +57,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @throws NullPointerException if {@code state} is {@code null}.
    */
   @Override
-  public <S, A> @NonNull Kind<StateKind.Witness<S>, A> widen(@NonNull State<S, A> state) {
+  public <S, A> Kind<StateKind.Witness<S>, A> widen(State<S, A> state) {
     Objects.requireNonNull(state, "Input State cannot be null for widen");
     return new StateHolder<>(state);
   }
@@ -78,7 +77,7 @@ public enum StateKindHelper implements StateConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <S, A> @NonNull State<S, A> narrow(@Nullable Kind<StateKind.Witness<S>, A> kind) {
+  public <S, A> State<S, A> narrow(@Nullable Kind<StateKind.Witness<S>, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(StateKindHelper.INVALID_KIND_NULL_MSG);
       case StateKindHelper.StateHolder<?, A> holder -> (State<S, A>) holder.stateInstance();
@@ -96,7 +95,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @param value The value to lift.
    * @return A non-null {@link Kind<StateKind.Witness<S>, A>} representing the pure computation.
    */
-  public <S, A> @NonNull Kind<StateKind.Witness<S>, A> pure(@Nullable A value) {
+  public <S, A> Kind<StateKind.Witness<S>, A> pure(@Nullable A value) {
     return this.widen(State.pure(value));
   }
 
@@ -106,7 +105,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @param <S> The type of the state.
    * @return A non-null {@link Kind<StateKind.Witness<S>, S>} that yields the current state.
    */
-  public <S> @NonNull Kind<StateKind.Witness<S>, S> get() {
+  public <S> Kind<StateKind.Witness<S>, S> get() {
     return this.widen(State.get());
   }
 
@@ -117,7 +116,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @param newState The non-null new state to be set.
    * @return A non-null {@link Kind<StateKind.Witness<S>, Unit>} that performs the state update.
    */
-  public <S> @NonNull Kind<StateKind.Witness<S>, Unit> set(@NonNull S newState) {
+  public <S> Kind<StateKind.Witness<S>, Unit> set(S newState) {
     return this.widen(State.set(newState));
   }
 
@@ -129,8 +128,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @return A non-null {@link Kind<StateKind.Witness<S>, Unit>} that performs the state
    *     modification.
    */
-  public <S> @NonNull Kind<StateKind.Witness<S>, Unit> modify(
-      @NonNull Function<@NonNull S, @NonNull S> f) {
+  public <S> Kind<StateKind.Witness<S>, Unit> modify(Function<S, S> f) {
     return this.widen(State.modify(f));
   }
 
@@ -143,8 +141,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @return A non-null {@link Kind<StateKind.Witness<S>, A>} that returns the result of inspecting
    *     the state.
    */
-  public <S, A> @NonNull Kind<StateKind.Witness<S>, A> inspect(
-      @NonNull Function<@NonNull S, @Nullable A> f) {
+  public <S, A> Kind<StateKind.Witness<S>, A> inspect(Function<S, @Nullable A> f) {
     return this.widen(State.inspect(f));
   }
 
@@ -159,8 +156,8 @@ public enum StateKindHelper implements StateConverterOps {
    * @throws KindUnwrapException if {@code kind} is invalid.
    * @throws NullPointerException if {@code initialState} is {@code null}.
    */
-  public <S, A> @NonNull StateTuple<S, A> runState(
-      @Nullable Kind<StateKind.Witness<S>, A> kind, @NonNull S initialState) {
+  public <S, A> StateTuple<S, A> runState(
+      @Nullable Kind<StateKind.Witness<S>, A> kind, S initialState) {
     Objects.requireNonNull(initialState, "Initial state cannot be null for runState");
     return this.narrow(kind).run(initialState);
   }
@@ -177,7 +174,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @throws NullPointerException if {@code initialState} is {@code null}.
    */
   public <S, A> @Nullable A evalState(
-      @Nullable Kind<StateKind.Witness<S>, A> kind, @NonNull S initialState) {
+      @Nullable Kind<StateKind.Witness<S>, A> kind, S initialState) {
     return this.runState(kind, initialState).value();
   }
 
@@ -192,8 +189,7 @@ public enum StateKindHelper implements StateConverterOps {
    * @throws KindUnwrapException if {@code kind} is invalid.
    * @throws NullPointerException if {@code initialState} is {@code null}.
    */
-  public <S, A> @NonNull S execState(
-      @Nullable Kind<StateKind.Witness<S>, A> kind, @NonNull S initialState) {
+  public <S, A> S execState(@Nullable Kind<StateKind.Witness<S>, A> kind, S initialState) {
     return this.runState(kind, initialState).state();
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateMonad.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.state.StateKindHelper.STATE;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Monad implementation for {@link State}, using {@link StateKind.Witness} as the HKT marker. An
@@ -37,9 +36,9 @@ public class StateMonad<S> extends StateApplicative<S> implements Monad<StateKin
    *     operation.
    */
   @Override
-  public @NonNull <A, B> Kind<StateKind.Witness<S>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<StateKind.Witness<S>, B>> f,
-      @NonNull Kind<StateKind.Witness<S>, A> ma) {
+  public <A, B> Kind<StateKind.Witness<S>, B> flatMap(
+      Function<? super A, ? extends Kind<StateKind.Witness<S>, B>> f,
+      Kind<StateKind.Witness<S>, A> ma) {
 
     State<S, A> stateA = STATE.narrow(ma);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateTuple.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateTuple.java
@@ -5,7 +5,6 @@ package org.higherkindedj.hkt.state;
 import java.util.Objects;
 import org.higherkindedj.hkt.unit.Unit;
 import org.higherkindedj.optics.annotations.GenerateLenses;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -38,7 +37,7 @@ import org.jspecify.annotations.Nullable;
  * @see Unit
  */
 @GenerateLenses
-public record StateTuple<S, A>(@Nullable A value, @NonNull S state) {
+public record StateTuple<S, A>(@Nullable A value, S state) {
 
   /**
    * Compact constructor for {@link StateTuple}. Ensures that the {@code state} component is never
@@ -68,7 +67,7 @@ public record StateTuple<S, A>(@Nullable A value, @NonNull S state) {
    * @return A new, non-null {@link StateTuple} instance.
    * @throws NullPointerException if {@code state} is {@code null}.
    */
-  public static <S, A> @NonNull StateTuple<S, A> of(@NonNull S state, @Nullable A value) {
+  public static <S, A> StateTuple<S, A> of(S state, @Nullable A value) {
     return new StateTuple<>(value, state);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.state_t;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +27,7 @@ public interface StateTConverterOps {
    * @return The {@code Kind} representation.
    * @throws NullPointerException if {@code stateT} is {@code null}.
    */
-  <S, F, A> @NonNull Kind<StateTKind.Witness<S, F>, A> widen(@NonNull StateT<S, F, A> stateT);
+  <S, F, A> Kind<StateTKind.Witness<S, F>, A> widen(StateT<S, F, A> stateT);
 
   /**
    * Narrows a {@code Kind<StateTKind.Witness<S, F>, A>} back to its concrete {@link StateT
@@ -41,5 +40,5 @@ public interface StateTConverterOps {
    * @return The unwrapped, non-null {@link StateT StateT&lt;S, F, A&gt;} instance.
    * @throws KindUnwrapException if {@code kind} is null or not a valid {@link StateT} instance.
    */
-  <S, F, A> @NonNull StateT<S, F, A> narrow(@Nullable Kind<StateTKind.Witness<S, F>, A> kind);
+  <S, F, A> StateT<S, F, A> narrow(@Nullable Kind<StateTKind.Witness<S, F>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKind.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKind.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.state_t;
 
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -118,8 +117,7 @@ public interface StateTKind<S, F, A> extends Kind<StateTKind.Witness<S, F>, A> {
    * @throws ClassCastException if {@code kind} is {@code null} or not actually an instance of
    *     {@link StateT} (or a compatible subtype).
    */
-  static <S, F, A> @NonNull StateT<S, F, A> narrow(
-      @Nullable Kind<StateTKind.Witness<S, F>, A> kind) {
+  static <S, F, A> StateT<S, F, A> narrow(@Nullable Kind<StateTKind.Witness<S, F>, A> kind) {
     // The null check here is important.
     // A ClassCastException is appropriate if kind is null, as null cannot be cast to StateT.
     if (kind == null) {
@@ -164,7 +162,7 @@ public interface StateTKind<S, F, A> extends Kind<StateTKind.Witness<S, F>, A> {
    *     {@link StateT}.
    */
   @SuppressWarnings("unchecked") // This method is explicitly for unsafe, unchecked casting.
-  static <S, F, A> @NonNull StateT<S, F, A> narrowK(@Nullable Kind<?, A> kind) {
+  static <S, F, A> StateT<S, F, A> narrowK(@Nullable Kind<?, A> kind) {
     if (kind == null) {
       throw new ClassCastException("Cannot narrowK a null Kind to StateT");
     }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKindHelper.java
@@ -8,7 +8,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
 import org.higherkindedj.hkt.state.StateTuple;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -47,8 +46,7 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @throws NullPointerException if {@code stateT} is {@code null}.
    */
   @Override
-  public <S, F, A> @NonNull Kind<StateTKind.Witness<S, F>, A> widen(
-      @NonNull StateT<S, F, A> stateT) {
+  public <S, F, A> Kind<StateTKind.Witness<S, F>, A> widen(StateT<S, F, A> stateT) {
     Objects.requireNonNull(stateT, INVALID_KIND_TYPE_NULL_MSG);
     return stateT;
   }
@@ -66,8 +64,7 @@ public enum StateTKindHelper implements StateTConverterOps {
    *     instance.
    */
   @Override
-  public <S, F, A> @NonNull StateT<S, F, A> narrow(
-      @Nullable Kind<StateTKind.Witness<S, F>, A> kind) {
+  public <S, F, A> StateT<S, F, A> narrow(@Nullable Kind<StateTKind.Witness<S, F>, A> kind) {
     if (kind == null) {
       throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
     }
@@ -84,8 +81,8 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @param monadF The non-null {@link Monad} instance for the underlying monad {@code F}.
    * @return A new, non-null {@link StateT} instance.
    */
-  public <S, F, A> @NonNull StateT<S, F, A> stateT(
-      @NonNull Function<S, Kind<F, StateTuple<S, A>>> runStateTFn, @NonNull Monad<F> monadF) {
+  public <S, F, A> StateT<S, F, A> stateT(
+      Function<S, Kind<F, StateTuple<S, A>>> runStateTFn, Monad<F> monadF) {
     return StateT.create(runStateTFn, monadF);
   }
 
@@ -97,7 +94,7 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @param fa The non-null computation {@code Kind<F, A>}.
    * @return A new, non-null {@link StateT} instance wrapping the lifted computation.
    */
-  public <S, F, A> @NonNull StateT<S, F, A> lift(@NonNull Monad<F> monadF, @NonNull Kind<F, A> fa) {
+  public <S, F, A> StateT<S, F, A> lift(Monad<F> monadF, Kind<F, A> fa) {
     Objects.requireNonNull(monadF, "Monad<F> for lift cannot be null.");
     Objects.requireNonNull(fa, "Kind<F, A> to lift cannot be null.");
     Function<S, Kind<F, StateTuple<S, A>>> runFn = s -> monadF.map(a -> StateTuple.of(s, a), fa);
@@ -113,8 +110,8 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @param initialState The initial state.
    * @return A {@code Kind<F, StateTuple<S, A>>}.
    */
-  public <S, F, A> @NonNull Kind<F, StateTuple<S, A>> runStateT(
-      @NonNull Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
+  public <S, F, A> Kind<F, StateTuple<S, A>> runStateT(
+      Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
     return this.narrow(kind).runStateT(initialState);
   }
 
@@ -125,8 +122,7 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @param initialState The initial state.
    * @return A {@code Kind<F, A>} representing the final value.
    */
-  public <S, F, A> @NonNull Kind<F, A> evalStateT(
-      @NonNull Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
+  public <S, F, A> Kind<F, A> evalStateT(Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
     return this.narrow(kind).evalStateT(initialState);
   }
 
@@ -137,8 +133,7 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @param initialState The initial state.
    * @return A {@code Kind<F, S>} representing the final state.
    */
-  public <S, F, A> @NonNull Kind<F, S> execStateT(
-      @NonNull Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
+  public <S, F, A> Kind<F, S> execStateT(Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
     return this.narrow(kind).execStateT(initialState);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTMonad.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.state.StateTuple;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -78,7 +77,7 @@ public final class StateTMonad<S, F> implements Monad<StateTKind.Witness<S, F>> 
    */
   @Override
   public <A, B> Kind<StateTKind.Witness<S, F>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<StateTKind.Witness<S, F>, A> fa) {
+      Function<? super A, ? extends B> f, Kind<StateTKind.Witness<S, F>, A> fa) {
     StateT<S, F, A> stateT = StateTKind.narrow(fa);
     Function<S, Kind<F, StateTuple<S, B>>> newRunFn =
         s ->
@@ -126,8 +125,8 @@ public final class StateTMonad<S, F> implements Monad<StateTKind.Witness<S, F>> 
    */
   @Override
   public <A, B> Kind<StateTKind.Witness<S, F>, B> ap(
-      @NonNull Kind<StateTKind.Witness<S, F>, ? extends Function<A, B>> ff,
-      @NonNull Kind<StateTKind.Witness<S, F>, A> fa) {
+      Kind<StateTKind.Witness<S, F>, ? extends Function<A, B>> ff,
+      Kind<StateTKind.Witness<S, F>, A> fa) {
     StateT<S, F, ? extends Function<A, B>> stateTf = StateTKind.narrow(ff);
     StateT<S, F, A> stateTa = StateTKind.narrow(fa);
 
@@ -195,9 +194,9 @@ public final class StateTMonad<S, F> implements Monad<StateTKind.Witness<S, F>> 
    *     StateTKind.narrow(fa).runStateT(s0))}.
    */
   @Override
-  public <A, B> @NonNull Kind<StateTKind.Witness<S, F>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<StateTKind.Witness<S, F>, B>> f,
-      @NonNull Kind<StateTKind.Witness<S, F>, A> fa) {
+  public <A, B> Kind<StateTKind.Witness<S, F>, B> flatMap(
+      Function<? super A, ? extends Kind<StateTKind.Witness<S, F>, B>> f,
+      Kind<StateTKind.Witness<S, F>, A> fa) {
     StateT<S, F, A> stateTa = StateTKind.narrow(fa);
 
     Function<S, Kind<F, StateTuple<S, B>>> newRunFn =

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/Try.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/Try.java
@@ -8,7 +8,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.either.Either;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -79,7 +78,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    *     exception occurs.
    * @throws NullPointerException if {@code supplier} is null.
    */
-  static <T> @NonNull Try<T> of(@NonNull Supplier<? extends T> supplier) {
+  static <T> Try<T> of(Supplier<? extends T> supplier) {
     requireNonNull(supplier, "Supplier cannot be null");
     try {
       // The result from supplier.get() can be null, and Success can hold a null value.
@@ -98,7 +97,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @param <T> The type of the value.
    * @return A non-null {@link Success} instance holding the provided value.
    */
-  static <T> @NonNull Try<T> success(@Nullable T value) {
+  static <T> Try<T> success(@Nullable T value) {
     return new Success<>(value);
   }
 
@@ -110,7 +109,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @return A non-null {@link Failure} instance holding the {@link Throwable}.
    * @throws NullPointerException if {@code throwable} is null.
    */
-  static <T> @NonNull Try<T> failure(@NonNull Throwable throwable) {
+  static <T> Try<T> failure(Throwable throwable) {
     requireNonNull(throwable, "Throwable for Failure cannot be null");
     return new Failure<>(throwable);
   }
@@ -178,7 +177,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @throws NullPointerException if {@code supplier} is null (but only if this is a {@link Failure}
    *     and the supplier needs to be invoked by the concrete implementation).
    */
-  @Nullable T orElseGet(@NonNull Supplier<? extends T> supplier);
+  @Nullable T orElseGet(Supplier<? extends T> supplier);
 
   /**
    * Applies one of two functions depending on whether this is a {@link Success} or a {@link
@@ -206,8 +205,8 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @throws NullPointerException if either {@code successMapper} or {@code failureMapper} is null.
    */
   default <U> U fold(
-      @NonNull Function<? super T, ? extends U> successMapper,
-      @NonNull Function<? super Throwable, ? extends U> failureMapper) {
+      Function<? super T, ? extends U> successMapper,
+      Function<? super Throwable, ? extends U> failureMapper) {
     requireNonNull(successMapper, "successMapper cannot be null");
     requireNonNull(failureMapper, "failureMapper cannot be null");
 
@@ -244,8 +243,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @return An {@code Either<L, T>} representing the outcome of this {@code Try}.
    * @throws NullPointerException if {@code failureToLeftMapper} is null.
    */
-  default <L> @NonNull Either<L, T> toEither(
-      @NonNull Function<? super Throwable, ? extends L> failureToLeftMapper) {
+  default <L> Either<L, T> toEither(Function<? super Throwable, ? extends L> failureToLeftMapper) {
     requireNonNull(failureToLeftMapper, "failureToLeftMapper cannot be null");
     return switch (this) {
       case Success<T>(var value) -> Either.<L, T>right(value);
@@ -279,7 +277,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @return A new non-null {@code Try<U>} resulting from applying the mapper, or a {@link Failure}.
    * @throws NullPointerException if {@code mapper} is null (checked by implementations).
    */
-  @NonNull <U> Try<U> map(@NonNull Function<? super T, ? extends U> mapper);
+  <U> Try<U> map(Function<? super T, ? extends U> mapper);
 
   /**
    * If this is a {@link Success}, applies the given {@code Try}-bearing function to its value and
@@ -296,8 +294,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @throws NullPointerException if {@code mapper} is null, or if {@code mapper} returns null
    *     (checked by implementations).
    */
-  @NonNull <U> Try<U> flatMap(
-      @NonNull Function<? super T, ? extends @NonNull Try<? extends U>> mapper);
+  <U> Try<U> flatMap(Function<? super T, ? extends Try<? extends U>> mapper);
 
   /**
    * If this is a {@link Failure}, applies the given recovery function to the {@link Throwable}. If
@@ -320,7 +317,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    *     Success} from recovery, or a new {@link Failure} if recovery also failed.
    * @throws NullPointerException if {@code recoveryFunction} is null (checked by implementations).
    */
-  @NonNull Try<T> recover(@NonNull Function<? super Throwable, ? extends T> recoveryFunction);
+  Try<T> recover(Function<? super Throwable, ? extends T> recoveryFunction);
 
   /**
    * If this is a {@link Failure}, applies the given {@code Try}-bearing recovery function to the
@@ -337,8 +334,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @throws NullPointerException if {@code recoveryFunction} is null, or if it returns null
    *     (checked by implementations).
    */
-  @NonNull Try<T> recoverWith(
-      @NonNull Function<? super Throwable, ? extends @NonNull Try<? extends T>> recoveryFunction);
+  Try<T> recoverWith(Function<? super Throwable, ? extends Try<? extends T>> recoveryFunction);
 
   /**
    * Performs one of two actions depending on whether this is a {@link Success} or a {@link
@@ -352,9 +348,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @param failureAction The non-null action to perform if this is a {@link Failure}.
    * @throws NullPointerException if either {@code successAction} or {@code failureAction} is null.
    */
-  default void match(
-      @NonNull Consumer<? super T> successAction,
-      @NonNull Consumer<? super Throwable> failureAction) {
+  default void match(Consumer<? super T> successAction, Consumer<? super Throwable> failureAction) {
     requireNonNull(successAction, "successAction cannot be null");
     requireNonNull(failureAction, "failureAction cannot be null");
 
@@ -411,13 +405,13 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @Nullable T orElseGet(@NonNull Supplier<? extends T> supplier) {
+    public @Nullable T orElseGet(Supplier<? extends T> supplier) {
       requireNonNull(supplier, "supplier cannot be null");
       return value;
     }
 
     @Override
-    public @NonNull <U> Try<U> map(@NonNull Function<? super T, ? extends U> mapper) {
+    public <U> Try<U> map(Function<? super T, ? extends U> mapper) {
       requireNonNull(mapper, "mapper cannot be null");
       try {
         return new Success<>(mapper.apply(value));
@@ -427,8 +421,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @NonNull <U> Try<U> flatMap(
-        @NonNull Function<? super T, ? extends @NonNull Try<? extends U>> mapper) {
+    public <U> Try<U> flatMap(Function<? super T, ? extends Try<? extends U>> mapper) {
       requireNonNull(mapper, "mapper cannot be null");
       Try<? extends U> result;
       try {
@@ -444,16 +437,14 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @NonNull Try<T> recover(
-        @NonNull Function<? super Throwable, ? extends T> recoveryFunction) {
+    public Try<T> recover(Function<? super Throwable, ? extends T> recoveryFunction) {
       requireNonNull(recoveryFunction, "recoveryFunction cannot be null");
       return this;
     }
 
     @Override
-    public @NonNull Try<T> recoverWith(
-        @NonNull Function<? super Throwable, ? extends @NonNull Try<? extends T>>
-            recoveryFunction) {
+    public Try<T> recoverWith(
+        Function<? super Throwable, ? extends Try<? extends T>> recoveryFunction) {
       requireNonNull(recoveryFunction, "recoveryFunction cannot be null");
       return this;
     }
@@ -466,7 +457,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
    * @param <T> The phantom type of the value (as there is no successful value).
    * @param cause The non-null {@link Throwable} that caused the failure.
    */
-  record Failure<T>(@NonNull Throwable cause) implements Try<T> {
+  record Failure<T>(Throwable cause) implements Try<T> {
 
     @Override
     public boolean isSuccess() {
@@ -494,13 +485,13 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @Nullable T orElseGet(@NonNull Supplier<? extends T> supplier) {
+    public @Nullable T orElseGet(Supplier<? extends T> supplier) {
       requireNonNull(supplier, "supplier cannot be null for orElseGet");
       return supplier.get();
     }
 
     @Override
-    public @NonNull <U> Try<U> map(@NonNull Function<? super T, ? extends U> mapper) {
+    public <U> Try<U> map(Function<? super T, ? extends U> mapper) {
       requireNonNull(mapper, "mapper cannot be null");
       // Map does nothing on Failure, just propagates the Failure with the new type U.
       @SuppressWarnings(
@@ -510,8 +501,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @NonNull <U> Try<U> flatMap(
-        @NonNull Function<? super T, ? extends @NonNull Try<? extends U>> mapper) {
+    public <U> Try<U> flatMap(Function<? super T, ? extends Try<? extends U>> mapper) {
       requireNonNull(mapper, "mapper cannot be null");
       @SuppressWarnings("unchecked")
       Try<U> self = (Try<U>) this;
@@ -519,8 +509,7 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @NonNull Try<T> recover(
-        @NonNull Function<? super Throwable, ? extends T> recoveryFunction) {
+    public Try<T> recover(Function<? super Throwable, ? extends T> recoveryFunction) {
       requireNonNull(recoveryFunction, "recoveryFunction cannot be null");
       try {
         // The result of recoveryFunction.apply(cause) can be null; Success<T> can hold null.
@@ -531,9 +520,8 @@ public sealed interface Try<T> permits Try.Success, Try.Failure {
     }
 
     @Override
-    public @NonNull Try<T> recoverWith(
-        @NonNull Function<? super Throwable, ? extends @NonNull Try<? extends T>>
-            recoveryFunction) {
+    public Try<T> recoverWith(
+        Function<? super Throwable, ? extends Try<? extends T>> recoveryFunction) {
       requireNonNull(recoveryFunction, "recoveryFunction cannot be null");
       Try<? extends T> result;
       try {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryApplicative.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.trymonad.TryKindHelper.*;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -29,7 +28,7 @@ public class TryApplicative extends TryFunctor implements Applicative<TryKind.Wi
    * @return A {@code Kind<TryKind.Witness, A>} representing {@code Try.success(value)}.
    */
   @Override
-  public <A> @NonNull Kind<TryKind.Witness, A> of(@Nullable A value) {
+  public <A> Kind<TryKind.Witness, A> of(@Nullable A value) {
     return TRY.widen(Try.success(value));
   }
 
@@ -47,9 +46,8 @@ public class TryApplicative extends TryFunctor implements Applicative<TryKind.Wi
    *     Try.Failure} is returned.
    */
   @Override
-  public <A, B> @NonNull Kind<TryKind.Witness, B> ap(
-      @NonNull Kind<TryKind.Witness, ? extends Function<A, B>> ff,
-      @NonNull Kind<TryKind.Witness, A> fa) {
+  public <A, B> Kind<TryKind.Witness, B> ap(
+      Kind<TryKind.Witness, ? extends Function<A, B>> ff, Kind<TryKind.Witness, A> fa) {
     Try<? extends Function<A, B>> tryF = TRY.narrow(ff);
     Try<A> tryA = TRY.narrow(fa);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.trymonad;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +25,7 @@ public interface TryConverterOps {
    *     {@code Try} computation.
    * @throws NullPointerException if {@code tryInstance} is {@code null}.
    */
-  <A> @NonNull Kind<TryKind.Witness, A> widen(@NonNull Try<A> tryInstance);
+  <A> Kind<TryKind.Witness, A> widen(Try<A> tryInstance);
 
   /**
    * Narrows a {@link Kind}&lt;{@link TryKind.Witness}, A&gt; back to its concrete {@link
@@ -39,5 +38,5 @@ public interface TryConverterOps {
    *     cannot be properly converted to a {@link Try} instance (e.g., wrong type or invalid
    *     internal state).
    */
-  <A> @NonNull Try<A> narrow(@Nullable Kind<TryKind.Witness, A> kind);
+  <A> Try<A> narrow(@Nullable Kind<TryKind.Witness, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryFunctor.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.trymonad.TryKindHelper.TRY;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Functor} interface for {@link Try}, using {@link TryKind.Witness}.
@@ -27,8 +26,8 @@ public class TryFunctor implements Functor<TryKind.Witness> {
    * @return A new {@code Kind<TryKind.Witness, B>} representing the result of the map operation.
    */
   @Override
-  public <A, B> @NonNull Kind<TryKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<TryKind.Witness, A> fa) {
+  public <A, B> Kind<TryKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<TryKind.Witness, A> fa) {
     Try<A> tryA = TRY.narrow(fa);
     Try<B> resultTry = tryA.map(f);
     return TRY.widen(resultTry);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryKindHelper.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -54,7 +53,7 @@ public enum TryKindHelper implements TryConverterOps {
    * @throws NullPointerException if {@code tryInstance} is {@code null}.
    */
   @Override
-  public <A> @NonNull Kind<TryKind.Witness, A> widen(@NonNull Try<A> tryInstance) {
+  public <A> Kind<TryKind.Witness, A> widen(Try<A> tryInstance) {
     Objects.requireNonNull(tryInstance, "Input Try cannot be null for widen");
     return new TryHolder<>(tryInstance);
   }
@@ -73,7 +72,7 @@ public enum TryKindHelper implements TryConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <A> @NonNull Try<A> narrow(@Nullable Kind<TryKind.Witness, A> kind) {
+  public <A> Try<A> narrow(@Nullable Kind<TryKind.Witness, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
       case TryKindHelper.TryHolder<?> holder -> {
@@ -95,7 +94,7 @@ public enum TryKindHelper implements TryConverterOps {
    * @param value The successful value.
    * @return A non-null {@code Kind<TryKind.Witness, A>} representing the successful computation.
    */
-  public <A> @NonNull Kind<TryKind.Witness, A> success(@Nullable A value) {
+  public <A> Kind<TryKind.Witness, A> success(@Nullable A value) {
     return this.widen(Try.success(value));
   }
 
@@ -107,7 +106,7 @@ public enum TryKindHelper implements TryConverterOps {
    * @param throwable The non-null {@link Throwable} representing the failure.
    * @return A non-null {@code Kind<TryKind.Witness, A>} representing the failed computation.
    */
-  public <A> @NonNull Kind<TryKind.Witness, A> failure(@NonNull Throwable throwable) {
+  public <A> Kind<TryKind.Witness, A> failure(Throwable throwable) {
     return this.widen(Try.failure(throwable));
   }
 
@@ -119,7 +118,7 @@ public enum TryKindHelper implements TryConverterOps {
    * @param supplier The non-null {@link Supplier} to execute.
    * @return A non-null {@code Kind<TryKind.Witness, A>} representing the outcome.
    */
-  public <A> @NonNull Kind<TryKind.Witness, A> tryOf(@NonNull Supplier<? extends A> supplier) {
+  public <A> Kind<TryKind.Witness, A> tryOf(Supplier<? extends A> supplier) {
     return this.widen(Try.of(supplier));
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryMonad.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.trymonad.TryKindHelper.*;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link MonadError} interface for the {@link Try} data type.
@@ -61,9 +60,8 @@ public class TryMonad extends TryApplicative implements MonadError<TryKind.Witne
    * @return A new {@code Kind<TryKind.Witness, B>} representing the composed operation. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<TryKind.Witness, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<TryKind.Witness, B>> f,
-      @NonNull Kind<TryKind.Witness, A> ma) {
+  public <A, B> Kind<TryKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<TryKind.Witness, B>> f, Kind<TryKind.Witness, A> ma) {
     Try<A> tryA = TRY.narrow(ma);
 
     Try<B> resultTry =
@@ -88,7 +86,7 @@ public class TryMonad extends TryApplicative implements MonadError<TryKind.Witne
    * @return A {@code Kind<TryKind.Witness, A>} representing {@code Try.failure(error)}.
    */
   @Override
-  public <A> @NonNull Kind<TryKind.Witness, A> raiseError(@NonNull Throwable error) {
+  public <A> Kind<TryKind.Witness, A> raiseError(Throwable error) {
     return TRY.widen(Try.failure(error));
   }
 
@@ -105,9 +103,9 @@ public class TryMonad extends TryApplicative implements MonadError<TryKind.Witne
    *     result of the error handler.
    */
   @Override
-  public <A> @NonNull Kind<TryKind.Witness, A> handleErrorWith(
-      @NonNull Kind<TryKind.Witness, A> ma,
-      @NonNull Function<? super Throwable, ? extends Kind<TryKind.Witness, A>> handler) {
+  public <A> Kind<TryKind.Witness, A> handleErrorWith(
+      Kind<TryKind.Witness, A> ma,
+      Function<? super Throwable, ? extends Kind<TryKind.Witness, A>> handler) {
     Try<A> tryA = TRY.narrow(ma);
 
     Try<A> resultTry =

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryTraverse.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.Traverse;
-import org.jspecify.annotations.NonNull;
 
 /**
  * The Traverse and Foldable instance for {@link Try}.
@@ -21,17 +20,17 @@ public enum TryTraverse implements Traverse<TryKind.Witness> {
   INSTANCE;
 
   @Override
-  public <A, B> @NonNull Kind<TryKind.Witness, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<TryKind.Witness, A> fa) {
+  public <A, B> Kind<TryKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<TryKind.Witness, A> fa) {
     // Delegate to Try's own map method and widen the result.
     return TRY.widen(TRY.narrow(fa).map(f));
   }
 
   @Override
-  public <G, A, B> @NonNull Kind<G, Kind<TryKind.Witness, B>> traverse(
-      @NonNull Applicative<G> applicative,
-      @NonNull Function<? super A, ? extends Kind<G, ? extends B>> f,
-      @NonNull Kind<TryKind.Witness, A> ta) {
+  public <G, A, B> Kind<G, Kind<TryKind.Witness, B>> traverse(
+      Applicative<G> applicative,
+      Function<? super A, ? extends Kind<G, ? extends B>> f,
+      Kind<TryKind.Witness, A> ta) {
 
     return TRY.narrow(ta)
         .fold(
@@ -44,9 +43,7 @@ public enum TryTraverse implements Traverse<TryKind.Witness> {
 
   @Override
   public <A, M> M foldMap(
-      @NonNull Monoid<M> monoid,
-      @NonNull Function<? super A, ? extends M> f,
-      @NonNull Kind<TryKind.Witness, A> fa) {
+      Monoid<M> monoid, Function<? super A, ? extends M> f, Kind<TryKind.Witness, A> fa) {
 
     // If the Try is a Success, apply the function `f` to the value.
     // If it's a Failure, return the identity element of the Monoid.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/unit/Unit.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/unit/Unit.java
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.unit;
 
-import org.jspecify.annotations.NonNull;
-
 /**
  * Represents a type with a single value, {@link Unit#INSTANCE}. It is used to signify the absence
  * of a specific, meaningful value or the completion of an operation that produces no specific
@@ -19,7 +17,7 @@ public enum Unit {
    * @return "()"
    */
   @Override
-  public @NonNull String toString() {
+  public String toString() {
     return "()";
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Invalid.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Invalid.java
@@ -8,7 +8,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.Semigroup;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents the erroneous (Invalid) case of a {@link Validated}. It holds a non-null error value
@@ -22,7 +21,7 @@ import org.jspecify.annotations.NonNull;
  *     {@link Validated} contract).
  * @param error The non-null error value held by this {@code Invalid} instance.
  */
-public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, ValidatedKind<E, A> {
+public record Invalid<E, A>(E error) implements Validated<E, A>, ValidatedKind<E, A> {
 
   // --- Message Constants ---
   static final String CANNOT_GET_FROM_INVALID_INSTANCE_PREFIX_MSG =
@@ -96,7 +95,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    * @return The non-null encapsulated error.
    */
   @Override
-  public @NonNull E getError() {
+  public E getError() {
     return error;
   }
 
@@ -108,7 +107,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    * @throws NullPointerException if {@code other} is null.
    */
   @Override
-  public @NonNull A orElse(@NonNull A other) {
+  public A orElse(A other) {
     Objects.requireNonNull(other, OR_ELSE_OTHER_CANNOT_BE_NULL_MSG);
     return other;
   }
@@ -123,7 +122,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    *     returns null.
    */
   @Override
-  public @NonNull A orElseGet(@NonNull Supplier<? extends @NonNull A> otherSupplier) {
+  public A orElseGet(Supplier<? extends A> otherSupplier) {
     Objects.requireNonNull(otherSupplier, OR_ELSE_GET_SUPPLIER_CANNOT_BE_NULL_MSG);
     A suppliedValue = otherSupplier.get();
     Objects.requireNonNull(suppliedValue, OR_ELSE_GET_SUPPLIER_RETURNED_NULL_MSG);
@@ -144,8 +143,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    *     exceptionSupplier.get()} returns a null throwable.
    */
   @Override
-  public <X extends Throwable> A orElseThrow(@NonNull Supplier<? extends X> exceptionSupplier)
-      throws X {
+  public <X extends Throwable> A orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
     Objects.requireNonNull(exceptionSupplier, OR_ELSE_THROW_SUPPLIER_CANNOT_BE_NULL_MSG);
     X throwable = exceptionSupplier.get();
     Objects.requireNonNull(throwable, OR_ELSE_THROW_SUPPLIER_PRODUCED_NULL_MSG);
@@ -161,7 +159,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    * @throws NullPointerException if {@code consumer} is null.
    */
   @Override
-  public void ifValid(@NonNull Consumer<? super A> consumer) {
+  public void ifValid(Consumer<? super A> consumer) {
     Objects.requireNonNull(consumer, IF_VALID_CONSUMER_CANNOT_BE_NULL_MSG);
   }
 
@@ -172,7 +170,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    * @throws NullPointerException if {@code consumer} is null.
    */
   @Override
-  public void ifInvalid(@NonNull Consumer<? super E> consumer) {
+  public void ifInvalid(Consumer<? super E> consumer) {
     Objects.requireNonNull(consumer, IF_INVALID_CONSUMER_CANNOT_BE_NULL_MSG).accept(error);
   }
 
@@ -187,7 +185,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    */
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull <B> Validated<E, B> map(@NonNull Function<? super A, ? extends B> fn) {
+  public <B> Validated<E, B> map(Function<? super A, ? extends B> fn) {
     Objects.requireNonNull(fn, MAP_FN_CANNOT_BE_NULL_MSG);
     return (Validated<E, B>) this;
   }
@@ -203,8 +201,7 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    */
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull <B> Validated<E, B> flatMap(
-      @NonNull Function<? super A, ? extends @NonNull Validated<E, ? extends B>> fn) {
+  public <B> Validated<E, B> flatMap(Function<? super A, ? extends Validated<E, ? extends B>> fn) {
     Objects.requireNonNull(fn, FLATMAP_FN_CANNOT_BE_NULL_MSG);
     return (Validated<E, B>) this;
   }
@@ -222,9 +219,8 @@ public record Invalid<E, A>(@NonNull E error) implements Validated<E, A>, Valida
    */
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull <B> Validated<E, B> ap(
-      @NonNull Validated<E, Function<? super A, ? extends B>> fnValidated,
-      @NonNull Semigroup<E> semigroup) {
+  public <B> Validated<E, B> ap(
+      Validated<E, Function<? super A, ? extends B>> fnValidated, Semigroup<E> semigroup) {
     Objects.requireNonNull(fnValidated, AP_FN_VALIDATED_CANNOT_BE_NULL_MSG);
     Objects.requireNonNull(semigroup, SEMIGROUP_FOR_FOR_AP_CANNOT_BE_NULL_MSG);
     if (fnValidated.isInvalid()) {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Valid.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Valid.java
@@ -8,7 +8,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.Semigroup;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents the correct (Valid) case of a {@link Validated}. It holds a non-null value of type
@@ -22,7 +21,7 @@ import org.jspecify.annotations.NonNull;
  * @param <A> The type of the encapsulated value.
  * @param value The non-null value held by this {@code Valid} instance.
  */
-public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, ValidatedKind<E, A> {
+public record Valid<E, A>(A value) implements Validated<E, A>, ValidatedKind<E, A> {
 
   static String CANNOT_GET_ERROR_FROM_VALID_INSTANCE_MSG =
       "Cannot getError() from a Valid instance.";
@@ -79,7 +78,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @return The non-null encapsulated value.
    */
   @Override
-  public @NonNull A get() {
+  public A get() {
     return value;
   }
 
@@ -103,7 +102,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @return The non-null encapsulated value.
    */
   @Override
-  public @NonNull A orElse(@NonNull A other) {
+  public A orElse(A other) {
     Objects.requireNonNull(other, OR_ELSE_CANNOT_BE_NULL_MSG);
     return value;
   }
@@ -118,7 +117,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @throws NullPointerException if {@code otherSupplier} is null (due to eager null check).
    */
   @Override
-  public @NonNull A orElseGet(@NonNull Supplier<? extends @NonNull A> otherSupplier) {
+  public A orElseGet(Supplier<? extends A> otherSupplier) {
     Objects.requireNonNull(otherSupplier, OR_ELSE_GET_CANNOT_BE_NULL_MSG);
     return value;
   }
@@ -135,8 +134,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @throws NullPointerException if {@code exceptionSupplier} is null (due to eager null check).
    */
   @Override
-  public <X extends Throwable> @NonNull A orElseThrow(
-      @NonNull Supplier<? extends X> exceptionSupplier) throws X {
+  public <X extends Throwable> A orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
     Objects.requireNonNull(exceptionSupplier, OR_ELSE_THROW_CANNOT_BE_NULL_MSG);
     return value;
   }
@@ -148,7 +146,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @throws NullPointerException if {@code consumer} is null.
    */
   @Override
-  public void ifValid(@NonNull Consumer<? super A> consumer) {
+  public void ifValid(Consumer<? super A> consumer) {
     Objects.requireNonNull(consumer, IF_VALID_CANNOT_BE_NULL_MSG).accept(value);
   }
 
@@ -161,7 +159,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @throws NullPointerException if {@code consumer} is null.
    */
   @Override
-  public void ifInvalid(@NonNull Consumer<? super E> consumer) {
+  public void ifInvalid(Consumer<? super E> consumer) {
     Objects.requireNonNull(consumer, IF_INVALID_CANNOT_BE_NULL_MSG);
   }
 
@@ -177,7 +175,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    *     results in a null value.
    */
   @Override
-  public @NonNull <B> Validated<E, B> map(@NonNull Function<? super A, ? extends B> fn) {
+  public <B> Validated<E, B> map(Function<? super A, ? extends B> fn) {
     Objects.requireNonNull(fn, MAP_FN_CANNOT_BE_NULL_MSG);
     B newValue = fn.apply(value);
     Objects.requireNonNull(newValue, MAP_FN_RETURNED_NULL_MSG);
@@ -198,8 +196,7 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    *     Validated} instance.
    */
   @Override
-  public @NonNull <B> Validated<E, B> flatMap(
-      @NonNull Function<? super A, ? extends @NonNull Validated<E, ? extends B>> fn) {
+  public <B> Validated<E, B> flatMap(Function<? super A, ? extends Validated<E, ? extends B>> fn) {
     Objects.requireNonNull(fn, FLATMAP_FN_CANNOT_BE_NULL_MSG);
     Validated<E, ? extends B> result = fn.apply(value);
     Objects.requireNonNull(result, FLATMAP_FN_RETURNED_NULL_MSG);
@@ -228,9 +225,8 @@ public record Valid<E, A>(@NonNull A value) implements Validated<E, A>, Validate
    * @return a new {@code Validated<E, B>} instance.
    */
   @Override
-  public @NonNull <B> Validated<E, B> ap(
-      @NonNull Validated<E, Function<? super A, ? extends B>> fnValidated,
-      @NonNull Semigroup<E> semigroup) {
+  public <B> Validated<E, B> ap(
+      Validated<E, Function<? super A, ? extends B>> fnValidated, Semigroup<E> semigroup) {
     Objects.requireNonNull(fnValidated, AP_FN_CANNOT_BE_NULL);
     Objects.requireNonNull(semigroup, SEMIGROUP_FOR_FOR_AP_CANNOT_BE_NULL_MSG);
     return fnValidated.fold(

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Validated.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Validated.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.Semigroup;
 import org.higherkindedj.hkt.either.Either;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Represents a value that is either Valid (correct) or Invalid (erroneous). This is a sealed
@@ -67,7 +66,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @param other The value to return if this is {@code Invalid}.
    * @return The value if {@code Valid}, or {@code other}.
    */
-  A orElse(@NonNull A other);
+  A orElse(A other);
 
   /**
    * Returns the value if {@code Valid}, otherwise returns the result of {@code
@@ -77,7 +76,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    *     null and must produce a non-null value.
    * @return The value if {@code Valid}, or the result of the supplier.
    */
-  A orElseGet(@NonNull Supplier<? extends @NonNull A> otherSupplier);
+  A orElseGet(Supplier<? extends A> otherSupplier);
 
   /**
    * Returns the value if {@code Valid}, otherwise throws the exception supplied by {@code
@@ -88,21 +87,21 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @return The value if {@code Valid}.
    * @throws X if this is {@code Invalid}.
    */
-  <X extends Throwable> A orElseThrow(@NonNull Supplier<? extends X> exceptionSupplier) throws X;
+  <X extends Throwable> A orElseThrow(Supplier<? extends X> exceptionSupplier) throws X;
 
   /**
    * Performs the given action with the value if it is {@code Valid}.
    *
    * @param consumer The action to perform. Must not be null.
    */
-  void ifValid(@NonNull Consumer<? super A> consumer);
+  void ifValid(Consumer<? super A> consumer);
 
   /**
    * Performs the given action with the error if it is {@code Invalid}.
    *
    * @param consumer The action to perform. Must not be null.
    */
-  void ifInvalid(@NonNull Consumer<? super E> consumer);
+  void ifInvalid(Consumer<? super E> consumer);
 
   /**
    * Maps the value {@code A} to {@code B} if this is {@code Valid}, otherwise returns the {@code
@@ -112,7 +111,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @param <B> The new value type.
    * @return A {@code Validated<E, B>} instance.
    */
-  @NonNull <B> Validated<E, B> map(@NonNull Function<? super A, ? extends B> fn);
+  <B> Validated<E, B> map(Function<? super A, ? extends B> fn);
 
   /**
    * Applies the function {@code fn} if this is {@code Valid}, otherwise returns the {@code Invalid}
@@ -123,8 +122,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @param <B> The new value type of the resulting {@code Validated}.
    * @return A {@code Validated<E, B>} instance.
    */
-  @NonNull <B> Validated<E, B> flatMap(
-      @NonNull Function<? super A, ? extends @NonNull Validated<E, ? extends B>> fn);
+  <B> Validated<E, B> flatMap(Function<? super A, ? extends Validated<E, ? extends B>> fn);
 
   /**
    * Applies a function contained within a {@code Validated} to this {@code Validated}'s value.
@@ -143,9 +141,8 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @param <B> The new value type.
    * @return A {@code Validated<E, B>} instance.
    */
-  @NonNull <B> Validated<E, B> ap(
-      @NonNull Validated<E, Function<? super A, ? extends B>> fnValidated,
-      @NonNull Semigroup<E> semigroup);
+  <B> Validated<E, B> ap(
+      Validated<E, Function<? super A, ? extends B>> fnValidated, Semigroup<E> semigroup);
 
   /**
    * Applies one of two functions depending on whether this instance is {@link Invalid} or {@link
@@ -157,8 +154,8 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @return The result of applying the appropriate mapping function.
    */
   default <T> T fold(
-      @NonNull Function<? super E, ? extends T> invalidMapper,
-      @NonNull Function<? super A, ? extends T> validMapper) {
+      Function<? super E, ? extends T> invalidMapper,
+      Function<? super A, ? extends T> validMapper) {
     Objects.requireNonNull(invalidMapper, FOLD_INVALID_MAPPER_CANNOT_BE_NULL_MSG);
     Objects.requireNonNull(validMapper, FOLD_VALID_MAPPER_CANNOT_BE_NULL_MSG);
     if (isInvalid()) {
@@ -176,7 +173,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    *
    * @return An {@code Either<E, A>} representing the state of this {@code Validated}.
    */
-  default @NonNull Either<E, A> toEither() {
+  default Either<E, A> toEither() {
     return fold(Either::left, Either::right);
   }
 
@@ -189,7 +186,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @return A {@code Valid<E, A>} instance.
    * @throws NullPointerException if value is null.
    */
-  static <E, A> @NonNull Validated<E, A> valid(@NonNull A value) {
+  static <E, A> Validated<E, A> valid(A value) {
     Objects.requireNonNull(value, VALID_VALUE_CANNOT_BE_NULL_MSG);
     return new Valid<>(value);
   }
@@ -203,7 +200,7 @@ public sealed interface Validated<E, A> permits Valid, Invalid {
    * @return An {@code Invalid<E, A>} instance.
    * @throws NullPointerException if error is null.
    */
-  static <E, A> @NonNull Validated<E, A> invalid(@NonNull E error) {
+  static <E, A> Validated<E, A> invalid(E error) {
     Objects.requireNonNull(error, INVALID_ERROR_CANNOT_BE_NULL_MSG);
     return new Invalid<>(error);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedConverterOps.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.validated;
 
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Defines conversion operations (widen and narrow) specific to Validated types and their Kind
@@ -22,7 +21,7 @@ public interface ValidatedConverterOps {
    * @param <A> The value type.
    * @return The {@link Kind} representation.
    */
-  <E, A> @NonNull Kind<ValidatedKind.Witness<E>, A> widen(@NonNull Validated<E, A> validated);
+  <E, A> Kind<ValidatedKind.Witness<E>, A> widen(Validated<E, A> validated);
 
   /**
    * Narrows a {@link Kind} representation to a {@link Validated}.
@@ -34,5 +33,5 @@ public interface ValidatedConverterOps {
    * @return The {@link Validated} instance.
    * @throws ClassCastException if the kind is not a Validated instance of the expected types.
    */
-  <E, A> @NonNull Validated<E, A> narrow(@NonNull Kind<ValidatedKind.Witness<E>, A> kind);
+  <E, A> Validated<E, A> narrow(Kind<ValidatedKind.Witness<E>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedKindHelper.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.validated;
 
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Enum implementing {@link ValidatedConverterOps} for widen/narrow operations, and providing
@@ -25,8 +24,7 @@ public enum ValidatedKindHelper implements ValidatedConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <E, A> @NonNull Kind<ValidatedKind.Witness<E>, A> widen(
-      @NonNull Validated<E, A> validated) {
+  public <E, A> Kind<ValidatedKind.Witness<E>, A> widen(Validated<E, A> validated) {
     return (Kind<ValidatedKind.Witness<E>, A>) validated;
   }
 
@@ -38,7 +36,7 @@ public enum ValidatedKindHelper implements ValidatedConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <E, A> @NonNull Validated<E, A> narrow(@NonNull Kind<ValidatedKind.Witness<E>, A> kind) {
+  public <E, A> Validated<E, A> narrow(Kind<ValidatedKind.Witness<E>, A> kind) {
     return (Validated<E, A>) kind;
   }
 
@@ -51,7 +49,7 @@ public enum ValidatedKindHelper implements ValidatedConverterOps {
    * @param <A> The value type.
    * @return A {@code Kind} representing a valid instance.
    */
-  public <E, A> @NonNull Kind<ValidatedKind.Witness<E>, A> valid(@NonNull A value) {
+  public <E, A> Kind<ValidatedKind.Witness<E>, A> valid(A value) {
     return this.widen(Validated.valid(value));
   }
 
@@ -64,7 +62,7 @@ public enum ValidatedKindHelper implements ValidatedConverterOps {
    * @param <A> The value type (associated with the Witness).
    * @return A {@code Kind} representing an invalid instance.
    */
-  public <E, A> @NonNull Kind<ValidatedKind.Witness<E>, A> invalid(@NonNull E error) {
+  public <E, A> Kind<ValidatedKind.Witness<E>, A> invalid(E error) {
     return this.widen(Validated.invalid(error));
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedMonad.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.Semigroup;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Monad instance for {@link Validated}. The error type {@code E} is fixed for this Monad instance.
@@ -66,14 +65,13 @@ public final class ValidatedMonad<E> implements MonadError<ValidatedKind.Witness
    * @param <E> The error type.
    * @return A new instance of {@code ValidatedMonad}.
    */
-  public static <E> @NonNull ValidatedMonad<E> instance(@NonNull Semigroup<E> semigroup) {
+  public static <E> ValidatedMonad<E> instance(Semigroup<E> semigroup) {
     return new ValidatedMonad<>(semigroup);
   }
 
   @Override
-  public <A, B> @NonNull Kind<ValidatedKind.Witness<E>, B> map(
-      @NonNull Function<? super A, ? extends B> fn,
-      @NonNull Kind<ValidatedKind.Witness<E>, A> valueKind) {
+  public <A, B> Kind<ValidatedKind.Witness<E>, B> map(
+      Function<? super A, ? extends B> fn, Kind<ValidatedKind.Witness<E>, A> valueKind) {
     requireNonNull(fn, MAP_FN_NULL_MSG);
     requireNonNull(valueKind, MAP_VALUE_KIND_NULL_MSG);
 
@@ -93,16 +91,16 @@ public final class ValidatedMonad<E> implements MonadError<ValidatedKind.Witness
    * @throws NullPointerException if value is null.
    */
   @Override
-  public <A> @NonNull Kind<ValidatedKind.Witness<E>, A> of(@NonNull A value) {
+  public <A> Kind<ValidatedKind.Witness<E>, A> of(A value) {
     requireNonNull(value, OF_VALUE_NULL_MSG);
     Validated<E, A> validInstance = Validated.valid(value);
     return VALIDATED.widen(validInstance);
   }
 
   @Override
-  public <A, B> @NonNull Kind<ValidatedKind.Witness<E>, B> ap(
-      @NonNull Kind<ValidatedKind.Witness<E>, ? extends Function<A, B>> fnKind,
-      @NonNull Kind<ValidatedKind.Witness<E>, A> valueKind) {
+  public <A, B> Kind<ValidatedKind.Witness<E>, B> ap(
+      Kind<ValidatedKind.Witness<E>, ? extends Function<A, B>> fnKind,
+      Kind<ValidatedKind.Witness<E>, A> valueKind) {
 
     requireNonNull(fnKind, AP_FN_KIND_NULL_MSG);
     requireNonNull(valueKind, AP_VALUE_KIND_NULL_MSG);
@@ -130,9 +128,9 @@ public final class ValidatedMonad<E> implements MonadError<ValidatedKind.Witness
    *     returns a null {@code Kind}.
    */
   @Override
-  public <A, B> @NonNull Kind<ValidatedKind.Witness<E>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<ValidatedKind.Witness<E>, B>> fn,
-      @NonNull Kind<ValidatedKind.Witness<E>, A> valueKind) {
+  public <A, B> Kind<ValidatedKind.Witness<E>, B> flatMap(
+      Function<? super A, ? extends Kind<ValidatedKind.Witness<E>, B>> fn,
+      Kind<ValidatedKind.Witness<E>, A> valueKind) {
     requireNonNull(fn, FLATMAP_FN_NULL_MSG);
     requireNonNull(valueKind, FLATMAP_VALUE_KIND_NULL_MSG);
 
@@ -159,7 +157,7 @@ public final class ValidatedMonad<E> implements MonadError<ValidatedKind.Witness
    * @throws NullPointerException if error is null.
    */
   @Override
-  public <A> @NonNull Kind<ValidatedKind.Witness<E>, A> raiseError(@NonNull E error) {
+  public <A> Kind<ValidatedKind.Witness<E>, A> raiseError(E error) {
     requireNonNull(error, RAISE_ERROR_ERROR_NULL_MSG);
     return VALIDATED.invalid(error);
   }
@@ -180,9 +178,9 @@ public final class ValidatedMonad<E> implements MonadError<ValidatedKind.Witness
    * @throws NullPointerException if ma, handler, or the result of the handler is null.
    */
   @Override
-  public <A> @NonNull Kind<ValidatedKind.Witness<E>, A> handleErrorWith(
-      @NonNull Kind<ValidatedKind.Witness<E>, A> ma,
-      @NonNull Function<? super E, ? extends Kind<ValidatedKind.Witness<E>, A>> handler) {
+  public <A> Kind<ValidatedKind.Witness<E>, A> handleErrorWith(
+      Kind<ValidatedKind.Witness<E>, A> ma,
+      Function<? super E, ? extends Kind<ValidatedKind.Witness<E>, A>> handler) {
     requireNonNull(ma, HANDLE_ERROR_WITH_MA_NULL_MSG);
     requireNonNull(handler, HANDLE_ERROR_WITH_HANDLER_NULL_MSG);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedTraverse.java
@@ -10,7 +10,6 @@ import org.higherkindedj.hkt.Foldable;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.Traverse;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Traverse} and {@link Foldable} typeclasses for {@link Validated}.
@@ -32,16 +31,16 @@ public final class ValidatedTraverse<E> implements Traverse<ValidatedKind.Witnes
   }
 
   @Override
-  public <A, B> @NonNull Kind<ValidatedKind.Witness<E>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<ValidatedKind.Witness<E>, A> fa) {
+  public <A, B> Kind<ValidatedKind.Witness<E>, B> map(
+      Function<? super A, ? extends B> f, Kind<ValidatedKind.Witness<E>, A> fa) {
     return VALIDATED.widen(VALIDATED.narrow(fa).map(f));
   }
 
   @Override
-  public <G, A, B> @NonNull Kind<G, Kind<ValidatedKind.Witness<E>, B>> traverse(
-      @NonNull Applicative<G> applicative,
-      @NonNull Function<? super A, ? extends Kind<G, ? extends B>> f,
-      @NonNull Kind<ValidatedKind.Witness<E>, A> ta) {
+  public <G, A, B> Kind<G, Kind<ValidatedKind.Witness<E>, B>> traverse(
+      Applicative<G> applicative,
+      Function<? super A, ? extends Kind<G, ? extends B>> f,
+      Kind<ValidatedKind.Witness<E>, A> ta) {
 
     return VALIDATED
         .narrow(ta)
@@ -55,9 +54,7 @@ public final class ValidatedTraverse<E> implements Traverse<ValidatedKind.Witnes
 
   @Override
   public <A, M> M foldMap(
-      @NonNull Monoid<M> monoid,
-      @NonNull Function<? super A, ? extends M> f,
-      @NonNull Kind<ValidatedKind.Witness<E>, A> fa) {
+      Monoid<M> monoid, Function<? super A, ? extends M> f, Kind<ValidatedKind.Witness<E>, A> fa) {
 
     // If Valid, map the value. If Invalid, return the monoid's empty value.
     return VALIDATED.narrow(fa).fold(error -> monoid.empty(), f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/Writer.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/Writer.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -48,7 +47,7 @@ import org.jspecify.annotations.Nullable;
  * @see WriterMonad
  * @see WriterKindHelper
  */
-public record Writer<W, A>(@NonNull W log, @Nullable A value) {
+public record Writer<W, A>(W log, @Nullable A value) {
 
   /**
    * Compact constructor for {@link Writer}. Ensures that the log component {@code W} is never
@@ -75,7 +74,7 @@ public record Writer<W, A>(@NonNull W log, @Nullable A value) {
    * @return A new {@code Writer<W, A>} with the given value and an empty log.
    * @throws NullPointerException if {@code monoidW} is {@code null}.
    */
-  public static <W, A> @NonNull Writer<W, A> value(@NonNull Monoid<W> monoidW, @Nullable A value) {
+  public static <W, A> Writer<W, A> value(Monoid<W> monoidW, @Nullable A value) {
     Objects.requireNonNull(monoidW, "Monoid<W> cannot be null for Writer.value");
     return new Writer<>(monoidW.empty(), value);
   }
@@ -91,7 +90,7 @@ public record Writer<W, A>(@NonNull W log, @Nullable A value) {
    *     value.
    * @throws NullPointerException if {@code log} is {@code null}.
    */
-  public static <W> @NonNull Writer<W, Unit> tell(@NonNull W log) {
+  public static <W> Writer<W, Unit> tell(W log) {
     Objects.requireNonNull(log, "Log message for Writer.tell cannot be null");
     return new Writer<>(log, Unit.INSTANCE);
   }
@@ -107,7 +106,7 @@ public record Writer<W, A>(@NonNull W log, @Nullable A value) {
    * @return A new {@code Writer<W, B>} with the original log and the transformed value.
    * @throws NullPointerException if {@code f} is {@code null}.
    */
-  public <B> @NonNull Writer<W, B> map(@NonNull Function<? super A, ? extends B> f) {
+  public <B> Writer<W, B> map(Function<? super A, ? extends B> f) {
     Objects.requireNonNull(f, "Mapper function cannot be null for Writer.map");
     return new Writer<>(this.log, f.apply(this.value));
   }
@@ -133,9 +132,8 @@ public record Writer<W, A>(@NonNull W log, @Nullable A value) {
    * @throws NullPointerException if {@code monoidW} or {@code f} is {@code null}, or if {@code f}
    *     returns a {@code null} {@code Writer}.
    */
-  public <B> @NonNull Writer<W, B> flatMap(
-      @NonNull Monoid<W> monoidW,
-      @NonNull Function<? super A, ? extends Writer<W, ? extends B>> f) {
+  public <B> Writer<W, B> flatMap(
+      Monoid<W> monoidW, Function<? super A, ? extends Writer<W, ? extends B>> f) {
     Objects.requireNonNull(monoidW, "Monoid<W> cannot be null for Writer.flatMap");
     Objects.requireNonNull(f, "flatMap mapper function cannot be null");
 
@@ -164,7 +162,7 @@ public record Writer<W, A>(@NonNull W log, @Nullable A value) {
    *
    * @return The non-null accumulated log {@code W}.
    */
-  public @NonNull W exec() {
+  public W exec() {
     return log;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterApplicative.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -32,7 +31,7 @@ import org.jspecify.annotations.Nullable;
 public class WriterApplicative<W> extends WriterFunctor<W>
     implements Applicative<WriterKind.Witness<W>> {
 
-  protected final @NonNull Monoid<W> monoidW;
+  protected final Monoid<W> monoidW;
 
   /**
    * Constructs a {@code WriterApplicative}.
@@ -40,7 +39,7 @@ public class WriterApplicative<W> extends WriterFunctor<W>
    * @param monoidW The {@link Monoid} instance for the log type {@code W}. Must not be null. This
    *     is used for combining logs in operations like {@code ap}.
    */
-  public WriterApplicative(@NonNull Monoid<W> monoidW) {
+  public WriterApplicative(Monoid<W> monoidW) {
     this.monoidW = requireNonNull(monoidW, "Monoid<W> cannot be null for WriterApplicative");
   }
 
@@ -55,7 +54,7 @@ public class WriterApplicative<W> extends WriterFunctor<W>
    *     empty log and the given {@code value}. Never null.
    */
   @Override
-  public <A> @NonNull Kind<WriterKind.Witness<W>, A> of(@Nullable A value) {
+  public <A> Kind<WriterKind.Witness<W>, A> of(@Nullable A value) {
     return WRITER.value(monoidW, value);
   }
 
@@ -78,10 +77,9 @@ public class WriterApplicative<W> extends WriterFunctor<W>
    *     generally not expected for a valid {@code ap} operation.
    */
   @Override
-  public <A, B> @NonNull Kind<WriterKind.Witness<W>, B> ap(
+  public <A, B> Kind<WriterKind.Witness<W>, B> ap(
       // 1. Update the signature to match the Applicative interface
-      @NonNull Kind<WriterKind.Witness<W>, ? extends Function<A, B>> ff,
-      @NonNull Kind<WriterKind.Witness<W>, A> fa) {
+      Kind<WriterKind.Witness<W>, ? extends Function<A, B>> ff, Kind<WriterKind.Witness<W>, A> fa) {
 
     Writer<W, ? extends Function<A, B>> writerF = WRITER.narrow(ff);
     Writer<W, A> writerA = WRITER.narrow(fa);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterConverterOps.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.writer;
 
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +27,7 @@ public interface WriterConverterOps {
    *     Writer}.
    * @throws NullPointerException if {@code writer} is {@code null}.
    */
-  <W, A> @NonNull Kind<WriterKind.Witness<W>, A> widen(@NonNull Writer<W, A> writer);
+  <W, A> Kind<WriterKind.Witness<W>, A> widen(Writer<W, A> writer);
 
   /**
    * Narrows a {@code Kind<WriterKind.Witness<W>, A>} back to its concrete {@link Writer
@@ -42,5 +41,5 @@ public interface WriterConverterOps {
    * @throws KindUnwrapException if the input {@code kind} is null or not an instance of the
    *     expected underlying holder type for Writer.
    */
-  <W, A> @NonNull Writer<W, A> narrow(@Nullable Kind<WriterKind.Witness<W>, A> kind);
+  <W, A> Writer<W, A> narrow(@Nullable Kind<WriterKind.Witness<W>, A> kind);
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterFunctor.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.writer.WriterKindHelper.WRITER;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Functor} interface for the {@link Writer} type. This allows mapping a
@@ -38,8 +37,8 @@ public class WriterFunctor<W> implements Functor<WriterKind.Witness<W>> {
    *     Writer<W, B>}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<WriterKind.Witness<W>, B> map(
-      @NonNull Function<? super A, ? extends B> f, @NonNull Kind<WriterKind.Witness<W>, A> fa) {
+  public <A, B> Kind<WriterKind.Witness<W>, B> map(
+      Function<? super A, ? extends B> f, Kind<WriterKind.Witness<W>, A> fa) {
     Writer<W, A> writerA = WRITER.narrow(fa);
     Writer<W, B> writerB = writerA.map(f);
     return WRITER.widen(writerB);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterKindHelper.java
@@ -7,7 +7,6 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoid;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
 import org.higherkindedj.hkt.unit.Unit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -45,7 +44,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    * @param <A> The value type.
    * @param writer The non-null {@link Writer Writer&lt;W, A&gt;} instance.
    */
-  record WriterHolder<W, A>(@NonNull Writer<W, A> writer) implements WriterKind<W, A> {}
+  record WriterHolder<W, A>(Writer<W, A> writer) implements WriterKind<W, A> {}
 
   /**
    * Widens a concrete {@link Writer Writer&lt;W, A&gt;} instance into its higher-kinded
@@ -61,7 +60,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    * @throws NullPointerException if {@code writer} is null.
    */
   @Override
-  public <W, A> @NonNull Kind<WriterKind.Witness<W>, A> widen(@NonNull Writer<W, A> writer) {
+  public <W, A> Kind<WriterKind.Witness<W>, A> widen(Writer<W, A> writer) {
     Objects.requireNonNull(writer, "Input Writer cannot be null for widen");
     return new WriterHolder<>(writer);
   }
@@ -80,7 +79,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <W, A> @NonNull Writer<W, A> narrow(@Nullable Kind<WriterKind.Witness<W>, A> kind) {
+  public <W, A> Writer<W, A> narrow(@Nullable Kind<WriterKind.Witness<W>, A> kind) {
     return switch (kind) {
       case null -> throw new KindUnwrapException(INVALID_KIND_NULL_MSG);
       case WriterKindHelper.WriterHolder<?, ?> holder -> (Writer<W, A>) holder.writer();
@@ -100,8 +99,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    * @param value The computed value. Can be {@code @Nullable}.
    * @return A {@code Kind<WriterKind.Witness<W>, A>} representing the value with an empty log.
    */
-  public <W, A> @NonNull Kind<WriterKind.Witness<W>, A> value(
-      @NonNull Monoid<W> monoidW, @Nullable A value) {
+  public <W, A> Kind<WriterKind.Witness<W>, A> value(Monoid<W> monoidW, @Nullable A value) {
     return this.widen(Writer.value(monoidW, value));
   }
 
@@ -110,11 +108,11 @@ public enum WriterKindHelper implements WriterConverterOps {
    * Unit#INSTANCE} value.
    *
    * @param <W> The type of the accumulated log/output.
-   * @param log The log message to accumulate. Must be {@code @NonNull}.
+   * @param log The log message to accumulate. Must be {@code }.
    * @return A {@code Kind<WriterKind.Witness<W>, Unit>} representing only the log action.
    * @throws NullPointerException if {@code log} is null (delegated to Writer.tell).
    */
-  public <W> @NonNull Kind<WriterKind.Witness<W>, Unit> tell(@NonNull W log) {
+  public <W> Kind<WriterKind.Witness<W>, Unit> tell(W log) {
     Objects.requireNonNull(log, "Log message for tell cannot be null");
     return this.widen(Writer.tell(log));
   }
@@ -130,7 +128,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    * @return The {@link Writer Writer&lt;W, A&gt;} record containing the final value and log.
    * @throws KindUnwrapException if the input {@code kind} is invalid.
    */
-  public <W, A> @NonNull Writer<W, A> runWriter(@NonNull Kind<WriterKind.Witness<W>, A> kind) {
+  public <W, A> Writer<W, A> runWriter(Kind<WriterKind.Witness<W>, A> kind) {
     return this.narrow(kind);
   }
 
@@ -145,7 +143,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    * @return The computed value {@code A}.
    * @throws KindUnwrapException if the input {@code kind} is invalid.
    */
-  public <W, A> @Nullable A run(@NonNull Kind<WriterKind.Witness<W>, A> kind) {
+  public <W, A> @Nullable A run(Kind<WriterKind.Witness<W>, A> kind) {
     return this.narrow(kind).run();
   }
 
@@ -160,7 +158,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    * @return The accumulated log {@code W}.
    * @throws KindUnwrapException if the input {@code kind} is invalid.
    */
-  public <W, A> @NonNull W exec(@NonNull Kind<WriterKind.Witness<W>, A> kind) {
+  public <W, A> W exec(Kind<WriterKind.Witness<W>, A> kind) {
     return this.narrow(kind).exec();
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterMonad.java
@@ -8,7 +8,6 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.Monoid;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Implements the {@link Monad} interface for the {@link Writer} type. This provides the full
@@ -35,7 +34,7 @@ public class WriterMonad<W> extends WriterApplicative<W> implements Monad<Writer
    * @param monoidW The {@link Monoid} instance for the log type {@code W}. Must not be null. This
    *     is essential for combining logs in {@code flatMap}.
    */
-  public WriterMonad(@NonNull Monoid<W> monoidW) {
+  public WriterMonad(Monoid<W> monoidW) {
     super(monoidW);
   }
 
@@ -58,9 +57,9 @@ public class WriterMonad<W> extends WriterApplicative<W> implements Monad<Writer
    *     B>}. Never null.
    */
   @Override
-  public <A, B> @NonNull Kind<WriterKind.Witness<W>, B> flatMap(
-      @NonNull Function<? super A, ? extends Kind<WriterKind.Witness<W>, B>> f,
-      @NonNull Kind<WriterKind.Witness<W>, A> ma) {
+  public <A, B> Kind<WriterKind.Witness<W>, B> flatMap(
+      Function<? super A, ? extends Kind<WriterKind.Witness<W>, B>> f,
+      Kind<WriterKind.Witness<W>, A> ma) {
 
     Writer<W, A> writerA = WRITER.narrow(ma);
 


### PR DESCRIPTION
Removes unnecessary @NonNull annotations now that we are using @NullMarked in package-info.java