### PR TITLE
Update documentation to include flatMapN methods

### DIFF
--- a/hkj-book/src/glossary.md
+++ b/hkj-book/src/glossary.md
@@ -424,10 +424,16 @@ Kind<ListKind.Witness, Integer> lengths = functor.map(String::length, strings);
 **Core Operation:**
 - `flatMap(Function<A, Kind<F,B>> f, Kind<F,A> ma)` - Chain computations where each depends on the previous result
 
+**Additional Operations:**
+- `flatMap2/3/4/5(...)` - Combine multiple monadic values with a function that returns a monadic value (similar to `map2/3/4/5` but with effectful combining function)
+- `as(B value, Kind<F,A> ma)` - Replace the result while preserving the effect
+- `peek(Consumer<A> action, Kind<F,A> ma)` - Perform side effect without changing the value
+
 **Example:**
 ```java
 Monad<OptionalKind.Witness> monad = OptionalMonad.INSTANCE;
 
+// Chain dependent operations
 Kind<OptionalKind.Witness, String> result =
     monad.flatMap(
         userId -> monad.flatMap(
@@ -436,7 +442,14 @@ Kind<OptionalKind.Witness, String> result =
         ),
         findUser("user123")
     );
-// Each step depends on the previous result
+
+// Combine multiple monadic values with effectful result
+Kind<OptionalKind.Witness, Order> order =
+    monad.flatMap2(
+        findUser("user123"),
+        findProduct("prod456"),
+        (user, product) -> validateAndCreateOrder(user, product)
+    );
 ```
 
 **Laws:**

--- a/hkj-book/src/hkts/quick_reference.md
+++ b/hkj-book/src/hkts/quick_reference.md
@@ -88,16 +88,25 @@ Kind<ValidatedKind.Witness<List<String>>, User> userLogin =
 **Utility Methods:**
 - `as(B value, Kind<F,A> fa)` - replace value, keep effect
 - `peek(Consumer<A> action, Kind<F,A> fa)` - side effect without changing value
+- `flatMap2/3/4/5(...)` - combine multiple monadic values with effectful function
 
 **Example:**
 ```java
 // Chain database operations where each depends on the previous
-Kind<OptionalKind.Witness, Account> account = 
-    monad.flatMap(userLogin -> 
-        monad.flatMap(profile -> 
+Kind<OptionalKind.Witness, Account> account =
+    monad.flatMap(userLogin ->
+        monad.flatMap(profile ->
             findAccount(profile.accountId()),
             findProfile(userLogin.id())),
         findUser(userId));
+
+// Combine multiple monadic values with effectful result
+Kind<OptionalKind.Witness, Order> order =
+    monad.flatMap2(
+        findUser(userId),
+        findProduct(productId),
+        (user, product) -> validateAndCreateOrder(user, product) // Returns Optional
+    );
 ```
 
 **Think Of It As:** Chaining operations where each "opens the box" and "puts result in new box"

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListMonadTest.java
@@ -10,6 +10,7 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.function.Function3;
 import org.higherkindedj.hkt.function.Function4;
