### PR TITLE
Refactor IO, Maybe, and Either to directly implement Kind interfaces

### DIFF
--- a/hkj-book/src/hkts/core-concepts.md
+++ b/hkj-book/src/hkts/core-concepts.md
@@ -101,12 +101,13 @@ For each Java type constructor (like `List`, `Optional`, `IO`) you want to simul
 
 ![defunctionalisation_external.svg](../images/puml/defunctionalisation_external.svg)
 
-* **For Types Defined Within Higher-Kinded-J (e.g., `Id`, `Maybe`, `IO`, Monad Transformers like `EitherT`):**
+* **For Types Defined Within Higher-Kinded-J (e.g., `Id`, `IO`, `Maybe`, `Either`, Monad Transformers like `EitherT`):**
     * These types are designed to directly participate in the HKT simulation.
-    * The type itself (e.g., `Id<A>`, `MaybeT<F, A>`) will directly implement its corresponding `XxxKind` interface (e.g., `Id<A> implements IdKind<A>`, where `IdKind<A> extends Kind<IdKind.Witness, A>`).
-    * In this case, a separate `Holder` record is **not needed** for the primary `wrap`/`unwrap` mechanism in the `KindHelper`.
-    * `XxxKindHelper.wrap(Id<A> id)` would effectively be a type cast (after null checks) to `Kind<IdKind.Witness, A>` because `Id<A>` *is already* an `IdKind<A>`.
-    * `XxxKindHelper.unwrap(Kind<IdKind.Witness, A> kind)` would check `instanceof Id` (or `instanceof MaybeT`, etc.) and perform a cast.
+    * The type itself (e.g., `Id<A>`, `IO<A>`, `Just<T>`, `Either.Right<L,R>`) will directly implement its corresponding `XxxKind` interface (e.g., `Id<A> implements IdKind<A>`, `IO<A> extends IOKind<A>`, `Just<T> implements MaybeKind<T>`, `Either.Right<L,R> implements EitherKind<L,R>`).
+    * In this case, a separate `Holder` record is **not needed** for the primary `widen`/`narrow` mechanism in the `KindHelper`.
+    * `XxxKindHelper.widen(IO<A> io)` would effectively be a type cast (after null checks) to `Kind<IOKind.Witness, A>` because `IO<A>` *is already* an `IOKind<A>`.
+    * `XxxKindHelper.narrow(Kind<IOKind.Witness, A> kind)` would check `instanceof IO` and perform a cast.
+    * This approach provides **zero runtime overhead** for widen/narrow operations (no wrapper object allocation) and improved debugging experience (actual types visible in stack traces).
 
 This distinction is important for understanding how `wrap` and `unwrap` function for different types. However, from the perspective of a user of a type class instance (like `OptionalMonad`), the interaction remains consistent: you provide a `Kind` object, and the type class instance handles the necessary operations.
 

--- a/hkj-book/src/hkts/extending-simulation.md
+++ b/hkj-book/src/hkts/extending-simulation.md
@@ -9,6 +9,8 @@ There are two main scenarios:
 1. **Adapting External Types**: For types you don't own (e.g., JDK classes like `java.util.Set`, `java.util.Map`, or classes from other libraries).
 2. **Integrating Custom Library Types**: For types defined within your own project or a library you control, where you can modify the type itself.
 
+> **Note:** Within Higher-Kinded-J, core library types like `IO`, `Maybe`, and `Either` follow Scenario 2—they directly implement their respective Kind interfaces (`IOKind`, `MaybeKind`, `EitherKind`). This provides zero runtime overhead for widen/narrow operations.
+
 The core pattern involves creating:
 
 * An `XxxKind` interface with a nested `Witness` type (this remains the same).
@@ -125,6 +127,8 @@ Since we cannot modify `java.util.Set` to directly implement our `Kind` structur
 ## Scenario 2: Integrating a Custom Library Type
 
 If you are defining a new type *within your library* (e.g., a custom `MyType<A>`), you can design it to directly participate in the HKT simulation. This approach typically doesn't require an explicit `Holder` record if your type can directly implement the `XxxKind` interface.
