### PR TITLE
Add Alternative type class and implementations

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/hkt/Alternative.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/Alternative.java
@@ -1,0 +1,219 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Represents the Alternative type class, which combines the structure of {@link Applicative} with
+ * choice and failure.
+ *
+ * <p>Alternative provides two key operations:
+ *
+ * <ul>
+ *   <li>{@link #empty()} - Represents failure or the identity of choice
+ *   <li>{@link #orElse(Kind, Supplier)} - Combines two alternatives, preferring the first if it
+ *       succeeds
+ * </ul>
+ *
+ * <p>Alternative sits at the same level as {@link Applicative} in the type class hierarchy,
+ * providing a more general abstraction than {@link MonadZero}. While MonadZero provides similar
+ * functionality for monads, Alternative works at the applicative level, making it applicable to a
+ * broader range of types.
+ *
+ * <p><b>Common Use Cases:</b>
+ *
+ * <ul>
+ *   <li><b>Parser combinators:</b> Try one parser, if it fails, try another
+ *   <li><b>Validation:</b> Attempt multiple validation strategies
+ *   <li><b>Non-deterministic computation:</b> Represent multiple possible results (e.g., List)
+ *   <li><b>Optional values:</b> Provide fallback chains (Maybe, Optional)
+ *   <li><b>Racing computations:</b> Take the first successful result
+ * </ul>
+ *
+ * <p><b>Alternative Laws:</b>
+ *
+ * <p>Alternative instances must satisfy these laws:
+ *
+ * <pre>
+ * 1. Left Identity:     orElse(empty(), () -&gt; fa) ≡ fa
+ * 2. Right Identity:    orElse(fa, () -&gt; empty()) ≡ fa
+ * 3. Associativity:     orElse(fa, () -&gt; orElse(fb, () -&gt; fc)) ≡ orElse(orElse(fa, () -&gt; fb), () -&gt; fc)
+ * 4. Left Absorption:   ap(empty(), fa) ≡ empty()
+ * 5. Right Absorption:  ap(ff, empty()) ≡ empty()
+ * </pre>
+ *
+ * <p><b>Examples:</b>
+ *
+ * <pre>{@code
+ * // Maybe Alternative: first Just wins
+ * Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+ * Kind<MaybeKind.Witness, Integer> result =
+ *     alt.orElse(
+ *         alt.of(42),
+ *         () -> alt.of(10)
+ *     ); // Just(42)
+ *
+ * Kind<MaybeKind.Witness, Integer> fallback =
+ *     alt.orElse(
+ *         alt.empty(),
+ *         () -> alt.of(10)
+ *     ); // Just(10)
+ *
+ * // List Alternative: concatenation
+ * Alternative<ListKind.Witness> listAlt = ListMonad.INSTANCE;
+ * Kind<ListKind.Witness, Integer> combined =
+ *     listAlt.orElse(
+ *         ListKind.widen(List.of(1, 2)),
+ *         () -> ListKind.widen(List.of(3, 4))
+ *     ); // [1, 2, 3, 4]
+ *
+ * // Guard: conditional success
+ * Kind<MaybeKind.Witness, Unit> check = alt.guard(someCondition);
+ * // Returns of(Unit.INSTANCE) if true, empty() if false
+ * }</pre>
+ *
+ * @param <F> The higher-kinded type witness representing the type constructor (e.g., {@code
+ *     MaybeKind.Witness}, {@code ListKind.Witness}).
+ * @see Applicative
+ * @see MonadZero
+ * @see Kind
+ */
+@NullMarked
+public interface Alternative<F> extends Applicative<F> {
+
+  /**
+   * Returns the identity element for the {@code orElse} operation, representing failure or an empty
+   * result.
+   *
+   * <p>For different types:
+   *
+   * <ul>
+   *   <li>{@code Maybe}: {@code Nothing}
+   *   <li>{@code Optional}: {@code Optional.empty()}
+   *   <li>{@code List}: {@code []} (empty list)
+   *   <li>{@code Stream}: empty stream
+   * </ul>
+   *
+   * <p>This is the left and right identity for {@link #orElse(Kind, Supplier)}.
+   *
+   * @param <A> The type parameter of the result, which is not present (phantom type)
+   * @return A non-null {@link Kind Kind&lt;F, A&gt;} representing the empty/failure state
+   */
+  <A> Kind<F, A> empty();
+
+  /**
+   * Combines two alternatives, preferring the first if it succeeds, otherwise evaluating and
+   * returning the second.
+   *
+   * <p>The second argument is lazy (provided via {@link Supplier}) to avoid unnecessary computation
+   * when the first alternative succeeds.
+   *
+   * <p><b>Semantics by type:</b>
+   *
+   * <ul>
+   *   <li><b>Maybe/Optional:</b> Returns {@code fa} if it's Just/present, otherwise evaluates and
+   *       returns {@code fb}
+   *   <li><b>List/Stream:</b> Concatenates {@code fa} and {@code fb} (always evaluates both)
+   *   <li><b>Parser:</b> Tries {@code fa}, if it fails, tries {@code fb}
+   * </ul>
+   *
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
+   * // Fallback chain with Maybe
+   * Kind<MaybeKind.Witness, String> result =
+   *     alt.orElse(
+   *         tryPrimarySource(),
+   *         () -> alt.orElse(
+   *             trySecondarySource(),
+   *             () -> alt.of("default")
+   *         )
+   *     );
+   * }</pre>
+   *
+   * @param fa The first non-null alternative {@code Kind<F, A>}
+   * @param fb A non-null {@link Supplier} providing the second alternative (evaluated lazily)
+   * @param <A> The type of the value
+   * @return A non-null {@link Kind Kind&lt;F, A&gt;} representing the combined result
+   * @throws NullPointerException if {@code fa} or {@code fb} is null
+   */
+  <A> Kind<F, A> orElse(Kind<F, A> fa, Supplier<Kind<F, A>> fb);
+
+  /**
+   * Conditionally returns a success value based on a boolean condition.
+   *
+   * <p>If the condition is {@code true}, returns {@code of(Unit.INSTANCE)}. If {@code false},
+   * returns {@code empty()}.
+   *
+   * <p>This is useful for filtering and conditional logic in for-comprehensions and do-notation
+   * style code.
+   *
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
+   * // Only proceed if user is authenticated
+   * Kind<MaybeKind.Witness, Unit> authCheck =
+   *     alt.guard(user.isAuthenticated());
+   *
+   * // In a for-comprehension context:
+   * Kind<MaybeKind.Witness, Result> result =
+   *     alt.flatMap(
+   *         alt.guard(user.hasPermission()),
+   *         unit -> performAction()
+   *     );
+   * // Returns empty() if guard fails, otherwise performs action
+   * }</pre>
+   *
+   * @param condition The boolean condition to check
+   * @return A non-null {@link Kind Kind&lt;F, Unit&gt;} containing {@link Unit#INSTANCE} if the
+   *     condition is true, otherwise {@code empty()}
+   */
+  default Kind<F, Unit> guard(boolean condition) {
+    return condition ? of(Unit.INSTANCE) : empty();
+  }
+
+  /**
+   * Combines multiple alternatives in sequence, returning the result of the first successful one.
+   *
+   * <p>This is a convenience method for chaining multiple {@link #orElse(Kind, Supplier)} calls.
+   * The alternatives are evaluated lazily from left to right.
+   *
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
+   * Kind<MaybeKind.Witness, Config> config =
+   *     alt.orElseAll(
+   *         readFromEnv(),
+   *         () -> readFromFile(),
+   *         () -> readFromDefaults()
+   *     );
+   * }</pre>
+   *
+   * @param fa The first non-null alternative
+   * @param fb The second non-null alternative supplier
+   * @param more Additional non-null alternative suppliers
+   * @param <A> The type of the value
+   * @return A non-null {@link Kind Kind&lt;F, A&gt;} representing the first successful alternative
+   * @throws NullPointerException if any argument is null
+   */
+  @SuppressWarnings("unchecked")
+  default <A> Kind<F, A> orElseAll(
+      Kind<F, A> fa, Supplier<Kind<F, A>> fb, Supplier<Kind<F, A>>... more) {
+    requireNonNull(fa, "First alternative for orElseAll cannot be null");
+    requireNonNull(fb, "Second alternative for orElseAll cannot be null");
+    requireNonNull(more, "Additional alternatives for orElseAll cannot be null");
+
+    Kind<F, A> result = orElse(fa, fb);
+
+    for (Supplier<Kind<F, A>> supplier : more) {
+      requireNonNull(supplier, "Alternative supplier in orElseAll cannot be null");
+      result = orElse(result, supplier);
+    }
+
+    return result;
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/hkt/MonadZero.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/MonadZero.java
@@ -5,27 +5,52 @@ package org.higherkindedj.hkt;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A Monad that also has a "zero" or "empty" element, which allows it to represent failure or an
- * empty result.
+ * A Monad that also has a "zero" or "empty" element and supports alternative/choice operations.
  *
- * <p>This is useful for monads that can be filtered, such as {@code List}, {@code Optional}, or
- * {@code Maybe}. The {@code zero()} method provides the empty value for that monad (e.g., an empty
- * list or {@code Optional.empty()}).
+ * <p>MonadZero combines the power of {@link Monad} with {@link Alternative}, providing both monadic
+ * bind and choice operations. This is useful for monads that can be filtered and combined, such as
+ * {@code List}, {@code Optional}, or {@code Maybe}.
+ *
+ * <p>The {@code zero()} method provides the empty value for that monad (e.g., an empty list or
+ * {@code Optional.empty()}), which serves as the implementation for {@link Alternative#empty()}.
  *
  * <p>This interface is particularly important for enabling the {@code when()} (filtering) clause in
  * for-comprehensions, allowing computations to be short-circuited.
  *
+ * <p><b>Key Operations:</b>
+ *
+ * <ul>
+ *   <li>{@link #zero()} - The empty/failure element (implements {@link Alternative#empty()})
+ *   <li>{@link Alternative#orElse(Kind, java.util.function.Supplier)} - Combine alternatives
+ *   <li>{@link Alternative#guard(boolean)} - Conditional success
+ * </ul>
+ *
  * @param <F> The witness type of the Monad.
  * @see Monad
+ * @see Alternative
  */
 @NullMarked
-public interface MonadZero<F> extends Monad<F> {
+public interface MonadZero<F> extends Monad<F>, Alternative<F> {
 
   /**
    * Returns the "zero" or "empty" value for this Monad.
+   *
+   * <p>This method provides the implementation for {@link Alternative#empty()}. The {@code zero()}
+   * method is retained for compatibility and semantic clarity in the context of MonadZero.
    *
    * @param <A> The type parameter of the Kind, which will not be present.
    * @return The empty value for the monad (non-null), e.g., {@code Optional.empty()}.
    */
   <A> Kind<F, A> zero();
+
+  /**
+   * Provides the {@link Alternative#empty()} implementation by delegating to {@link #zero()}.
+   *
+   * @param <A> The type parameter of the Kind
+   * @return The empty value for this Alternative, same as {@link #zero()}
+   */
+  @Override
+  default <A> Kind<F, A> empty() {
+    return zero();
+  }
 }

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Functional Api](functional/functional_api.md)
   - [Functor](functional/functor.md)
   - [Applicative](functional/applicative.md)
+  - [Alternative](functional/alternative.md)
   - [Monad](functional/monad.md)
   - [MonadError](functional/monad_error.md)
   - [Semigroup and Monoid](functional/semigroup_and_monoid.md)

--- a/hkj-book/src/functional/alternative.md
+++ b/hkj-book/src/functional/alternative.md
@@ -1,0 +1,291 @@
+# Alternative
+
+The `Alternative` type class represents applicative functors that support choice and failure. It extends the `Applicative` interface with operations for combining alternatives and representing empty/failed computations. Alternative sits at the same level as `Applicative` in the type class hierarchy, providing a more general abstraction than `MonadZero`.
+
+The interface for Alternative in hkj-api extends Applicative:
+
+```java
+public interface Alternative<F> extends Applicative<F> {
+    <A> Kind<F, A> empty();
+    <A> Kind<F, A> orElse(Kind<F, A> fa, Supplier<Kind<F, A>> fb);
+    default Kind<F, Unit> guard(boolean condition);
+}
+```
+
+### Why is it useful?
+
+An `Applicative` provides a way to apply functions within a context and combine multiple values. An `Alternative` adds two critical operations to this structure:
+
+* `empty()`: Returns the "empty" or "failure" element for the applicative functor.
+* `orElse(fa, fb)`: Combines two alternatives, preferring the first if it succeeds, otherwise evaluating and returning the second.
+
+These operations enable:
+* **Choice and fallback mechanisms**: Try one computation, if it fails, try another
+* **Non-deterministic computation**: Represent multiple possible results (e.g., List concatenation)
+* **Parser combinators**: Essential for building flexible parsers that try alternatives
+* **Conditional effects**: Using the `guard()` helper for filtering
+
+### Relationship with MonadZero
+
+In higher-kinded-j, `MonadZero` extends both `Monad` and `Alternative`:
+
+```java
+public interface MonadZero<F> extends Monad<F>, Alternative<F> {
+    <A> Kind<F, A> zero();
+
+    @Override
+    default <A> Kind<F, A> empty() {
+        return zero();
+    }
+}
+```
+
+This means:
+* Every `MonadZero` is also an `Alternative`
+* The `zero()` method provides the implementation for `empty()`
+* Types that are MonadZero (List, Maybe, Optional, Stream) automatically get Alternative operations
+
+### Key Implementations in this Project
+
+For different types, Alternative has different semantics:
+
+* **Maybe**: `empty()` returns `Nothing`. `orElse()` returns the first `Just`, or the second if the first is `Nothing`.
+* **Optional**: `empty()` returns `Optional.empty()`. `orElse()` returns the first present value, or the second if the first is empty.
+* **List**: `empty()` returns an empty list `[]`. `orElse()` concatenates both lists (non-deterministic choice).
+* **Stream**: `empty()` returns an empty stream. `orElse()` concatenates both streams lazily.
+
+### Primary Uses
+
+#### 1. Fallback Chains with Maybe/Optional
+
+Try multiple sources, using the first successful one:
+
+```java
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+
+// Get the Alternative instance for Maybe
+final Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+
+// Simulate trying multiple configuration sources
+Kind<MaybeKind.Witness, String> fromEnv = MAYBE.nothing();      // Not found
+Kind<MaybeKind.Witness, String> fromFile = MAYBE.just("config.txt");  // Found!
+Kind<MaybeKind.Witness, String> fromDefault = MAYBE.just("default");
+
+// Try sources in order
+Kind<MaybeKind.Witness, String> config = alt.orElse(
+    fromEnv,
+    () -> alt.orElse(
+        fromFile,
+        () -> fromDefault
+    )
+);
+
+Maybe<String> result = MAYBE.narrow(config);
+System.out.println("Config: " + result.get()); // "config.txt"
+```
+
+**Using `orElseAll()` for cleaner syntax:**
+
+```java
+Kind<MaybeKind.Witness, String> config = alt.orElseAll(
+    fromEnv,
+    () -> fromFile,
+    () -> fromDefault
+);
+```
+
+#### 2. Non-Deterministic Computation with List
+
+Represent all possible outcomes:
+
+```java
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+
+// Get the Alternative instance for List
+final Alternative<ListKind.Witness> alt = ListMonad.INSTANCE;
+
+// Possible actions
+Kind<ListKind.Witness, String> actions1 = LIST.widen(Arrays.asList("move_left", "move_right"));
+Kind<ListKind.Witness, String> actions2 = LIST.widen(Arrays.asList("jump", "duck"));
+
+// Combine all possibilities
+Kind<ListKind.Witness, String> allActions = alt.orElse(actions1, () -> actions2);
+
+List<String> result = LIST.narrow(allActions);
+System.out.println("All actions: " + result);
+// Output: [move_left, move_right, jump, duck]
+```
+
+#### 3. Conditional Success with guard()
+
+Filter based on conditions:
+
+```java
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+
+final Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+
+// Check authentication
+boolean isAuthenticated = true;
+Kind<MaybeKind.Witness, Unit> authCheck = alt.guard(isAuthenticated);
+
+Maybe<Unit> result = MAYBE.narrow(authCheck);
+System.out.println("Authenticated: " + result.isJust()); // true
+
+// guard(false) returns empty()
+Kind<MaybeKind.Witness, Unit> failedCheck = alt.guard(false);
+System.out.println("Failed: " + MAYBE.narrow(failedCheck).isNothing()); // true
+```
+
+#### 4. Lazy Evaluation
+
+The second argument to `orElse()` is provided via `Supplier`, enabling lazy evaluation:
+
+```java
+final Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+
+Kind<MaybeKind.Witness, String> primary = MAYBE.just("found");
+
+Kind<MaybeKind.Witness, String> result = alt.orElse(
+    primary,
+    () -> {
+        System.out.println("Computing fallback...");
+        return MAYBE.just("fallback");
+    }
+);
+
+// "Computing fallback..." is never printed because primary succeeded
+System.out.println("Result: " + MAYBE.narrow(result).get()); // "found"
+```
+
+For **Maybe** and **Optional**, the second alternative is only evaluated if the first is empty.
+
+For **List** and **Stream**, both alternatives are always evaluated (to concatenate them), but the `Supplier` still provides control over when the second collection is created.
+
+### Alternative Laws
+
+Alternative instances must satisfy these laws:
+
+1. **Left Identity**: `orElse(empty(), () -> fa) ≡ fa`
+   - empty is the left identity for orElse
+
+2. **Right Identity**: `orElse(fa, () -> empty()) ≡ fa`
+   - empty is the right identity for orElse
+
+3. **Associativity**: `orElse(fa, () -> orElse(fb, () -> fc)) ≡ orElse(orElse(fa, () -> fb), () -> fc)`
+   - The order of combining alternatives doesn't matter
+
+4. **Left Absorption**: `ap(empty(), fa) ≡ empty()`
+   - Applying an empty function gives empty
+
+5. **Right Absorption**: `ap(ff, empty()) ≡ empty()`
+   - Applying any function to empty gives empty
+
+### Practical Example: Configuration Loading
+
+Here's a complete example showing how Alternative enables elegant fallback chains:
+
+```java
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+
+public class ConfigLoader {
+    private final Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+
+    public Kind<MaybeKind.Witness, String> loadConfig(String key) {
+        return alt.orElseAll(
+            readFromEnvironment(key),
+            () -> readFromConfigFile(key),
+            () -> readFromDatabase(key),
+            () -> getDefaultValue(key)
+        );
+    }
+
+    private Kind<MaybeKind.Witness, String> readFromEnvironment(String key) {
+        String value = System.getenv(key);
+        return value != null ? MAYBE.just(value) : MAYBE.nothing();
+    }
+
+    private Kind<MaybeKind.Witness, String> readFromConfigFile(String key) {
+        // Simulate file reading
+        return MAYBE.nothing(); // Not found
+    }
+
+    private Kind<MaybeKind.Witness, String> readFromDatabase(String key) {
+        // Simulate database query
+        return MAYBE.just("db-value-" + key);
+    }
+
+    private Kind<MaybeKind.Witness, String> getDefaultValue(String key) {
+        return MAYBE.just("default-" + key);
+    }
+}
+
+// Usage
+ConfigLoader loader = new ConfigLoader();
+Kind<MaybeKind.Witness, String> config = loader.loadConfig("APP_NAME");
+Maybe<String> result = MAYBE.narrow(config);
+System.out.println("Config value: " + result.get()); // "db-value-APP_NAME"
+```
+
+### Comparison: Alternative vs MonadZero
+
+| Aspect | Alternative | MonadZero |
+|--------|-------------|-----------|
+| Extends | Applicative | Monad (and Alternative) |
+| Power Level | Less powerful | More powerful |
+| Core Methods | `empty()`, `orElse()` | `zero()`, inherits `orElse()` |
+| Use Case | Choice, fallback, alternatives | Filtering, monadic zero |
+| Examples | Parser combinators, fallback chains | For-comprehension filtering |
+
+In practice, since `MonadZero` extends `Alternative` in higher-kinded-j, types like List, Maybe, Optional, and Stream have access to both sets of operations.
+
+### When to Use Alternative
+
+Use Alternative when you need to:
+* **Try multiple alternatives** with fallback behavior
+* **Combine all possibilities** (for List/Stream)
+* **Conditionally proceed** based on boolean conditions (`guard()`)
+* **Build parser combinators** or similar choice-based systems
+* Work at the **Applicative level** without requiring full Monad power
+
+Alternative provides a principled, composable way to handle choice and failure in functional programming.
+
+## Complete Working Example
+
+For a complete, runnable example demonstrating Alternative with configuration loading, see:
+
+**[AlternativeConfigExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java)**
+
+This example demonstrates:
+- Basic `orElse()` fallback patterns
+- `orElseAll()` for multiple fallback sources
+- `guard()` for conditional validation
+- Lazy evaluation benefits
+- Parser combinator patterns using Alternative

--- a/hkj-book/src/functional/functional_api.md
+++ b/hkj-book/src/functional/functional_api.md
@@ -49,6 +49,16 @@ A **`MonadError`** is a specialised `Monad` that has a defined error type `E`. I
   * `raiseError(E error)`: Lifts an error `E` into the monadic context `F<A>`.
   * `handleErrorWith(Kind<F, A> fa, Function<E, Kind<F, A>> f)`: Provides a way to recover from a failed computation.
 
+### **`Alternative<F>`**
+
+An **`Alternative`** is an `Applicative` that adds the concept of choice and failure. It provides operations for combining alternatives and representing empty/failed computations. Alternative sits at the same level as `Applicative` in the type class hierarchy.
+
+* **Key Methods**:
+  * `empty()`: Returns the empty/failure element for the applicative.
+  * `orElse(Kind<F, A> fa, Supplier<Kind<F, A>> fb)`: Combines two alternatives, preferring the first if it succeeds, otherwise evaluating and returning the second.
+  * `guard(boolean condition)`: Returns success (`of(Unit.INSTANCE)`) if true, otherwise empty.
+* **Use Case**: Essential for parser combinators, fallback chains, non-deterministic computation, and trying multiple alternatives with lazy evaluation.
+
 ### **`Selective<F>`**
 
 A **`Selective`** functor sits between `Applicative` and `Monad` in terms of power. It extends `Applicative` with the ability to conditionally apply effects based on the result of a previous computation, whilst maintaining a static structure where all possible branches are visible upfront.
@@ -58,6 +68,15 @@ A **`Selective`** functor sits between `Applicative` and `Monad` in terms of pow
   * `whenS(Kind<F, Boolean> fcond, Kind<F, Unit> fa)`: Conditionally executes an effect based on a boolean condition.
   * `ifS(Kind<F, Boolean> fcond, Kind<F, A> fthen, Kind<F, A> felse)`: Provides if-then-else semantics with both branches visible upfront.
 * **Use Case**: Perfect for feature flags, conditional logging, configuration-based behaviour, and any scenario where you need conditional effects with static analysis capabilities.
+
+### **`MonadZero<F>`**
+
+A **`MonadZero`** is a `Monad` that also extends `Alternative`, combining monadic bind with choice operations. It adds the concept of a "zero" or "empty" element, allowing it to represent failure or absence.
+
+* **Key Methods**:
+  * `zero()`: Returns the zero/empty element for the monad (implements `empty()` from Alternative).
+  * Inherits `orElse()` and `guard()` from `Alternative`.
+* **Use Case**: Primarily enables filtering in for-comprehensions via the `when()` clause. Also provides all Alternative operations for monadic contexts. Implemented by List, Maybe, Optional, and Stream.
 
 ---
 

--- a/hkj-book/src/functional/monad_zero.md
+++ b/hkj-book/src/functional/monad_zero.md
@@ -1,20 +1,27 @@
 # MonadZero
 
-The `MonadZero` is a more advanced type class extends the `Monad` interface to include the concept of a "zero" or "empty" element. It is designed for monads that can represent failure, absence, or emptiness, allowing them to be used in filtering operations.
+The `MonadZero` is a more advanced type class that extends both `Monad` and `Alternative` to combine the power of monadic bind with choice operations. It includes the concept of a "zero" or "empty" element and is designed for monads that can represent failure, absence, or emptiness, allowing them to be used in filtering operations and alternative chains.
 
-The interface for MonadZero in hkj-api extends Monad:
+The interface for MonadZero in hkj-api extends Monad and Alternative:
 
 ```java
-public interface MonadZero<F> extends Monad<F> {
+public interface MonadZero<F> extends Monad<F>, Alternative<F> {
     <A> Kind<F, A> zero();
+
+    @Override
+    default <A> Kind<F, A> empty() {
+        return zero();
+    }
 }
 ```
 
 ### Why is it useful?
 
-A `Monad` provides a way to sequence computations within a context (`flatMap`, `map`, `of`). A `MonadZero` adds one critical operation to this structure:
+A `Monad` provides a way to sequence computations within a context (`flatMap`, `map`, `of`). An `Alternative` provides choice and failure operations (`empty()`, `orElse()`). A `MonadZero` combines both:
 
-* `zero()`: Returns the "empty" or "zero" element for the monad.
+* `zero()`: Returns the "empty" or "zero" element for the monad (implements `empty()` from Alternative).
+* `orElse()`: Combines two alternatives (inherited from Alternative).
+* `guard()`: Conditional success helper (inherited from Alternative).
 
 This `zero` element acts as an absorbing element in a monadic sequence, similar to how multiplying by zero results in zero. If a computation results in a `zero`, subsequent operations in the chain are typically skipped.
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
@@ -45,6 +45,7 @@ public enum Operation {
   FOLD("fold"),
   TO_EITHER("toEither"),
   MATCH("match"),
+  OR_ELSE("orElse"),
   OR_ELSE_GET("orElseGet"),
   OR_EITHER("orEither"),
   RECOVER_FUNCTION("recoverFunction"),

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListAlternativeTest.java
@@ -1,0 +1,220 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.list;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+
+import java.util.Arrays;
+import java.util.List;
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ListMonad Alternative Operations Test Suite")
+class ListAlternativeTest {
+
+  private Alternative<ListKind.Witness> alternative;
+
+  @BeforeEach
+  void setUpAlternative() {
+    alternative = ListMonad.INSTANCE;
+  }
+
+  @Nested
+  @DisplayName("empty() Tests")
+  class EmptyTests {
+
+    @Test
+    @DisplayName("empty() returns empty list")
+    void emptyReturnsEmptyList() {
+      Kind<ListKind.Witness, Integer> empty = alternative.empty();
+
+      List<Integer> list = LIST.narrow(empty);
+      assertThat(list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("empty() is polymorphic")
+    void emptyIsPolymorphic() {
+      Kind<ListKind.Witness, String> emptyString = alternative.empty();
+      Kind<ListKind.Witness, Integer> emptyInt = alternative.empty();
+
+      assertThat(LIST.narrow(emptyString)).isEmpty();
+      assertThat(LIST.narrow(emptyInt)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElse() Tests")
+  class OrElseTests {
+
+    @Test
+    @DisplayName("orElse() concatenates two non-empty lists")
+    void orElseConcatenatesLists() {
+      Kind<ListKind.Witness, Integer> list1 = LIST.widen(Arrays.asList(1, 2));
+      Kind<ListKind.Witness, Integer> list2 = LIST.widen(Arrays.asList(3, 4));
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElse(list1, () -> list2);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("orElse() with empty first list")
+    void orElseWithEmptyFirst() {
+      Kind<ListKind.Witness, Integer> empty = alternative.empty();
+      Kind<ListKind.Witness, Integer> list = LIST.widen(Arrays.asList(1, 2));
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElse(empty, () -> list);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("orElse() with empty second list")
+    void orElseWithEmptySecond() {
+      Kind<ListKind.Witness, Integer> list = LIST.widen(Arrays.asList(1, 2));
+      Kind<ListKind.Witness, Integer> empty = alternative.empty();
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElse(list, () -> empty);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("orElse() with both empty lists")
+    void orElseWithBothEmpty() {
+      Kind<ListKind.Witness, Integer> empty1 = alternative.empty();
+      Kind<ListKind.Witness, Integer> empty2 = alternative.empty();
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElse(empty1, () -> empty2);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElse() always evaluates both lists")
+    void orElseAlwaysEvaluatesBoth() {
+      Kind<ListKind.Witness, Integer> list1 = LIST.widen(Arrays.asList(1, 2));
+      boolean[] evaluated = {false};
+
+      Kind<ListKind.Witness, Integer> result =
+          alternative.orElse(
+              list1,
+              () -> {
+                evaluated[0] = true;
+                return LIST.widen(Arrays.asList(3, 4));
+              });
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).containsExactly(1, 2, 3, 4);
+      assertThat(evaluated[0]).isTrue(); // For List, second is always evaluated
+    }
+  }
+
+  @Nested
+  @DisplayName("guard() Tests")
+  class GuardTests {
+
+    @Test
+    @DisplayName("guard(true) returns singleton list with Unit")
+    void guardTrueReturnsSingletonList() {
+      Kind<ListKind.Witness, Unit> result = alternative.guard(true);
+
+      List<Unit> list = LIST.narrow(result);
+      assertThat(list).hasSize(1);
+      assertThat(list.get(0)).isEqualTo(Unit.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("guard(false) returns empty list")
+    void guardFalseReturnsEmptyList() {
+      Kind<ListKind.Witness, Unit> result = alternative.guard(false);
+
+      List<Unit> list = LIST.narrow(result);
+      assertThat(list).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll() Tests")
+  class OrElseAllTests {
+
+    @Test
+    @DisplayName("orElseAll() concatenates all lists")
+    void orElseAllConcatenatesAll() {
+      Kind<ListKind.Witness, Integer> list1 = LIST.widen(Arrays.asList(1, 2));
+      Kind<ListKind.Witness, Integer> list2 = LIST.widen(Arrays.asList(3, 4));
+      Kind<ListKind.Witness, Integer> list3 = LIST.widen(Arrays.asList(5, 6));
+
+      Kind<ListKind.Witness, Integer> result =
+          alternative.orElseAll(list1, () -> list2, () -> list3);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    @DisplayName("orElseAll() with some empty lists")
+    void orElseAllWithSomeEmpty() {
+      Kind<ListKind.Witness, Integer> list1 = LIST.widen(Arrays.asList(1, 2));
+      Kind<ListKind.Witness, Integer> empty = alternative.empty();
+      Kind<ListKind.Witness, Integer> list2 = LIST.widen(Arrays.asList(3, 4));
+
+      Kind<ListKind.Witness, Integer> result =
+          alternative.orElseAll(list1, () -> empty, () -> list2);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).containsExactly(1, 2, 3, 4);
+    }
+  }
+
+  @Nested
+  @DisplayName("Alternative Laws")
+  class AlternativeLaws {
+
+    @Test
+    @DisplayName("Left Identity: orElse(empty(), () -> fa) == fa")
+    void leftIdentityLaw() {
+      Kind<ListKind.Witness, Integer> fa = LIST.widen(Arrays.asList(1, 2, 3));
+      Kind<ListKind.Witness, Integer> result = alternative.orElse(alternative.empty(), () -> fa);
+
+      assertThat(LIST.narrow(result)).isEqualTo(LIST.narrow(fa));
+    }
+
+    @Test
+    @DisplayName("Right Identity: orElse(fa, () -> empty()) == fa")
+    void rightIdentityLaw() {
+      Kind<ListKind.Witness, Integer> fa = LIST.widen(Arrays.asList(1, 2, 3));
+      Kind<ListKind.Witness, Integer> result = alternative.orElse(fa, alternative::empty);
+
+      assertThat(LIST.narrow(result)).isEqualTo(LIST.narrow(fa));
+    }
+
+    @Test
+    @DisplayName(
+        "Associativity: orElse(fa, () -> orElse(fb, () -> fc)) == orElse(orElse(fa, () -> fb), ()"
+            + " -> fc)")
+    void associativityLaw() {
+      Kind<ListKind.Witness, Integer> fa = LIST.widen(Arrays.asList(1, 2));
+      Kind<ListKind.Witness, Integer> fb = LIST.widen(Arrays.asList(3, 4));
+      Kind<ListKind.Witness, Integer> fc = LIST.widen(Arrays.asList(5, 6));
+
+      Kind<ListKind.Witness, Integer> left =
+          alternative.orElse(fa, () -> alternative.orElse(fb, () -> fc));
+      Kind<ListKind.Witness, Integer> right =
+          alternative.orElse(alternative.orElse(fa, () -> fb), () -> fc);
+
+      assertThat(LIST.narrow(left)).isEqualTo(LIST.narrow(right));
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/maybe/MaybeAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/maybe/MaybeAlternativeTest.java
@@ -1,0 +1,229 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.maybe;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MaybeMonad Alternative Operations Test Suite")
+class MaybeAlternativeTest extends MaybeTestBase {
+
+  private Alternative<MaybeKind.Witness> alternative;
+
+  @BeforeEach
+  void setUpAlternative() {
+    alternative = MaybeMonad.INSTANCE;
+  }
+
+  @Nested
+  @DisplayName("empty() Tests")
+  class EmptyTests {
+
+    @Test
+    @DisplayName("empty() returns Nothing")
+    void emptyReturnsNothing() {
+      Kind<MaybeKind.Witness, Integer> empty = alternative.empty();
+
+      Maybe<Integer> maybe = narrowToMaybe(empty);
+      assertThat(maybe.isNothing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("empty() is polymorphic")
+    void emptyIsPolymorphic() {
+      Kind<MaybeKind.Witness, String> emptyString = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> emptyInt = alternative.empty();
+
+      assertThat(narrowToMaybe(emptyString).isNothing()).isTrue();
+      assertThat(narrowToMaybe(emptyInt).isNothing()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElse() Tests")
+  class OrElseTests {
+
+    @Test
+    @DisplayName("orElse() returns first when Just")
+    void orElseReturnsFirstWhenJust() {
+      Kind<MaybeKind.Witness, Integer> just = alternative.of(42);
+      Kind<MaybeKind.Witness, Integer> fallback = alternative.of(10);
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElse(just, () -> fallback);
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("orElse() returns second when first is Nothing")
+    void orElseReturnsSecondWhenFirstIsNothing() {
+      Kind<MaybeKind.Witness, Integer> nothing = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> fallback = alternative.of(10);
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElse(nothing, () -> fallback);
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("orElse() returns Nothing when both are Nothing")
+    void orElseReturnsNothingWhenBothAreNothing() {
+      Kind<MaybeKind.Witness, Integer> nothing1 = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> nothing2 = alternative.empty();
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElse(nothing1, () -> nothing2);
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.isNothing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("orElse() is lazy - doesn't evaluate second when first is Just")
+    void orElseIsLazy() {
+      Kind<MaybeKind.Witness, Integer> just = alternative.of(42);
+      boolean[] evaluated = {false};
+
+      Kind<MaybeKind.Witness, Integer> result =
+          alternative.orElse(
+              just,
+              () -> {
+                evaluated[0] = true;
+                return alternative.of(10);
+              });
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.get()).isEqualTo(42);
+      assertThat(evaluated[0]).isFalse();
+    }
+
+    @Test
+    @DisplayName("orElse() evaluates second when first is Nothing")
+    void orElseEvaluatesSecondWhenNeeded() {
+      Kind<MaybeKind.Witness, Integer> nothing = alternative.empty();
+      boolean[] evaluated = {false};
+
+      Kind<MaybeKind.Witness, Integer> result =
+          alternative.orElse(
+              nothing,
+              () -> {
+                evaluated[0] = true;
+                return alternative.of(10);
+              });
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.get()).isEqualTo(10);
+      assertThat(evaluated[0]).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("guard() Tests")
+  class GuardTests {
+
+    @Test
+    @DisplayName("guard(true) returns Just(Unit)")
+    void guardTrueReturnsJustUnit() {
+      Kind<MaybeKind.Witness, Unit> result = alternative.guard(true);
+
+      Maybe<Unit> maybe = narrowToMaybe(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).isEqualTo(Unit.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("guard(false) returns Nothing")
+    void guardFalseReturnsNothing() {
+      Kind<MaybeKind.Witness, Unit> result = alternative.guard(false);
+
+      Maybe<Unit> maybe = narrowToMaybe(result);
+      assertThat(maybe.isNothing()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll() Tests")
+  class OrElseAllTests {
+
+    @Test
+    @DisplayName("orElseAll() returns first Just")
+    void orElseAllReturnsFirstJust() {
+      Kind<MaybeKind.Witness, Integer> nothing1 = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> just = alternative.of(42);
+      Kind<MaybeKind.Witness, Integer> nothing2 = alternative.empty();
+
+      Kind<MaybeKind.Witness, Integer> result =
+          alternative.orElseAll(nothing1, () -> just, () -> nothing2);
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("orElseAll() with multiple fallbacks")
+    void orElseAllWithMultipleFallbacks() {
+      Kind<MaybeKind.Witness, Integer> nothing1 = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> nothing2 = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> nothing3 = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> fallback = alternative.of(99);
+
+      Kind<MaybeKind.Witness, Integer> result =
+          alternative.orElseAll(nothing1, () -> nothing2, () -> nothing3, () -> fallback);
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).isEqualTo(99);
+    }
+  }
+
+  @Nested
+  @DisplayName("Alternative Laws")
+  class AlternativeLaws {
+
+    @Test
+    @DisplayName("Left Identity: orElse(empty(), () -> fa) == fa")
+    void leftIdentityLaw() {
+      Kind<MaybeKind.Witness, Integer> fa = alternative.of(42);
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElse(alternative.empty(), () -> fa);
+
+      assertThat(narrowToMaybe(result).get()).isEqualTo(narrowToMaybe(fa).get());
+    }
+
+    @Test
+    @DisplayName("Right Identity: orElse(fa, () -> empty()) == fa")
+    void rightIdentityLaw() {
+      Kind<MaybeKind.Witness, Integer> fa = alternative.of(42);
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElse(fa, alternative::empty);
+
+      assertThat(narrowToMaybe(result).get()).isEqualTo(narrowToMaybe(fa).get());
+    }
+
+    @Test
+    @DisplayName(
+        "Associativity: orElse(fa, () -> orElse(fb, () -> fc)) == orElse(orElse(fa, () -> fb), ()"
+            + " -> fc)")
+    void associativityLaw() {
+      Kind<MaybeKind.Witness, Integer> fa = alternative.empty();
+      Kind<MaybeKind.Witness, Integer> fb = alternative.of(10);
+      Kind<MaybeKind.Witness, Integer> fc = alternative.of(20);
+
+      Kind<MaybeKind.Witness, Integer> left =
+          alternative.orElse(fa, () -> alternative.orElse(fb, () -> fc));
+      Kind<MaybeKind.Witness, Integer> right =
+          alternative.orElse(alternative.orElse(fa, () -> fb), () -> fc);
+
+      assertThat(narrowToMaybe(left).get()).isEqualTo(narrowToMaybe(right).get());
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalAlternativeTest.java
@@ -1,0 +1,232 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+import java.util.Optional;
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OptionalMonad Alternative Operations Test Suite")
+class OptionalAlternativeTest {
+
+  private Alternative<OptionalKind.Witness> alternative;
+
+  @BeforeEach
+  void setUpAlternative() {
+    alternative = OptionalMonad.INSTANCE;
+  }
+
+  @Nested
+  @DisplayName("empty() Tests")
+  class EmptyTests {
+
+    @Test
+    @DisplayName("empty() returns Optional.empty()")
+    void emptyReturnsOptionalEmpty() {
+      Kind<OptionalKind.Witness, Integer> empty = alternative.empty();
+
+      Optional<Integer> optional = OPTIONAL.narrow(empty);
+      assertThat(optional).isEmpty();
+    }
+
+    @Test
+    @DisplayName("empty() is polymorphic")
+    void emptyIsPolymorphic() {
+      Kind<OptionalKind.Witness, String> emptyString = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> emptyInt = alternative.empty();
+
+      assertThat(OPTIONAL.narrow(emptyString)).isEmpty();
+      assertThat(OPTIONAL.narrow(emptyInt)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElse() Tests")
+  class OrElseTests {
+
+    @Test
+    @DisplayName("orElse() returns first when present")
+    void orElseReturnsFirstWhenPresent() {
+      Kind<OptionalKind.Witness, Integer> present = alternative.of(42);
+      Kind<OptionalKind.Witness, Integer> fallback = alternative.of(10);
+
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElse(present, () -> fallback);
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isPresent();
+      assertThat(optional.get()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("orElse() returns second when first is empty")
+    void orElseReturnsSecondWhenFirstIsEmpty() {
+      Kind<OptionalKind.Witness, Integer> empty = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> fallback = alternative.of(10);
+
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElse(empty, () -> fallback);
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isPresent();
+      assertThat(optional.get()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("orElse() returns empty when both are empty")
+    void orElseReturnsEmptyWhenBothAreEmpty() {
+      Kind<OptionalKind.Witness, Integer> empty1 = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> empty2 = alternative.empty();
+
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElse(empty1, () -> empty2);
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElse() is lazy - doesn't evaluate second when first is present")
+    void orElseIsLazy() {
+      Kind<OptionalKind.Witness, Integer> present = alternative.of(42);
+      boolean[] evaluated = {false};
+
+      Kind<OptionalKind.Witness, Integer> result =
+          alternative.orElse(
+              present,
+              () -> {
+                evaluated[0] = true;
+                return alternative.of(10);
+              });
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional.get()).isEqualTo(42);
+      assertThat(evaluated[0]).isFalse();
+    }
+
+    @Test
+    @DisplayName("orElse() evaluates second when first is empty")
+    void orElseEvaluatesSecondWhenNeeded() {
+      Kind<OptionalKind.Witness, Integer> empty = alternative.empty();
+      boolean[] evaluated = {false};
+
+      Kind<OptionalKind.Witness, Integer> result =
+          alternative.orElse(
+              empty,
+              () -> {
+                evaluated[0] = true;
+                return alternative.of(10);
+              });
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional.get()).isEqualTo(10);
+      assertThat(evaluated[0]).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("guard() Tests")
+  class GuardTests {
+
+    @Test
+    @DisplayName("guard(true) returns Optional.of(Unit)")
+    void guardTrueReturnsOptionalOfUnit() {
+      Kind<OptionalKind.Witness, Unit> result = alternative.guard(true);
+
+      Optional<Unit> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isPresent();
+      assertThat(optional.get()).isEqualTo(Unit.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("guard(false) returns Optional.empty()")
+    void guardFalseReturnsOptionalEmpty() {
+      Kind<OptionalKind.Witness, Unit> result = alternative.guard(false);
+
+      Optional<Unit> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll() Tests")
+  class OrElseAllTests {
+
+    @Test
+    @DisplayName("orElseAll() returns first present")
+    void orElseAllReturnsFirstPresent() {
+      Kind<OptionalKind.Witness, Integer> empty1 = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> present = alternative.of(42);
+      Kind<OptionalKind.Witness, Integer> empty2 = alternative.empty();
+
+      Kind<OptionalKind.Witness, Integer> result =
+          alternative.orElseAll(empty1, () -> present, () -> empty2);
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isPresent();
+      assertThat(optional.get()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("orElseAll() with multiple fallbacks")
+    void orElseAllWithMultipleFallbacks() {
+      Kind<OptionalKind.Witness, Integer> empty1 = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> empty2 = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> empty3 = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> fallback = alternative.of(99);
+
+      Kind<OptionalKind.Witness, Integer> result =
+          alternative.orElseAll(empty1, () -> empty2, () -> empty3, () -> fallback);
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isPresent();
+      assertThat(optional.get()).isEqualTo(99);
+    }
+  }
+
+  @Nested
+  @DisplayName("Alternative Laws")
+  class AlternativeLaws {
+
+    @Test
+    @DisplayName("Left Identity: orElse(empty(), () -> fa) == fa")
+    void leftIdentityLaw() {
+      Kind<OptionalKind.Witness, Integer> fa = alternative.of(42);
+      Kind<OptionalKind.Witness, Integer> result =
+          alternative.orElse(alternative.empty(), () -> fa);
+
+      assertThat(OPTIONAL.narrow(result).get()).isEqualTo(OPTIONAL.narrow(fa).get());
+    }
+
+    @Test
+    @DisplayName("Right Identity: orElse(fa, () -> empty()) == fa")
+    void rightIdentityLaw() {
+      Kind<OptionalKind.Witness, Integer> fa = alternative.of(42);
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElse(fa, alternative::empty);
+
+      assertThat(OPTIONAL.narrow(result).get()).isEqualTo(OPTIONAL.narrow(fa).get());
+    }
+
+    @Test
+    @DisplayName(
+        "Associativity: orElse(fa, () -> orElse(fb, () -> fc)) == orElse(orElse(fa, () -> fb), ()"
+            + " -> fc)")
+    void associativityLaw() {
+      Kind<OptionalKind.Witness, Integer> fa = alternative.empty();
+      Kind<OptionalKind.Witness, Integer> fb = alternative.of(10);
+      Kind<OptionalKind.Witness, Integer> fc = alternative.of(20);
+
+      Kind<OptionalKind.Witness, Integer> left =
+          alternative.orElse(fa, () -> alternative.orElse(fb, () -> fc));
+      Kind<OptionalKind.Witness, Integer> right =
+          alternative.orElse(alternative.orElse(fa, () -> fb), () -> fc);
+
+      assertThat(OPTIONAL.narrow(left).get()).isEqualTo(OPTIONAL.narrow(right).get());
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/stream/StreamAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/stream/StreamAlternativeTest.java
@@ -1,0 +1,251 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.stream.StreamKindHelper.STREAM;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StreamMonad Alternative Operations Test Suite")
+class StreamAlternativeTest {
+
+  private Alternative<StreamKind.Witness> alternative;
+
+  @BeforeEach
+  void setUpAlternative() {
+    alternative = StreamMonad.INSTANCE;
+  }
+
+  @Nested
+  @DisplayName("empty() Tests")
+  class EmptyTests {
+
+    @Test
+    @DisplayName("empty() returns empty stream")
+    void emptyReturnsEmptyStream() {
+      Kind<StreamKind.Witness, Integer> empty = alternative.empty();
+
+      Stream<Integer> stream = STREAM.narrow(empty);
+      List<Integer> list = stream.collect(Collectors.toList());
+      assertThat(list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("empty() is polymorphic")
+    void emptyIsPolymorphic() {
+      Kind<StreamKind.Witness, String> emptyString = alternative.empty();
+      Kind<StreamKind.Witness, Integer> emptyInt = alternative.empty();
+
+      assertThat(STREAM.narrow(emptyString).collect(Collectors.toList())).isEmpty();
+      assertThat(STREAM.narrow(emptyInt).collect(Collectors.toList())).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElse() Tests")
+  class OrElseTests {
+
+    @Test
+    @DisplayName("orElse() concatenates two non-empty streams")
+    void orElseConcatenatesStreams() {
+      Kind<StreamKind.Witness, Integer> stream1 = STREAM.widen(Stream.of(1, 2));
+      Kind<StreamKind.Witness, Integer> stream2 = STREAM.widen(Stream.of(3, 4));
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElse(stream1, () -> stream2);
+
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+      assertThat(list).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("orElse() with empty first stream")
+    void orElseWithEmptyFirst() {
+      Kind<StreamKind.Witness, Integer> empty = alternative.empty();
+      Kind<StreamKind.Witness, Integer> stream = STREAM.widen(Stream.of(1, 2));
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElse(empty, () -> stream);
+
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+      assertThat(list).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("orElse() with empty second stream")
+    void orElseWithEmptySecond() {
+      Kind<StreamKind.Witness, Integer> stream = STREAM.widen(Stream.of(1, 2));
+      Kind<StreamKind.Witness, Integer> empty = alternative.empty();
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElse(stream, () -> empty);
+
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+      assertThat(list).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("orElse() with both empty streams")
+    void orElseWithBothEmpty() {
+      Kind<StreamKind.Witness, Integer> empty1 = alternative.empty();
+      Kind<StreamKind.Witness, Integer> empty2 = alternative.empty();
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElse(empty1, () -> empty2);
+
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+      assertThat(list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElse() is lazy - doesn't evaluate second until stream is consumed")
+    void orElseIsLazy() {
+      Kind<StreamKind.Witness, Integer> stream1 = STREAM.widen(Stream.of(1, 2));
+      boolean[] evaluated = {false};
+
+      Kind<StreamKind.Witness, Integer> result =
+          alternative.orElse(
+              stream1,
+              () -> {
+                evaluated[0] = true;
+                return STREAM.widen(Stream.of(3, 4));
+              });
+
+      // Supplier not called yet
+      assertThat(evaluated[0]).isFalse();
+
+      // Now consume the stream
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+
+      // Now the supplier has been called
+      assertThat(evaluated[0]).isTrue();
+      assertThat(list).containsExactly(1, 2, 3, 4);
+    }
+  }
+
+  @Nested
+  @DisplayName("guard() Tests")
+  class GuardTests {
+
+    @Test
+    @DisplayName("guard(true) returns stream with Unit")
+    void guardTrueReturnsStreamWithUnit() {
+      Kind<StreamKind.Witness, Unit> result = alternative.guard(true);
+
+      Stream<Unit> stream = STREAM.narrow(result);
+      List<Unit> list = stream.collect(Collectors.toList());
+      assertThat(list).hasSize(1);
+      assertThat(list.get(0)).isEqualTo(Unit.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("guard(false) returns empty stream")
+    void guardFalseReturnsEmptyStream() {
+      Kind<StreamKind.Witness, Unit> result = alternative.guard(false);
+
+      Stream<Unit> stream = STREAM.narrow(result);
+      List<Unit> list = stream.collect(Collectors.toList());
+      assertThat(list).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll() Tests")
+  class OrElseAllTests {
+
+    @Test
+    @DisplayName("orElseAll() concatenates all streams")
+    void orElseAllConcatenatesAll() {
+      Kind<StreamKind.Witness, Integer> stream1 = STREAM.widen(Stream.of(1, 2));
+      Kind<StreamKind.Witness, Integer> stream2 = STREAM.widen(Stream.of(3, 4));
+      Kind<StreamKind.Witness, Integer> stream3 = STREAM.widen(Stream.of(5, 6));
+
+      Kind<StreamKind.Witness, Integer> result =
+          alternative.orElseAll(stream1, () -> stream2, () -> stream3);
+
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+      assertThat(list).containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    @DisplayName("orElseAll() with some empty streams")
+    void orElseAllWithSomeEmpty() {
+      Kind<StreamKind.Witness, Integer> stream1 = STREAM.widen(Stream.of(1, 2));
+      Kind<StreamKind.Witness, Integer> empty = alternative.empty();
+      Kind<StreamKind.Witness, Integer> stream2 = STREAM.widen(Stream.of(3, 4));
+
+      Kind<StreamKind.Witness, Integer> result =
+          alternative.orElseAll(stream1, () -> empty, () -> stream2);
+
+      Stream<Integer> resultStream = STREAM.narrow(result);
+      List<Integer> list = resultStream.collect(Collectors.toList());
+      assertThat(list).containsExactly(1, 2, 3, 4);
+    }
+  }
+
+  @Nested
+  @DisplayName("Alternative Laws")
+  class AlternativeLaws {
+
+    @Test
+    @DisplayName("Left Identity: orElse(empty(), () -> fa) == fa")
+    void leftIdentityLaw() {
+      Kind<StreamKind.Witness, Integer> fa = STREAM.widen(Stream.of(1, 2, 3));
+      Kind<StreamKind.Witness, Integer> result = alternative.orElse(alternative.empty(), () -> fa);
+
+      List<Integer> resultList = STREAM.narrow(result).collect(Collectors.toList());
+      // Create a fresh stream for comparison since streams can only be consumed once
+      List<Integer> expected = java.util.Arrays.asList(1, 2, 3);
+      assertThat(resultList).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Right Identity: orElse(fa, () -> empty()) == fa")
+    void rightIdentityLaw() {
+      Kind<StreamKind.Witness, Integer> fa = STREAM.widen(Stream.of(1, 2, 3));
+      Kind<StreamKind.Witness, Integer> result = alternative.orElse(fa, alternative::empty);
+
+      List<Integer> resultList = STREAM.narrow(result).collect(Collectors.toList());
+      // Create a fresh stream for comparison since streams can only be consumed once
+      List<Integer> expected = java.util.Arrays.asList(1, 2, 3);
+      assertThat(resultList).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName(
+        "Associativity: orElse(fa, () -> orElse(fb, () -> fc)) == orElse(orElse(fa, () -> fb), ()"
+            + " -> fc)")
+    void associativityLaw() {
+      Kind<StreamKind.Witness, Integer> fa = STREAM.widen(Stream.of(1, 2));
+      Kind<StreamKind.Witness, Integer> fb = STREAM.widen(Stream.of(3, 4));
+      Kind<StreamKind.Witness, Integer> fc = STREAM.widen(Stream.of(5, 6));
+
+      Kind<StreamKind.Witness, Integer> left =
+          alternative.orElse(fa, () -> alternative.orElse(fb, () -> fc));
+
+      // Need fresh streams for right side since streams can only be consumed once
+      Kind<StreamKind.Witness, Integer> fa2 = STREAM.widen(Stream.of(1, 2));
+      Kind<StreamKind.Witness, Integer> fb2 = STREAM.widen(Stream.of(3, 4));
+      Kind<StreamKind.Witness, Integer> fc2 = STREAM.widen(Stream.of(5, 6));
+
+      Kind<StreamKind.Witness, Integer> right =
+          alternative.orElse(alternative.orElse(fa2, () -> fb2), () -> fc2);
+
+      List<Integer> leftList = STREAM.narrow(left).collect(Collectors.toList());
+      List<Integer> rightList = STREAM.narrow(right).collect(Collectors.toList());
+      assertThat(leftList).isEqualTo(rightList);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java
@@ -1,0 +1,244 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.basic.alternative;
+
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+
+/**
+ * Demonstrates the Alternative type class with a practical configuration loading example.
+ *
+ * <p>This example shows how Alternative enables elegant fallback chains when loading configuration
+ * from multiple sources. The system tries sources in priority order, using the first successful
+ * one.
+ *
+ * <p>Key Alternative concepts demonstrated:
+ *
+ * <ul>
+ *   <li><b>orElse()</b>: Combining alternatives with lazy evaluation
+ *   <li><b>empty()</b>: Representing the absence of configuration
+ *   <li><b>guard()</b>: Conditional validation
+ *   <li><b>orElseAll()</b>: Chaining multiple fallback sources
+ * </ul>
+ */
+public class AlternativeConfigExample {
+
+  // Alternative instance for Maybe
+  private static final Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+
+  public static void main(String[] args) {
+    System.out.println("=== Alternative Type Class Example: Configuration Loading ===\n");
+
+    demonstrateBasicOrElse();
+    demonstrateOrElseChain();
+    demonstrateGuard();
+    demonstrateLazyEvaluation();
+    demonstrateParserCombinator();
+  }
+
+  /** Demonstrates basic orElse() for trying two sources. */
+  private static void demonstrateBasicOrElse() {
+    System.out.println("1. Basic orElse() - Fallback Pattern");
+    System.out.println("-----------------------------------");
+
+    // Primary source (environment variable) - not found
+    Kind<MaybeKind.Witness, ConfigValue> fromEnv = readFromEnvironment("DATABASE_URL");
+
+    // Fallback source (config file) - found
+    Kind<MaybeKind.Witness, ConfigValue> fromFile = readFromConfigFile("DATABASE_URL");
+
+    // Use Alternative.orElse() to try env first, then file
+    Kind<MaybeKind.Witness, ConfigValue> result = alt.orElse(fromEnv, () -> fromFile);
+
+    Maybe<ConfigValue> config = MAYBE.narrow(result);
+    if (config.isJust()) {
+      System.out.println("  ✓ Loaded: " + config.get());
+    }
+    System.out.println();
+  }
+
+  /** Demonstrates orElseAll() for chaining multiple sources. */
+  private static void demonstrateOrElseChain() {
+    System.out.println("2. orElseAll() - Multiple Fallback Sources");
+    System.out.println("------------------------------------------");
+
+    String key = "API_KEY";
+
+    // Try multiple sources in priority order
+    Kind<MaybeKind.Witness, ConfigValue> config =
+        alt.orElseAll(
+            readFromEnvironment(key),
+            () -> readFromSystemProperty(key),
+            () -> readFromConfigFile(key),
+            () -> readFromDatabase(key),
+            () -> getDefaultValue(key));
+
+    Maybe<ConfigValue> result = MAYBE.narrow(config);
+    if (result.isJust()) {
+      System.out.println("  ✓ Loaded: " + result.get());
+    }
+    System.out.println();
+  }
+
+  /** Demonstrates guard() for conditional validation. */
+  private static void demonstrateGuard() {
+    System.out.println("3. guard() - Conditional Validation");
+    System.out.println("-----------------------------------");
+
+    String key = "MAX_CONNECTIONS";
+
+    Kind<MaybeKind.Witness, ConfigValue> config = readFromConfigFile(key);
+
+    // Validate that the config value is reasonable
+    Kind<MaybeKind.Witness, ConfigValue> validated =
+        MaybeMonad.INSTANCE.flatMap(
+            value -> {
+              int maxConn = Integer.parseInt(value.value());
+              boolean isValid = maxConn > 0 && maxConn <= 1000;
+
+              // guard(true) returns Just(Unit), guard(false) returns Nothing
+              return MaybeMonad.INSTANCE.map(unit -> value, alt.guard(isValid));
+            },
+            config);
+
+    Maybe<ConfigValue> result = MAYBE.narrow(validated);
+    if (result.isJust()) {
+      System.out.println("  ✓ Valid: " + result.get());
+    } else {
+      System.out.println("  ✗ Validation failed (value out of range)");
+    }
+    System.out.println();
+  }
+
+  /** Demonstrates lazy evaluation - fallback not computed unless needed. */
+  private static void demonstrateLazyEvaluation() {
+    System.out.println("4. Lazy Evaluation - Efficiency");
+    System.out.println("-------------------------------");
+
+    boolean[] expensiveCallExecuted = {false};
+
+    Kind<MaybeKind.Witness, ConfigValue> primary =
+        MAYBE.just(new ConfigValue("found-in-primary", ConfigSource.ENVIRONMENT_VARIABLE));
+
+    Kind<MaybeKind.Witness, ConfigValue> result =
+        alt.orElse(
+            primary,
+            () -> {
+              expensiveCallExecuted[0] = true;
+              System.out.println("  ⚠ Expensive fallback computation running...");
+              return readFromDatabase("SOME_KEY");
+            });
+
+    Maybe<ConfigValue> config = MAYBE.narrow(result);
+    System.out.println("  ✓ Result: " + config.get());
+    System.out.println("  ℹ Expensive call executed: " + expensiveCallExecuted[0]);
+    System.out.println();
+  }
+
+  /** Demonstrates using Alternative for simple parser combinators. */
+  private static void demonstrateParserCombinator() {
+    System.out.println("5. Parser Combinator Pattern");
+    System.out.println("----------------------------");
+
+    String input1 = "true";
+    String input2 = "123";
+    String input3 = "hello";
+
+    System.out.println("  Parsing '" + input1 + "':");
+    Maybe<String> result1 = parseValue(input1);
+    if (result1.isJust()) {
+      System.out.println("    ✓ " + result1.get());
+    }
+
+    System.out.println("  Parsing '" + input2 + "':");
+    Maybe<String> result2 = parseValue(input2);
+    if (result2.isJust()) {
+      System.out.println("    ✓ " + result2.get());
+    }
+
+    System.out.println("  Parsing '" + input3 + "':");
+    Maybe<String> result3 = parseValue(input3);
+    if (result3.isNothing()) {
+      System.out.println("    ✗ Not a boolean or integer");
+    }
+    System.out.println();
+  }
+
+  /** Tries to parse input as boolean, then as integer, then returns original string. */
+  private static Maybe<String> parseValue(String input) {
+    Kind<MaybeKind.Witness, String> result =
+        alt.orElseAll(
+            parseBoolean(input), () -> parseInt(input), () -> MAYBE.just("String: " + input));
+    return MAYBE.narrow(result);
+  }
+
+  private static Kind<MaybeKind.Witness, String> parseBoolean(String s) {
+    if ("true".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s)) {
+      return MAYBE.just("Boolean: " + s);
+    }
+    return MAYBE.nothing();
+  }
+
+  private static Kind<MaybeKind.Witness, String> parseInt(String s) {
+    try {
+      int value = Integer.parseInt(s);
+      return MAYBE.just("Integer: " + value);
+    } catch (NumberFormatException e) {
+      return MAYBE.nothing();
+    }
+  }
+
+  // === Simulated Configuration Sources ===
+
+  private static Kind<MaybeKind.Witness, ConfigValue> readFromEnvironment(String key) {
+    // Simulate environment variable lookup
+    String value = System.getenv(key);
+    if (value != null) {
+      return MAYBE.just(new ConfigValue(value, ConfigSource.ENVIRONMENT_VARIABLE));
+    }
+    System.out.println("  ✗ Not found in environment variables");
+    return MAYBE.nothing();
+  }
+
+  private static Kind<MaybeKind.Witness, ConfigValue> readFromSystemProperty(String key) {
+    // Simulate system property lookup
+    String value = System.getProperty(key);
+    if (value != null) {
+      return MAYBE.just(new ConfigValue(value, ConfigSource.SYSTEM_PROPERTY));
+    }
+    System.out.println("  ✗ Not found in system properties");
+    return MAYBE.nothing();
+  }
+
+  private static Kind<MaybeKind.Witness, ConfigValue> readFromConfigFile(String key) {
+    // Simulate reading from config file
+    System.out.println("  → Checking config file...");
+    // Simulate some keys being found
+    if (key.equals("DATABASE_URL") || key.equals("MAX_CONNECTIONS")) {
+      String value = key.equals("DATABASE_URL") ? "jdbc:postgresql://localhost:5432/mydb" : "100";
+      return MAYBE.just(new ConfigValue(value, ConfigSource.CONFIG_FILE));
+    }
+    System.out.println("  ✗ Not found in config file");
+    return MAYBE.nothing();
+  }
+
+  private static Kind<MaybeKind.Witness, ConfigValue> readFromDatabase(String key) {
+    // Simulate database lookup (expensive operation)
+    System.out.println("  → Querying database...");
+    // Simulate not found
+    System.out.println("  ✗ Not found in database");
+    return MAYBE.nothing();
+  }
+
+  private static Kind<MaybeKind.Witness, ConfigValue> getDefaultValue(String key) {
+    // Always provides a default value
+    System.out.println("  → Using default value");
+    String defaultValue = "default-" + key.toLowerCase();
+    return MAYBE.just(new ConfigValue(defaultValue, ConfigSource.DEFAULT_VALUE));
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/ConfigSource.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/ConfigSource.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.basic.alternative;
+
+/** Represents different sources from which configuration can be loaded. */
+public enum ConfigSource {
+  ENVIRONMENT_VARIABLE,
+  SYSTEM_PROPERTY,
+  CONFIG_FILE,
+  DATABASE,
+  DEFAULT_VALUE
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/ConfigValue.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/ConfigValue.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.basic.alternative;
+
+/**
+ * Represents a configuration value along with its source.
+ *
+ * @param value The configuration value
+ * @param source The source from which the value was loaded
+ */
+public record ConfigValue(String value, ConfigSource source) {
+
+  @Override
+  public String toString() {
+    return String.format("ConfigValue[value='%s', source=%s]", value, source);
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/package-info.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/package-info.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+/**
+ * Demonstrates the Alternative type class through practical configuration loading examples.
+ *
+ * <p>The Alternative type class provides:
+ *
+ * <ul>
+ *   <li><b>empty()</b> - Represents failure/absence
+ *   <li><b>orElse()</b> - Combines alternatives with lazy evaluation
+ *   <li><b>guard()</b> - Conditional success based on predicates
+ *   <li><b>orElseAll()</b> - Chains multiple fallback sources
+ * </ul>
+ *
+ * <p>Run {@link org.higherkindedj.example.basic.alternative.AlternativeConfigExample} to see
+ * Alternative in action with configuration loading fallback chains.
+ *
+ * @see org.higherkindedj.hkt.Alternative
+ * @see org.higherkindedj.example.basic.alternative.AlternativeConfigExample
+ */
+package org.higherkindedj.example.basic.alternative;


### PR DESCRIPTION
This commit introduces the Alternative type class to higher-kinded-j, providing choice and failure operations for applicative functors.



Fixes #159 