+import org.higherkindedj.hkt.function.Function5;
 import org.higherkindedj.hkt.test.api.TypeClassTest;
 import org.higherkindedj.hkt.test.validation.TestPatternValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -343,6 +344,175 @@ class ListMonadTest extends ListTestBase {
       var result = listMonad.map4(list1, list2, list3, list4, f4);
 
       assertThatList(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("flatMapN Tests")
+  class FlatMapNTests {
+
+    @Test
+    @DisplayName("flatMap2() sequences two lists and applies combining function")
+    void flatMap2SequencesTwoListsAndAppliesCombiningFunction() {
+      var list1 = listOf(1, 2);
+      var list2 = listOf("a", "b");
+
+      var result = listMonad.flatMap2(list1, list2, (i, s) -> listOf(i + s, i + s.toUpperCase()));
+
+      assertThatList(result).containsExactly("1a", "1A", "1b", "1B", "2a", "2A", "2b", "2B");
+    }
+
+    @Test
+    @DisplayName("flatMap2() returns empty if first list is empty")
+    void flatMap2ReturnsEmptyIfFirstListIsEmpty() {
+      Kind<ListKind.Witness, Integer> list1 = emptyList();
+      var list2 = listOf("a", "b");
+
+      var result = listMonad.flatMap2(list1, list2, (i, s) -> listOf(i + s));
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap2() returns empty if second list is empty")
+    void flatMap2ReturnsEmptyIfSecondListIsEmpty() {
+      var list1 = listOf(1, 2);
+      Kind<ListKind.Witness, String> list2 = emptyList();
+
+      var result = listMonad.flatMap2(list1, list2, (i, s) -> listOf(i + s));
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap2() handles function returning empty list")
+    void flatMap2HandlesFunctionReturningEmptyList() {
+      var list1 = listOf(1, 2);
+      var list2 = listOf("a", "b");
+
+      var result = listMonad.flatMap2(list1, list2, (i, s) -> emptyList());
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap3() sequences three lists and applies combining function")
+    void flatMap3SequencesThreeListsAndAppliesCombiningFunction() {
+      var list1 = listOf(1, 2);
+      var list2 = listOf("x");
+      var list3 = listOf(10.0);
+      Function3<Integer, String, Double, Kind<ListKind.Witness, String>> f3 =
+          (i, s, d) -> listOf(String.format("%d-%s-%.0f", i, s, d));
+
+      var result = listMonad.flatMap3(list1, list2, list3, f3);
+
+      assertThatList(result).containsExactly("1-x-10", "2-x-10");
+    }
+
+    @Test
+    @DisplayName("flatMap3() returns empty if middle list is empty")
+    void flatMap3ReturnsEmptyIfMiddleListIsEmpty() {
+      var list1 = listOf(1, 2);
+      Kind<ListKind.Witness, String> list2 = emptyList();
+      var list3 = listOf(10.0);
+      Function3<Integer, String, Double, Kind<ListKind.Witness, String>> f3 =
+          (i, s, d) -> listOf("Should not execute");
+
+      var result = listMonad.flatMap3(list1, list2, list3, f3);
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap3() with function returning multiple results")
+    void flatMap3WithFunctionReturningMultipleResults() {
+      var list1 = listOf(1);
+      var list2 = listOf("a");
+      var list3 = listOf(2.0);
+      Function3<Integer, String, Double, Kind<ListKind.Witness, String>> f3 =
+          (i, s, d) -> listOf(i + s, s + d, i + s + d);
+
+      var result = listMonad.flatMap3(list1, list2, list3, f3);
+
+      assertThatList(result).containsExactly("1a", "a2.0", "1a2.0");
+    }
+
+    @Test
+    @DisplayName("flatMap4() sequences four lists and applies combining function")
+    void flatMap4SequencesFourListsAndAppliesCombiningFunction() {
+      var list1 = listOf(1);
+      var list2 = listOf("a");
+      var list3 = listOf(2.0);
+      var list4 = listOf(true);
+      Function4<Integer, String, Double, Boolean, Kind<ListKind.Witness, String>> f4 =
+          (i, s, d, b) -> listOf(String.format("%d-%s-%.0f-%b", i, s, d, b));
+
+      var result = listMonad.flatMap4(list1, list2, list3, list4, f4);
+
+      assertThatList(result).containsExactly("1-a-2-true");
+    }
+
+    @Test
+    @DisplayName("flatMap4() returns empty if any list is empty")
+    void flatMap4ReturnsEmptyIfAnyListIsEmpty() {
+      var list1 = listOf(1);
+      var list2 = listOf("a");
+      Kind<ListKind.Witness, Double> list3 = emptyList();
+      var list4 = listOf(true);
+      Function4<Integer, String, Double, Boolean, Kind<ListKind.Witness, String>> f4 =
+          (i, s, d, b) -> listOf("Should not execute");
+
+      var result = listMonad.flatMap4(list1, list2, list3, list4, f4);
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap5() sequences five lists and applies combining function")
+    void flatMap5SequencesFiveListsAndAppliesCombiningFunction() {
+      var list1 = listOf(1);
+      var list2 = listOf("a");
+      var list3 = listOf(2.0);
+      var list4 = listOf(true);
+      var list5 = listOf('X');
+      Function5<Integer, String, Double, Boolean, Character, Kind<ListKind.Witness, String>> f5 =
+          (i, s, d, b, c) -> listOf(String.format("%d-%s-%.0f-%b-%c", i, s, d, b, c));
+
+      var result = listMonad.flatMap5(list1, list2, list3, list4, list5, f5);
+
+      assertThatList(result).containsExactly("1-a-2-true-X");
+    }
+
+    @Test
+    @DisplayName("flatMap5() returns empty if any list is empty")
+    void flatMap5ReturnsEmptyIfAnyListIsEmpty() {
+      var list1 = listOf(1);
+      var list2 = listOf("a");
+      var list3 = listOf(2.0);
+      var list4 = listOf(true);
+      Kind<ListKind.Witness, Character> list5 = emptyList();
+      Function5<Integer, String, Double, Boolean, Character, Kind<ListKind.Witness, String>> f5 =
+          (i, s, d, b, c) -> listOf("Should not execute");
+
+      var result = listMonad.flatMap5(list1, list2, list3, list4, list5, f5);
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap5() with function returning multiple results")
+    void flatMap5WithFunctionReturningMultipleResults() {
+      var list1 = listOf(1);
+      var list2 = listOf("a");
+      var list3 = listOf(2.0);
+      var list4 = listOf(true);
+      var list5 = listOf('X');
+      Function5<Integer, String, Double, Boolean, Character, Kind<ListKind.Witness, String>> f5 =
+          (i, s, d, b, c) -> listOf("first", "second", "third");
+
+      var result = listMonad.flatMap5(list1, list2, list3, list4, list5, f5);
+
+      assertThatList(result).containsExactly("first", "second", "third");
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalMonadTest.java
@@ -9,6 +9,9 @@ import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.function.Function3;
+import org.higherkindedj.hkt.function.Function4;
+import org.higherkindedj.hkt.function.Function5;
 import org.higherkindedj.hkt.test.api.TypeClassTest;
 import org.higherkindedj.hkt.test.validation.TestPatternValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -274,6 +277,161 @@ class OptionalMonadTest extends OptionalTestBase {
 
       assertThat(result).isSameAs(presentVal);
       assertThatOptional(result).isPresent().contains(100);
+    }
+  }
+
+  @Nested
+  @DisplayName("flatMapN Tests")
+  class FlatMapNTests {
+
+    @Test
+    @DisplayName("flatMap2() combines two present Optionals")
+    void flatMap2CombinesTwoPresentOptionals() {
+      var opt1 = presentOf(10);
+      var opt2 = presentOf("x");
+
+      var result = optionalMonad.flatMap2(opt1, opt2, (i, s) -> presentOf(i + s));
+
+      assertThatOptional(result).isPresent().contains("10x");
+    }
+
+    @Test
+    @DisplayName("flatMap2() returns empty if first Optional is empty")
+    void flatMap2ReturnsEmptyIfFirstOptionalIsEmpty() {
+      Kind<OptionalKind.Witness, Integer> opt1 = emptyOptional();
+      var opt2 = presentOf("x");
+
+      var result = optionalMonad.flatMap2(opt1, opt2, (i, s) -> presentOf(i + s));
+
+      assertThatOptional(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap2() returns empty if second Optional is empty")
+    void flatMap2ReturnsEmptyIfSecondOptionalIsEmpty() {
+      var opt1 = presentOf(10);
+      Kind<OptionalKind.Witness, String> opt2 = emptyOptional();
+
+      var result = optionalMonad.flatMap2(opt1, opt2, (i, s) -> presentOf(i + s));
+
+      assertThatOptional(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap2() returns empty if function returns empty")
+    void flatMap2ReturnsEmptyIfFunctionReturnsEmpty() {
+      var opt1 = presentOf(10);
+      var opt2 = presentOf("x");
+
+      var result = optionalMonad.flatMap2(opt1, opt2, (i, s) -> emptyOptional());
+
+      assertThatOptional(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap3() combines three present Optionals")
+    void flatMap3CombinesThreePresentOptionals() {
+      var opt1 = presentOf(1);
+      var opt2 = presentOf("a");
+      var opt3 = presentOf(2.5);
+      Function3<Integer, String, Double, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d) -> presentOf(String.format("%d-%s-%.1f", i, s, d));
+
+      var result = optionalMonad.flatMap3(opt1, opt2, opt3, f);
+
+      assertThatOptional(result).isPresent().contains("1-a-2.5");
+    }
+
+    @Test
+    @DisplayName("flatMap3() returns empty if middle Optional is empty")
+    void flatMap3ReturnsEmptyIfMiddleOptionalIsEmpty() {
+      var opt1 = presentOf(1);
+      Kind<OptionalKind.Witness, String> opt2 = emptyOptional();
+      var opt3 = presentOf(2.5);
+      Function3<Integer, String, Double, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d) -> presentOf("Should not execute");
+
+      var result = optionalMonad.flatMap3(opt1, opt2, opt3, f);
+
+      assertThatOptional(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap4() combines four present Optionals")
+    void flatMap4CombinesFourPresentOptionals() {
+      var opt1 = presentOf(1);
+      var opt2 = presentOf("a");
+      var opt3 = presentOf(2.0);
+      var opt4 = presentOf(true);
+      Function4<Integer, String, Double, Boolean, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d, b) -> presentOf(String.format("%d-%s-%.0f-%b", i, s, d, b));
+
+      var result = optionalMonad.flatMap4(opt1, opt2, opt3, opt4, f);
+
+      assertThatOptional(result).isPresent().contains("1-a-2-true");
+    }
+
+    @Test
+    @DisplayName("flatMap4() returns empty if any Optional is empty")
+    void flatMap4ReturnsEmptyIfAnyOptionalIsEmpty() {
+      var opt1 = presentOf(1);
+      var opt2 = presentOf("a");
+      Kind<OptionalKind.Witness, Double> opt3 = emptyOptional();
+      var opt4 = presentOf(true);
+      Function4<Integer, String, Double, Boolean, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d, b) -> presentOf("Should not execute");
+
+      var result = optionalMonad.flatMap4(opt1, opt2, opt3, opt4, f);
+
+      assertThatOptional(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap5() combines five present Optionals")
+    void flatMap5CombinesFivePresentOptionals() {
+      var opt1 = presentOf(1);
+      var opt2 = presentOf("a");
+      var opt3 = presentOf(2.0);
+      var opt4 = presentOf(true);
+      var opt5 = presentOf('X');
+      Function5<Integer, String, Double, Boolean, Character, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d, b, c) -> presentOf(String.format("%d-%s-%.0f-%b-%c", i, s, d, b, c));
+
+      var result = optionalMonad.flatMap5(opt1, opt2, opt3, opt4, opt5, f);
+
+      assertThatOptional(result).isPresent().contains("1-a-2-true-X");
+    }
+
+    @Test
+    @DisplayName("flatMap5() returns empty if any Optional is empty")
+    void flatMap5ReturnsEmptyIfAnyOptionalIsEmpty() {
+      var opt1 = presentOf(1);
+      var opt2 = presentOf("a");
+      var opt3 = presentOf(2.0);
+      var opt4 = presentOf(true);
+      Kind<OptionalKind.Witness, Character> opt5 = emptyOptional();
+      Function5<Integer, String, Double, Boolean, Character, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d, b, c) -> presentOf("Should not execute");
+
+      var result = optionalMonad.flatMap5(opt1, opt2, opt3, opt4, opt5, f);
+
+      assertThatOptional(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flatMap5() returns empty if function returns empty")
+    void flatMap5ReturnsEmptyIfFunctionReturnsEmpty() {
+      var opt1 = presentOf(1);
+      var opt2 = presentOf("a");
+      var opt3 = presentOf(2.0);
+      var opt4 = presentOf(true);
+      var opt5 = presentOf('X');
+      Function5<Integer, String, Double, Boolean, Character, Kind<OptionalKind.Witness, String>> f =
+          (i, s, d, b, c) -> emptyOptional();
+
+      var result = optionalMonad.flatMap5(opt1, opt2, opt3, opt4, opt5, f);
+
+      assertThatOptional(result).isEmpty();
     }
   }
 


### PR DESCRIPTION

Add flatMapN methods to Monad for combining effects

Add flatMap2, flatMap3, flatMap4, and flatMap5 methods to the Monad interface, following the same pattern as the mapN methods in Applicative. These methods sequence multiple monadic values and combine their results using a function that itself returns a monadic value, enabling powerful composition of effectful operations.


Fixes #98 
