### PR TITLE
Add At type class for indexed CRUD operations on collections

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/optics/At.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/At.java
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics;
+
+import java.util.Optional;
+
+/**
+ * A type class for structures that support indexed access with insertion and deletion semantics.
+ *
+ * <p>{@code At} provides a {@link Lens} focusing on the optional presence of a value at a given
+ * index. This enables CRUD (Create, Read, Update, Delete) operations on indexed structures like
+ * {@link java.util.Map} or {@link java.util.List}.
+ *
+ * <p>The key insight is that setting to {@link Optional#empty()} deletes the entry, while setting
+ * to {@link Optional#of(Object)} inserts or updates the entry. This makes {@code At} more powerful
+ * than a simple indexed accessor.
+ *
+ * <h3>Example Usage:</h3>
+ *
+ * <pre>{@code
+ * // Create an At instance for Map<String, Integer>
+ * At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+ *
+ * Map<String, Integer> scores = new HashMap<>();
+ * scores.put("alice", 100);
+ *
+ * // Insert a new entry
+ * Map<String, Integer> updated = mapAt.insertOrUpdate("bob", 85, scores);
+ * // scores is unchanged, updated = {alice=100, bob=85}
+ *
+ * // Remove an entry
+ * Map<String, Integer> afterRemove = mapAt.remove("alice", updated);
+ * // afterRemove = {bob=85}
+ *
+ * // Check for presence
+ * Optional<Integer> bobScore = mapAt.at("bob").get(afterRemove);
+ * // bobScore = Optional[85]
+ *
+ * // Compose with other optics
+ * Lens<Map<String, Integer>, Optional<Integer>> aliceLens = mapAt.at("alice");
+ * }</pre>
+ *
+ * <h3>Composition with Prisms:</h3>
+ *
+ * <p>To compose through the {@code Optional} layer, use a {@code Prism} that unwraps {@code
+ * Optional}:
+ *
+ * <pre>{@code
+ * Lens<User, Map<String, Address>> addressMapLens = ...;
+ * At<Map<String, Address>, String, Address> mapAt = AtInstances.mapAt();
+ * Prism<Optional<Address>, Address> somePrism = Prisms.some();
+ *
+ * // Compose to get a Traversal (0-or-1 focus)
+ * Traversal<User, Address> homeAddressTraversal =
+ *     addressMapLens
+ *         .andThen(mapAt.at("home"))  // Lens<User, Optional<Address>>
+ *         .asTraversal()
+ *         .andThen(somePrism.asTraversal());
+ * }</pre>
+ *
+ * @param <S> The structure type (e.g., {@code Map<K, V>} or {@code List<A>})
+ * @param <I> The index type (e.g., {@code K} for maps, {@code Integer} for lists)
+ * @param <A> The value type stored at each index
+ */
+@FunctionalInterface
+public interface At<S, I, A> {
+
+  /**
+   * Returns a {@link Lens} that focuses on the optional presence of a value at the given index.
+   *
+   * <p>The returned lens has the following semantics:
+   *
+   * <ul>
+   *   <li>{@code get(source)} returns {@link Optional#empty()} if the index is absent, or {@link
+   *       Optional#of(Object)} if present
+   *   <li>{@code set(Optional.empty(), source)} removes the entry at the index
+   *   <li>{@code set(Optional.of(value), source)} inserts or updates the entry at the index
+   * </ul>
+   *
+   * <p>Note on null values: Due to Java's {@link Optional} semantics, an index present with a
+   * {@code null} value is indistinguishable from an absent index. Both will result in {@link
+   * Optional#empty()} from a {@code get} operation.
+   *
+   * @param index The index to focus on
+   * @return A {@link Lens} focusing on {@code Optional<A>} at the given index
+   */
+  Lens<S, Optional<A>> at(I index);
+
+  /**
+   * Retrieves the value at the given index, if present.
+   *
+   * <p>This is a convenience method equivalent to {@code at(index).get(source)}.
+   *
+   * @param index The index to look up
+   * @param source The structure to query
+   * @return An {@link Optional} containing the value if present, or empty if absent
+   */
+  default Optional<A> get(I index, S source) {
+    return at(index).get(source);
+  }
+
+  /**
+   * Sets the optional value at the given index.
+   *
+   * <p>This is a convenience method equivalent to {@code at(index).set(value, source)}.
+   *
+   * @param index The index to modify
+   * @param value The optional value to set (empty to remove, present to insert/update)
+   * @param source The original structure
+   * @return A new structure with the modification applied
+   */
+  default S set(I index, Optional<A> value, S source) {
+    return at(index).set(value, source);
+  }
+
+  /**
+   * Removes the entry at the given index.
+   *
+   * <p>This is equivalent to {@code at(index).set(Optional.empty(), source)}.
+   *
+   * @param index The index to remove
+   * @param source The original structure
+   * @return A new structure with the entry removed (or unchanged if not present)
+   */
+  default S remove(I index, S source) {
+    return at(index).set(Optional.empty(), source);
+  }
+
+  /**
+   * Inserts or updates the value at the given index.
+   *
+   * <p>This is equivalent to {@code at(index).set(Optional.of(value), source)}.
+   *
+   * @param index The index to insert or update
+   * @param value The value to set
+   * @param source The original structure
+   * @return A new structure with the entry inserted or updated
+   */
+  default S insertOrUpdate(I index, A value, S source) {
+    return at(index).set(Optional.of(value), source);
+  }
+
+  /**
+   * Modifies the value at the given index if present, using the provided function.
+   *
+   * <p>If the index is absent, the structure is returned unchanged.
+   *
+   * @param index The index to modify
+   * @param modifier The function to apply to the existing value
+   * @param source The original structure
+   * @return A new structure with the modified value, or unchanged if absent
+   */
+  default S modify(I index, java.util.function.Function<A, A> modifier, S source) {
+    return at(index).modify(opt -> opt.map(modifier), source);
+  }
+
+  /**
+   * Checks if a value is present at the given index.
+   *
+   * @param index The index to check
+   * @param source The structure to query
+   * @return {@code true} if a value is present at the index, {@code false} otherwise
+   */
+  default boolean contains(I index, S source) {
+    return get(index, source).isPresent();
+  }
+}

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -62,6 +62,7 @@
   - [Folds](optics/folds.md)
   - [Getters](optics/getters.md)
   - [Setters](optics/setters.md)
+  - [At Type Class](optics/at.md)
   - [Profunctor Optics](optics/profunctor_optics.md)
   - [Combining Optics - Validation](optics/composing_optics.md)
   - [Practical Examples](optics/optics_examples.md)

--- a/hkj-book/src/glossary.md
+++ b/hkj-book/src/glossary.md
@@ -685,6 +685,42 @@ Kind<OptionalKind.Witness, String> empty =
 
 ## Optics Terminology
 
+### At
+
+**Definition:** A type class for structures that support indexed access with insertion and deletion semantics. Provides a `Lens<S, Optional<A>>` where setting to `Optional.empty()` deletes the entry and setting to `Optional.of(value)` inserts or updates it.
+
+**Core Operations:**
+- `at(I index)` - Returns `Lens<S, Optional<A>>` for the index
+- `get(I index, S source)` - Read value at index (returns Optional)
+- `insertOrUpdate(I index, A value, S source)` - Insert or update entry
+- `remove(I index, S source)` - Delete entry at index
+- `modify(I index, Function<A,A> f, S source)` - Update value if present
+
+**Example:**
+```java
+At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+
+Map<String, Integer> scores = new HashMap<>(Map.of("alice", 100));
+
+// Insert new entry
+Map<String, Integer> withBob = mapAt.insertOrUpdate("bob", 85, scores);
+// Result: {alice=100, bob=85}
+
+// Remove entry
+Map<String, Integer> noAlice = mapAt.remove("alice", withBob);
+// Result: {bob=85}
+
+// Compose with Lens for deep access
+Lens<UserProfile, Optional<String>> themeLens =
+    settingsLens.andThen(mapAt.at("theme"));
+```
+
+**When To Use:** CRUD operations on maps or lists where you need to insert new entries or delete existing ones whilst maintaining immutability and optics composability.
+
+**Related:** [At Type Class Documentation](optics/at.md)
+
+---
+
 ### Iso (Isomorphism)
 
 **Definition:** An optic representing a lossless, bidirectional conversion between two types. If you can convert `A` to `B` and back to `A` without losing information, you have an isomorphism.