+
+> **Examples in Higher-Kinded-J:** `IO<A>`, `Maybe<A>` (via `Just<T>` and `Nothing<T>`), `Either<L,R>` (via `Left` and `Right`), `Validated<E,A>`, `Id<A>`, and monad transformers all use this pattern. Their widen/narrow operations are simple type-safe casts with no wrapper object allocation.
 
 ~~~admonish
 

--- a/hkj-book/src/hkts/usage-guide.md
+++ b/hkj-book/src/hkts/usage-guide.md
@@ -72,7 +72,7 @@ Convert your standard Java object (e.g., a `List<Integer>`, an `Optional<String>
 * Helper enums provide convenience factory methods that also return `Kind` instances, e.g., `MAYBE.just("value")`, `TRY.failure(ex)`, `IO_OP.delay(() -> ...)`, `LAZY.defer(() -> ...)`. Remember to import thes statically from the XxxKindHelper classes.
 * **Note on Widening**:
   * For JDK types (like `List`, `Optional`), `widen` typically creates an internal `Holder` object that wraps the JDK type and implements the necessary `XxxKind` interface.
-  * For library-defined types (`Id`, `Maybe`, `IO`, Transformers like `EitherT`) that directly implement their `XxxKind` interface (which in turn extends `Kind`), the `widen` method on the helper enum often performs a null check and then a direct (and safe) cast to the `Kind` type.
+  * For library-defined types (`Id`, `IO`, `Maybe`, `Either`, `Validated`, Transformers like `EitherT`) that directly implement their `XxxKind` interface (which in turn extends `Kind`), the `widen` method on the helper enum performs a null check and then a direct (and safe) cast to the `Kind` type. This provides zero runtime overhead—no wrapper object allocation needed.
 ~~~
 
 ~~~admonish title="Step 4: Apply Type Class Methods"

--- a/hkj-book/src/monads/either_monad.md
+++ b/hkj-book/src/monads/either_monad.md
@@ -25,7 +25,7 @@ Unlike throwing exceptions, `Either` makes the possibility of failure explicit i
 
 We can think of `Either` as an extension of `Maybe`. The `Right` is equivalent to `Maybe.Just`, and the `Left` is the equivalent of `Maybe.Nothing` **but now we can allow it to carry a value.**
 
-The implementation in this library is a `sealed interface Either<L, R>` with two `record` implementations: `Left<L, R>` and `Right<L, R>`. `Either<L, R>` directly implements `EitherKind<L, R>`, which in turn extends `Kind<EitherKind.Witness<L>, R>`.
+The implementation in this library is a `sealed interface Either<L, R>` with two `record` implementations: `Left<L, R>` and `Right<L, R>`. Both `Left` and `Right` directly implement `EitherKind<L, R>` (and `EitherKind2<L, R>` for bifunctor operations), which extend `Kind<EitherKind.Witness<L>, R>`. This means widen/narrow operations have zero runtime overhead—no wrapper object allocation needed.
 
 ## Structure
 

--- a/hkj-book/src/monads/io_monad.md
+++ b/hkj-book/src/monads/io_monad.md
@@ -35,11 +35,11 @@ The key idea is that an `IO<A>` value doesn't *perform* the side effect immediat
 
 The `IO` functionality is built upon several related components:
 
-1. **`IO<A>`**: The core functional interface. An `IO<A>` instance essentially wraps a `Supplier<A>` (or similar function) that performs the side effect and returns a value `A`. The crucial method is `unsafeRunSync()`, which executes the encapsulated computation.
-2. **`IOKind<A>`**: The HKT marker interface (`Kind<IOKind.Witness, A>`) for `IO`. This allows `IO` to be treated as a generic type constructor `F` in type classes like `Functor`, `Applicative`, and `Monad`. The witness type is `IOKind.Witness`.
+1. **`IO<A>`**: The core functional interface. An `IO<A>` instance essentially wraps a `Supplier<A>` (or similar function) that performs the side effect and returns a value `A`. The crucial method is `unsafeRunSync()`, which executes the encapsulated computation. `IO<A>` directly extends `IOKind<A>`, making it a first-class participant in the HKT simulation.
+2. **`IOKind<A>`**: The HKT marker interface (`Kind<IOKind.Witness, A>`) for `IO`. This allows `IO` to be treated as a generic type constructor `F` in type classes like `Functor`, `Applicative`, and `Monad`. The witness type is `IOKind.Witness`. Since `IO<A>` directly extends this interface, no wrapper types are needed.
 3. **`IOKindHelper`**: The essential utility class for working with `IO` in the HKT simulation. It provides:
-   * `widen(IO<A>)`: Wraps a concrete `IO<A>` instance into its HKT representation `IOKind<A>`.
-   * `narrow(Kind<IOKind.Witness, A>)`: Unwraps an `IOKind<A>` back to the concrete `IO<A>`. Throws `KindUnwrapException` if the input Kind is invalid.
+   * `widen(IO<A>)`: Converts a concrete `IO<A>` instance into its HKT representation `Kind<IOKind.Witness, A>`. Since `IO` directly implements `IOKind`, this is a null-checked cast with zero runtime overhead.
+   * `narrow(Kind<IOKind.Witness, A>)`: Converts back to the concrete `IO<A>`. Performs an `instanceof IO` check and cast. Throws `KindUnwrapException` if the input Kind is invalid.
    * `delay(Supplier<A>)`: The primary factory method to create an `IOKind<A>` by wrapping a side-effecting computation described by a `Supplier`.
    * `unsafeRunSync(Kind<IOKind.Witness, A>)`: The method to *execute* the computation described by an `IOKind`. This is typically called at the "end of the world" in your application (e.g., in the `main` method) to run the composed IO program.
 4. **`IOFunctor`**: Implements `Functor<IOKind.Witness>`. Provides the `map` operation to transform the result value `A` of an `IO` computation *without* executing the effect.

--- a/hkj-book/src/monads/maybe_monad.md
+++ b/hkj-book/src/monads/maybe_monad.md
@@ -39,7 +39,7 @@ It implements `MonadError<MaybeKind.Witness, Unit>`, which transitively includes
 
 ### Creating Instances
 
-`Maybe<A>` instances can be created directly using static factory methods on `Maybe`, or via `MaybeMonad` for HKT integration. `MaybeKind<A>` is the HKT wrapper.
+`Maybe<A>` instances can be created directly using static factory methods on `Maybe`, or via `MaybeMonad` for HKT integration. Since `Just<T>` and `Nothing<T>` directly implement `MaybeKind<T>`, they are first-class participants in the HKT simulation with zero runtime overhead for widen/narrow operations.
 
 **Direct `Maybe` Creation:**
  ~~~admonish  title="_Maybe.just(@NonNull T value)_"
@@ -66,7 +66,7 @@ It implements `MonadError<MaybeKind.Witness, Unit>`, which transitively includes
 **`MaybeKindHelper` (for HKT wrapping):**
 ~~~admonish  title="_MaybeKindHelper.widen(Maybe<A> maybe)_"
 
-Converts a `Maybe<A>` to `MaybeKind<A>`.
+Converts a `Maybe<A>` to `Kind<MaybeKind.Witness, A>`. Since `Just` and `Nothing` directly implement `MaybeKind`, this performs a null check and type-safe cast (zero overhead—no wrapper object allocation).
   ```java
   Kind<MaybeKind.Witness, String> kindJust = MAYBE.widen(Maybe.just("Wrapped"));
   Kind<MaybeKind.Witness,Integer> kindNothing = MAYBE.widen(Maybe.nothing());

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/Either.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/Either.java
@@ -393,11 +393,17 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
    * Represents the {@link Left} case of an {@link Either}. By convention, this holds an error or
    * alternative value. This is a {@link Record} for conciseness and immutability.
    *
+   * <p>As part of the HKT pattern, this class implements both {@link EitherKind} and {@link
+   * EitherKind2}, allowing it to be used with typeclasses expecting {@code
+   * Kind<EitherKind.Witness<L>, R>} (for functors/monads) or {@code Kind2<EitherKind2.Witness, L,
+   * R>} (for bifunctors).
+   *
    * @param <L> The type of the value held.
    * @param <R> The type of the {@link Right} value (phantom type for {@code Left}).
    * @param value The value of type {@code L}. Can be {@code null}.
    */
-  record Left<L, R>(@Nullable L value) implements Either<L, R> {
+  record Left<L, R>(@Nullable L value)
+      implements Either<L, R>, EitherKind<L, R>, EitherKind2<L, R> {
 
     @Override
     public boolean isLeft() {
@@ -455,11 +461,17 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
    * Represents the {@link Right} case of an {@link Either}. By convention, this holds the
    * successful or primary value. This is a {@link Record} for conciseness and immutability.
    *
+   * <p>As part of the HKT pattern, this class implements both {@link EitherKind} and {@link
+   * EitherKind2}, allowing it to be used with typeclasses expecting {@code
+   * Kind<EitherKind.Witness<L>, R>} (for functors/monads) or {@code Kind2<EitherKind2.Witness, L,
+   * R>} (for bifunctors).
+   *
    * @param <L> The type of the {@link Left} value (phantom type for {@code Right}).
    * @param <R> The type of the value held.
    * @param value The value of type {@code R}. Can be {@code null}.
    */
-  record Right<L, R>(@Nullable R value) implements Either<L, R> {
+  record Right<L, R>(@Nullable R value)
+      implements Either<L, R>, EitherKind<L, R>, EitherKind2<L, R> {
     @Override
     public boolean isLeft() {
       return false;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherKindHelper.java
@@ -21,95 +21,70 @@ public enum EitherKindHelper implements EitherConverterOps {
   private static final Class<Either> EITHER_CLASS = Either.class;
 
   /**
-   * Internal record implementing {@link EitherKind} to hold the concrete {@link Either} instance.
-   *
-   * @param <L> The type of the {@code Left} value.
-   * @param <R> The type of the {@code Right} value.
-   * @param either The non-null, actual {@link Either} instance.
-   */
-  record EitherHolder<L, R>(Either<L, R> either) implements EitherKind<L, R> {
-
-    public EitherHolder {
-      Validation.kind().requireForWiden(either, EITHER_CLASS);
-    }
-  }
-
-  /**
-   * Internal record implementing {@link EitherKind2} to hold the concrete {@link Either} instance
-   * for bifunctor operations.
-   *
-   * @param <L> The type of the {@code Left} value.
-   * @param <R> The type of the {@code Right} value.
-   * @param either The non-null, actual {@link Either} instance.
-   */
-  record EitherKind2Holder<L, R>(Either<L, R> either) implements EitherKind2<L, R> {
-
-    public EitherKind2Holder {
-      Validation.kind().requireForWiden(either, EITHER_CLASS);
-    }
-  }
-
-  /**
    * Widens a concrete {@code Either<L, R>} instance into its higher-kinded representation, {@code
    * Kind<EitherKind.Witness<L>, R>}. Implements {@link EitherConverterOps#widen}.
+   *
+   * <p>Since {@code Left} and {@code Right} directly implement {@code EitherKind}, this method
+   * performs a simple type-safe cast without requiring a wrapper object.
    *
    * @param <L> The type of the "Left" value of the {@code Either}.
    * @param <R> The type of the "Right" value of the {@code Either}.
    * @param either The concrete {@code Either<L, R>} instance to widen. Must not be null.
-   * @return A {@code Kind<EitherKind.Witness<L>, R>} representing the wrapped {@code Either}. Never
-   *     null.
+   * @return A {@code Kind<EitherKind.Witness<L>, R>} representing the {@code Either}. Never null.
    * @throws NullPointerException if {@code either} is {@code null}.
    */
   @Override
+  @SuppressWarnings("unchecked")
   public <L, R> Kind<EitherKind.Witness<L>, R> widen(Either<L, R> either) {
-    return new EitherHolder<>(either);
+    Validation.kind().requireForWiden(either, EITHER_CLASS);
+    return (Kind<EitherKind.Witness<L>, R>) either;
   }
 
   /**
    * Narrows a {@code Kind<EitherKind.Witness<L>, R>} back to its concrete {@code Either<L, R>}
    * type. Implements {@link EitherConverterOps#narrow}.
    *
-   * <p>This implementation uses a holder-based approach with modern switch expressions for
-   * consistent pattern matching.
+   * <p>Since {@code Left} and {@code Right} directly implement {@code EitherKind}, this method
+   * performs a direct type check and cast without needing to unwrap from a holder.
    *
    * @param <L> The type of the "Left" value of the target {@code Either}.
    * @param <R> The type of the "Right" value of the target {@code Either}.
    * @param kind The {@code Kind<EitherKind.Witness<L>, R>} instance to narrow. May be {@code null}.
    * @return The underlying {@code Either<L, R>} instance. Never null.
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if the input {@code kind} is {@code
-   *     null} or not a representation of an {@code Either<L,R>}.
+   *     null} or not an instance of {@code Either}.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <L, R> Either<L, R> narrow(@Nullable Kind<EitherKind.Witness<L>, R> kind) {
-    return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            EITHER_CLASS,
-            EitherHolder.class,
-            // Safe cast due to type erasure and holder validation
-            holder -> ((EitherHolder<L, R>) holder).either());
+    return Validation.kind().narrowWithTypeCheck(kind, EITHER_CLASS);
   }
 
   /**
    * Widens a concrete {@code Either<L, R>} instance into its Kind2 representation, {@code
    * Kind2<EitherKind2.Witness, L, R>}. Implements {@link EitherConverterOps#widen2}.
    *
+   * <p>Since {@code Left} and {@code Right} directly implement {@code EitherKind2}, this method
+   * performs a simple type-safe cast without requiring a wrapper object.
+   *
    * @param <L> The type of the "Left" value of the {@code Either}.
    * @param <R> The type of the "Right" value of the {@code Either}.
    * @param either The concrete {@code Either<L, R>} instance to widen. Must not be null.
-   * @return A {@code Kind2<EitherKind2.Witness, L, R>} representing the wrapped {@code Either}.
-   *     Never null.
+   * @return A {@code Kind2<EitherKind2.Witness, L, R>} representing the {@code Either}. Never null.
    * @throws NullPointerException if {@code either} is {@code null}.
    */
   @Override
+  @SuppressWarnings("unchecked")
   public <L, R> Kind2<EitherKind2.Witness, L, R> widen2(Either<L, R> either) {
-    return new EitherKind2Holder<>(either);
+    Validation.kind().requireForWiden(either, EITHER_CLASS);
+    return (Kind2<EitherKind2.Witness, L, R>) either;
   }
 
   /**
    * Narrows a {@code Kind2<EitherKind2.Witness, L, R>} back to its concrete {@code Either<L, R>}
    * type. Implements {@link EitherConverterOps#narrow2}.
+   *
+   * <p>Since {@code Left} and {@code Right} directly implement {@code EitherKind2}, this method
+   * performs a direct type check and cast without needing to unwrap from a holder.
    *
    * @param <L> The type of the "Left" value of the target {@code Either}.
    * @param <R> The type of the "Right" value of the target {@code Either}.
@@ -117,7 +92,7 @@ public enum EitherKindHelper implements EitherConverterOps {
    *     null}.
    * @return The underlying {@code Either<L, R>} instance. Never null.
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if the input {@code kind} is {@code
-   *     null} or not a representation of an {@code Either<L,R>}.
+   *     null} or not an instance of {@code Either}.
    */
   @Override
   @SuppressWarnings("unchecked")
@@ -126,13 +101,12 @@ public enum EitherKindHelper implements EitherConverterOps {
       throw new org.higherkindedj.hkt.exception.KindUnwrapException(
           "Cannot narrow null Kind2 for Either");
     }
-    if (!(kind instanceof EitherKind2Holder<?, ?>)) {
+    if (!(kind instanceof Either<?, ?>)) {
       throw new org.higherkindedj.hkt.exception.KindUnwrapException(
           "Kind2 instance cannot be narrowed to Either (received: "
               + kind.getClass().getSimpleName()
               + ")");
     }
-    // Safe cast due to type erasure and holder validation
-    return ((EitherKind2Holder<L, R>) kind).either();
+    return (Either<L, R>) kind;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/package-info.java
@@ -1,7 +1,16 @@
 /**
  * Provides components for the {@code Either} type and its simulation as a Higher-Kinded Type.
  * {@code Either} represents a value of one of two possible types, typically used for error
- * handling. Includes {@link org.higherkindedj.hkt.either.Either}, {@link
+ * handling.
+ *
+ * <p>{@link org.higherkindedj.hkt.either.Either.Left} and {@link
+ * org.higherkindedj.hkt.either.Either.Right} directly implement {@link
+ * org.higherkindedj.hkt.either.EitherKind} and {@link org.higherkindedj.hkt.either.EitherKind2},
+ * allowing them to participate in the HKT simulation without requiring wrapper types. This means
+ * that {@code widen} and {@code narrow} operations are simple type-safe casts rather than object
+ * wrapping.
+ *
+ * <p>Includes {@link org.higherkindedj.hkt.either.Either}, {@link
  * org.higherkindedj.hkt.either.EitherKind}, {@link org.higherkindedj.hkt.either.EitherMonad}, and
  * helpers.
  */

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IO.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IO.java
@@ -32,6 +32,10 @@ import org.higherkindedj.hkt.util.validation.Validation;
  *   <li><b>Composability:</b> {@code IO} operations can be easily chained and combined using
  *       methods like {@link #map(Function)} and {@link #flatMap(Function)} to build more complex
  *       effectful workflows.
+ *   <li><b>HKT Integration:</b> {@code IO<A>} directly extends {@link IOKind IOKind<A>}, making it
+ *       a first-class participant in the Higher-Kinded-J HKT simulation. This means widen/narrow
+ *       operations via {@link IOKindHelper} have zero runtime overhead (simple type-safe casts
+ *       rather than wrapper object allocation).
  * </ul>
  *
  * <p><b>Example:</b>
@@ -70,7 +74,7 @@ import org.higherkindedj.hkt.util.validation.Validation;
  *     often used as the type parameter {@code A}.
  */
 @FunctionalInterface
-public interface IO<A> {
+public interface IO<A> extends IOKind<A> {
 
   /**
    * Executes the described computation synchronously, potentially performing side effects and

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOKindHelper.java
@@ -21,51 +21,39 @@ public enum IOKindHelper implements IOConverterOps {
   private static final Class<IO> IO_CLASS = IO.class;
 
   /**
-   * Internal record implementing {@link IOKind} to hold the concrete {@link IO} instance.
-   *
-   * @param <A> The result type of the IO computation.
-   * @param ioInstance The non-null, actual {@link IO} instance.
-   */
-  record IOHolder<A>(IO<A> ioInstance) implements IOKind<A> {
-    IOHolder {
-      Validation.kind().requireForWiden(ioInstance, IO_CLASS);
-    }
-  }
-
-  /**
    * Widens a concrete {@link IO<A>} instance into its higher-kinded representation, {@code
    * Kind<IOKind.Witness, A>}. Implements {@link IOConverterOps#widen}.
    *
+   * <p>Since {@code IO} directly extends {@code IOKind}, this method performs a simple type-safe
+   * cast without requiring a wrapper object.
+   *
    * @param <A> The result type of the {@code IO} computation.
    * @param io The non-null, concrete {@link IO<A>} instance to widen.
-   * @return A non-null {@link Kind<IOKind.Witness, A>} representing the wrapped {@code IO}
-   *     computation.
+   * @return A non-null {@link Kind<IOKind.Witness, A>} representing the {@code IO} computation.
    * @throws NullPointerException if {@code io} is {@code null}.
    */
   @Override
   public <A> Kind<IOKind.Witness, A> widen(IO<A> io) {
-    return new IOHolder<>(io);
+    Validation.kind().requireForWiden(io, IO_CLASS);
+    return io;
   }
 
   /**
    * Narrows a {@code Kind<IOKind.Witness, A>} back to its concrete {@link IO<A>} type. Implements
    * {@link IOConverterOps#narrow}.
    *
-   * <p>This implementation uses a holder-based approach with modern switch expressions for
-   * consistent pattern matching.
+   * <p>Since {@code IO} directly extends {@code IOKind}, this method performs a direct type check
+   * and cast without needing to unwrap from a holder.
    *
    * @param <A> The result type of the {@code IO} computation.
    * @param kind The {@code Kind<IOKind.Witness, A>} instance to narrow. May be {@code null}.
    * @return The underlying, non-null {@link IO<A>} instance.
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if the input {@code kind} is {@code
-   *     null}, or not an instance of the expected underlying holder type for IO.
+   *     null}, or not an instance of {@code IO}.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <A> IO<A> narrow(@Nullable Kind<IOKind.Witness, A> kind) {
-    return Validation.kind()
-        .narrowWithPattern(
-            kind, IO_CLASS, IOHolder.class, holder -> ((IOHolder<A>) holder).ioInstance());
+    return Validation.kind().narrowWithTypeCheck(kind, IO_CLASS);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/package-info.java
@@ -1,8 +1,13 @@
 /**
  * Provides components for the {@code IO} monad and its simulation as a Higher-Kinded Type. The
- * {@code IO} monad is used for encapsulating side-effecting computations. Includes the {@link
- * org.higherkindedj.hkt.io.IO} type, {@link org.higherkindedj.hkt.io.IOKind}, {@link
- * org.higherkindedj.hkt.io.IOMonad}, and helper utilities.
+ * {@code IO} monad is used for encapsulating side-effecting computations.
+ *
+ * <p>{@code IO<A>} directly implements {@link org.higherkindedj.hkt.io.IOKind}, allowing it to
+ * participate in the HKT simulation without requiring wrapper types. This means that {@code widen}
+ * and {@code narrow} operations are simple type-safe casts rather than object wrapping.
+ *
+ * <p>Includes the {@link org.higherkindedj.hkt.io.IO} type, {@link
+ * org.higherkindedj.hkt.io.IOKind}, {@link org.higherkindedj.hkt.io.IOMonad}, and helper utilities.
  */
 @org.jspecify.annotations.NullMarked
 package org.higherkindedj.hkt.io;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
@@ -10,9 +10,14 @@ import java.util.function.Supplier;
 import org.higherkindedj.hkt.util.validation.Validation;
 import org.jspecify.annotations.Nullable;
 
-/** Concrete implementation of Maybe representing the presence of a value. */
+/**
+ * Concrete implementation of Maybe representing the presence of a value.
+ *
+ * <p>As part of the HKT pattern, this class implements {@link MaybeKind}, allowing it to be used
+ * with typeclasses expecting {@code Kind<MaybeKind.Witness, T>}.
+ */
 // Value must be NonNull because Maybe.just requires it
-record Just<T>(T value) implements Maybe<T> {
+record Just<T>(T value) implements Maybe<T>, MaybeKind<T> {
   // Constructor implicitly checks value is non-null via Maybe.just factory
 
   @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Maybe.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Maybe.java
@@ -22,6 +22,11 @@ import org.jspecify.annotations.Nullable;
  * within a {@link Just} instance; the {@code Nothing} state should be used to represent the absence
  * of a value.
  *
+ * <p>As part of the Higher-Kinded-J HKT simulation, both {@link Just} and {@link Nothing} directly
+ * implement {@link MaybeKind}, allowing them to participate in the HKT framework without requiring
+ * wrapper types. This means that widen/narrow operations via {@link MaybeKindHelper} have zero
+ * runtime overhead (simple type-safe casts rather than object allocation).
+ *
  * @param <T> the type of the value held by this {@code Maybe} instance. This type parameter itself
  *     can be nullable if {@code T} represents a type that can be null, but a {@link Just} instance
  *     will always wrap a non-null value.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Nothing.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Nothing.java
@@ -10,8 +10,13 @@ import java.util.function.Supplier;
 import org.higherkindedj.hkt.util.validation.Validation;
 import org.jspecify.annotations.Nullable;
 
-/** Concrete implementation of Maybe representing the absence of a value (singleton). */
-final class Nothing<T> implements Maybe<T> {
+/**
+ * Concrete implementation of Maybe representing the absence of a value (singleton).
+ *
+ * <p>As part of the HKT pattern, this class implements {@link MaybeKind}, allowing it to be used
+ * with typeclasses expecting {@code Kind<MaybeKind.Witness, T>}.
+ */
+final class Nothing<T> implements Maybe<T>, MaybeKind<T> {
   // Singleton instance
   private static final Nothing<?> INSTANCE = new Nothing<>();
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/package-info.java
@@ -1,8 +1,15 @@
 /**
  * Provides components for the {@code Maybe} type and its simulation as a Higher-Kinded Type. {@code
- * Maybe} is a custom type similar to Optional, representing a value that might be absent. Includes
- * {@link org.higherkindedj.hkt.maybe.Maybe}, {@link org.higherkindedj.hkt.maybe.MaybeKind}, {@link
- * org.higherkindedj.hkt.maybe.MaybeMonad}, and helpers.
+ * Maybe} is a custom type similar to Optional, representing a value that might be absent.
+ *
+ * <p>{@link org.higherkindedj.hkt.maybe.Just} and {@link org.higherkindedj.hkt.maybe.Nothing}
+ * directly implement {@link org.higherkindedj.hkt.maybe.MaybeKind}, allowing them to participate in
+ * the HKT simulation without requiring wrapper types. This means that {@code widen} and {@code
+ * narrow} operations are simple type-safe casts rather than object wrapping.
+ *
+ * <p>Includes {@link org.higherkindedj.hkt.maybe.Maybe}, {@link
+ * org.higherkindedj.hkt.maybe.MaybeKind}, {@link org.higherkindedj.hkt.maybe.MaybeMonad}, and
+ * helpers.
  */
 @org.jspecify.annotations.NullMarked
 package org.higherkindedj.hkt.maybe;

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/io/IOKindHelperTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/io/IOKindHelperTest.java
@@ -205,10 +205,12 @@ class IOKindHelperTest extends IOTestBase {
   @DisplayName("IO_OP.widen()")
   class WidenTests {
     @Test
-    @DisplayName("widen should return holder for IO")
+    @DisplayName("widen should return the same IO instance (direct implementation)")
     void widenShouldReturnHolderForIO() {
       Kind<IOKind.Witness, String> kind = IO_OP.widen(baseIO);
-      assertThat(kind).isInstanceOf(IOKindHelper.IOHolder.class);
+      assertThat(kind).isInstanceOf(IO.class);
+      // Verify identity is preserved (no wrapping)
+      assertThat(kind).isSameAs(baseIO);
       // Unwrap to verify
       assertThat(IO_OP.narrow(kind)).isSameAs(baseIO);
     }


### PR DESCRIPTION
This refactoring eliminates the wrapper/holder pattern for library typeclasses, making them consistent with the existing Id and Validated implementations.

Changes:
- IO<A> now extends IOKind<A> directly (functional interface preserved)
- Just<T> and Nothing<T> now implement MaybeKind<T> directly
- Either.Left<L,R> and Either.Right<L,R> now implement EitherKind<L,R> and EitherKind2<L,R>
- Updated all corresponding KindHelper classes to use direct casting instead of holder wrapping

Benefits:
- Zero runtime overhead for widen() operations (simple cast vs object allocation)
- Reduced memory footprint and GC pressure
- Simpler and more consistent codebase
- Better debugging experience (actual types visible, not wrapped in holders)
- Matches the established pattern from Validated and Id
