### PR TITLE
Add Ixed type class for safe indexed access to existing elements

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/optics/Ixed.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/Ixed.java
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics;
+
+/**
+ * A type class for structures that support safe indexed access to existing elements.
+ *
+ * <p>{@code Ixed} provides a {@link Traversal} focusing on zero or one element at a given index.
+ * Unlike {@link At}, which provides CRUD (Create, Read, Update, Delete) operations via {@code
+ * Optional}, {@code Ixed} only allows reading and updating existing elements. If the index is not
+ * present, the traversal focuses on zero elements.
+ *
+ * <p>This makes {@code Ixed} ideal for safe, partial access patterns where you want to modify an
+ * element only if it exists, without the ability to insert or delete.
+ *
+ * <h3>Example Usage:</h3>
+ *
+ * <pre>{@code
+ * // Create an Ixed instance for Map<String, Integer>
+ * Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+ *
+ * Map<String, Integer> scores = new HashMap<>();
+ * scores.put("alice", 100);
+ * scores.put("bob", 85);
+ *
+ * // Get the traversal for a specific key
+ * Traversal<Map<String, Integer>, Integer> aliceTraversal = mapIx.ix("alice");
+ *
+ * // Use Traversals utility methods for operations
+ * List<Integer> aliceScore = Traversals.getAll(aliceTraversal, scores);
+ * // aliceScore = [100]
+ *
+ * // Get a non-existent element returns empty list
+ * List<Integer> charlieScore = Traversals.getAll(mapIx.ix("charlie"), scores);
+ * // charlieScore = []
+ *
+ * // Update an existing element
+ * Map<String, Integer> updated = Traversals.modify(aliceTraversal, x -> x + 5, scores);
+ * // updated = {alice=105, bob=85}
+ *
+ * // Trying to update a non-existent element has no effect
+ * Map<String, Integer> unchanged = Traversals.modify(mapIx.ix("charlie"), x -> x + 10, scores);
+ * // unchanged = {alice=100, bob=85} (charlie not added)
+ * }</pre>
+ *
+ * <h3>Relationship to At:</h3>
+ *
+ * <p>{@code Ixed} can be derived from {@link At} by composing with a prism that unwraps the
+ * optional:
+ *
+ * <pre>{@code
+ * // Ixed is At composed with a "some" prism
+ * At<Map<K, V>, K, V> at = AtInstances.mapAt();
+ * Prism<Optional<V>, V> somePrism = Prisms.some();
+ *
+ * Traversal<Map<K, V>, V> ixTraversal =
+ *     at.at(key).asTraversal().andThen(somePrism.asTraversal());
+ * }</pre>
+ *
+ * <h3>Composition:</h3>
+ *
+ * <p>The traversal returned by {@code ix} composes naturally with other optics:
+ *
+ * <pre>{@code
+ * Lens<User, Map<String, Address>> addressMapLens = ...;
+ * Ixed<Map<String, Address>, String, Address> mapIx = IxedInstances.mapIx();
+ * Lens<Address, String> cityLens = ...;
+ *
+ * // Compose to get a Traversal that focuses on the city of a specific address
+ * Traversal<User, String> homeCityTraversal =
+ *     addressMapLens.asTraversal()
+ *         .andThen(mapIx.ix("home"))
+ *         .andThen(cityLens.asTraversal());
+ *
+ * // Modify the city if the home address exists
+ * User updatedUser = Traversals.modify(
+ *     homeCityTraversal,
+ *     city -> city.toUpperCase(),
+ *     user
+ * );
+ * }</pre>
+ *
+ * <h3>Convenience Methods:</h3>
+ *
+ * <p>For convenience, use the {@code Traversals} utility class from {@code hkj-core} to perform
+ * common operations on the returned traversal:
+ *
+ * <ul>
+ *   <li>{@code Traversals.getAll(ixed.ix(index), source)} - Get all focused elements (0 or 1)
+ *   <li>{@code Traversals.modify(ixed.ix(index), f, source)} - Modify if present
+ * </ul>
+ *
+ * @param <S> The structure type (e.g., {@code Map<K, V>} or {@code List<A>})
+ * @param <I> The index type (e.g., {@code K} for maps, {@code Integer} for lists)
+ * @param <A> The value type at each index
+ */
+@FunctionalInterface
+public interface Ixed<S, I, A> {
+
+  /**
+   * Returns a {@link Traversal} that focuses on zero or one element at the given index.
+   *
+   * <p>The returned traversal has the following semantics:
+   *
+   * <ul>
+   *   <li>If the index exists in the structure, focuses on that single element
+   *   <li>If the index does not exist, focuses on zero elements (modifications have no effect)
+   *   <li>Cannot insert new elements or delete existing ones
+   * </ul>
+   *
+   * <p>Use {@code Traversals.getAll()} and {@code Traversals.modify()} from {@code hkj-core} for
+   * convenient operations on the returned traversal.
+   *
+   * @param index The index to focus on
+   * @return A {@link Traversal} focusing on zero or one element at the given index
+   */
+  Traversal<S, A> ix(I index);
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/package-info.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/package-info.java
@@ -1,7 +1,7 @@
 /**
- * This package provides a collection of functional optics (Lens, Prism, Traversal) for the
- * higher-kinded-j library. Optics are powerful, composable tools for inspecting and manipulating
- * complex, immutable data structures in a purely functional way.
+ * This package provides a collection of functional optics (Lens, Prism, Traversal, and more) for
+ * the higher-kinded-j library. Optics are powerful, composable tools for inspecting and
+ * manipulating complex, immutable data structures in a purely functional way.
  *
  * <h2>Core Concepts</h2>
  *
@@ -13,15 +13,25 @@
  *
  * <ul>
  *   <li>{@link org.higherkindedj.optics.Lens}: For focusing on a single field within a product type
- *       (e.g., a record or class). A Lens provides a way to get and set a part of a whole. For
- *       example, focusing on the {@code street} field of an {@code Address} record.
+ *       (e.g., a record or class). A Lens provides a way to get and set a part of a whole.
  *   <li>{@link org.higherkindedj.optics.Prism}: For focusing on a single variant within a sum type
  *       (e.g., a sealed interface). A Prism can be seen as a "partial" Lens—it allows you to get an
- *       optional value (only if the variant matches) and to construct the whole from a part. For
- *       example, focusing on the {@code JsonString} case of a {@code Json} sealed interface.
+ *       optional value (only if the variant matches) and to construct the whole from a part.
  *   <li>{@link org.higherkindedj.optics.Traversal}: For focusing on multiple values within a
- *       structure (e.g., all elements in a {@code List}, or all values in a {@code Map}). A
- *       Traversal allows you to modify all focused elements at once.
+ *       structure (e.g., all elements in a {@code List}). A Traversal allows you to modify all
+ *       focused elements at once.
+ *   <li>{@link org.higherkindedj.optics.Iso}: For isomorphisms—bidirectional, lossless conversions
+ *       between two types.
+ *   <li>{@link org.higherkindedj.optics.Fold}: For read-only aggregation over multiple elements
+ *       using a monoid.
+ *   <li>{@link org.higherkindedj.optics.Getter}: For read-only access to a single value within a
+ *       structure.
+ *   <li>{@link org.higherkindedj.optics.Setter}: For write-only modification of values within a
+ *       structure.
+ *   <li>{@link org.higherkindedj.optics.At}: A type class for indexed CRUD operations with
+ *       insert/delete semantics via {@code Optional}.
+ *   <li>{@link org.higherkindedj.optics.Ixed}: A type class for safe indexed access to existing
+ *       elements, providing a Traversal that focuses on zero or one element.
  * </ul>
  *
  * <h2>Composition</h2>
@@ -35,6 +45,30 @@
  * // Given a Prism<Result, Json> and a Lens<Json, String>
  * // You can compose them to create a Traversal<Result, String>
  * Traversal<Result, String> composed = successPrism.asTraversal().andThen(jsonStringLens.asTraversal());
+ * }</pre>
+ *
+ * <h2>Indexed Access with At and Ixed</h2>
+ *
+ * <p>The {@link org.higherkindedj.optics.At} and {@link org.higherkindedj.optics.Ixed} type classes
+ * provide complementary patterns for indexed access:
+ *
+ * <ul>
+ *   <li>{@code At} provides CRUD operations via {@code Lens<S, Optional<A>>}, allowing insertion
+ *       and deletion.
+ *   <li>{@code Ixed} provides safe read/update via {@code Traversal<S, A>}, focusing only on
+ *       existing elements.
+ * </ul>
+ *
+ * <pre>{@code
+ * // At: Can insert and delete
+ * At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+ * Map<String, Integer> withNew = mapAt.insertOrUpdate("bob", 85, scores);
+ * Map<String, Integer> withoutAlice = mapAt.remove("alice", scores);
+ *
+ * // Ixed: Only updates existing elements
+ * Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+ * Map<String, Integer> updated = IxedInstances.update(mapIx, "alice", 110, scores); // Updates existing
+ * Map<String, Integer> unchanged = IxedInstances.update(mapIx, "bob", 85, scores);  // No-op if missing
  * }</pre>
  *
  * <h2>Integration with HKT</h2>

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -63,6 +63,7 @@
   - [Getters](optics/getters.md)
   - [Setters](optics/setters.md)
   - [At Type Class](optics/at.md)
+  - [Ixed Type Class](optics/ixed.md)
   - [Profunctor Optics](optics/profunctor_optics.md)
   - [Combining Optics - Validation](optics/composing_optics.md)
   - [Practical Examples](optics/optics_examples.md)

--- a/hkj-book/src/optics/at.md
+++ b/hkj-book/src/optics/at.md
@@ -732,6 +732,8 @@ The **At** type class provides a powerful abstraction for indexed CRUD operation
 
 At bridges the gap between pure functional optics and practical collection manipulation, enabling you to build robust, immutable data pipelines that handle the full lifecycle of indexed data.
 
+**Related**: For read/update-only operations without insert/delete semantics, see the [Ixed Type Class](ixed.md) guide, which provides safe partial access via `Traversal<S, A>`.
+
 ---
 
-[Previous: Setters](setters.md) | [Next: Profunctor Optics](profunctor_optics.md)
+[Previous: Setters](setters.md) | [Next: Ixed Type Class](ixed.md)

--- a/hkj-book/src/optics/ixed.md
+++ b/hkj-book/src/optics/ixed.md
@@ -1,0 +1,799 @@
+# Ixed Type Class: Safe Indexed Access
+
+## _Zero-or-One Element Traversals_
+
+~~~admonish info title="What You'll Learn"
+- How to safely access and update existing elements in indexed structures
+- Understanding the `Traversal<S, A>` pattern for partial access
+- Factory methods: `mapIx()`, `listIx()`, `fromAt()`
+- The key difference between Ixed (read/update only) and At (full CRUD)
+- Composing Ixed with Lenses for safe deep access into nested collections
+- How Ixed is built on At internally using `Prisms.some()`
+- When to use Ixed vs At vs direct collection operations
+- Building safe, structure-preserving data pipelines
+~~~
+
+~~~admonish title="Example Code"
+[IxedUsageExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/IxedUsageExample.java)
+~~~
+
+In the previous guide on [At](at.md), we explored how to perform full CRUD operations on indexed structures—inserting new entries, deleting existing ones, and updating values. But what if you only need to *read* and *update* elements that already exist, without the ability to insert or delete? What if you want operations that automatically become no-ops when an index is absent, preserving the structure unchanged?
+
+This is where **`Ixed`** shines. It provides a `Traversal` that focuses on zero or one element at a given index—perfect for safe, partial access patterns where you want to modify existing data without changing the structure's shape.
+
+---
+
+## The Scenario: Safe Configuration Reading
+
+Consider a configuration system where you need to read and update existing settings, but deliberately want to avoid accidentally creating new entries:
+
+**The Data Model:**
+
+```java
+public record ServerConfig(
+    String serverName,
+    Map<String, String> environment,
+    Map<String, Integer> ports,
+    List<String> allowedHosts
+) {}
+
+public record DatabaseConfig(
+    String connectionString,
+    Map<String, String> poolSettings,
+    List<String> replicaHosts
+) {}
+
+public record ApplicationSettings(
+    ServerConfig server,
+    DatabaseConfig database,
+    Map<String, String> featureToggles
+) {}
+```
+
+**Common Operations:**
+* "Read the current database pool size setting"
+* "Update the max connections if it exists"
+* "Modify the port number for an existing service"
+* "Safely access the nth replica host if it exists"
+* "Never accidentally create new configuration keys"
+
+The key requirement here is **safety**: you want to interact with existing data without risk of accidentally expanding the structure. If a key doesn't exist, the operation should simply do nothing rather than insert a new entry.
+
+---
+
+## Think of Ixed Like...
+
+* **A read-only database view with UPDATE privileges** 🔍: You can SELECT and UPDATE existing rows, but cannot INSERT new ones or DELETE existing ones
+* **A safe array accessor** 🛡️: Returns nothing for out-of-bounds indices instead of throwing exceptions
+* **A peephole in a door** 👁️: You can see what's there and modify it if present, but you can't add or remove anything
+* **A library card catalogue lookup** 📚: You can find and update existing book entries, but adding new books requires different permissions
+* **A partial function** 🎯: Operates only where defined, silently ignores undefined inputs
+
+---
+
+## Ixed vs At vs Traversal vs Prism: Understanding the Relationships
+
+| Aspect | Ixed | At | Traversal | Prism |
+|--------|------|-----|-----------|-------|
+| **Focus** | Zero or one element at index | Optional presence at index | Zero or more elements | Zero or one variant case |
+| **Can insert?** | ❌ No | ✅ Yes | ❌ No | ✅ Yes (via `build`) |
+| **Can delete?** | ❌ No | ✅ Yes | ❌ No | ❌ No |
+| **Core operation** | `Traversal<S, A>` | `Lens<S, Optional<A>>` | `modifyF(f, s, app)` | `getOptional`, `build` |
+| **Returns** | Traversal (0-or-1 focus) | Lens to Optional | Modified structure | Optional value |
+| **Use case** | Safe partial access | Map/List CRUD | Bulk modifications | Sum type handling |
+| **Intent** | "Access if exists" | "Manage entry at index" | "Transform all elements" | "Match this case" |
+| **Structure change** | ❌ Never changes | ✅ Can change size | ❌ Preserves count | ✅ Can change type |
+
+**Key Insight**: `Ixed` is actually built *on top of* `At`. Internally, it composes `At.at(index)` with `Prisms.some()` to unwrap the Optional layer. This means `Ixed` inherits the precise boundary behaviour of `At` whilst removing the ability to insert or delete entries.
+
+```java
+// Ixed is conceptually:
+// at.at(index).asTraversal().andThen(Prisms.some().asTraversal())
+
+// At gives:     Lens<S, Optional<A>>
+// Prisms.some() gives: Prism<Optional<A>, A>
+// Composed:     Traversal<S, A> focusing on 0-or-1 elements
+```
+
+---
+
+## A Step-by-Step Walkthrough
+
+### Step 1: Creating Ixed Instances
+
+Like `At`, `Ixed` instances are created using factory methods from `IxedInstances`:
+
+```java
+import org.higherkindedj.optics.Ixed;
+import org.higherkindedj.optics.ixed.IxedInstances;
+
+// Ixed instance for Map<String, Integer>
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+// Ixed instance for List<String>
+Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+
+// Create Ixed from any At instance
+At<Map<String, String>, String, String> customAt = AtInstances.mapAt();
+Ixed<Map<String, String>, String, String> customIx = IxedInstances.fromAt(customAt);
+```
+
+Each factory method returns an `Ixed` instance parameterised by:
+* `S` – The structure type (e.g., `Map<String, Integer>`)
+* `I` – The index type (e.g., `String` for maps, `Integer` for lists)
+* `A` – The element type (e.g., `Integer`)
+
+### Step 2: Safe Read Operations
+
+`Ixed` provides safe reading that returns `Optional.empty()` for missing indices:
+
+```java
+Map<String, Integer> ports = new HashMap<>();
+ports.put("http", 8080);
+ports.put("https", 8443);
+
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+// Read existing key
+Optional<Integer> httpPort = IxedInstances.get(mapIx, "http", ports);
+// Result: Optional[8080]
+
+// Read missing key - no exception, just empty
+Optional<Integer> ftpPort = IxedInstances.get(mapIx, "ftp", ports);
+// Result: Optional.empty()
+
+// Check existence
+boolean hasHttp = IxedInstances.contains(mapIx, "http", ports);
+// Result: true
+
+boolean hasFtp = IxedInstances.contains(mapIx, "ftp", ports);
+// Result: false
+```
+
+Compare this to direct map access which might return `null` or require explicit containment checks.
+
+### Step 3: Update Operations (No Insertion!)
+
+The crucial difference from `At` is that `update` only modifies *existing* entries:
+
+```java
+Map<String, Integer> ports = new HashMap<>();
+ports.put("http", 8080);
+ports.put("https", 8443);
+
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+// Update existing key - works as expected
+Map<String, Integer> updatedPorts = IxedInstances.update(mapIx, "http", 9000, ports);
+// Result: {http=9000, https=8443}
+
+// Attempt to "update" non-existent key - NO-OP!
+Map<String, Integer> samePorts = IxedInstances.update(mapIx, "ftp", 21, ports);
+// Result: {http=8080, https=8443} - NO ftp key added!
+
+// Original unchanged (immutability)
+System.out.println(ports); // {http=8080, https=8443}
+```
+
+**This is the defining characteristic of Ixed**: it will never change the structure's shape. If an index doesn't exist, operations silently become no-ops.
+
+### Step 4: Functional Modification
+
+Apply functions to existing elements only:
+
+```java
+Map<String, Integer> scores = new HashMap<>();
+scores.put("alice", 100);
+scores.put("bob", 85);
+
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+// Modify existing value
+Map<String, Integer> bonusAlice = IxedInstances.modify(mapIx, "alice", x -> x + 10, scores);
+// Result: {alice=110, bob=85}
+
+// Modify non-existent key - no-op
+Map<String, Integer> unchanged = IxedInstances.modify(mapIx, "charlie", x -> x + 10, scores);
+// Result: {alice=100, bob=85} - no charlie key created
+```
+
+This pattern is excellent for operations like "increment if exists" or "apply transformation to known entries".
+
+### Step 5: Composition with Other Optics
+
+`Ixed` composes naturally with Lenses for deep, safe access:
+
+```java
+record Config(Map<String, Integer> settings) {}
+
+Lens<Config, Map<String, Integer>> settingsLens =
+    Lens.of(Config::settings, (c, s) -> new Config(s));
+
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+// Compose: Config → Map<String, Integer> → Integer (0-or-1)
+Traversal<Config, Integer> maxConnectionsTraversal =
+    settingsLens.asTraversal().andThen(mapIx.ix("maxConnections"));
+
+Config config = new Config(new HashMap<>(Map.of("maxConnections", 100, "timeout", 30)));
+
+// Safe access through composed traversal
+List<Integer> values = Traversals.getAll(maxConnectionsTraversal, config);
+// Result: [100]
+
+// Safe modification through composed traversal
+Config updated = Traversals.modify(maxConnectionsTraversal, x -> x * 2, config);
+// Result: Config[settings={maxConnections=200, timeout=30}]
+
+// Missing key = empty focus, modification is no-op
+Traversal<Config, Integer> missingTraversal =
+    settingsLens.asTraversal().andThen(mapIx.ix("nonexistent"));
+
+Config unchanged = Traversals.modify(missingTraversal, x -> x + 1, config);
+// Result: Config unchanged, no "nonexistent" key added
+```
+
+This composition gives you type-safe, deep access that automatically handles missing intermediate keys.
+
+---
+
+## List Operations: Safe Indexed Access
+
+`Ixed` for lists provides bounds-safe operations:
+
+### Safe Element Access
+
+```java
+Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+
+List<String> items = new ArrayList<>(List.of("apple", "banana", "cherry"));
+
+// Access valid index
+Optional<String> second = IxedInstances.get(listIx, 1, items);
+// Result: Optional["banana"]
+
+// Access out-of-bounds - no exception!
+Optional<String> tenth = IxedInstances.get(listIx, 10, items);
+// Result: Optional.empty()
+
+// Negative index - safely handled
+Optional<String> negative = IxedInstances.get(listIx, -1, items);
+// Result: Optional.empty()
+```
+
+### Safe Element Update
+
+```java
+// Update existing index
+List<String> updated = IxedInstances.update(listIx, 1, "BANANA", items);
+// Result: ["apple", "BANANA", "cherry"]
+
+// Update out-of-bounds - no-op, no exception
+List<String> unchanged = IxedInstances.update(listIx, 10, "grape", items);
+// Result: ["apple", "banana", "cherry"] - no element added!
+
+// Modify with function
+List<String> uppercased = IxedInstances.modify(listIx, 0, String::toUpperCase, items);
+// Result: ["APPLE", "banana", "cherry"]
+
+// Original always unchanged
+System.out.println(items); // ["apple", "banana", "cherry"]
+```
+
+**Important Contrast with At**: `At.insertOrUpdate()` on a list will throw `IndexOutOfBoundsException` for invalid indices (unless using padding), whilst `IxedInstances.update()` simply returns the list unchanged.
+
+---
+
+## When to Use Ixed vs Other Approaches
+
+### ✅ Use `Ixed` When:
+
+* **You want safe partial access**: Operations that become no-ops on missing indices
+* **Structure preservation is critical**: You must not accidentally add or remove entries
+* **You're reading configuration files**: Accessing known keys without creating defaults
+* **You need composable traversals**: Building deep access paths that handle missing intermediates
+* **You want to avoid exceptions**: Out-of-bounds list access should be safe, not throw
+* **Immutability matters**: All operations return new structures
+
+### ❌ Avoid `Ixed` When:
+
+* **You need to insert new entries**: Use `At.insertOrUpdate()` instead
+* **You need to delete entries**: Use `At.remove()` instead
+* **You want to set defaults for missing keys**: Use `At` with `Optional.of(defaultValue)`
+* **You need bulk operations**: Use `Traversal` for all-element modifications
+* **Performance is critical**: Direct collection access may be faster (measure first!)
+
+### Ixed vs At: Choosing the Right Tool
+
+```java
+// Scenario: Update user's email if they exist, do nothing if they don't
+Map<String, String> users = new HashMap<>(Map.of("alice", "alice@example.com"));
+
+// With At - DANGER: Might accidentally create user!
+At<Map<String, String>, String, String> at = AtInstances.mapAt();
+Map<String, String> result1 = at.insertOrUpdate("bob", "bob@example.com", users);
+// Result: {alice=alice@example.com, bob=bob@example.com} - Bob added!
+
+// With Ixed - SAFE: Will not create if missing
+Ixed<Map<String, String>, String, String> ix = IxedInstances.mapIx();
+Map<String, String> result2 = IxedInstances.update(ix, "bob", "bob@example.com", users);
+// Result: {alice=alice@example.com} - No Bob, as intended!
+```
+
+Use **At** when you explicitly want CRUD semantics; use **Ixed** when you want read/update-only with automatic no-ops for missing indices.
+
+---
+
+## Common Pitfalls
+
+### ❌ Don't: Expect Ixed to insert new entries
+
+```java
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+Map<String, Integer> empty = new HashMap<>();
+
+Map<String, Integer> result = IxedInstances.update(mapIx, "key", 100, empty);
+// Result: {} - STILL EMPTY! No insertion occurred.
+
+// If you need insertion, use At instead:
+At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+Map<String, Integer> withKey = mapAt.insertOrUpdate("key", 100, empty);
+// Result: {key=100}
+```
+
+### ✅ Do: Use Ixed for safe, non-inserting updates
+
+```java
+// Perfect for updating known configuration keys
+Map<String, String> config = new HashMap<>(Map.of("theme", "dark", "language", "en"));
+
+Ixed<Map<String, String>, String, String> ix = IxedInstances.mapIx();
+
+// Only updates keys that exist
+Map<String, String> updated = IxedInstances.update(ix, "theme", "light", config);
+// Result: {theme=light, language=en}
+
+// Typo in key name? No problem - just a no-op
+Map<String, String> unchanged = IxedInstances.update(ix, "tehme", "light", config); // typo!
+// Result: {theme=dark, language=en} - no new key created
+```
+
+---
+
+### ❌ Don't: Assume update failure means an error
+
+```java
+Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+List<String> items = new ArrayList<>(List.of("a", "b", "c"));
+
+List<String> result = IxedInstances.update(listIx, 10, "z", items);
+// Result is the same list - but this is SUCCESS, not failure!
+// The operation correctly did nothing because index 10 doesn't exist.
+```
+
+### ✅ Do: Check for existence first if you need to know
+
+```java
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+Map<String, Integer> scores = new HashMap<>(Map.of("alice", 100));
+
+// If you need to know whether update will succeed:
+if (IxedInstances.contains(mapIx, "bob", scores)) {
+    Map<String, Integer> updated = IxedInstances.update(mapIx, "bob", 90, scores);
+    System.out.println("Updated Bob's score");
+} else {
+    System.out.println("Bob not found - consider using At to insert");
+}
+```
+
+---
+
+### ❌ Don't: Forget that Ixed inherits At's null value limitations
+
+```java
+Map<String, Integer> map = new HashMap<>();
+map.put("nullValue", null);
+
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+Optional<Integer> result = IxedInstances.get(mapIx, "nullValue", map);
+// Result: Optional.empty() - NOT Optional.of(null)!
+
+// Java's Optional cannot hold null values
+// This is inherited from the underlying At implementation
+```
+
+### ✅ Do: Avoid null values in collections
+
+```java
+// Use sentinel values or wrapper types if you need to distinguish null from absent
+Map<String, Optional<Integer>> map = new HashMap<>();
+map.put("maybeNull", Optional.empty()); // Explicitly absent value
+map.put("hasValue", Optional.of(42));   // Present value
+
+// Or use At directly if you need to distinguish presence from null
+At<Map<String, Integer>, String, Integer> at = AtInstances.mapAt();
+// at.contains("key", map) checks key presence, not value
+```
+
+---
+
+## Performance Considerations
+
+### Immutability Overhead
+
+Like `At`, all `Ixed` operations create new collection instances:
+
+```java
+Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+// Each operation creates a new HashMap copy - O(n)
+Map<String, Integer> step1 = IxedInstances.update(mapIx, "a", 1, original);   // Copy
+Map<String, Integer> step2 = IxedInstances.modify(mapIx, "b", x -> x + 1, step1); // Copy
+Map<String, Integer> step3 = IxedInstances.update(mapIx, "c", 3, step2);     // Copy
+```
+
+**Best Practice**: Batch modifications when possible, or accept the immutability overhead for correctness:
+
+```java
+// For multiple updates, consider direct immutable construction
+Map<String, Integer> result = new HashMap<>(original);
+result.put("a", 1);  // Mutable during construction
+result.compute("b", (k, v) -> v != null ? v + 1 : v);
+result.put("c", 3);
+// Now use Ixed for subsequent safe operations
+```
+
+### Composition Overhead
+
+Composed traversals have minimal overhead since they're just function compositions:
+
+```java
+// Composition is cheap - just wraps functions
+Traversal<Config, Integer> deep = lens.asTraversal().andThen(mapIx.ix("key"));
+
+// The overhead is in the actual modification, not the composition
+Config result = Traversals.modify(deep, x -> x + 1, config);
+```
+
+### Compared to At
+
+`Ixed` has essentially the same performance characteristics as `At` since it's built on top of it. The additional Prism composition adds negligible overhead.
+
+---
+
+## Real-World Example: Safe Feature Toggle Reader
+
+Consider a system where feature toggles are read from external configuration but should never be accidentally created:
+
+```java
+public class SafeFeatureReader {
+
+    private final Ixed<Map<String, Boolean>, String, Boolean> featureIx =
+        IxedInstances.mapIx();
+    private final Map<String, Boolean> features;
+
+    public SafeFeatureReader(Map<String, Boolean> initialFeatures) {
+        // Create immutable snapshot
+        this.features = new HashMap<>(initialFeatures);
+    }
+
+    public boolean isEnabled(String featureName) {
+        // Safe read - returns false for unknown features
+        return IxedInstances.get(featureIx, featureName, features).orElse(false);
+    }
+
+    public boolean isKnownFeature(String featureName) {
+        return IxedInstances.contains(featureIx, featureName, features);
+    }
+
+    public Map<String, Boolean> withFeatureUpdated(String featureName, boolean enabled) {
+        // Safe update - only modifies existing features
+        // Will NOT add new features even if called with unknown name
+        return IxedInstances.update(featureIx, featureName, enabled, features);
+    }
+
+    public Map<String, Boolean> withFeatureToggled(String featureName) {
+        // Safe toggle - flips value if exists, no-op if missing
+        return IxedInstances.modify(featureIx, featureName, current -> !current, features);
+    }
+
+    public Set<String> getKnownFeatures() {
+        return Collections.unmodifiableSet(features.keySet());
+    }
+}
+
+// Usage
+Map<String, Boolean> config = Map.of(
+    "dark_mode", true,
+    "new_dashboard", false,
+    "beta_features", true
+);
+
+SafeFeatureReader reader = new SafeFeatureReader(config);
+
+// Safe reads
+System.out.println(reader.isEnabled("dark_mode"));      // true
+System.out.println(reader.isEnabled("unknown"));        // false (default)
+System.out.println(reader.isKnownFeature("unknown"));   // false
+
+// Safe updates - won't create new features
+Map<String, Boolean> updated = reader.withFeatureUpdated("new_dashboard", true);
+// Result: {dark_mode=true, new_dashboard=true, beta_features=true}
+
+Map<String, Boolean> unchanged = reader.withFeatureUpdated("typo_feature", true);
+// Result: {dark_mode=true, new_dashboard=false, beta_features=true}
+// No "typo_feature" added!
+
+// Safe toggle
+Map<String, Boolean> toggled = reader.withFeatureToggled("beta_features");
+// Result: {dark_mode=true, new_dashboard=false, beta_features=false}
+```
+
+This pattern ensures configuration integrity—you can never accidentally pollute your feature flags with typos or unknown keys.
+
+---
+
+## Complete, Runnable Example
+
+Here's a comprehensive example demonstrating all major Ixed features:
+
+```java
+package org.higherkindedj.example.optics;
+
+import java.util.*;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Ixed;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.ixed.IxedInstances;
+import org.higherkindedj.optics.util.Traversals;
+
+public class IxedUsageExample {
+
+    @GenerateLenses
+    public record ServerConfig(
+        String name,
+        Map<String, Integer> ports,
+        Map<String, String> environment,
+        List<String> allowedOrigins
+    ) {}
+
+    public static void main(String[] args) {
+        System.out.println("=== Ixed Type Class Usage Examples ===\n");
+
+        // 1. Basic Map Operations - Safe Access Only
+        System.out.println("--- Map Safe Access (No Insertion) ---");
+
+        Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+        Map<String, Integer> ports = new HashMap<>(Map.of("http", 8080, "https", 8443));
+
+        System.out.println("Initial ports: " + ports);
+
+        // Safe read
+        System.out.println("HTTP port: " + IxedInstances.get(mapIx, "http", ports));
+        System.out.println("FTP port (missing): " + IxedInstances.get(mapIx, "ftp", ports));
+
+        // Safe update - only existing keys
+        Map<String, Integer> updatedPorts = IxedInstances.update(mapIx, "http", 9000, ports);
+        System.out.println("After update 'http': " + updatedPorts);
+
+        // Attempted update of non-existent key - NO-OP!
+        Map<String, Integer> samePorts = IxedInstances.update(mapIx, "ftp", 21, ports);
+        System.out.println("After 'update' non-existent 'ftp': " + samePorts);
+        System.out.println("FTP was NOT added (Ixed doesn't insert)");
+
+        // Modify with function
+        Map<String, Integer> doubled = IxedInstances.modify(mapIx, "https", x -> x * 2, ports);
+        System.out.println("After doubling 'https': " + doubled);
+
+        System.out.println("Original unchanged: " + ports);
+        System.out.println();
+
+        // 2. Contrast with At (CRUD)
+        System.out.println("--- Ixed vs At: Insertion Behaviour ---");
+
+        At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+
+        Map<String, Integer> empty = new HashMap<>();
+
+        // At CAN insert
+        Map<String, Integer> withNew = mapAt.insertOrUpdate("newKey", 42, empty);
+        System.out.println("At.insertOrUpdate on empty map: " + withNew);
+
+        // Ixed CANNOT insert
+        Map<String, Integer> stillEmpty = IxedInstances.update(mapIx, "newKey", 42, empty);
+        System.out.println("Ixed.update on empty map: " + stillEmpty);
+        System.out.println("Ixed preserves structure - no insertion occurred");
+        System.out.println();
+
+        // 3. List Safe Indexed Access
+        System.out.println("--- List Safe Indexed Access ---");
+
+        Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+        List<String> origins = new ArrayList<>(List.of("localhost", "example.com", "api.example.com"));
+
+        System.out.println("Initial origins: " + origins);
+
+        // Safe bounds checking
+        System.out.println("Index 1: " + IxedInstances.get(listIx, 1, origins));
+        System.out.println("Index 10 (out of bounds): " + IxedInstances.get(listIx, 10, origins));
+        System.out.println("Index -1 (negative): " + IxedInstances.get(listIx, -1, origins));
+
+        // Safe update within bounds
+        List<String> updated = IxedInstances.update(listIx, 1, "www.example.com", origins);
+        System.out.println("After update index 1: " + updated);
+
+        // Update out of bounds - no-op, no exception!
+        List<String> unchanged = IxedInstances.update(listIx, 10, "invalid.com", origins);
+        System.out.println("After 'update' out-of-bounds index 10: " + unchanged);
+        System.out.println("No exception thrown, list unchanged");
+
+        // Functional modification
+        List<String> uppercased = IxedInstances.modify(listIx, 0, String::toUpperCase, origins);
+        System.out.println("After uppercase index 0: " + uppercased);
+
+        System.out.println("Original unchanged: " + origins);
+        System.out.println();
+
+        // 4. Composition with Lenses
+        System.out.println("--- Deep Composition: Lens + Ixed ---");
+
+        // Use generated lenses from @GenerateLenses annotation
+        Lens<ServerConfig, Map<String, Integer>> portsLens = ServerConfigLenses.ports();
+        Lens<ServerConfig, Map<String, String>> envLens = ServerConfigLenses.environment();
+
+        ServerConfig config = new ServerConfig(
+            "production",
+            new HashMap<>(Map.of("http", 8080, "https", 8443, "ws", 8765)),
+            new HashMap<>(Map.of("NODE_ENV", "production", "LOG_LEVEL", "info")),
+            new ArrayList<>(List.of("*.example.com"))
+        );
+
+        System.out.println("Initial config: " + config);
+
+        // Compose: ServerConfig → Map<String, Integer> → Integer (0-or-1)
+        Ixed<Map<String, Integer>, String, Integer> portIx = IxedInstances.mapIx();
+        Traversal<ServerConfig, Integer> httpPortTraversal =
+            portsLens.asTraversal().andThen(portIx.ix("http"));
+
+        // Safe access through composition
+        List<Integer> httpPorts = Traversals.getAll(httpPortTraversal, config);
+        System.out.println("HTTP port via traversal: " + httpPorts);
+
+        // Safe modification through composition
+        ServerConfig updatedConfig = Traversals.modify(httpPortTraversal, p -> p + 1000, config);
+        System.out.println("After incrementing HTTP port: " + updatedConfig.ports());
+
+        // Non-existent key = empty focus
+        Traversal<ServerConfig, Integer> ftpPortTraversal =
+            portsLens.asTraversal().andThen(portIx.ix("ftp"));
+
+        List<Integer> ftpPorts = Traversals.getAll(ftpPortTraversal, config);
+        System.out.println("FTP port (missing): " + ftpPorts);
+
+        ServerConfig stillSameConfig = Traversals.modify(ftpPortTraversal, p -> p + 1, config);
+        System.out.println("After 'modify' missing FTP: " + stillSameConfig.ports());
+        System.out.println("Config unchanged - Ixed didn't insert FTP");
+        System.out.println();
+
+        // 5. Checking existence
+        System.out.println("--- Existence Checking ---");
+
+        System.out.println("Contains 'http': " + IxedInstances.contains(portIx, "http", config.ports()));
+        System.out.println("Contains 'ftp': " + IxedInstances.contains(portIx, "ftp", config.ports()));
+
+        // Pattern: Check before deciding on operation
+        String keyToUpdate = "ws";
+        if (IxedInstances.contains(portIx, keyToUpdate, config.ports())) {
+            Map<String, Integer> newPorts = IxedInstances.update(portIx, keyToUpdate, 9999, config.ports());
+            System.out.println("WebSocket port updated to 9999: " + newPorts);
+        } else {
+            System.out.println(keyToUpdate + " not found - would need At to insert");
+        }
+        System.out.println();
+
+        // 6. Building Ixed from At
+        System.out.println("--- Creating Ixed from At ---");
+
+        At<Map<String, String>, String, String> stringMapAt = AtInstances.mapAt();
+        Ixed<Map<String, String>, String, String> envIx = IxedInstances.fromAt(stringMapAt);
+
+        Map<String, String> env = config.environment();
+        System.out.println("Initial environment: " + env);
+
+        // Use derived Ixed for safe operations
+        Map<String, String> updatedEnv = IxedInstances.update(envIx, "LOG_LEVEL", "debug", env);
+        System.out.println("After update LOG_LEVEL: " + updatedEnv);
+
+        Map<String, String> unchangedEnv = IxedInstances.update(envIx, "NEW_VAR", "value", env);
+        System.out.println("After 'update' non-existent NEW_VAR: " + unchangedEnv);
+        System.out.println("NEW_VAR not added - Ixed from At still can't insert");
+
+        System.out.println("\n=== All operations maintain immutability and structure ===");
+    }
+}
+```
+
+**Expected Output:**
+
+```
+=== Ixed Type Class Usage Examples ===
+
+--- Map Safe Access (No Insertion) ---
+Initial ports: {http=8080, https=8443}
+HTTP port: Optional[8080]
+FTP port (missing): Optional.empty
+After update 'http': {http=9000, https=8443}
+After 'update' non-existent 'ftp': {http=8080, https=8443}
+FTP was NOT added (Ixed doesn't insert)
+After doubling 'https': {http=8080, https=16886}
+Original unchanged: {http=8080, https=8443}
+
+--- Ixed vs At: Insertion Behaviour ---
+At.insertOrUpdate on empty map: {newKey=42}
+Ixed.update on empty map: {}
+Ixed preserves structure - no insertion occurred
+
+--- List Safe Indexed Access ---
+Initial origins: [localhost, example.com, api.example.com]
+Index 1: Optional[example.com]
+Index 10 (out of bounds): Optional.empty
+Index -1 (negative): Optional.empty
+After update index 1: [localhost, www.example.com, api.example.com]
+After 'update' out-of-bounds index 10: [localhost, example.com, api.example.com]
+No exception thrown, list unchanged
+After uppercase index 0: [LOCALHOST, example.com, api.example.com]
+Original unchanged: [localhost, example.com, api.example.com]
+
+--- Deep Composition: Lens + Ixed ---
+Initial config: ServerConfig[name=production, ports={http=8080, https=8443, ws=8765}, environment={NODE_ENV=production, LOG_LEVEL=info}, allowedOrigins=[*.example.com]]
+HTTP port via traversal: [8080]
+After incrementing HTTP port: {http=9080, https=8443, ws=8765}
+FTP port (missing): []
+After 'modify' missing FTP: {http=8080, https=8443, ws=8765}
+Config unchanged - Ixed didn't insert FTP
+
+--- Existence Checking ---
+Contains 'http': true
+Contains 'ftp': false
+WebSocket port updated to 9999: {http=8080, https=8443, ws=9999}
+
+--- Creating Ixed from At ---
+Initial environment: {NODE_ENV=production, LOG_LEVEL=info}
+After update LOG_LEVEL: {NODE_ENV=production, LOG_LEVEL=debug}
+After 'update' non-existent NEW_VAR: {NODE_ENV=production, LOG_LEVEL=info}
+NEW_VAR not added - Ixed from At still can't insert
+
+=== All operations maintain immutability and structure ===
+```
+
+---
+
+## Further Reading
+
+* [Haskell Lens Library - Ixed Type Class](https://hackage.haskell.org/package/lens/docs/Control-Lens-At.html#t:Ixed)
+* [Optics By Example](https://leanpub.com/optics-by-example) - Comprehensive optics guide
+* [At Type Class Guide](at.md) - Full CRUD operations with insert/delete
+* [Traversals Guide](traversals.md) - Bulk operations on collections
+* [Prisms Guide](prisms.md) - Understanding the `some()` Prism used internally
+
+---
+
+## Summary
+
+The **Ixed** type class provides a powerful abstraction for safe, partial access to indexed structures:
+
+* **Traversal to existing elements**: `ix(index)` returns `Traversal<S, A>` focusing on 0-or-1 elements
+* **No insertion or deletion**: Operations become no-ops for missing indices
+* **Structure preservation**: The shape of your data never changes unexpectedly
+* **Built on At**: Inherits precise semantics whilst removing CRUD mutations
+* **Composable**: Chains naturally with other optics for safe deep access
+* **Exception-free**: Out-of-bounds access returns empty, doesn't throw
+
+Ixed complements At by providing read/update-only semantics when you need safe partial access without the risk of accidentally modifying your data structure's shape. Use Ixed when correctness and structure preservation matter more than the ability to insert or delete entries.
+
+---
+
+[Previous: At Type Class](at.md) | [Next: Profunctor Optics](profunctor_optics.md)

--- a/hkj-core/src/main/java/module-info.java
+++ b/hkj-core/src/main/java/module-info.java
@@ -32,5 +32,6 @@ module org.higherkindedj.core {
   exports org.higherkindedj.hkt.writer;
   exports org.higherkindedj.optics.util;
   exports org.higherkindedj.optics.at;
+  exports org.higherkindedj.optics.ixed;
   exports org.higherkindedj.optics.prism;
 }

--- a/hkj-core/src/main/java/org/higherkindedj/optics/ixed/IxedInstances.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/ixed/IxedInstances.java
@@ -1,0 +1,285 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.ixed;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Ixed;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.prism.Prisms;
+import org.higherkindedj.optics.util.Traversals;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Provides standard {@link Ixed} instances for common Java collection types.
+ *
+ * <p>This class contains factory methods that create {@code Ixed} instances for:
+ *
+ * <ul>
+ *   <li>{@link Map} - indexed by key type {@code K}
+ *   <li>{@link List} - indexed by {@link Integer} position
+ * </ul>
+ *
+ * <p>All instances are built on top of {@link At} instances, composing with a prism that unwraps
+ * the optional layer. This ensures consistency between {@code At} and {@code Ixed} semantics.
+ *
+ * <h3>Usage Examples:</h3>
+ *
+ * <pre>{@code
+ * // Map operations - only updates existing keys
+ * Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+ * Map<String, Integer> scores = Map.of("alice", 100, "bob", 85);
+ *
+ * // Get value at key using convenience method
+ * Optional<Integer> aliceScore = IxedInstances.get(mapIx, "alice", scores);
+ * // aliceScore = Optional[100]
+ *
+ * // Update existing key
+ * Map<String, Integer> updated = IxedInstances.update(mapIx, "alice", 110, scores);
+ * // updated = {alice=110, bob=85}
+ *
+ * // Non-existent key - no change
+ * Map<String, Integer> unchanged = IxedInstances.update(mapIx, "charlie", 90, scores);
+ * // unchanged = {alice=100, bob=85}
+ *
+ * // Modify with function
+ * Optional<Integer> bobScore = IxedInstances.get(mapIx, "bob", scores);
+ * // bobScore = Optional[85]
+ *
+ * Map<String, Integer> updatedBob = IxedInstances.modify(mapIx, "bob", x -> x + 10, scores);
+ * // updatedBob = {alice=100, bob=95}
+ *
+ * // List operations - only updates existing indices
+ * Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+ * List<String> names = List.of("alice", "bob", "charlie");
+ *
+ * // Update existing index
+ * List<String> updatedNames = IxedInstances.modify(listIx, 1, String::toUpperCase, names);
+ * // updatedNames = ["alice", "BOB", "charlie"]
+ *
+ * // Out of bounds index - no change
+ * List<String> unchangedNames = IxedInstances.modify(listIx, 10, String::toUpperCase, names);
+ * // unchangedNames = ["alice", "bob", "charlie"]
+ * }</pre>
+ *
+ * <h3>Design Note:</h3>
+ *
+ * <p>These instances are intentionally built on {@link At} to maintain consistency. The composition
+ * pattern is:
+ *
+ * <pre>{@code
+ * at.at(index).asTraversal().andThen(somePrism.asTraversal())
+ * }</pre>
+ *
+ * <p>This ensures that the boundary behaviour of {@code Ixed} aligns with {@code At}, and both can
+ * be used interchangeably based on whether insert/delete semantics are needed.
+ */
+@NullMarked
+public final class IxedInstances {
+
+  /** Private constructor to prevent instantiation. */
+  private IxedInstances() {}
+
+  /**
+   * Creates an {@link Ixed} instance for {@link Map} types.
+   *
+   * <p>The returned {@code Ixed} provides a traversal to an existing value at a given key:
+   *
+   * <ul>
+   *   <li>{@code ix(key)} focuses on the value if key exists, or zero elements if absent
+   *   <li>Modifications are no-ops for absent keys (no insertion)
+   * </ul>
+   *
+   * <p><strong>Null Value Limitation:</strong> Due to Java's {@link Optional} semantics, null map
+   * values cannot be distinguished from absent keys. A key with null value appears the same as an
+   * absent key.
+   *
+   * <p><strong>Immutability:</strong> All operations return new {@link Map} instances, leaving the
+   * original unchanged.
+   *
+   * @param <K> The key type of the map
+   * @param <V> The value type of the map
+   * @return An {@code Ixed} instance for maps
+   */
+  public static <K, V> Ixed<Map<K, V>, K, @Nullable V> mapIx() {
+    return fromAt(AtInstances.mapAt());
+  }
+
+  /**
+   * Creates an {@link Ixed} instance for {@link List} types.
+   *
+   * <p>The returned {@code Ixed} provides a traversal to an existing element at a given index:
+   *
+   * <ul>
+   *   <li>{@code ix(index)} focuses on the element if index is valid, or zero elements if out of
+   *       bounds
+   *   <li>Modifications are no-ops for invalid indices (no insertion, no exception)
+   * </ul>
+   *
+   * <p><strong>Bounds Checking:</strong> Unlike {@link At#insertOrUpdate}, updating at an
+   * out-of-bounds index has no effect and returns the original list unchanged. This is consistent
+   * with the "zero or one element" semantics of {@code Ixed}.
+   *
+   * <p><strong>Immutability:</strong> All operations return new {@link List} instances, leaving the
+   * original unchanged.
+   *
+   * @param <A> The element type of the list
+   * @return An {@code Ixed} instance for lists
+   */
+  public static <A> Ixed<List<A>, Integer, A> listIx() {
+    return fromAt(AtInstances.listAt());
+  }
+
+  /**
+   * Creates an {@link Ixed} instance for {@link List} types using a custom {@link At} instance.
+   *
+   * <p>This factory method allows using alternative {@code At} implementations, such as {@link
+   * AtInstances#listAtWithPadding(Object)}.
+   *
+   * <p><strong>Example:</strong>
+   *
+   * <pre>{@code
+   * // Create Ixed that uses padding semantics from underlying At
+   * At<List<String>, Integer, String> paddingAt = AtInstances.listAtWithPadding(null);
+   * Ixed<List<String>, Integer, String> listIx = IxedInstances.listIxFrom(paddingAt);
+   * }</pre>
+   *
+   * @param at The {@link At} instance to build upon
+   * @param <A> The element type of the list
+   * @return An {@code Ixed} instance for lists using the provided {@code At}
+   */
+  public static <A> Ixed<List<A>, Integer, A> listIxFrom(At<List<A>, Integer, A> at) {
+    return fromAt(at);
+  }
+
+  /**
+   * Creates a generic {@link Ixed} instance from any {@link At} instance.
+   *
+   * <p>This factory method allows creating {@code Ixed} for any type that has an {@code At}
+   * instance. The resulting {@code Ixed} composes the {@code At} with a prism that unwraps the
+   * optional layer.
+   *
+   * <p><strong>Example:</strong>
+   *
+   * <pre>{@code
+   * // Custom At for a tree structure
+   * At<Tree<A>, Path, A> treeAt = ...;
+   * Ixed<Tree<A>, Path, A> treeIx = IxedInstances.fromAt(treeAt);
+   *
+   * // Now can safely access tree nodes
+   * List<A> nodes = Traversals.getAll(treeIx.ix(somePath), tree);
+   * }</pre>
+   *
+   * @param at The {@link At} instance to convert
+   * @param <S> The structure type
+   * @param <I> The index type
+   * @param <A> The value type
+   * @return An {@code Ixed} instance derived from the provided {@code At}
+   */
+  public static <S, I, A> Ixed<S, I, A> fromAt(At<S, I, A> at) {
+    Prism<Optional<A>, A> somePrism = Prisms.some();
+    return index ->
+        new Traversal<>() {
+          @Override
+          public <F> Kind<F, S> modifyF(
+              Function<A, Kind<F, A>> f, S source, Applicative<F> applicative) {
+            Optional<A> optValue = at.at(index).get(source);
+            if (optValue.isEmpty()) {
+              // Do not modify if absent - this prevents deletion semantics from leaking
+              return applicative.of(source);
+            }
+            // Value is present, so we can proceed with modification
+            Kind<F, Optional<A>> newOptValueF = somePrism.modifyF(f, optValue, applicative);
+            return applicative.map(
+                newOptValue -> at.at(index).set(newOptValue, source), newOptValueF);
+          }
+        };
+  }
+
+  // =========================================================================
+  // Convenience Methods for Common Operations
+  // =========================================================================
+
+  /**
+   * Retrieves the value at the given index, if present.
+   *
+   * <p>This is a convenience method equivalent to:
+   *
+   * <pre>{@code
+   * List<A> results = Traversals.getAll(ixed.ix(index), source);
+   * return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+   * }</pre>
+   *
+   * @param ixed The Ixed instance
+   * @param index The index to look up
+   * @param source The structure to query
+   * @param <S> The structure type
+   * @param <I> The index type
+   * @param <A> The value type
+   * @return An {@link Optional} containing the value if present, or empty if absent
+   */
+  public static <S, I, A> Optional<A> get(Ixed<S, I, A> ixed, I index, S source) {
+    List<A> results = Traversals.getAll(ixed.ix(index), source);
+    return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+  }
+
+  /**
+   * Updates the value at the given index if it exists.
+   *
+   * <p>If the index does not exist in the structure, the original structure is returned unchanged.
+   * This differs from {@link At#insertOrUpdate}, which would insert the value at a missing index.
+   *
+   * @param ixed The Ixed instance
+   * @param index The index to update
+   * @param value The new value
+   * @param source The original structure
+   * @param <S> The structure type
+   * @param <I> The index type
+   * @param <A> The value type
+   * @return A new structure with the value updated, or unchanged if the index is absent
+   */
+  public static <S, I, A> S update(Ixed<S, I, A> ixed, I index, A value, S source) {
+    return Traversals.modify(ixed.ix(index), _ -> value, source);
+  }
+
+  /**
+   * Modifies the value at the given index using the provided function, if the index exists.
+   *
+   * <p>If the index does not exist, the structure is returned unchanged.
+   *
+   * @param ixed The Ixed instance
+   * @param index The index to modify
+   * @param modifier The function to apply to the existing value
+   * @param source The original structure
+   * @param <S> The structure type
+   * @param <I> The index type
+   * @param <A> The value type
+   * @return A new structure with the modified value, or unchanged if absent
+   */
+  public static <S, I, A> S modify(Ixed<S, I, A> ixed, I index, Function<A, A> modifier, S source) {
+    return Traversals.modify(ixed.ix(index), modifier, source);
+  }
+
+  /**
+   * Checks if a value is present at the given index.
+   *
+   * @param ixed The Ixed instance
+   * @param index The index to check
+   * @param source The structure to query
+   * @param <S> The structure type
+   * @param <I> The index type
+   * @param <A> The value type
+   * @return {@code true} if a value is present at the index, {@code false} otherwise
+   */
+  public static <S, I, A> boolean contains(Ixed<S, I, A> ixed, I index, S source) {
+    return get(ixed, index, source).isPresent();
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/ixed/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/ixed/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Provides {@link org.higherkindedj.optics.Ixed} instances for common Java collection types.
+ *
+ * <p>This package contains {@link org.higherkindedj.optics.ixed.IxedInstances}, which provides
+ * factory methods for creating {@code Ixed} instances for {@link java.util.Map} and {@link
+ * java.util.List} types.
+ *
+ * @see org.higherkindedj.optics.Ixed
+ * @see org.higherkindedj.optics.ixed.IxedInstances
+ */
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.optics.ixed;

--- a/hkj-core/src/test/java/org/higherkindedj/optics/ixed/IxedInstancesTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/ixed/IxedInstancesTest.java
@@ -1,0 +1,595 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.ixed;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import org.higherkindedj.optics.Ixed;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IxedInstances Tests")
+class IxedInstancesTest {
+
+  @Nested
+  @DisplayName("Map Ixed Instance")
+  class MapIxTests {
+
+    private final Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+    @Test
+    @DisplayName("ix() should return traversal focusing on zero or one element")
+    void ixReturnsTraversal() {
+      Traversal<Map<String, Integer>, Integer> traversal = mapIx.ix("key");
+      assertThat(traversal).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get() should return empty for missing key")
+    void getMissingKey() {
+      Map<String, Integer> map = new HashMap<>();
+      Optional<Integer> result = IxedInstances.get(mapIx, "missing", map);
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("get() should return present value for existing key")
+    void getExistingKey() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+      Optional<Integer> result = IxedInstances.get(mapIx, "alice", map);
+      assertThat(result).hasValue(100);
+    }
+
+    @Test
+    @DisplayName("get() should treat null values as empty (Java Optional limitation)")
+    void getNullValue() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("nullKey", null);
+
+      Optional<Integer> nullResult = IxedInstances.get(mapIx, "nullKey", map);
+      Optional<Integer> absentResult = IxedInstances.get(mapIx, "absent", map);
+
+      // Java's Optional cannot hold null values
+      assertThat(nullResult).isEmpty();
+      assertThat(absentResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName("update() should modify existing entry")
+    void updateExistingEntry() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = IxedInstances.update(mapIx, "alice", 150, original);
+
+      assertThat(updated).containsEntry("alice", 150);
+      assertThat(original).containsEntry("alice", 100); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("update() should be no-op for missing key (cannot insert)")
+    void updateMissingKey() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = IxedInstances.update(mapIx, "bob", 85, original);
+
+      // Unlike At.insertOrUpdate, Ixed.update does NOT insert new keys
+      assertThat(updated).containsEntry("alice", 100).doesNotContainKey("bob").hasSize(1);
+    }
+
+    @Test
+    @DisplayName("modify() should update existing value with function")
+    void modifyExistingValue() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = IxedInstances.modify(mapIx, "alice", x -> x + 10, original);
+
+      assertThat(updated).containsEntry("alice", 110);
+    }
+
+    @Test
+    @DisplayName("modify() should be no-op for missing key")
+    void modifyMissingKey() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> updated = IxedInstances.modify(mapIx, "missing", x -> x + 10, original);
+
+      assertThat(updated).containsExactlyEntriesOf(original);
+    }
+
+    @Test
+    @DisplayName("contains() should return true for existing key")
+    void containsExistingKey() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+
+      assertThat(IxedInstances.contains(mapIx, "alice", map)).isTrue();
+    }
+
+    @Test
+    @DisplayName("contains() should return false for missing key")
+    void containsMissingKey() {
+      Map<String, Integer> map = new HashMap<>();
+
+      assertThat(IxedInstances.contains(mapIx, "alice", map)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Traversal should focus on zero elements for missing key")
+    void traversalFocusesZeroElements() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+
+      List<Integer> results = Traversals.getAll(mapIx.ix("missing"), map);
+
+      assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Traversal should focus on one element for existing key")
+    void traversalFocusesOneElement() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+      map.put("bob", 85);
+
+      List<Integer> results = Traversals.getAll(mapIx.ix("alice"), map);
+
+      assertThat(results).containsExactly(100);
+    }
+
+    @Test
+    @DisplayName("Traversal composition should work with map ix")
+    void traversalComposition() {
+      record Container(Map<String, Integer> scores) {}
+      Lens<Container, Map<String, Integer>> scoresLens =
+          Lens.of(Container::scores, (c, s) -> new Container(s));
+
+      Container original = new Container(Map.of("alice", 100, "bob", 85));
+
+      // Compose to get traversal focusing on alice's score
+      Traversal<Container, Integer> aliceScoreTraversal =
+          scoresLens.asTraversal().andThen(mapIx.ix("alice"));
+
+      List<Integer> scores = Traversals.getAll(aliceScoreTraversal, original);
+      assertThat(scores).containsExactly(100);
+
+      Container updated = Traversals.modify(aliceScoreTraversal, x -> x + 50, original);
+      assertThat(updated.scores()).containsEntry("alice", 150).containsEntry("bob", 85);
+    }
+
+    @Test
+    @DisplayName("Multiple Ixed operations should chain correctly")
+    void chainingOperations() {
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+      original.put("bob", 85);
+      original.put("charlie", 90);
+
+      Map<String, Integer> result =
+          IxedInstances.modify(
+              mapIx,
+              "alice",
+              x -> x + 10,
+              IxedInstances.modify(mapIx, "bob", x -> x + 5, original));
+
+      assertThat(result)
+          .containsEntry("alice", 110)
+          .containsEntry("bob", 90)
+          .containsEntry("charlie", 90);
+    }
+  }
+
+  @Nested
+  @DisplayName("List Ixed Instance")
+  class ListIxTests {
+
+    private final Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+
+    @Test
+    @DisplayName("get() should return empty for out of bounds index")
+    void getOutOfBounds() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(IxedInstances.get(listIx, -1, list)).isEmpty();
+      assertThat(IxedInstances.get(listIx, 3, list)).isEmpty();
+      assertThat(IxedInstances.get(listIx, 100, list)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("get() should return element at valid index")
+    void getValidIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(IxedInstances.get(listIx, 0, list)).hasValue("a");
+      assertThat(IxedInstances.get(listIx, 1, list)).hasValue("b");
+      assertThat(IxedInstances.get(listIx, 2, list)).hasValue("c");
+    }
+
+    @Test
+    @DisplayName("update() should modify element at valid index")
+    void updateValidIndex() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated = IxedInstances.update(listIx, 1, "B", original);
+
+      assertThat(updated).containsExactly("a", "B", "c");
+      assertThat(original).containsExactly("a", "b", "c"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("update() should be no-op for out of bounds index (cannot insert)")
+    void updateOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      // Unlike At.insertOrUpdate, Ixed.update does NOT insert at out-of-bounds indices
+      List<String> updatedHigh = IxedInstances.update(listIx, 5, "x", original);
+      List<String> updatedNegative = IxedInstances.update(listIx, -1, "x", original);
+
+      assertThat(updatedHigh).containsExactly("a", "b", "c");
+      assertThat(updatedNegative).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("modify() should update element with function")
+    void modifyValidIndex() {
+      List<String> original = new ArrayList<>(List.of("hello", "world"));
+
+      List<String> updated = IxedInstances.modify(listIx, 0, String::toUpperCase, original);
+
+      assertThat(updated).containsExactly("HELLO", "world");
+    }
+
+    @Test
+    @DisplayName("modify() should be no-op for out of bounds index")
+    void modifyOutOfBounds() {
+      List<String> original = new ArrayList<>(List.of("hello", "world"));
+
+      List<String> updated = IxedInstances.modify(listIx, 10, String::toUpperCase, original);
+
+      assertThat(updated).containsExactly("hello", "world");
+    }
+
+    @Test
+    @DisplayName("contains() should check index validity")
+    void containsChecksIndex() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      assertThat(IxedInstances.contains(listIx, 0, list)).isTrue();
+      assertThat(IxedInstances.contains(listIx, 2, list)).isTrue();
+      assertThat(IxedInstances.contains(listIx, 3, list)).isFalse();
+      assertThat(IxedInstances.contains(listIx, -1, list)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Traversal should focus on zero elements for out of bounds")
+    void traversalFocusesZeroElements() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> results = Traversals.getAll(listIx.ix(10), list);
+
+      assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Traversal should focus on one element for valid index")
+    void traversalFocusesOneElement() {
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> results = Traversals.getAll(listIx.ix(1), list);
+
+      assertThat(results).containsExactly("b");
+    }
+
+    @Test
+    @DisplayName("Traversal composition should work with list ix")
+    void traversalComposition() {
+      record Container(List<String> items) {}
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+
+      Container original = new Container(new ArrayList<>(List.of("alice", "bob", "charlie")));
+
+      // Compose to get traversal focusing on first item
+      Traversal<Container, String> firstItemTraversal =
+          itemsLens.asTraversal().andThen(listIx.ix(0));
+
+      List<String> items = Traversals.getAll(firstItemTraversal, original);
+      assertThat(items).containsExactly("alice");
+
+      Container updated = Traversals.modify(firstItemTraversal, String::toUpperCase, original);
+      assertThat(updated.items()).containsExactly("ALICE", "bob", "charlie");
+    }
+
+    @Test
+    @DisplayName("Multiple indices can be modified independently")
+    void multipleIndicesModified() {
+      List<String> original = new ArrayList<>(List.of("a", "b", "c", "d"));
+
+      List<String> result =
+          IxedInstances.modify(
+              listIx,
+              0,
+              String::toUpperCase,
+              IxedInstances.modify(listIx, 2, String::toUpperCase, original));
+
+      assertThat(result).containsExactly("A", "b", "C", "d");
+    }
+  }
+
+  @Nested
+  @DisplayName("Generic Ixed Factory Methods")
+  class GenericFactoryTests {
+
+    @Test
+    @DisplayName("fromAt() should create Ixed from any At instance")
+    void fromAtCreatesIxed() {
+      var mapAt = AtInstances.<String, Integer>mapAt();
+      Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.fromAt(mapAt);
+
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+
+      assertThat(IxedInstances.get(mapIx, "alice", map)).hasValue(100);
+      assertThat(IxedInstances.get(mapIx, "missing", map)).isEmpty();
+
+      Map<String, Integer> updated = IxedInstances.update(mapIx, "alice", 200, map);
+      assertThat(updated).containsEntry("alice", 200);
+    }
+
+    @Test
+    @DisplayName("listIxFrom() should create Ixed from custom At instance")
+    void listIxFromCreatesIxed() {
+      var paddingAt = AtInstances.<String>listAtWithPadding("X");
+      Ixed<List<String>, Integer, String> listIx = IxedInstances.listIxFrom(paddingAt);
+
+      List<String> list = new ArrayList<>(List.of("a", "b"));
+
+      // Even though underlying At supports padding, Ixed.update won't insert
+      List<String> updated = IxedInstances.update(listIx, 5, "z", list);
+
+      // Update at non-existent index is no-op
+      assertThat(updated).containsExactly("a", "b");
+
+      // But update at existing index works
+      List<String> modified = IxedInstances.update(listIx, 0, "A", list);
+      assertThat(modified).containsExactly("A", "b");
+    }
+  }
+
+  @Nested
+  @DisplayName("Ixed vs At Semantic Differences")
+  class SemanticDifferenceTests {
+
+    @Test
+    @DisplayName("At can insert new entries, Ixed cannot")
+    void insertionDifference() {
+      var mapAt = AtInstances.<String, Integer>mapAt();
+      var mapIx = IxedInstances.<String, Integer>mapIx();
+
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      // At can insert
+      Map<String, Integer> afterAtInsert = mapAt.insertOrUpdate("bob", 85, original);
+      assertThat(afterAtInsert).containsKey("bob");
+
+      // Ixed cannot insert
+      Map<String, Integer> afterIxUpdate = IxedInstances.update(mapIx, "charlie", 90, original);
+      assertThat(afterIxUpdate).doesNotContainKey("charlie");
+    }
+
+    @Test
+    @DisplayName("At can delete entries, Ixed cannot")
+    void deletionDifference() {
+      var mapAt = AtInstances.<String, Integer>mapAt();
+      var mapIx = IxedInstances.<String, Integer>mapIx();
+
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+      original.put("bob", 85);
+
+      // At can delete
+      Map<String, Integer> afterAtRemove = mapAt.remove("alice", original);
+      assertThat(afterAtRemove).doesNotContainKey("alice");
+
+      // Ixed has no remove method - can only update existing values
+      // This is by design: Ixed focuses on existing elements only
+      assertThat(mapIx).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Ixed preserves structure, At can change it")
+    void structurePreservation() {
+      var listAt = AtInstances.<String>listAt();
+      var listIx = IxedInstances.<String>listIx();
+
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      // At remove changes structure (list size)
+      List<String> afterAtRemove = listAt.remove(1, original);
+      assertThat(afterAtRemove).hasSize(2);
+
+      // Ixed update preserves structure (list size)
+      List<String> afterIxUpdate = IxedInstances.update(listIx, 1, "B", original);
+      assertThat(afterIxUpdate).hasSize(3);
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases and Corner Cases")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("Empty map operations should be safe")
+    void emptyMapOperations() {
+      var mapIx = IxedInstances.<String, Integer>mapIx();
+      Map<String, Integer> emptyMap = new HashMap<>();
+
+      // Get from empty map
+      assertThat(IxedInstances.get(mapIx, "any", emptyMap)).isEmpty();
+
+      // Update on empty map (no-op)
+      Map<String, Integer> afterUpdate = IxedInstances.update(mapIx, "any", 100, emptyMap);
+      assertThat(afterUpdate).isEmpty();
+
+      // Modify on empty map (no-op)
+      Map<String, Integer> afterModify = IxedInstances.modify(mapIx, "any", x -> x + 1, emptyMap);
+      assertThat(afterModify).isEmpty();
+
+      // Contains on empty map
+      assertThat(IxedInstances.contains(mapIx, "any", emptyMap)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Empty list operations should be safe")
+    void emptyListOperations() {
+      var listIx = IxedInstances.<String>listIx();
+      List<String> emptyList = new ArrayList<>();
+
+      // Get from empty list
+      assertThat(IxedInstances.get(listIx, 0, emptyList)).isEmpty();
+
+      // Update on empty list (no-op)
+      List<String> afterUpdate = IxedInstances.update(listIx, 0, "x", emptyList);
+      assertThat(afterUpdate).isEmpty();
+
+      // Modify on empty list (no-op)
+      List<String> afterModify = IxedInstances.modify(listIx, 0, String::toUpperCase, emptyList);
+      assertThat(afterModify).isEmpty();
+
+      // Contains on empty list
+      assertThat(IxedInstances.contains(listIx, 0, emptyList)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Null elements in list should be handled")
+    void nullElementsInList() {
+      var listIx = IxedInstances.<String>listIx();
+      List<String> list = new ArrayList<>();
+      list.add("a");
+      list.add(null);
+      list.add("c");
+
+      // Null elements appear as empty (Java Optional limitation)
+      Optional<String> result = IxedInstances.get(listIx, 1, list);
+      assertThat(result).isEmpty();
+
+      // Contains reports false for null element
+      assertThat(IxedInstances.contains(listIx, 1, list)).isFalse();
+
+      // Update of null element position is a no-op. Since the element at index 1 is null,
+      // the underlying At treats it as absent (Optional.empty()), and Ixed does not perform
+      // insertions or deletions. The list remains unchanged.
+      List<String> updated = IxedInstances.update(listIx, 1, "b", list);
+      assertThat(updated).containsExactly("a", null, "c");
+    }
+
+    @Test
+    @DisplayName("Large index values should be handled gracefully")
+    void largeIndexValues() {
+      var listIx = IxedInstances.<String>listIx();
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      // Very large index
+      assertThat(IxedInstances.get(listIx, Integer.MAX_VALUE, list)).isEmpty();
+      assertThat(IxedInstances.contains(listIx, Integer.MAX_VALUE, list)).isFalse();
+
+      List<String> updated = IxedInstances.update(listIx, Integer.MAX_VALUE, "x", list);
+      assertThat(updated).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("Negative index values should be handled gracefully")
+    void negativeIndexValues() {
+      var listIx = IxedInstances.<String>listIx();
+      List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+
+      // Negative index
+      assertThat(IxedInstances.get(listIx, Integer.MIN_VALUE, list)).isEmpty();
+      assertThat(IxedInstances.contains(listIx, Integer.MIN_VALUE, list)).isFalse();
+
+      List<String> updated = IxedInstances.update(listIx, Integer.MIN_VALUE, "x", list);
+      assertThat(updated).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("Identity function in modify should preserve value")
+    void identityModify() {
+      var mapIx = IxedInstances.<String, Integer>mapIx();
+      Map<String, Integer> original = new HashMap<>();
+      original.put("alice", 100);
+
+      Map<String, Integer> result = IxedInstances.modify(mapIx, "alice", x -> x, original);
+
+      assertThat(result).containsEntry("alice", 100);
+    }
+
+    @Test
+    @DisplayName("Immutability should be preserved across operations")
+    void immutabilityPreserved() {
+      var listIx = IxedInstances.<String>listIx();
+      List<String> original = new ArrayList<>(List.of("a", "b", "c"));
+
+      List<String> updated1 = IxedInstances.update(listIx, 0, "A", original);
+      List<String> updated2 = IxedInstances.update(listIx, 1, "B", original);
+      List<String> updated3 = IxedInstances.modify(listIx, 2, String::toUpperCase, original);
+
+      // All operations should return different list instances
+      assertThat(original).containsExactly("a", "b", "c");
+      assertThat(updated1).containsExactly("A", "b", "c");
+      assertThat(updated2).containsExactly("a", "B", "c");
+      assertThat(updated3).containsExactly("a", "b", "C");
+
+      // All should be distinct objects
+      assertThat(original).isNotSameAs(updated1);
+      assertThat(original).isNotSameAs(updated2);
+      assertThat(original).isNotSameAs(updated3);
+    }
+  }
+
+  @Nested
+  @DisplayName("Traversal Properties")
+  class TraversalPropertyTests {
+
+    @Test
+    @DisplayName("Ixed traversal should satisfy identity law")
+    void identityLaw() {
+      var mapIx = IxedInstances.<String, Integer>mapIx();
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+
+      // Modifying with identity should return equivalent map
+      Map<String, Integer> result = Traversals.modify(mapIx.ix("alice"), x -> x, map);
+
+      assertThat(result).containsExactlyEntriesOf(map);
+    }
+
+    @Test
+    @DisplayName("Ixed traversal should satisfy composition law")
+    void compositionLaw() {
+      var mapIx = IxedInstances.<String, Integer>mapIx();
+      Map<String, Integer> map = new HashMap<>();
+      map.put("alice", 100);
+
+      // f . g should equal doing g then f
+      java.util.function.Function<Integer, Integer> f = x -> x + 10;
+      java.util.function.Function<Integer, Integer> g = x -> x * 2;
+
+      Map<String, Integer> composed = Traversals.modify(mapIx.ix("alice"), f.compose(g), map);
+      Map<String, Integer> sequential =
+          Traversals.modify(mapIx.ix("alice"), f, Traversals.modify(mapIx.ix("alice"), g, map));
+
+      assertThat(composed).containsExactlyEntriesOf(sequential);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/ixed/package-info.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/ixed/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.optics.ixed;

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/IxedUsageExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/IxedUsageExample.java
@@ -1,0 +1,216 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.*;
+import org.higherkindedj.optics.At;
+import org.higherkindedj.optics.Ixed;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.ixed.IxedInstances;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A runnable example demonstrating the Ixed type class for safe indexed access to existing
+ * elements.
+ *
+ * <p>Ixed provides a Traversal that focuses on zero or one element at a given index:
+ *
+ * <ul>
+ *   <li>Reading returns Optional.empty() for missing indices
+ *   <li>Updating is a no-op for missing indices (no insertion)
+ *   <li>Structure is always preserved (no size changes)
+ * </ul>
+ *
+ * <p>This contrasts with At which provides full CRUD semantics including insert and delete.
+ */
+public class IxedUsageExample {
+
+  // Domain model for server configuration with nested collections
+  // @GenerateLenses creates ServerConfigLenses with lens accessors for each field
+  @GenerateLenses
+  public record ServerConfig(
+      String name,
+      Map<String, Integer> ports,
+      Map<String, String> environment,
+      List<String> allowedOrigins) {}
+
+  public static void main(String[] args) {
+    System.out.println("=== Ixed Type Class Usage Examples ===\n");
+
+    demonstrateMapSafeAccess();
+    demonstrateIxedVsAt();
+    demonstrateListSafeAccess();
+    demonstrateLensComposition();
+    demonstrateExistenceChecking();
+    demonstrateIxedFromAt();
+  }
+
+  private static void demonstrateMapSafeAccess() {
+    System.out.println("--- Map Safe Access (No Insertion) ---");
+
+    // Create Ixed instance for Map<String, Integer>
+    Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+    // Initial data
+    Map<String, Integer> ports = new HashMap<>(Map.of("http", 8080, "https", 8443));
+
+    System.out.println("Initial ports: " + ports);
+
+    // Safe read operations
+    System.out.println("HTTP port: " + IxedInstances.get(mapIx, "http", ports));
+    System.out.println("FTP port (missing): " + IxedInstances.get(mapIx, "ftp", ports));
+
+    // Safe update - only affects existing keys
+    Map<String, Integer> updatedPorts = IxedInstances.update(mapIx, "http", 9000, ports);
+    System.out.println("After update 'http': " + updatedPorts);
+
+    // Attempted update of non-existent key - NO-OP!
+    Map<String, Integer> samePorts = IxedInstances.update(mapIx, "ftp", 21, ports);
+    System.out.println("After 'update' non-existent 'ftp': " + samePorts);
+    System.out.println("FTP was NOT added (Ixed doesn't insert)");
+
+    // Modify with function
+    Map<String, Integer> doubled = IxedInstances.modify(mapIx, "https", x -> x * 2, ports);
+    System.out.println("After doubling 'https': " + doubled);
+
+    // Original unchanged (immutability)
+    System.out.println("Original unchanged: " + ports);
+    System.out.println();
+  }
+
+  private static void demonstrateIxedVsAt() {
+    System.out.println("--- Ixed vs At: Insertion Behaviour ---");
+
+    At<Map<String, Integer>, String, Integer> mapAt = AtInstances.mapAt();
+    Ixed<Map<String, Integer>, String, Integer> mapIx = IxedInstances.mapIx();
+
+    Map<String, Integer> empty = new HashMap<>();
+
+    // At CAN insert new entries
+    Map<String, Integer> withNew = mapAt.insertOrUpdate("newKey", 42, empty);
+    System.out.println("At.insertOrUpdate on empty map: " + withNew);
+
+    // Ixed CANNOT insert - update is a no-op
+    Map<String, Integer> stillEmpty = IxedInstances.update(mapIx, "newKey", 42, empty);
+    System.out.println("Ixed.update on empty map: " + stillEmpty);
+    System.out.println("Ixed preserves structure - no insertion occurred");
+    System.out.println();
+  }
+
+  private static void demonstrateListSafeAccess() {
+    System.out.println("--- List Safe Indexed Access ---");
+
+    Ixed<List<String>, Integer, String> listIx = IxedInstances.listIx();
+
+    List<String> origins = new ArrayList<>(List.of("localhost", "example.com", "api.example.com"));
+
+    System.out.println("Initial origins: " + origins);
+
+    // Safe bounds checking - no exceptions
+    System.out.println("Index 1: " + IxedInstances.get(listIx, 1, origins));
+    System.out.println("Index 10 (out of bounds): " + IxedInstances.get(listIx, 10, origins));
+    System.out.println("Index -1 (negative): " + IxedInstances.get(listIx, -1, origins));
+
+    // Safe update within bounds
+    List<String> updated = IxedInstances.update(listIx, 1, "www.example.com", origins);
+    System.out.println("After update index 1: " + updated);
+
+    // Update out of bounds - no-op, no exception!
+    List<String> unchanged = IxedInstances.update(listIx, 10, "invalid.com", origins);
+    System.out.println("After 'update' out-of-bounds index 10: " + unchanged);
+    System.out.println("No exception thrown, list unchanged");
+
+    // Functional modification
+    List<String> uppercased = IxedInstances.modify(listIx, 0, String::toUpperCase, origins);
+    System.out.println("After uppercase index 0: " + uppercased);
+
+    // Original unchanged (immutability)
+    System.out.println("Original unchanged: " + origins);
+    System.out.println();
+  }
+
+  private static void demonstrateLensComposition() {
+    System.out.println("--- Deep Composition: Lens + Ixed ---");
+
+    // Use generated lenses from @GenerateLenses annotation
+    Lens<ServerConfig, Map<String, Integer>> portsLens = ServerConfigLenses.ports();
+
+    ServerConfig config =
+        new ServerConfig(
+            "production",
+            new HashMap<>(Map.of("http", 8080, "https", 8443, "ws", 8765)),
+            new HashMap<>(Map.of("NODE_ENV", "production", "LOG_LEVEL", "info")),
+            new ArrayList<>(List.of("*.example.com")));
+
+    System.out.println("Initial config: " + config);
+
+    // Compose: ServerConfig → Map<String, Integer> → Integer (0-or-1)
+    Ixed<Map<String, Integer>, String, Integer> portIx = IxedInstances.mapIx();
+    Traversal<ServerConfig, Integer> httpPortTraversal =
+        portsLens.asTraversal().andThen(portIx.ix("http"));
+
+    // Safe access through composition
+    List<Integer> httpPorts = Traversals.getAll(httpPortTraversal, config);
+    System.out.println("HTTP port via traversal: " + httpPorts);
+
+    // Safe modification through composition
+    ServerConfig updatedConfig = Traversals.modify(httpPortTraversal, p -> p + 1000, config);
+    System.out.println("After incrementing HTTP port: " + updatedConfig.ports());
+
+    // Non-existent key = empty focus
+    Traversal<ServerConfig, Integer> ftpPortTraversal =
+        portsLens.asTraversal().andThen(portIx.ix("ftp"));
+
+    List<Integer> ftpPorts = Traversals.getAll(ftpPortTraversal, config);
+    System.out.println("FTP port (missing): " + ftpPorts);
+
+    ServerConfig stillSameConfig = Traversals.modify(ftpPortTraversal, p -> p + 1, config);
+    System.out.println("After 'modify' missing FTP: " + stillSameConfig.ports());
+    System.out.println("Config unchanged - Ixed didn't insert FTP");
+    System.out.println();
+  }
+
+  private static void demonstrateExistenceChecking() {
+    System.out.println("--- Existence Checking ---");
+
+    Ixed<Map<String, Integer>, String, Integer> portIx = IxedInstances.mapIx();
+
+    Map<String, Integer> ports = new HashMap<>(Map.of("http", 8080, "https", 8443, "ws", 8765));
+
+    System.out.println("Contains 'http': " + IxedInstances.contains(portIx, "http", ports));
+    System.out.println("Contains 'ftp': " + IxedInstances.contains(portIx, "ftp", ports));
+
+    // Pattern: Check before deciding on operation
+    String keyToUpdate = "ws";
+    if (IxedInstances.contains(portIx, keyToUpdate, ports)) {
+      Map<String, Integer> newPorts = IxedInstances.update(portIx, keyToUpdate, 9999, ports);
+      System.out.println("WebSocket port updated to 9999: " + newPorts);
+    } else {
+      System.out.println(keyToUpdate + " not found - would need At to insert");
+    }
+    System.out.println();
+  }
+
+  private static void demonstrateIxedFromAt() {
+    System.out.println("--- Creating Ixed from At ---");
+
+    At<Map<String, String>, String, String> stringMapAt = AtInstances.mapAt();
+    Ixed<Map<String, String>, String, String> envIx = IxedInstances.fromAt(stringMapAt);
+
+    Map<String, String> env = new HashMap<>(Map.of("NODE_ENV", "production", "LOG_LEVEL", "info"));
+    System.out.println("Initial environment: " + env);
+
+    // Use derived Ixed for safe operations
+    Map<String, String> updatedEnv = IxedInstances.update(envIx, "LOG_LEVEL", "debug", env);
+    System.out.println("After update LOG_LEVEL: " + updatedEnv);
+
+    Map<String, String> unchangedEnv = IxedInstances.update(envIx, "NEW_VAR", "value", env);
+    System.out.println("After 'update' non-existent NEW_VAR: " + unchangedEnv);
+    System.out.println("NEW_VAR not added - Ixed from At still can't insert");
+
+    System.out.println("\n=== All operations maintain immutability and structure ===");
+  }
+}


### PR DESCRIPTION
Ixed provides a Traversal that focuses on zero or one element at a given index, enabling safe read/update operations without insert/delete semantics. This complements the At type class:

- At: CRUD operations via Lens<S, Optional<A>> (can insert/delete)
- Ixed: Safe access via Traversal<S, A> (update existing only)

The implementation builds on At internally by composing with Prisms.some() to unwrap the Optional layer, ensuring consistency between the two type classes.

Includes:
- Ixed interface in hkj-api with convenience methods (get, update, modify)
- IxedInstances in hkj-core with factory methods for Map and List
- Comprehensive test suite covering all operations and edge cases
- Updated package-info.java documentation

closes #165 