--- a/hkj-book/src/optics/at.md
+++ b/hkj-book/src/optics/at.md
@@ -1,0 +1,737 @@
+# At Type Class: A Practical Guide
+
+## _Indexed CRUD Operations on Collections_
+
+~~~admonish info title="What You'll Learn"
+- How to insert, update, and delete entries in indexed structures using optics
+- Understanding the `Lens<S, Optional<A>>` pattern for CRUD operations
+- Factory methods: `mapAt()`, `listAt()`, `listAtWithPadding()`
+- Composing At with Lenses for deep access into nested collections
+- Using `Prisms.some()` to unwrap Optional for chained modifications
+- When to use At vs `Traversals.forMap()` vs direct Map operations
+- Handling Java's Optional limitations with null values
+- Building immutable configuration management systems
+~~~
+
+~~~admonish title="Example Code"
+[AtUsageExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/AtUsageExample.java)
+~~~
+
+In previous guides, we explored **`Lens`** for accessing product fields and **`Traversal`** for operating over collections. But what happens when you need to *insert* a new entry into a map, *delete* an existing key, or *update* a specific list index? Standard lenses can't express these operations because they focus on values that already exist.
+
+This is where **`At`** fills a crucial gap. It provides a `Lens` that focuses on the *optional presence* of a value at a given index—enabling full CRUD (Create, Read, Update, Delete) operations whilst maintaining immutability and composability.
+
+---
+
+## The Scenario: Application Configuration Management
+
+Consider a configuration management system where settings are stored in nested maps and lists:
+
+**The Data Model:**
+
+```java
+public record AppConfig(
+    String appName,
+    Map<String, String> settings,
+    Map<String, Map<String, Integer>> featureFlags,
+    List<String> enabledModules
+) {}
+
+public record UserPreferences(
+    String userId,
+    Map<String, String> preferences,
+    List<String> favouriteFeatures
+) {}
+
+public record SystemState(
+    AppConfig config,
+    Map<String, UserPreferences> userPrefs,
+    Map<String, Integer> metrics
+) {}
+```
+
+**Common Operations:**
+* "Add a new setting to the configuration"
+* "Remove an outdated feature flag"
+* "Update a specific user's preference"
+* "Check if a metric exists before incrementing it"
+* "Delete a user's preferences entirely"
+
+Traditional optics struggle with these operations. `Traversals.forMap(key)` can modify existing entries but cannot insert new ones or delete them. Direct map manipulation breaks composability. **`At`** solves this elegantly.
+
+---
+
+## Think of At Like...
+
+* **A key to a lockbox** 🔑: You can open it (read), put something in (insert), replace the contents (update), or empty it (delete)
+* **An index card in a filing cabinet** 📇: You can retrieve the card, file a new one, update its contents, or remove it entirely
+* **A dictionary entry** 📖: Looking up a word gives you its definition (if present) or nothing (if absent)
+* **A database row accessor** 🗃️: SELECT, INSERT, UPDATE, and DELETE operations on a specific key
+* **A nullable field lens** 🎯: Focusing on presence itself, not just the value
+
+---
+
+## At vs Lens vs Traversal: Understanding the Differences
+
+| Aspect | At | Lens | Traversal |
+|--------|-----|------|-----------|
+| **Focus** | Optional presence at index | Exactly one value | Zero or more values |
+| **Can insert?** | ✅ Yes | ❌ No | ❌ No |
+| **Can delete?** | ✅ Yes | ❌ No | ❌ No |
+| **Core operation** | `Lens<S, Optional<A>>` | `get(s)`, `set(a, s)` | `modifyF(f, s, app)` |
+| **Returns** | `Lens` to Optional | Direct value | Modified structure |
+| **Use case** | Map/List CRUD | Product field access | Bulk modifications |
+| **Intent** | "Manage entry at this index" | "Access this field" | "Transform all elements" |
+
+**Key Insight**: `At` returns a `Lens` that focuses on `Optional<A>`, not `A` directly. This means setting `Optional.empty()` *removes* the entry, whilst setting `Optional.of(value)` *inserts or updates* it. This simple abstraction enables powerful CRUD semantics within the optics framework.
+
+---
+
+## A Step-by-Step Walkthrough
+
+### Step 1: Creating At Instances
+
+Unlike `Lens` which can be generated with annotations, `At` instances are created using factory methods from `AtInstances`:
+
+```java
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.at.AtInstances;
+
+// At instance for Map<String, Integer>
+At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+
+// At instance for List<String>
+At<List<String>, Integer, String> listAt = AtInstances.listAt();
+
+// At instance for List with auto-padding
+At<List<String>, Integer, String> paddedListAt = AtInstances.listAtWithPadding(null);
+```
+
+Each factory method returns an `At` instance parameterised by:
+* `S` – The structure type (e.g., `Map<String, Integer>`)
+* `I` – The index type (e.g., `String` for maps, `Integer` for lists)
+* `A` – The element type (e.g., `Integer`)
+
+### Step 2: Basic CRUD Operations
+
+Once you have an `At` instance, you can perform full CRUD operations:
+
+#### **Create / Insert**
+
+```java
+Map<String, Integer> scores = new HashMap<>();
+scores.put("alice", 100);
+
+At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+
+// Insert a new entry
+Map<String, Integer> withBob = mapAt.insertOrUpdate("bob", 85, scores);
+// Result: {alice=100, bob=85}
+
+// Original unchanged (immutability)
+System.out.println(scores); // {alice=100}
+```
+
+#### **Read / Query**
+
+```java
+Optional<Integer> aliceScore = mapAt.get("alice", withBob);
+// Result: Optional[100]
+
+Optional<Integer> charlieScore = mapAt.get("charlie", withBob);
+// Result: Optional.empty()
+
+boolean hasAlice = mapAt.contains("alice", withBob);
+// Result: true
+```
+
+#### **Update / Modify**
+
+```java
+// Update existing value
+Map<String, Integer> updatedScores = mapAt.insertOrUpdate("alice", 110, withBob);
+// Result: {alice=110, bob=85}
+
+// Modify with function
+Map<String, Integer> bonusScores = mapAt.modify("bob", x -> x + 10, updatedScores);
+// Result: {alice=110, bob=95}
+
+// Modify non-existent key is a no-op
+Map<String, Integer> unchanged = mapAt.modify("charlie", x -> x + 10, bonusScores);
+// Result: {alice=110, bob=95} (no charlie key)
+```
+
+#### **Delete / Remove**
+
+```java
+Map<String, Integer> afterRemove = mapAt.remove("alice", bonusScores);
+// Result: {bob=95}
+
+// Remove non-existent key is a no-op
+Map<String, Integer> stillSame = mapAt.remove("charlie", afterRemove);
+// Result: {bob=95}
+```
+
+### Step 3: The Lens to Optional Pattern
+
+The core of `At` is its `at(index)` method, which returns a `Lens<S, Optional<A>>`:
+
+```java
+At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+Lens<Map<String, Integer>, Optional<Integer>> aliceLens = mapAt.at("alice");
+
+Map<String, Integer> scores = new HashMap<>(Map.of("alice", 100));
+
+// Get: Returns Optional
+Optional<Integer> score = aliceLens.get(scores);
+// Result: Optional[100]
+
+// Set with Optional.of(): Insert or update
+Map<String, Integer> updated = aliceLens.set(Optional.of(150), scores);
+// Result: {alice=150}
+
+// Set with Optional.empty(): Delete
+Map<String, Integer> deleted = aliceLens.set(Optional.empty(), scores);
+// Result: {}
+```
+
+This pattern is powerful because the lens composes naturally with other optics:
+
+```java
+record Config(Map<String, String> settings) {}
+
+Lens<Config, Map<String, String>> settingsLens =
+    Lens.of(Config::settings, (c, s) -> new Config(s));
+
+At<Map<String, String>, String, String> mapAt = AtInstances.mapAt();
+
+// Compose: Config → Map<String, String> → Optional<String>
+Lens<Config, Optional<String>> debugSettingLens =
+    settingsLens.andThen(mapAt.at("debug"));
+
+Config config = new Config(new HashMap<>());
+
+// Insert new setting through composed lens
+Config withDebug = debugSettingLens.set(Optional.of("true"), config);
+// Result: Config[settings={debug=true}]
+
+// Delete setting through composed lens
+Config withoutDebug = debugSettingLens.set(Optional.empty(), withDebug);
+// Result: Config[settings={}]
+```
+
+### Step 4: Deep Composition with Prisms
+
+When you need to access the actual value (not the `Optional` wrapper), compose with `Prisms.some()`:
+
+```java
+import org.higherkindedj.optics.prism.Prisms;
+
+Lens<Config, Optional<String>> debugLens =
+    settingsLens.andThen(mapAt.at("debug"));
+
+// Prism that unwraps Optional
+Prism<Optional<String>, String> somePrism = Prisms.some();
+
+// Compose into a Traversal (0-or-1 focus)
+Traversal<Config, String> debugValueTraversal =
+    debugLens.asTraversal().andThen(somePrism.asTraversal());
+
+Config config = new Config(new HashMap<>(Map.of("debug", "false")));
+
+// Modify the actual string value
+Config modified = Traversals.modify(debugValueTraversal, String::toUpperCase, config);
+// Result: Config[settings={debug=FALSE}]
+
+// Get all focused values (0 or 1)
+List<String> values = Traversals.getAll(debugValueTraversal, config);
+// Result: ["FALSE"]
+
+// If key is absent, traversal focuses on zero elements
+Config empty = new Config(new HashMap<>());
+List<String> noValues = Traversals.getAll(debugValueTraversal, empty);
+// Result: []
+```
+
+This composition creates an "affine" optic—focusing on zero or one element—which correctly models the semantics of optional map access.
+
+---
+
+## List Operations: Special Considerations
+
+`At` for lists has important behavioural differences from maps:
+
+### Basic List Operations
+
+```java
+At<List<String>, Integer, String> listAt = AtInstances.listAt();
+
+List<String> items = new ArrayList<>(List.of("apple", "banana", "cherry"));
+
+// Read element at index
+Optional<String> second = listAt.get(1, items);
+// Result: Optional["banana"]
+
+// Out of bounds returns empty
+Optional<String> outOfBounds = listAt.get(10, items);
+// Result: Optional.empty()
+
+// Update element at valid index
+List<String> updated = listAt.insertOrUpdate(1, "BANANA", items);
+// Result: ["apple", "BANANA", "cherry"]
+```
+
+### Deletion Shifts Indices
+
+**Important**: Removing a list element shifts all subsequent indices:
+
+```java
+List<String> afterRemove = listAt.remove(1, items);
+// Result: ["apple", "cherry"]
+// Note: "cherry" is now at index 1, not 2!
+
+// Original list unchanged
+System.out.println(items); // ["apple", "banana", "cherry"]
+```
+
+This behaviour differs from map deletion, where keys remain stable. Consider this carefully when chaining operations.
+
+### Bounds Checking
+
+```java
+// Update at invalid index throws exception
+assertThrows(IndexOutOfBoundsException.class, () ->
+    listAt.insertOrUpdate(10, "oops", items));
+
+// Use listAtWithPadding for auto-expansion
+At<List<String>, Integer, String> paddedAt = AtInstances.listAtWithPadding(null);
+
+List<String> sparse = new ArrayList<>(List.of("a"));
+List<String> expanded = paddedAt.insertOrUpdate(4, "e", sparse);
+// Result: ["a", null, null, null, "e"]
+```
+
+---
+
+## When to Use At vs Other Approaches
+
+### ✅ Use `At` When:
+
+* **You need CRUD semantics**: Insert, update, or delete operations on indexed structures
+* **Composability matters**: You want to chain At with Lenses for deep nested access
+* **Immutability is required**: You need functional, side-effect-free operations
+* **You're building configuration systems**: Dynamic settings management
+* **You want consistent optics patterns**: Keeping your codebase uniformly functional
+
+### ❌ Avoid `At` When:
+
+* **You only modify existing values**: Use `Traversals.forMap(key)` instead
+* **You need bulk operations**: Use `Traversal` for all-element modifications
+* **Performance is critical**: Direct Map operations may be faster (measure first!)
+* **You never delete entries**: A simple Lens might suffice
+
+### Comparison with Direct Map Operations
+
+```java
+// Direct Map manipulation (imperative)
+Map<String, Integer> scores = new HashMap<>();
+scores.put("alice", 100);           // Mutates!
+scores.remove("bob");                // Mutates!
+Integer value = scores.get("alice"); // May be null
+
+// At approach (functional)
+At<Map<String, Integer>, String, Integer> at = AtInstances.mapAt();
+Map<String, Integer> scores = new HashMap<>();
+Map<String, Integer> with = at.insertOrUpdate("alice", 100, scores);  // New map
+Map<String, Integer> without = at.remove("bob", with);                  // New map
+Optional<Integer> value = at.get("alice", without);                     // Safe Optional
+// Original 'scores' unchanged throughout
+```
+
+---
+
+## Common Pitfalls
+
+### ❌ Don't: Assume null map values are distinguishable from absent keys
+
+```java
+Map<String, Integer> map = new HashMap<>();
+map.put("nullKey", null);
+
+At<Map<String, Integer>, String, Integer> at = AtInstances.mapAt();
+Optional<Integer> result = at.get("nullKey", map);
+// Result: Optional.empty() - NOT Optional.of(null)!
+
+// Java's Optional cannot hold null values
+// Optional.ofNullable(null) returns Optional.empty()
+```
+
+### ✅ Do: Avoid null values in maps, or use wrapper types
+
+```java
+// Option 1: Use sentinel values
+Map<String, Integer> map = new HashMap<>();
+map.put("unset", -1); // Sentinel for "not set"
+
+// Option 2: Use Optional as the value type
+Map<String, Optional<Integer>> map = new HashMap<>();
+map.put("maybeNull", Optional.empty()); // Explicitly absent
+```
+
+---
+
+### ❌ Don't: Forget that list removal shifts indices
+
+```java
+At<List<String>, Integer, String> at = AtInstances.listAt();
+List<String> items = new ArrayList<>(List.of("a", "b", "c", "d"));
+
+// Remove "b" at index 1
+List<String> step1 = at.remove(1, items); // ["a", "c", "d"]
+
+// Now try to get what was at index 3 ("d")
+Optional<String> result = at.get(3, step1);
+// Result: Optional.empty() - index 3 is now out of bounds!
+// "d" is now at index 2
+```
+
+### ✅ Do: Recalculate indices or iterate from end
+
+```java
+// When removing multiple elements, iterate backwards
+List<String> items = new ArrayList<>(List.of("a", "b", "c", "d"));
+List<Integer> indicesToRemove = List.of(1, 3); // Remove "b" and "d"
+
+// Sort descending and remove from end
+List<String> result = items;
+for (int i : indicesToRemove.stream().sorted(Comparator.reverseOrder()).toList()) {
+    result = at.remove(i, result);
+}
+// Result: ["a", "c"]
+```
+
+---
+
+### ❌ Don't: Ignore Optional composition when you need the actual value
+
+```java
+Lens<Config, Optional<String>> settingLens = ...;
+
+// This gives you Optional, not the actual value
+Optional<String> optValue = settingLens.get(config);
+
+// To modify the actual string, you need to compose with a Prism
+// Otherwise you're stuck wrapping/unwrapping manually
+```
+
+### ✅ Do: Use `Prisms.some()` for value-level operations
+
+```java
+Prism<Optional<String>, String> some = Prisms.some();
+Traversal<Config, String> valueTraversal =
+    settingLens.asTraversal().andThen(some.asTraversal());
+
+// Now you can work with the actual String
+Config result = Traversals.modify(valueTraversal, String::trim, config);
+```
+
+---
+
+## Performance Considerations
+
+### HashMap Operations
+
+`mapAt()` creates a new `HashMap` on every modification:
+
+```java
+// Each operation copies the entire map
+Map<String, Integer> step1 = at.insertOrUpdate("a", 1, map);   // O(n) copy
+Map<String, Integer> step2 = at.insertOrUpdate("b", 2, step1); // O(n) copy
+Map<String, Integer> step3 = at.remove("c", step2);            // O(n) copy
+```
+
+**Best Practice**: Batch modifications when possible:
+
+```java
+// ❌ Multiple At operations (3 map copies)
+Map<String, Integer> result = at.insertOrUpdate("a", 1,
+    at.insertOrUpdate("b", 2,
+        at.remove("c", original)));
+
+// ✅ Single bulk operation
+Map<String, Integer> result = new HashMap<>(original);
+result.put("a", 1);
+result.put("b", 2);
+result.remove("c");
+// Then use At for subsequent immutable operations
+```
+
+### List Operations
+
+List modifications involve array copying:
+
+```java
+At<List<String>, Integer, String> at = AtInstances.listAt();
+
+// Update is O(n) - copies entire list
+List<String> updated = at.insertOrUpdate(0, "new", original);
+
+// Remove is O(n) - copies and shifts
+List<String> removed = at.remove(0, original);
+```
+
+For large lists with frequent modifications, consider alternative data structures (persistent collections, tree-based structures) or batch operations.
+
+---
+
+## Real-World Example: Feature Flag Management
+
+Consider a feature flag system where different environments have different configurations:
+
+```java
+public class FeatureFlagManager {
+
+    private final At<Map<String, Boolean>, String, Boolean> flagAt = AtInstances.mapAt();
+    private Map<String, Boolean> flags;
+
+    public FeatureFlagManager(Map<String, Boolean> initialFlags) {
+        this.flags = new HashMap<>(initialFlags);
+    }
+
+    public void enableFeature(String featureName) {
+        flags = flagAt.insertOrUpdate(featureName, true, flags);
+    }
+
+    public void disableFeature(String featureName) {
+        flags = flagAt.insertOrUpdate(featureName, false, flags);
+    }
+
+    public void removeFeature(String featureName) {
+        flags = flagAt.remove(featureName, flags);
+    }
+
+    public boolean isEnabled(String featureName) {
+        return flagAt.get(featureName, flags).orElse(false);
+    }
+
+    public Map<String, Boolean> getFlags() {
+        return Collections.unmodifiableMap(flags);
+    }
+}
+
+// Usage
+var manager = new FeatureFlagManager(Map.of("dark_mode", true));
+manager.enableFeature("new_dashboard");
+manager.disableFeature("legacy_api");
+manager.removeFeature("deprecated_feature");
+
+System.out.println(manager.isEnabled("dark_mode"));        // true
+System.out.println(manager.isEnabled("new_dashboard"));    // true
+System.out.println(manager.isEnabled("nonexistent"));      // false
+```
+
+This pattern ensures all flag operations maintain immutability internally whilst providing a clean mutable-style API externally.
+
+---
+
+## Complete, Runnable Example
+
+Here's a comprehensive example demonstrating all major At features:
+
+```java
+package org.higherkindedj.example.optics;
+
+import java.util.*;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.prism.Prisms;
+import org.higherkindedj.optics.util.Traversals;
+
+public class AtUsageExample {
+
+    @GenerateLenses
+    public record UserProfile(
+        String username,
+        Map<String, String> settings,
+        Map<String, Integer> scores,
+        List<String> tags
+    ) {}
+
+    public static void main(String[] args) {
+        System.out.println("=== At Type Class Usage Examples ===\n");
+
+        // 1. Map CRUD Operations
+        System.out.println("--- Map CRUD Operations ---");
+
+        At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+        Map<String, Integer> scores = new HashMap<>(Map.of("maths", 95, "english", 88));
+
+        System.out.println("Initial scores: " + scores);
+
+        // Insert
+        Map<String, Integer> withScience = mapAt.insertOrUpdate("science", 92, scores);
+        System.out.println("After insert 'science': " + withScience);
+
+        // Update
+        Map<String, Integer> updatedMaths = mapAt.insertOrUpdate("maths", 98, withScience);
+        System.out.println("After update 'maths': " + updatedMaths);
+
+        // Read
+        System.out.println("Physics score (absent): " + mapAt.get("physics", updatedMaths));
+        System.out.println("Maths score (present): " + mapAt.get("maths", updatedMaths));
+
+        // Delete
+        Map<String, Integer> afterRemove = mapAt.remove("english", updatedMaths);
+        System.out.println("After remove 'english': " + afterRemove);
+
+        // Modify
+        Map<String, Integer> bonusMaths = mapAt.modify("maths", x -> x + 5, afterRemove);
+        System.out.println("After modify 'maths' (+5): " + bonusMaths);
+
+        System.out.println("Original unchanged: " + scores);
+        System.out.println();
+
+        // 2. Lens Composition
+        System.out.println("--- Lens Composition with At ---");
+
+        // Use generated lenses from @GenerateLenses annotation
+        Lens<UserProfile, Map<String, String>> settingsLens = UserProfileLenses.settings();
+
+        At<Map<String, String>, String, String> stringMapAt = AtInstances.mapAt();
+
+        UserProfile profile = new UserProfile(
+            "alice",
+            new HashMap<>(Map.of("theme", "dark", "language", "en")),
+            new HashMap<>(Map.of("maths", 95)),
+            new ArrayList<>(List.of("developer"))
+        );
+
+        System.out.println("Initial profile: " + profile);
+
+        // Compose: UserProfile → Map → Optional<String>
+        Lens<UserProfile, Optional<String>> themeLens =
+            settingsLens.andThen(stringMapAt.at("theme"));
+
+        System.out.println("Current theme: " + themeLens.get(profile));
+
+        // Update through composed lens
+        UserProfile lightTheme = themeLens.set(Optional.of("light"), profile);
+        System.out.println("After setting theme: " + lightTheme.settings());
+
+        // Add new setting
+        Lens<UserProfile, Optional<String>> notifLens =
+            settingsLens.andThen(stringMapAt.at("notifications"));
+        UserProfile withNotif = notifLens.set(Optional.of("enabled"), lightTheme);
+        System.out.println("After adding notification: " + withNotif.settings());
+
+        // Remove setting
+        Lens<UserProfile, Optional<String>> langLens =
+            settingsLens.andThen(stringMapAt.at("language"));
+        UserProfile noLang = langLens.set(Optional.empty(), withNotif);
+        System.out.println("After removing language: " + noLang.settings());
+        System.out.println();
+
+        // 3. Deep Composition with Prism
+        System.out.println("--- Deep Composition: At + Prism ---");
+
+        Lens<UserProfile, Map<String, Integer>> scoresLens = UserProfileLenses.scores();
+
+        At<Map<String, Integer>, String, Integer> scoresAt = AtInstances.mapAt();
+        Prism<Optional<Integer>, Integer> somePrism = Prisms.some();
+
+        // Compose into Traversal (0-or-1 focus)
+        Lens<UserProfile, Optional<Integer>> mathsLens = scoresLens.andThen(scoresAt.at("maths"));
+        Traversal<UserProfile, Integer> mathsTraversal =
+            mathsLens.asTraversal().andThen(somePrism.asTraversal());
+
+        UserProfile bob = new UserProfile(
+            "bob",
+            new HashMap<>(),
+            new HashMap<>(Map.of("maths", 85, "science", 90)),
+            new ArrayList<>()
+        );
+
+        System.out.println("Bob's profile: " + bob);
+
+        // Get via traversal
+        List<Integer> mathsScores = Traversals.getAll(mathsTraversal, bob);
+        System.out.println("Maths score via traversal: " + mathsScores);
+
+        // Modify via traversal
+        UserProfile boostedBob = Traversals.modify(mathsTraversal, x -> x + 10, bob);
+        System.out.println("After boosting maths by 10: " + boostedBob.scores());
+
+        // Missing key = empty traversal
+        Traversal<UserProfile, Integer> historyTraversal =
+            scoresLens.andThen(scoresAt.at("history"))
+                      .asTraversal().andThen(somePrism.asTraversal());
+
+        List<Integer> historyScores = Traversals.getAll(historyTraversal, bob);
+        System.out.println("History score (absent): " + historyScores);
+
+        System.out.println("\n=== All operations maintain immutability ===");
+    }
+}
+```
+
+**Expected Output:**
+
+```
+=== At Type Class Usage Examples ===
+
+--- Map CRUD Operations ---
+Initial scores: {maths=95, english=88}
+After insert 'science': {maths=95, science=92, english=88}
+After update 'maths': {maths=98, science=92, english=88}
+Physics score (absent): Optional.empty
+Maths score (present): Optional[98]
+After remove 'english': {maths=98, science=92}
+After modify 'maths' (+5): {maths=103, science=92}
+Original unchanged: {maths=95, english=88}
+
+--- Lens Composition with At ---
+Initial profile: UserProfile[username=alice, settings={theme=dark, language=en}, scores={maths=95}, tags=[developer]]
+Current theme: Optional[dark]
+After setting theme: {theme=light, language=en}
+After adding notification: {theme=light, language=en, notifications=enabled}
+After removing language: {theme=light, notifications=enabled}
+
+--- Deep Composition: At + Prism ---
+Bob's profile: UserProfile[username=bob, settings={}, scores={maths=85, science=90}, tags=[]]
+Maths score via traversal: [85]
+After boosting maths by 10: {maths=95, science=90}
+History score (absent): []
+
+=== All operations maintain immutability ===
+```
+
+---
+
+## Further Reading
+
+* [Haskell Lens Library - At Type Class](https://hackage.haskell.org/package/lens/docs/Control-Lens-At.html)
+* [Optics By Example](https://leanpub.com/optics-by-example) - Comprehensive optics guide
+* [Lenses Guide](lenses.md) - Foundation for At composition
+* [Prisms Guide](prisms.md) - Unwrapping Optional with Prisms
+* [Traversals Guide](traversals.md) - Bulk operations on collections
+
+---
+
+## Summary
+
+The **At** type class provides a powerful abstraction for indexed CRUD operations on collections:
+
+* **Lens to Optional**: `at(index)` returns `Lens<S, Optional<A>>` enabling insert/update/delete
+* **Immutable by design**: All operations return new structures
+* **Composable**: Chains naturally with other optics for deep access
+* **Type-safe**: Leverages Java's type system for safety
+
+At bridges the gap between pure functional optics and practical collection manipulation, enabling you to build robust, immutable data pipelines that handle the full lifecycle of indexed data.
+
+---
+
+[Previous: Setters](setters.md) | [Next: Profunctor Optics](profunctor_optics.md)

--- a/hkj-core/src/main/java/module-info.java
+++ b/hkj-core/src/main/java/module-info.java
@@ -31,4 +31,6 @@ module org.higherkindedj.core {
   exports org.higherkindedj.hkt.validated;
   exports org.higherkindedj.hkt.writer;
   exports org.higherkindedj.optics.util;
+  exports org.higherkindedj.optics.at;
+  exports org.higherkindedj.optics.prism;
 }

--- a/hkj-core/src/main/java/org/higherkindedj/optics/at/AtInstances.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/at/AtInstances.java
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.at;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Lens;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Provides standard {@link At} instances for common Java collection types.
+ *
+ * <p>This class contains factory methods that create {@code At} instances for:
+ *
+ * <ul>
+ *   <li>{@link Map} - indexed by key type {@code K}
+ *   <li>{@link List} - indexed by {@link Integer} position
+ * </ul>
+ *
+ * <h3>Usage Examples:</h3>
+ *
+ * <pre>{@code
+ * // Map operations
+ * At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+ * Map<String, Integer> scores = Map.of("alice", 100);
+ *
+ * // Insert/update
+ * Map<String, Integer> updated = mapAt.insertOrUpdate("bob", 85, scores);
+ *
+ * // Remove
+ * Map<String, Integer> removed = mapAt.remove("alice", updated);
+ *
+ * // List operations
+ * At<List<String>, Integer, String> listAt = AtInstances.listAt();
+ * List<String> names = new ArrayList<>(List.of("alice", "bob", "charlie"));
+ *
+ * // Get element
+ * Optional<String> second = listAt.get(1, names);  // Optional["bob"]
+ *
+ * // Remove element (shifts indices)
+ * List<String> afterRemove = listAt.remove(1, names);  // ["alice", "charlie"]
+ * }</pre>
+ */
+@NullMarked
+public final class AtInstances {
+
+  /** Private constructor to prevent instantiation. */
+  private AtInstances() {}
+
+  /**
+   * Creates an {@link At} instance for {@link Map} types.
+   *
+   * <p>The returned {@code At} provides a lens to the optional presence of a value at a given key:
+   *
+   * <ul>
+   *   <li>{@code get(key)} returns {@code Optional.empty()} if key is absent or has null value
+   *   <li>{@code get(key)} returns {@code Optional.of(value)} if key is present with non-null value
+   *   <li>{@code set(Optional.empty())} removes the key from the map
+   *   <li>{@code set(Optional.of(value))} puts the key-value pair in the map
+   * </ul>
+   *
+   * <p><strong>Null Value Limitation:</strong> Due to Java's {@link Optional} semantics, null map
+   * values cannot be distinguished from absent keys. {@code Optional.ofNullable(null)} returns
+   * {@code Optional.empty()}, so a key with null value appears the same as an absent key. If you
+   * need to distinguish these cases, consider using a wrapper type or avoiding null values.
+   *
+   * <p><strong>Immutability:</strong> All operations return new {@link Map} instances, leaving the
+   * original unchanged.
+   *
+   * @param <K> The key type of the map
+   * @param <V> The value type of the map
+   * @return An {@code At} instance for maps
+   */
+  public static <K, V> At<Map<K, V>, K, @Nullable V> mapAt() {
+    return key ->
+        Lens.of(
+            map -> Optional.ofNullable(map.get(key)),
+            (map, optValue) -> {
+              Map<K, V> newMap = new HashMap<>(map);
+              if (optValue.isPresent()) {
+                newMap.put(key, optValue.get());
+              } else {
+                newMap.remove(key);
+              }
+              return newMap;
+            });
+  }
+
+  /**
+   * Creates an {@link At} instance for {@link List} types.
+   *
+   * <p>The returned {@code At} provides a lens to the optional presence of a value at a given
+   * index:
+   *
+   * <ul>
+   *   <li>{@code get(index)} returns {@code Optional.empty()} if index is out of bounds
+   *   <li>{@code get(index)} returns {@code Optional.of(value)} if index is valid
+   *   <li>{@code set(Optional.empty())} removes the element at index (shifts subsequent elements)
+   *   <li>{@code set(Optional.of(value))} updates the element at index (must be in bounds)
+   * </ul>
+   *
+   * <p><strong>Important:</strong> Removing an element shifts all subsequent indices. This means
+   * that after a removal, the list size decreases and elements after the removed index have new
+   * positions.
+   *
+   * <p><strong>Bounds Checking:</strong> Setting a value at an out-of-bounds index will throw an
+   * {@link IndexOutOfBoundsException}. Use {@link #listAtWithPadding(Object)} for auto-expanding
+   * behavior.
+   *
+   * <p><strong>Immutability:</strong> All operations return new {@link List} instances, leaving the
+   * original unchanged.
+   *
+   * @param <A> The element type of the list
+   * @return An {@code At} instance for lists
+   */
+  public static <A> At<List<A>, Integer, A> listAt() {
+    return index ->
+        Lens.of(
+            list ->
+                (index >= 0 && index < list.size())
+                    ? Optional.ofNullable(list.get(index))
+                    : Optional.empty(),
+            (list, optValue) -> {
+              List<A> newList = new ArrayList<>(list);
+              if (optValue.isPresent()) {
+                if (index < 0 || index >= newList.size()) {
+                  throw new IndexOutOfBoundsException(
+                      "Index " + index + " out of bounds for list of size " + newList.size());
+                }
+                newList.set(index, optValue.get());
+              } else {
+                if (index >= 0 && index < newList.size()) {
+                  newList.remove((int) index);
+                }
+                // If index is out of bounds for removal, no-op (nothing to remove)
+              }
+              return newList;
+            });
+  }
+
+  /**
+   * Creates an {@link At} instance for {@link List} types with automatic null-padding for
+   * insertions beyond current size.
+   *
+   * <p>This variant automatically expands the list with null values when setting a value at an
+   * index beyond the current size:
+   *
+   * <ul>
+   *   <li>Setting index 5 on a list of size 3 will pad indices 3 and 4 with the default value
+   *   <li>Useful for sparse list representations
+   * </ul>
+   *
+   * <p><strong>Warning:</strong> This behavior can lead to unexpected nulls in your list. Use with
+   * caution.
+   *
+   * @param <A> The element type of the list
+   * @param defaultValue The value to use for padding (typically null)
+   * @return An {@code At} instance for lists with padding behavior
+   */
+  public static <A> At<List<A>, Integer, A> listAtWithPadding(@Nullable A defaultValue) {
+    return index ->
+        Lens.of(
+            list ->
+                (index >= 0 && index < list.size())
+                    ? Optional.ofNullable(list.get(index))
+                    : Optional.empty(),
+            (list, optValue) -> {
+              List<A> newList = new ArrayList<>(list);
+              if (optValue.isPresent()) {
+                if (index < 0) {
+                  throw new IndexOutOfBoundsException("Index cannot be negative: " + index);
+                }
+                // Pad the list if necessary
+                while (newList.size() <= index) {
+                  newList.add(defaultValue);
+                }
+                newList.set(index, optValue.get());
+              } else {
+                if (index >= 0 && index < newList.size()) {
+                  newList.remove((int) index);
+                }
+              }
+              return newList;
+            });
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/prism/Prisms.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/prism/Prisms.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.prism;
+
+import java.util.Optional;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.optics.Prism;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Provides standard {@link Prism} instances for common Java types.
+ *
+ * <p>This class contains factory methods that create {@code Prism} instances for:
+ *
+ * <ul>
+ *   <li>{@link Optional} - focusing on the present case
+ * </ul>
+ *
+ * <h3>Usage with At:</h3>
+ *
+ * <p>The {@link #some()} prism is particularly useful when composing with {@code At} to access
+ * values through optional layers:
+ *
+ * <pre>{@code
+ * // Compose At with Prism for deep access
+ * Lens<User, Map<String, Address>> addressMapLens = ...;
+ * At<Map<String, Address>, String, Address> mapAt = AtInstances.mapAt();
+ * Prism<Optional<Address>, Address> somePrism = Prisms.some();
+ *
+ * // Create a Traversal that focuses on the home address (if present)
+ * Traversal<User, Address> homeAddressTraversal =
+ *     addressMapLens
+ *         .andThen(mapAt.at("home"))      // Lens<User, Optional<Address>>
+ *         .asTraversal()
+ *         .andThen(somePrism.asTraversal());
+ *
+ * // Now you can modify the address if it exists
+ * User updatedUser = Traversals.modify(
+ *     homeAddressTraversal,
+ *     addr -> addr.withCity("New York"),
+ *     user
+ * );
+ * }</pre>
+ */
+@NullMarked
+public final class Prisms {
+
+  /** Private constructor to prevent instantiation. */
+  private Prisms() {}
+
+  /**
+   * Creates a {@link Prism} that focuses on the present case of an {@link Optional}.
+   *
+   * <p>This prism has the following semantics:
+   *
+   * <ul>
+   *   <li>{@code getOptional(Optional.of(x))} returns {@code Optional.of(x)}
+   *   <li>{@code getOptional(Optional.empty())} returns {@code Optional.empty()}
+   *   <li>{@code build(x)} returns {@code Optional.of(x)}
+   * </ul>
+   *
+   * <p>This is useful for composing through optional layers, such as when working with {@code At}
+   * which returns {@code Lens<S, Optional<A>>}.
+   *
+   * @param <A> The type contained in the Optional
+   * @return A Prism focusing on the present case of Optional
+   */
+  public static <A> Prism<Optional<A>, A> some() {
+    return Prism.of(opt -> opt, Optional::of);
+  }
+
+  /**
+   * Creates a {@link Prism} that focuses on the empty case of an {@link Optional}.
+   *
+   * <p>This prism matches when the Optional is empty:
+   *
+   * <ul>
+   *   <li>{@code getOptional(Optional.empty())} returns {@code Optional.of(Unit.INSTANCE)}
+   *   <li>{@code getOptional(Optional.of(x))} returns {@code Optional.empty()}
+   *   <li>{@code build(Unit.INSTANCE)} returns {@code Optional.empty()}
+   * </ul>
+   *
+   * <p>This is less commonly used than {@link #some()}, but can be useful for checking absence.
+   *
+   * @param <A> The type that would be contained in the Optional (phantom type)
+   * @return A Prism focusing on the empty case of Optional
+   */
+  public static <A> Prism<Optional<A>, Unit> none() {
+    return Prism.of(
+        opt -> opt.isEmpty() ? Optional.of(Unit.INSTANCE) : Optional.empty(),
+        _unit -> Optional.empty());
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/future/CompletableFutureKindHelperTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/future/CompletableFutureKindHelperTest.java
@@ -98,83 +98,82 @@ class CompletableFutureKindHelperTest {
           .hasMessageContaining("Input CompletableFuture cannot be null for widen");
     }
   }
-}
 
-@Nested
-@DisplayName("join()")
-class JoinTests {
+  @Nested
+  @DisplayName("join()")
+  class JoinTests {
 
-  @Test
-  void join_shouldReturnResultOnSuccess() {
-    Kind<CompletableFutureKind.Witness, String> kind =
-        FUTURE.widen(CompletableFuture.completedFuture("Success"));
-    assertThat(FUTURE.join(kind)).isEqualTo("Success");
-  }
+    @Test
+    void join_shouldReturnResultOnSuccess() {
+      Kind<CompletableFutureKind.Witness, String> kind =
+          FUTURE.widen(CompletableFuture.completedFuture("Success"));
+      assertThat(FUTURE.join(kind)).isEqualTo("Success");
+    }
 
-  @Test
-  void join_shouldBlockAndWaitForCompletion() {
-    CompletableFuture<String> delayedFuture =
-        CompletableFuture.supplyAsync(
-            () -> {
-              try {
-                TimeUnit.MILLISECONDS.sleep(50);
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new CompletionException(e);
-              }
-              return "Delayed Result";
-            });
-    Kind<CompletableFutureKind.Witness, String> kind = FUTURE.widen(delayedFuture);
-    long startTime = System.nanoTime();
-    String result = FUTURE.join(kind);
-    long duration = System.nanoTime() - startTime;
-    assertThat(result).isEqualTo("Delayed Result");
-    assertThat(duration).isGreaterThan(TimeUnit.MILLISECONDS.toNanos(40));
-  }
+    @Test
+    void join_shouldBlockAndWaitForCompletion() {
+      CompletableFuture<String> delayedFuture =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  TimeUnit.MILLISECONDS.sleep(50);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new CompletionException(e);
+                }
+                return "Delayed Result";
+              });
+      Kind<CompletableFutureKind.Witness, String> kind = FUTURE.widen(delayedFuture);
+      long startTime = System.nanoTime();
+      String result = FUTURE.join(kind);
+      long duration = System.nanoTime() - startTime;
+      assertThat(result).isEqualTo("Delayed Result");
+      assertThat(duration).isGreaterThan(TimeUnit.MILLISECONDS.toNanos(40));
+    }
 
-  @Test
-  void join_shouldThrowRuntimeExceptionDirectly() {
-    RuntimeException ex = new IllegalStateException("Fail State");
-    Kind<CompletableFutureKind.Witness, String> kind =
-        FUTURE.widen(CompletableFuture.failedFuture(ex));
-    assertThatThrownBy(() -> FUTURE.join(kind))
-        .isInstanceOf(IllegalStateException.class)
-        .isSameAs(ex);
-  }
+    @Test
+    void join_shouldThrowRuntimeExceptionDirectly() {
+      RuntimeException ex = new IllegalStateException("Fail State");
+      Kind<CompletableFutureKind.Witness, String> kind =
+          FUTURE.widen(CompletableFuture.failedFuture(ex));
+      assertThatThrownBy(() -> FUTURE.join(kind))
+          .isInstanceOf(IllegalStateException.class)
+          .isSameAs(ex);
+    }
 
-  @Test
-  void join_shouldThrowErrorDirectly() {
-    Error err = new StackOverflowError("Fail Error");
-    Kind<CompletableFutureKind.Witness, String> kind =
-        FUTURE.widen(CompletableFuture.failedFuture(err));
-    assertThatThrownBy(() -> FUTURE.join(kind))
-        .isInstanceOf(StackOverflowError.class)
-        .isSameAs(err);
-  }
+    @Test
+    void join_shouldThrowErrorDirectly() {
+      Error err = new StackOverflowError("Fail Error");
+      Kind<CompletableFutureKind.Witness, String> kind =
+          FUTURE.widen(CompletableFuture.failedFuture(err));
+      assertThatThrownBy(() -> FUTURE.join(kind))
+          .isInstanceOf(StackOverflowError.class)
+          .isSameAs(err);
+    }
 
-  @Test
-  void join_shouldKeepCheckedExceptionWrappedInCompletionException() {
-    IOException ex = new IOException("IO Fail");
-    Kind<CompletableFutureKind.Witness, String> kind =
-        FUTURE.widen(CompletableFuture.failedFuture(ex));
-    assertThatThrownBy(() -> FUTURE.join(kind))
-        .isInstanceOf(CompletionException.class)
-        .hasCause(ex);
-  }
+    @Test
+    void join_shouldKeepCheckedExceptionWrappedInCompletionException() {
+      IOException ex = new IOException("IO Fail");
+      Kind<CompletableFutureKind.Witness, String> kind =
+          FUTURE.widen(CompletableFuture.failedFuture(ex));
+      assertThatThrownBy(() -> FUTURE.join(kind))
+          .isInstanceOf(CompletionException.class)
+          .hasCause(ex);
+    }
 
-  @Test
-  void join_shouldThrowCancellationExceptionIfCancelled() {
-    CompletableFuture<String> cancelledFuture = new CompletableFuture<>();
-    cancelledFuture.cancel(true);
-    Kind<CompletableFutureKind.Witness, String> kind = FUTURE.widen(cancelledFuture);
-    assertThatThrownBy(() -> FUTURE.join(kind)).isInstanceOf(CancellationException.class);
-  }
+    @Test
+    void join_shouldThrowCancellationExceptionIfCancelled() {
+      CompletableFuture<String> cancelledFuture = new CompletableFuture<>();
+      cancelledFuture.cancel(true);
+      Kind<CompletableFutureKind.Witness, String> kind = FUTURE.widen(cancelledFuture);
+      assertThatThrownBy(() -> FUTURE.join(kind)).isInstanceOf(CancellationException.class);
+    }
 
-  @Test
-  void join_shouldPropagateKindUnwrapExceptionFromFailedUnwrap() {
-    assertThatThrownBy(() -> FUTURE.join(null))
-        .isInstanceOf(KindUnwrapException.class)
-        .hasMessageContaining(
-            "Cannot narrow null Kind for %s".formatted("CompletableFutureHolder"));
+    @Test
+    void join_shouldPropagateKindUnwrapExceptionFromFailedUnwrap() {
+      assertThatThrownBy(() -> FUTURE.join(null))
+          .isInstanceOf(KindUnwrapException.class)
+          .hasMessageContaining("Cannot narrow null Kind for %s".formatted("CompletableFuture"));
+    }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/optics/at/AtInstancesTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/at/AtInstancesTest.java
@@ -1,0 +1,532 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.at;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Lens;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AtInstances Tests")
+class AtInstancesTest {
+
+  @Nested
+  @DisplayName("Map At Instance")
+  class MapAtTests {
+
+    private final At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+
+    @Test
+    @DisplayName("at() should return lens focusing on optional value")
+    void atReturnsLens() {
+      Lens<Map<String, Integer>, Optional<Integer>> lens = mapAt.at("key");
+      assertThat(lens).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get() should return empty for missing key")
+    void getMissingKey() {
+      Map<String, Integer> map = new HashMap<>();
+      Optional<Integer> result = mapAt.get("missing", map);
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("get() should return present value for existing key")
+    void getExistingKey() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+      Optional<Integer> result = mapAt.get("alice", map);
+      assertThat(result).hasValue(100);
+    }
+
+    @Test
+    @DisplayName("get() should treat null values as empty (Java Optional limitation)")
+    void getNullValue() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("nullKey", null);
+
+      Optional<Integer> nullResult = mapAt.get("nullKey", map);
+      Optional<Integer> absentResult = mapAt.get("absent", map);
+
+      // Note: Java's Optional cannot hold null values.
+      // Optional.ofNullable(null) returns Optional.empty()
+      // So null map values are indistinguishable from absent keys
+      assertThat(nullResult).isEmpty();
+
+      // Absent key
+      assertThat(absentResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName("insertOrUpdate() should add new entry")
+    void insertNewEntry() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = mapAt.insertOrUpdate("bob", 85, original);
+
+      assertThat(updated).containsEntry("alice", 100).containsEntry("bob", 85);
+      assertThat(original).doesNotContainKey("bob"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("insertOrUpdate() should update existing entry")
+    void updateExistingEntry() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = mapAt.insertOrUpdate("alice", 150, original);
+
+      assertThat(updated).containsEntry("alice", 150);
+      assertThat(original).containsEntry("alice", 100); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("remove() should delete existing entry")
+    void removeExistingEntry() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+      original.put("bob", 85);
+
+      Map<String, Integer> updated = mapAt.remove("alice", original);
+
+      assertThat(updated).doesNotContainKey("alice").containsEntry("bob", 85);
+      assertThat(original).containsKey("alice"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("remove() should be no-op for missing key")
+    void removeMissingKey() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = mapAt.remove("missing", original);
+
+      assertThat(updated).containsEntry("alice", 100).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("modify() should update existing value with function")
+    void modifyExistingValue() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = mapAt.modify("alice", x -> x + 10, original);
+
+      assertThat(updated).containsEntry("alice", 110);
+    }
+
+    @Test
+    @DisplayName("modify() should be no-op for missing key")
+    void modifyMissingKey() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = mapAt.modify("missing", x -> x + 10, original);
+
+      assertThat(updated).containsExactlyEntriesOf(original);
+    }
+
+    @Test
+    @DisplayName("contains() should return true for existing key")
+    void containsExistingKey() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+
+      assertThat(mapAt.contains("alice", map)).isTrue();
+    }
+
+    @Test
+    @DisplayName("contains() should return false for missing key")
+    void containsMissingKey() {
+      Map<String, Integer> map = new HashMap<>();
+
+      assertThat(mapAt.contains("alice", map)).isFalse();
+    }
+
+    @Test
+    @DisplayName("set() with Optional.empty() should remove key")
+    void setEmptyRemovesKey() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = mapAt.set("alice", Optional.empty(), original);
+
+      assertThat(updated).doesNotContainKey("alice");
+    }
+
+    @Test
+    @DisplayName("set() with Optional.of() should insert/update key")
+    void setPresentInsertsOrUpdates() {
+      Map<String, Integer> original = new HashMap<>();
+
+      Map<String, Integer> updated = mapAt.set("alice", Optional.of(100), original);
+
+      assertThat(updated).containsEntry("alice", 100);
+    }
+
+    @Test
+    @DisplayName("Lens composition should work with map at")
+    void lensComposition() {
+      record Container(Map<String, Integer> scores) {}
+      Lens<Container, Map<String, Integer>> scoresLens =
+          Lens.of(Container::scores, (c, s) -> new Container(s));
+
+      Container original = new Container(Map.of("alice", 100));
+
+      // Compose lenses
+      Lens<Container, Optional<Integer>> aliceScoreLens = scoresLens.andThen(mapAt.at("alice"));
+
+      Optional<Integer> score = aliceScoreLens.get(original);
+      assertThat(score).hasValue(100);
+
+      Container updated = aliceScoreLens.set(Optional.of(150), original);
+      assertThat(updated.scores()).containsEntry("alice", 150);
+    }
+  }
+
+  @Nested
+  @DisplayName("List At Instance")
+  class ListAtTests {
+
+    private final At<List<String>, Integer, String> listAt = AtInstances.listAt();
+
+    @Test
+    @DisplayName("get() should return empty for out of bounds index")
+    void getOutOfBounds() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(listAt.get(-1, list)).isEmpty();
+      assertThat(listAt.get(3, list)).isEmpty();
+      assertThat(listAt.get(100, list)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("get() should return element at valid index")
+    void getValidIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(listAt.get(0, list)).hasValue("a");
+      assertThat(listAt.get(1, list)).hasValue("b");
+      assertThat(listAt.get(2, list)).hasValue("c");
+    }
+
+    @Test
+    @DisplayName("insertOrUpdate() should update element at valid index")
+    void updateValidIndex() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = listAt.insertOrUpdate(1, "B", original);
+
+      assertThat(updated).containsExactly("a", "B", "c");
+      assertThat(original).containsExactly("a", "b", "c"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("insertOrUpdate() should throw for out of bounds index")
+    void updateOutOfBounds() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThatThrownBy(() -> listAt.insertOrUpdate(5, "x", list))
+          .isInstanceOf(IndexOutOfBoundsException.class);
+
+      assertThatThrownBy(() -> listAt.insertOrUpdate(-1, "x", list))
+          .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    @DisplayName("remove() should delete element and shift indices")
+    void removeShiftsIndices() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c", "d"));
+
+      List<String> updated = listAt.remove(1, original);
+
+      assertThat(updated).containsExactly("a", "c", "d");
+      assertThat(original).containsExactly("a", "b", "c", "d"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("remove() should be no-op for out of bounds index")
+    void removeOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = listAt.remove(10, original);
+
+      assertThat(updated).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("modify() should update element with function")
+    void modifyValidIndex() {
+      List<String> original = new ArrayList<>(List.of("hello", "world"));
+
+      List<String> updated = listAt.modify(0, String::toUpperCase, original);
+
+      assertThat(updated).containsExactly("HELLO", "world");
+    }
+
+    @Test
+    @DisplayName("modify() should be no-op for out of bounds index")
+    void modifyOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("hello", "world"));
+
+      List<String> updated = listAt.modify(10, String::toUpperCase, original);
+
+      assertThat(updated).containsExactly("hello", "world");
+    }
+
+    @Test
+    @DisplayName("contains() should check index validity")
+    void containsChecksIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(listAt.contains(0, list)).isTrue();
+      assertThat(listAt.contains(2, list)).isTrue();
+      assertThat(listAt.contains(3, list)).isFalse();
+      assertThat(listAt.contains(-1, list)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Lens from at() should be composable")
+    void lensComposition() {
+      record Container(List<String> items) {}
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+
+      Container original = new Container(new ArrayList<>(List.of("a", "b", "c")));
+
+      Lens<Container, Optional<String>> firstItemLens = itemsLens.andThen(listAt.at(0));
+
+      assertThat(firstItemLens.get(original)).hasValue("a");
+
+      Container updated = firstItemLens.set(Optional.of("A"), original);
+      assertThat(updated.items()).containsExactly("A", "b", "c");
+    }
+  }
+
+  @Nested
+  @DisplayName("List At With Padding Instance")
+  class ListAtWithPaddingTests {
+
+    private final At<List<String>, Integer, String> listAt = AtInstances.listAtWithPadding(null);
+
+    @Test
+    @DisplayName("insertOrUpdate() should pad list for out of bounds index")
+    void padForOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("a", "b"));
+
+      List<String> updated = listAt.insertOrUpdate(5, "f", original);
+
+      assertThat(updated).containsExactly("a", "b", null, null, null, "f");
+      assertThat(original).containsExactly("a", "b"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("insertOrUpdate() should throw for negative index")
+    void throwForNegativeIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b"));
+
+      assertThatThrownBy(() -> listAt.insertOrUpdate(-1, "x", list))
+          .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    @DisplayName("custom default value should be used for padding")
+    void customDefaultValue() {
+      At<List<String>, Integer, String> listAtWithDefault = AtInstances.listAtWithPadding("EMPTY");
+
+      List<String> original = new ArrayList<>(List.of("a"));
+
+      List<String> updated = listAtWithDefault.insertOrUpdate(3, "d", original);
+
+      assertThat(updated).containsExactly("a", "EMPTY", "EMPTY", "d");
+    }
+
+    @Test
+    @DisplayName("get() should return empty for out of bounds index")
+    void getOutOfBounds() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(listAt.get(-1, list)).isEmpty();
+      assertThat(listAt.get(3, list)).isEmpty();
+      assertThat(listAt.get(100, list)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("get() should return element at valid index")
+    void getValidIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(listAt.get(0, list)).hasValue("a");
+      assertThat(listAt.get(1, list)).hasValue("b");
+      assertThat(listAt.get(2, list)).hasValue("c");
+    }
+
+    @Test
+    @DisplayName("remove() should delete element and shift indices")
+    void removeShiftsIndices() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c", "d"));
+
+      List<String> updated = listAt.remove(1, original);
+
+      assertThat(updated).containsExactly("a", "c", "d");
+      assertThat(original).containsExactly("a", "b", "c", "d");
+    }
+
+    @Test
+    @DisplayName("remove() should be no-op for out of bounds index")
+    void removeOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updatedHigh = listAt.remove(10, original);
+      List<String> updatedNegative = listAt.remove(-1, original);
+
+      assertThat(updatedHigh).containsExactly("a", "b", "c");
+      assertThat(updatedNegative).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("modify() should update element with function")
+    void modifyValidIndex() {
+      List<String> original = new ArrayList<>(List.of("hello", "world"));
+
+      List<String> updated = listAt.modify(0, String::toUpperCase, original);
+
+      assertThat(updated).containsExactly("HELLO", "world");
+    }
+
+    @Test
+    @DisplayName("modify() should be no-op for out of bounds index")
+    void modifyOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("hello", "world"));
+
+      List<String> updated = listAt.modify(10, String::toUpperCase, original);
+
+      assertThat(updated).containsExactly("hello", "world");
+    }
+
+    @Test
+    @DisplayName("contains() should check index validity")
+    void containsChecksIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(listAt.contains(0, list)).isTrue();
+      assertThat(listAt.contains(2, list)).isTrue();
+      assertThat(listAt.contains(3, list)).isFalse();
+      assertThat(listAt.contains(-1, list)).isFalse();
+    }
+
+    @Test
+    @DisplayName("set() with Optional.empty() should remove element")
+    void setEmptyRemovesElement() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = listAt.set(1, Optional.empty(), original);
+
+      assertThat(updated).containsExactly("a", "c");
+    }
+
+    @Test
+    @DisplayName("set() with Optional.of() should update element")
+    void setPresentUpdatesElement() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = listAt.set(1, Optional.of("B"), original);
+
+      assertThat(updated).containsExactly("a", "B", "c");
+    }
+
+    @Test
+    @DisplayName("insertOrUpdate() should update existing element without padding")
+    void updateExistingWithoutPadding() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = listAt.insertOrUpdate(1, "B", original);
+
+      assertThat(updated).containsExactly("a", "B", "c");
+    }
+  }
+
+  @Nested
+  @DisplayName("List At Edge Cases")
+  class ListAtEdgeCaseTests {
+
+    @Test
+    @DisplayName("listAt() should handle null elements in list")
+    void handleNullElements() {
+      At<List<String>, Integer, String> listAt = AtInstances.listAt();
+      List<String> list = new ArrayList<>();
+      list.add("a");
+      list.add(null);
+      list.add("c");
+
+      // Null elements are returned as Optional.empty() due to Java's Optional semantics
+      Optional<String> result = listAt.get(1, list);
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listAt() remove with negative index should be no-op")
+    void removeNegativeIndex() {
+      At<List<String>, Integer, String> listAt = AtInstances.listAt();
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = listAt.remove(-5, original);
+
+      assertThat(updated).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("mapAt() should handle empty map operations")
+    void emptyMapOperations() {
+      At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+      Map<String, Integer> emptyMap = new HashMap<>();
+
+      // Get from empty map
+      assertThat(mapAt.get("any", emptyMap)).isEmpty();
+
+      // Remove from empty map
+      Map<String, Integer> afterRemove = mapAt.remove("any", emptyMap);
+      assertThat(afterRemove).isEmpty();
+
+      // Modify on empty map
+      Map<String, Integer> afterModify = mapAt.modify("any", x -> x + 1, emptyMap);
+      assertThat(afterModify).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listAt() should handle empty list operations")
+    void emptyListOperations() {
+      At<List<String>, Integer, String> listAt = AtInstances.listAt();
+      List<String> emptyList = new ArrayList<>();
+
+      // Get from empty list
+      assertThat(listAt.get(0, emptyList)).isEmpty();
+
+      // Remove from empty list
+      List<String> afterRemove = listAt.remove(0, emptyList);
+      assertThat(afterRemove).isEmpty();
+
+      // Modify on empty list
+      List<String> afterModify = listAt.modify(0, String::toUpperCase, emptyList);
+      assertThat(afterModify).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listAtWithPadding() should handle exact boundary padding")
+    void exactBoundaryPadding() {
+      At<List<String>, Integer, String> listAt = AtInstances.listAtWithPadding("X");
+      List<String> original = new ArrayList<>(List.of("a", "b"));
+
+      // Insert at exact next position (no padding needed, just appending concept)
+      List<String> updated = listAt.insertOrUpdate(2, "c", original);
+
+      assertThat(updated).containsExactly("a", "b", "c");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/at/package-info.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/at/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.optics.at;

--- a/hkj-core/src/test/java/org/higherkindedj/optics/prism/PrismsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/prism/PrismsTest.java
@@ -1,0 +1,263 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.prism;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Prisms Utility Tests")
+class PrismsTest {
+
+  @Nested
+  @DisplayName("some() Prism for Optional")
+  class SomePrismTests {
+
+    private final Prism<Optional<String>, String> somePrism = Prisms.some();
+
+    @Test
+    @DisplayName("getOptional() should return value when Optional is present")
+    void getOptionalWhenPresent() {
+      Optional<String> source = Optional.of("hello");
+
+      Optional<String> result = somePrism.getOptional(source);
+
+      assertThat(result).hasValue("hello");
+    }
+
+    @Test
+    @DisplayName("getOptional() should return empty when Optional is empty")
+    void getOptionalWhenEmpty() {
+      Optional<String> source = Optional.empty();
+
+      Optional<String> result = somePrism.getOptional(source);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("build() should wrap value in Optional.of()")
+    void buildWrapsInOptional() {
+      Optional<String> result = somePrism.build("world");
+
+      assertThat(result).hasValue("world");
+    }
+
+    @Test
+    @DisplayName("should satisfy Prism laws - review (getOptional ∘ build = Some)")
+    void prismReviewLaw() {
+      String value = "test";
+
+      Optional<String> result = somePrism.getOptional(somePrism.build(value));
+
+      assertThat(result).hasValue(value);
+    }
+
+    @Test
+    @DisplayName(
+        "should satisfy Prism laws - preview (getOptional.flatMap(build) = identity when present)")
+    void prismPreviewLaw() {
+      Optional<String> source = Optional.of("hello");
+
+      Optional<Optional<String>> rebuilt = somePrism.getOptional(source).map(somePrism::build);
+
+      assertThat(rebuilt).hasValue(source);
+    }
+
+    @Test
+    @DisplayName("asTraversal() should convert to working Traversal")
+    void asTraversalConversion() {
+      Traversal<Optional<String>, String> traversal = somePrism.asTraversal();
+
+      Optional<String> source = Optional.of("hello");
+      Optional<String> result = Traversals.modify(traversal, String::toUpperCase, source);
+
+      assertThat(result).hasValue("HELLO");
+    }
+
+    @Test
+    @DisplayName("asTraversal() should be no-op when Optional is empty")
+    void asTraversalNoOpWhenEmpty() {
+      Traversal<Optional<String>, String> traversal = somePrism.asTraversal();
+
+      Optional<String> source = Optional.empty();
+      Optional<String> result = Traversals.modify(traversal, String::toUpperCase, source);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should compose with At lens for deep access")
+    void composeWithAtLens() {
+      record User(String name, Map<String, Integer> scores) {}
+
+      Lens<User, Map<String, Integer>> scoresLens =
+          Lens.of(User::scores, (u, s) -> new User(u.name(), s));
+
+      var mapAt = AtInstances.<String, Integer>mapAt();
+      Prism<Optional<Integer>, Integer> intSomePrism = Prisms.some();
+
+      // Compose: User -> Map -> Optional<Integer> -> Integer
+      Lens<User, Optional<Integer>> mathScoreLens = scoresLens.andThen(mapAt.at("math"));
+      Traversal<User, Integer> mathScoreTraversal =
+          mathScoreLens.asTraversal().andThen(intSomePrism.asTraversal());
+
+      User user = new User("Alice", new HashMap<>(Map.of("math", 95, "english", 88)));
+
+      // Get all values (should be single element)
+      List<Integer> scores = Traversals.getAll(mathScoreTraversal, user);
+      assertThat(scores).containsExactly(95);
+
+      // Modify value
+      User updatedUser = Traversals.modify(mathScoreTraversal, x -> x + 5, user);
+      assertThat(updatedUser.scores()).containsEntry("math", 100);
+    }
+
+    @Test
+    @DisplayName("should handle missing key gracefully when composed with At")
+    void composeWithAtMissingKey() {
+      record User(Map<String, Integer> scores) {}
+
+      Lens<User, Map<String, Integer>> scoresLens = Lens.of(User::scores, (u, s) -> new User(s));
+
+      var mapAt = AtInstances.<String, Integer>mapAt();
+      Prism<Optional<Integer>, Integer> intSomePrism = Prisms.some();
+
+      Lens<User, Optional<Integer>> historyScoreLens = scoresLens.andThen(mapAt.at("history"));
+      Traversal<User, Integer> historyScoreTraversal =
+          historyScoreLens.asTraversal().andThen(intSomePrism.asTraversal());
+
+      User user = new User(new HashMap<>(Map.of("math", 95)));
+
+      // Should return empty list when key is missing
+      List<Integer> scores = Traversals.getAll(historyScoreTraversal, user);
+      assertThat(scores).isEmpty();
+
+      // Modify should be no-op when missing
+      User updatedUser = Traversals.modify(historyScoreTraversal, x -> x + 5, user);
+      assertThat(updatedUser.scores()).containsExactlyEntriesOf(user.scores());
+    }
+  }
+
+  @Nested
+  @DisplayName("none() Prism for Optional")
+  class NonePrismTests {
+
+    private final Prism<Optional<String>, Unit> nonePrism = Prisms.none();
+
+    @Test
+    @DisplayName("getOptional() should match when Optional is empty")
+    void getOptionalWhenEmpty() {
+      Optional<String> source = Optional.empty();
+
+      Optional<Unit> result = nonePrism.getOptional(source);
+
+      assertThat(result).isPresent();
+      assertThat(result.get()).isEqualTo(Unit.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("getOptional() should not match when Optional is present")
+    void getOptionalWhenPresent() {
+      Optional<String> source = Optional.of("hello");
+
+      Optional<Unit> result = nonePrism.getOptional(source);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("build() should create empty Optional")
+    void buildCreatesEmpty() {
+      Optional<String> result = nonePrism.build(Unit.INSTANCE);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition Patterns")
+  class CompositionPatterns {
+
+    @Test
+    @DisplayName("should enable insert through composed lens")
+    void insertThroughComposedLens() {
+      record Config(Map<String, String> settings) {}
+
+      Lens<Config, Map<String, String>> settingsLens =
+          Lens.of(Config::settings, (c, s) -> new Config(s));
+
+      var mapAt = AtInstances.<String, String>mapAt();
+
+      Config config = new Config(new HashMap<>());
+
+      // Insert a new setting
+      Lens<Config, Optional<String>> debugLens = settingsLens.andThen(mapAt.at("debug"));
+      Config updated = debugLens.set(Optional.of("true"), config);
+
+      assertThat(updated.settings()).containsEntry("debug", "true");
+    }
+
+    @Test
+    @DisplayName("should enable delete through composed lens")
+    void deleteThroughComposedLens() {
+      record Config(Map<String, String> settings) {}
+
+      Lens<Config, Map<String, String>> settingsLens =
+          Lens.of(Config::settings, (c, s) -> new Config(s));
+
+      var mapAt = AtInstances.<String, String>mapAt();
+
+      Config config = new Config(new HashMap<>(Map.of("debug", "true", "verbose", "false")));
+
+      // Delete a setting
+      Lens<Config, Optional<String>> debugLens = settingsLens.andThen(mapAt.at("debug"));
+      Config updated = debugLens.set(Optional.empty(), config);
+
+      assertThat(updated.settings()).doesNotContainKey("debug").containsEntry("verbose", "false");
+    }
+
+    @Test
+    @DisplayName("should chain multiple At operations")
+    void chainMultipleAtOperations() {
+      record NestedConfig(Map<String, Map<String, Integer>> nested) {}
+
+      Lens<NestedConfig, Map<String, Map<String, Integer>>> nestedLens =
+          Lens.of(NestedConfig::nested, (c, n) -> new NestedConfig(n));
+
+      var outerAt = AtInstances.<String, Map<String, Integer>>mapAt();
+      var innerAt = AtInstances.<String, Integer>mapAt();
+
+      NestedConfig config =
+          new NestedConfig(new HashMap<>(Map.of("database", new HashMap<>(Map.of("port", 5432)))));
+
+      // Navigate: NestedConfig -> Map -> Optional<Map> -> Map -> Optional<Integer>
+      Lens<NestedConfig, Optional<Map<String, Integer>>> dbSettingsLens =
+          nestedLens.andThen(outerAt.at("database"));
+
+      // Get the database settings
+      Optional<Map<String, Integer>> dbSettings = dbSettingsLens.get(config);
+      assertThat(dbSettings).isPresent();
+
+      // Get port from database settings
+      Integer port = innerAt.get("port", dbSettings.get()).orElse(0);
+      assertThat(port).isEqualTo(5432);
+
+      // Update port
+      Map<String, Integer> updatedDbSettings =
+          innerAt.insertOrUpdate("port", 5433, dbSettings.get());
+      NestedConfig updatedConfig = dbSettingsLens.set(Optional.of(updatedDbSettings), config);
+
+      assertThat(updatedConfig.nested().get("database")).containsEntry("port", 5433);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/prism/package-info.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/prism/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.optics.prism;

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/TraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/TraversalsTest.java
@@ -1756,6 +1756,7 @@ class TraversalsTest {
     }
   }
 
+  @Nested
   @DisplayName("SequenceStateList Combiner Function Coverage Tests")
   class SequenceStateListCombinerTest {
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/AtUsageExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/AtUsageExample.java
@@ -1,0 +1,219 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.*;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.prism.Prisms;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A runnable example demonstrating the At type class for indexed CRUD operations on collections.
+ *
+ * <p>At provides a Lens to an Optional value at a given index, enabling:
+ *
+ * <ul>
+ *   <li>Setting to Optional.empty() deletes the entry
+ *   <li>Setting to Optional.of(value) inserts or updates the entry
+ *   <li>Seamless composition with other optics for deep access
+ * </ul>
+ */
+public class AtUsageExample {
+
+  // Domain model for a user profile with nested collections
+  // @GenerateLenses creates UserProfileLenses with lens accessors for each field
+  @GenerateLenses
+  public record UserProfile(
+      String username,
+      Map<String, String> settings,
+      Map<String, Integer> scores,
+      List<String> tags) {}
+
+  public static void main(String[] args) {
+    System.out.println("=== At Type Class Usage Examples ===\n");
+
+    demonstrateMapOperations();
+    demonstrateListOperations();
+    demonstrateLensComposition();
+    demonstrateDeepComposition();
+  }
+
+  private static void demonstrateMapOperations() {
+    System.out.println("--- Map CRUD Operations ---");
+
+    // Create At instance for Map<String, Integer>
+    At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+
+    // Initial data
+    Map<String, Integer> scores = new HashMap<>();
+    scores.put("math", 95);
+    scores.put("english", 88);
+
+    System.out.println("Initial scores: " + scores);
+
+    // INSERT: Add a new subject score
+    Map<String, Integer> afterInsert = mapAt.insertOrUpdate("science", 92, scores);
+    System.out.println("After insert 'science': " + afterInsert);
+
+    // UPDATE: Modify an existing score
+    Map<String, Integer> afterUpdate = mapAt.insertOrUpdate("math", 98, afterInsert);
+    System.out.println("After update 'math': " + afterUpdate);
+
+    // READ: Get a score (returns Optional)
+    Optional<Integer> physicsScore = mapAt.get("physics", afterUpdate);
+    System.out.println("Physics score (absent): " + physicsScore);
+
+    Optional<Integer> mathScore = mapAt.get("math", afterUpdate);
+    System.out.println("Math score (present): " + mathScore);
+
+    // DELETE: Remove a subject
+    Map<String, Integer> afterRemove = mapAt.remove("english", afterUpdate);
+    System.out.println("After remove 'english': " + afterRemove);
+
+    // MODIFY: Apply function to existing value
+    Map<String, Integer> afterModify = mapAt.modify("math", x -> x + 5, afterRemove);
+    System.out.println("After modify 'math' (+5): " + afterModify);
+
+    // CHECK: Contains operation
+    System.out.println("Contains 'science': " + mapAt.contains("science", afterModify));
+    System.out.println("Contains 'english': " + mapAt.contains("english", afterModify));
+
+    // Original unchanged (immutability)
+    System.out.println("Original scores (unchanged): " + scores);
+    System.out.println();
+  }
+
+  private static void demonstrateListOperations() {
+    System.out.println("--- List CRUD Operations ---");
+
+    // Create At instance for List<String>
+    At<List<String>, Integer, String> listAt = AtInstances.listAt();
+
+    // Initial data
+    List<String> tags = new ArrayList<>(List.of("java", "functional", "optics"));
+
+    System.out.println("Initial tags: " + tags);
+
+    // UPDATE: Modify element at index
+    List<String> afterUpdate = listAt.insertOrUpdate(1, "FUNCTIONAL", tags);
+    System.out.println("After update index 1: " + afterUpdate);
+
+    // READ: Get element at index
+    Optional<String> first = listAt.get(0, afterUpdate);
+    System.out.println("Element at index 0: " + first);
+
+    Optional<String> outOfBounds = listAt.get(10, afterUpdate);
+    System.out.println("Element at index 10 (out of bounds): " + outOfBounds);
+
+    // DELETE: Remove element (shifts indices)
+    List<String> afterRemove = listAt.remove(1, afterUpdate);
+    System.out.println("After remove index 1 (shifts): " + afterRemove);
+
+    // MODIFY: Apply function to element
+    List<String> afterModify = listAt.modify(0, String::toUpperCase, afterRemove);
+    System.out.println("After modify index 0 (uppercase): " + afterModify);
+
+    // Original unchanged
+    System.out.println("Original tags (unchanged): " + tags);
+    System.out.println();
+  }
+
+  private static void demonstrateLensComposition() {
+    System.out.println("--- Lens Composition with At ---");
+
+    // Use generated lenses from @GenerateLenses annotation
+    Lens<UserProfile, Map<String, String>> settingsLens = UserProfileLenses.settings();
+    Lens<UserProfile, Map<String, Integer>> scoresLens = UserProfileLenses.scores();
+
+    // Create At instances
+    At<Map<String, String>, String, String> settingsAt = AtInstances.mapAt();
+    At<Map<String, Integer>, String, Integer> scoresAt = AtInstances.mapAt();
+
+    // Initial profile
+    UserProfile profile =
+        new UserProfile(
+            "alice",
+            new HashMap<>(Map.of("theme", "dark", "language", "en")),
+            new HashMap<>(Map.of("math", 95)),
+            new ArrayList<>(List.of("developer")));
+
+    System.out.println("Initial profile: " + profile);
+
+    // Compose: UserProfile -> settings Map -> Optional<String> at "theme"
+    Lens<UserProfile, Optional<String>> themeLens = settingsLens.andThen(settingsAt.at("theme"));
+
+    // Read setting
+    Optional<String> theme = themeLens.get(profile);
+    System.out.println("Current theme: " + theme);
+
+    // Update setting through composed lens
+    UserProfile lightProfile = themeLens.set(Optional.of("light"), profile);
+    System.out.println("After setting theme to 'light': " + lightProfile);
+
+    // Add new setting through composed lens
+    Lens<UserProfile, Optional<String>> notificationsLens =
+        settingsLens.andThen(settingsAt.at("notifications"));
+    UserProfile withNotifications = notificationsLens.set(Optional.of("enabled"), lightProfile);
+    System.out.println("After adding 'notifications': " + withNotifications);
+
+    // Remove setting through composed lens
+    Lens<UserProfile, Optional<String>> languageLens =
+        settingsLens.andThen(settingsAt.at("language"));
+    UserProfile withoutLanguage = languageLens.set(Optional.empty(), withNotifications);
+    System.out.println("After removing 'language': " + withoutLanguage);
+
+    // Original unchanged
+    System.out.println("Original profile (unchanged): " + profile);
+    System.out.println();
+  }
+
+  private static void demonstrateDeepComposition() {
+    System.out.println("--- Deep Composition: At + Prism ---");
+
+    // For truly deep access, compose At's Lens<S, Optional<A>> with a Prism to unwrap Optional
+    Lens<UserProfile, Map<String, Integer>> scoresLens = UserProfileLenses.scores();
+
+    At<Map<String, Integer>, String, Integer> scoresAt = AtInstances.mapAt();
+    Prism<Optional<Integer>, Integer> somePrism = Prisms.some();
+
+    // Compose into a Traversal (0-or-1 focus)
+    Lens<UserProfile, Optional<Integer>> mathScoreLens = scoresLens.andThen(scoresAt.at("math"));
+    Traversal<UserProfile, Integer> mathScoreTraversal =
+        mathScoreLens.asTraversal().andThen(somePrism.asTraversal());
+
+    UserProfile profile =
+        new UserProfile(
+            "bob",
+            new HashMap<>(),
+            new HashMap<>(Map.of("math", 85, "science", 90)),
+            new ArrayList<>());
+
+    System.out.println("Initial profile: " + profile);
+
+    // Get all focused values (0 or 1)
+    List<Integer> mathScores = Traversals.getAll(mathScoreTraversal, profile);
+    System.out.println("Math score via traversal: " + mathScores);
+
+    // Modify through traversal
+    UserProfile boosted = Traversals.modify(mathScoreTraversal, x -> x + 10, profile);
+    System.out.println("After boosting math by 10: " + boosted);
+
+    // Missing key results in no modification
+    Traversal<UserProfile, Integer> historyScoreTraversal =
+        scoresLens.andThen(scoresAt.at("history")).asTraversal().andThen(somePrism.asTraversal());
+
+    List<Integer> historyScores = Traversals.getAll(historyScoreTraversal, profile);
+    System.out.println("History score (absent): " + historyScores);
+
+    UserProfile unchanged = Traversals.modify(historyScoreTraversal, x -> x + 10, profile);
+    System.out.println("After trying to boost absent history: " + unchanged);
+    System.out.println("Profiles equal (no change): " + profile.equals(unchanged));
+
+    System.out.println();
+  }
+}


### PR DESCRIPTION
Implements the At type class which provides a Lens to an Optional value at a given index, enabling insert/update/delete semantics for indexed structures like Map and List. This fills a gap in the optics library where operations like map key deletion and list element removal were not easily composable with other optics.

Key features:
- At<S, I, A> interface with Lens<S, Optional<A>> at(I index)
- AtInstances with mapAt() and listAt() factory methods
- Prisms utility with some() for Optional unwrapping in composition
- Comprehensive test coverage for all operations
- Example demonstrating real-world usage patterns



Fixes #164 
