### PR TITLE
Add limiting traversals for focusing on portions of lists

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -61,6 +61,7 @@
   - [Traversals](optics/traversals.md)
   - [Folds](optics/folds.md)
   - [Filtered Optics](optics/filtered_optics.md)
+  - [Limiting Traversals](optics/limiting_traversals.md)
   - [Getters](optics/getters.md)
   - [Setters](optics/setters.md)
   - [At Type Class](optics/at.md)

--- a/hkj-book/src/optics/filtered_optics.md
+++ b/hkj-book/src/optics/filtered_optics.md
@@ -693,4 +693,4 @@ Filtered optics represent the pinnacle of declarative data manipulation in Javaâ
 ---
 
 **Previous:** [Folds: Querying Immutable Data](folds.md)
-**Next:** [Getters: Composable Read-Only Access](getters.md)
+**Next:** [Limiting Traversals: Focusing on List Portions](limiting_traversals.md)

--- a/hkj-book/src/optics/getters.md
+++ b/hkj-book/src/optics/getters.md
@@ -585,5 +585,5 @@ The key insight: **Getters make pure functions first-class composable citizens**
 
 ---
 
-**Previous:** [Filtered Optics: Predicate-Based Composition](filtered_optics.md)
+**Previous:** [Limiting Traversals: Focusing on List Portions](limiting_traversals.md)
 **Next:** [Setters: Composable Write-Only Modifications](setters.md)

--- a/hkj-book/src/optics/limiting_traversals.md
+++ b/hkj-book/src/optics/limiting_traversals.md
@@ -1,0 +1,630 @@
+# Limiting Traversals: Focusing on List Portions
+
+## _Declarative Slicing for Targeted Operations_
+
+~~~admonish info title="What You'll Learn"
+- How to focus on specific portions of lists (first n, last n, slices)
+- Using `ListTraversals` factory methods for index-based operations
+- The difference between limiting traversals and Stream's `limit()`/`skip()`
+- Composing limiting traversals with lenses, prisms, and filtered optics
+- Understanding edge case handling (negative indices, bounds exceeding list size)
+- Real-world patterns for pagination, batch processing, and time-series windowing
+- When to use limiting traversals vs Stream API vs manual loops
+~~~
+
+~~~admonish title="Example Code"
+[ListTraversalsExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/ListTraversalsExample.java)
+
+[PaginationExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/PaginationExample.java)
+
+[BatchProcessingExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/BatchProcessingExample.java)
+
+[TimeSeriesWindowingExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/TimeSeriesWindowingExample.java)
+~~~
+
+In our journey through optics, we've seen how **Traversal** handles bulk operations on all elements of a collection, and how **filtered optics** let us focus on elements matching a predicate. But what about focusing on elements by *position*—the first few items, the last few, or a specific slice?
+
+Traditionally, working with list portions requires breaking out of your optic composition to use streams or manual index manipulation. **Limiting traversals** solve this elegantly by making positional focus a first-class part of your optic composition.
+
+---
+
+## The Scenario: Product Catalogue Management
+
+Imagine you're building an e-commerce platform where you need to:
+- Display only the **first 10 products** on a landing page
+- Apply discounts to **all except the last 3** featured items
+- Process customer orders in **chunks of 50** for batch shipping
+- Analyse **the most recent 7 days** of time-series sales data
+- Update metadata for products **between positions 5 and 15** in a ranked list
+
+**The Data Model:**
+
+```java
+@GenerateLenses
+public record Product(String sku, String name, double price, int stock) {
+    Product applyDiscount(double percentage) {
+        return new Product(sku, name, price * (1 - percentage), stock);
+    }
+}
+
+@GenerateLenses
+public record Catalogue(String name, List<Product> products) {}
+
+@GenerateLenses
+public record Order(String id, List<LineItem> items, LocalDateTime created) {}
+
+@GenerateLenses
+public record LineItem(Product product, int quantity) {}
+
+@GenerateLenses
+public record SalesMetric(LocalDate date, double revenue, int transactions) {}
+```
+
+**The Traditional Approach:**
+
+```java
+// Verbose: Manual slicing breaks optic composition
+List<Product> firstTen = catalogue.products().subList(0, Math.min(10, catalogue.products().size()));
+List<Product> discounted = firstTen.stream()
+    .map(p -> p.applyDiscount(0.1))
+    .collect(Collectors.toList());
+// Now reconstruct the full list... tedious!
+List<Product> fullList = new ArrayList<>(discounted);
+fullList.addAll(catalogue.products().subList(Math.min(10, catalogue.products().size()), catalogue.products().size()));
+Catalogue updated = new Catalogue(catalogue.name(), fullList);
+
+// Even worse with nested structures
+List<Order> chunk = orders.subList(startIndex, Math.min(startIndex + chunkSize, orders.size()));
+// Process chunk... then what? How do we put it back?
+```
+
+This approach forces you to abandon the declarative power of optics, manually managing indices, bounds checking, and list reconstruction. **Limiting traversals** let you express this intent directly within your optic composition.
+
+---
+
+## Think of Limiting Traversals Like...
+
+* **Java Stream's `limit()` and `skip()`**: Like `stream.limit(n)` and `stream.skip(n)`, but composable with immutable data transformations and integrated into optic pipelines
+* **SQL's LIMIT and OFFSET clauses**: Like database pagination (`LIMIT 10 OFFSET 20`), but for in-memory immutable structures—enabling declarative pagination logic
+* **Spring Batch chunk processing**: Similar to Spring Batch's chunk-oriented processing—divide a list into manageable segments for targeted transformation whilst preserving the complete dataset
+* **ArrayList.subList() but better**: Like `List.subList(from, to)`, but instead of a mutable view, you get an immutable optic that composes with lenses, prisms, and filtered traversals
+
+The key insight: positional focus becomes part of your optic's *identity*, not an external slicing operation applied afterwards.
+
+---
+
+## Five Ways to Limit Focus
+
+Higher-kinded-j's `ListTraversals` utility class provides five complementary factory methods:
+
+| Method | Description | SQL Equivalent |
+|--------|-------------|----------------|
+| **`taking(n)`** | Focus on first n elements | `LIMIT n` |
+| **`dropping(n)`** | Skip first n, focus on rest | `OFFSET n` (then all) |
+| **`takingLast(n)`** | Focus on last n elements | `ORDER BY id DESC LIMIT n` |
+| **`droppingLast(n)`** | Focus on all except last n | `LIMIT (size - n)` |
+| **`slicing(from, to)`** | Focus on range [from, to) | `LIMIT (to-from) OFFSET from` |
+
+Each serves different needs, and they can be combined with other optics for powerful compositions.
+
+---
+
+## A Step-by-Step Walkthrough
+
+### Step 1: Basic Usage — `taking(int n)`
+
+The most intuitive method: focus on at most the first `n` elements.
+
+```java
+import org.higherkindedj.optics.util.ListTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+// Create a traversal for first 3 products
+Traversal<List<Product>, Product> first3 = ListTraversals.taking(3);
+
+List<Product> products = List.of(
+    new Product("SKU001", "Widget", 10.0, 100),
+    new Product("SKU002", "Gadget", 25.0, 50),
+    new Product("SKU003", "Gizmo", 15.0, 75),
+    new Product("SKU004", "Doohickey", 30.0, 25),
+    new Product("SKU005", "Thingamajig", 20.0, 60)
+);
+
+// Apply 10% discount to ONLY first 3 products
+List<Product> result = Traversals.modify(first3, p -> p.applyDiscount(0.1), products);
+// First 3 discounted; last 2 preserved unchanged
+
+// Extract ONLY first 3 products
+List<Product> firstThree = Traversals.getAll(first3, products);
+// Returns: [Widget, Gadget, Gizmo]
+```
+
+**Critical Semantic**: During **modification**, non-focused elements are *preserved unchanged* in the structure. During **queries** (like `getAll`), they are *excluded* from the results. This preserves the overall structure whilst focusing operations on the subset you care about.
+
+### Step 2: Skipping Elements — `dropping(int n)`
+
+Focus on all elements *after* skipping the first `n`:
+
+```java
+// Skip first 2, focus on the rest
+Traversal<List<Product>, Product> afterFirst2 = ListTraversals.dropping(2);
+
+List<Product> result = Traversals.modify(afterFirst2, p -> p.applyDiscount(0.15), products);
+// First 2 unchanged; last 3 get 15% discount
+
+List<Product> skipped = Traversals.getAll(afterFirst2, products);
+// Returns: [Gizmo, Doohickey, Thingamajig]
+```
+
+### Step 3: Focusing on the End — `takingLast(int n)`
+
+Focus on the last `n` elements—perfect for "most recent" scenarios:
+
+```java
+// Focus on last 2 products
+Traversal<List<Product>, Product> last2 = ListTraversals.takingLast(2);
+
+List<Product> result = Traversals.modify(last2, p -> p.applyDiscount(0.2), products);
+// First 3 unchanged; last 2 get 20% discount
+
+List<Product> lastTwo = Traversals.getAll(last2, products);
+// Returns: [Doohickey, Thingamajig]
+```
+
+### Step 4: Excluding from the End — `droppingLast(int n)`
+
+Focus on all elements *except* the last `n`:
+
+```java
+// Focus on all except last 2
+Traversal<List<Product>, Product> exceptLast2 = ListTraversals.droppingLast(2);
+
+List<Product> result = Traversals.modify(exceptLast2, p -> p.applyDiscount(0.05), products);
+// First 3 get 5% discount; last 2 unchanged
+
+List<Product> allButLastTwo = Traversals.getAll(exceptLast2, products);
+// Returns: [Widget, Gadget, Gizmo]
+```
+
+### Step 5: Precise Slicing — `slicing(int from, int to)`
+
+Focus on elements within a half-open range `[from, to)`, exactly like `List.subList()`:
+
+```java
+// Focus on indices 1, 2, 3 (0-indexed, exclusive end)
+Traversal<List<Product>, Product> slice = ListTraversals.slicing(1, 4);
+
+List<Product> result = Traversals.modify(slice, p -> p.applyDiscount(0.12), products);
+// Index 0 unchanged; indices 1-3 discounted; index 4 unchanged
+
+List<Product> sliced = Traversals.getAll(slice, products);
+// Returns: [Gadget, Gizmo, Doohickey]
+```
+
+---
+
+## Edge Case Handling
+
+All limiting traversal methods handle edge cases gracefully and consistently:
+
+| Edge Case | Behaviour | Rationale |
+|-----------|-----------|-----------|
+| **`n < 0`** | Treated as 0 (identity traversal) | Graceful degradation, no exceptions |
+| **`n > list.size()`** | Clamped to list bounds | Focus on all available elements |
+| **Empty list** | Returns empty list unchanged | No elements to focus on |
+| **`from >= to` in slicing** | Identity traversal (no focus) | Empty range semantics |
+| **Negative `from` in slicing** | Clamped to 0 | Start from beginning |
+
+```java
+// Examples of edge case handling
+List<Integer> numbers = List.of(1, 2, 3);
+
+// n > size: focuses on all elements
+List<Integer> result1 = Traversals.getAll(ListTraversals.taking(100), numbers);
+// Returns: [1, 2, 3]
+
+// Negative n: identity (no focus)
+List<Integer> result2 = Traversals.getAll(ListTraversals.taking(-5), numbers);
+// Returns: []
+
+// Inverted range: no focus
+List<Integer> result3 = Traversals.getAll(ListTraversals.slicing(3, 1), numbers);
+// Returns: []
+
+// Empty list: safe operation
+List<Integer> result4 = Traversals.modify(ListTraversals.taking(3), x -> x * 2, List.of());
+// Returns: []
+```
+
+This philosophy ensures **no runtime exceptions** from index bounds, making limiting traversals safe for dynamic data.
+
+---
+
+## Composing Limiting Traversals
+
+The real power emerges when you compose limiting traversals with other optics:
+
+### With Lenses — Deep Updates
+
+```java
+Traversal<List<Product>, Product> first5 = ListTraversals.taking(5);
+Lens<Product, Double> priceLens = ProductLenses.price();
+
+// Compose: first 5 products → their prices
+Traversal<List<Product>, Double> first5Prices =
+    first5.andThen(priceLens.asTraversal());
+
+// Increase prices of first 5 products by 10%
+List<Product> result = Traversals.modify(first5Prices, price -> price * 1.1, products);
+```
+
+### With Filtered Traversals — Conditional Slicing
+
+```java
+// First 10 products that are also low stock
+Traversal<List<Product>, Product> first10LowStock =
+    ListTraversals.taking(10).filtered(p -> p.stock() < 50);
+
+// Restock only first 10 low-stock products
+List<Product> restocked = Traversals.modify(
+    first10LowStock,
+    p -> new Product(p.sku(), p.name(), p.price(), p.stock() + 100),
+    products
+);
+```
+
+### With Nested Structures — Batch Processing
+
+```java
+// Focus on first 50 orders
+Traversal<List<Order>, Order> first50Orders = ListTraversals.taking(50);
+
+// Focus on all line items in those orders
+Traversal<List<Order>, LineItem> first50OrderItems =
+    first50Orders.andThen(OrderTraversals.items());
+
+// Apply bulk discount to items in first 50 orders
+List<Order> processed = Traversals.modify(
+    first50OrderItems,
+    item -> new LineItem(item.product().applyDiscount(0.05), item.quantity()),
+    orders
+);
+```
+
+---
+
+## When to Use Limiting Traversals vs Other Approaches
+
+### Use Limiting Traversals When:
+
+* **Positional focus** - You need to operate on elements by index position
+* **Structural preservation** - Non-focused elements must remain in the list
+* **Composable pipelines** - Building complex optic chains with lenses and prisms
+* **Immutable updates** - Transforming portions whilst keeping data immutable
+* **Reusable logic** - Define once, compose everywhere
+
+```java
+// Perfect: Declarative, composable, reusable
+Traversal<Catalogue, Double> first10Prices =
+    CatalogueLenses.products().asTraversal()
+        .andThen(ListTraversals.taking(10))
+        .andThen(ProductLenses.price().asTraversal());
+
+Catalogue updated = Traversals.modify(first10Prices, p -> p * 0.9, catalogue);
+```
+
+### Use Stream API When:
+
+* **Terminal operations** - Counting, finding, collecting to new structures
+* **Complex transformations** - Multiple chained operations with sorting/grouping
+* **No structural preservation needed** - You're extracting data, not updating in place
+* **Performance-critical paths** - Minimal abstraction overhead
+
+```java
+// Better with streams: Complex aggregation
+int totalStock = products.stream()
+    .limit(100)
+    .mapToInt(Product::stock)
+    .sum();
+```
+
+### Use Manual Loops When:
+
+* **Early termination with side effects** - Need to break out of loop
+* **Index-dependent logic** - Processing depends on knowing the exact index
+* **Imperative control flow** - Complex branching based on position
+
+```java
+// Sometimes explicit indexing is clearest
+for (int i = 0; i < Math.min(10, products.size()); i++) {
+    if (products.get(i).stock() == 0) {
+        notifyOutOfStock(products.get(i), i);
+        break;
+    }
+}
+```
+
+---
+
+## Common Pitfalls
+
+### ❌ Don't Do This:
+
+```java
+// Inefficient: Recreating traversals in loops
+for (int page = 0; page < totalPages; page++) {
+    var slice = ListTraversals.slicing(page * 10, (page + 1) * 10);
+    processPage(Traversals.getAll(slice, products));
+}
+
+// Confusing: Mixing with Stream operations unnecessarily
+List<Product> result = Traversals.getAll(ListTraversals.taking(5), products)
+    .stream()
+    .limit(3)  // Why limit again? Already took 5!
+    .collect(toList());
+
+// Wrong expectation: Thinking it removes elements
+Traversal<List<Product>, Product> first3 = ListTraversals.taking(3);
+List<Product> modified = Traversals.modify(first3, Product::applyDiscount, products);
+// modified.size() == products.size()! Structure preserved, not truncated
+
+// Over-engineering: Using slicing for single element
+Traversal<List<Product>, Product> atIndex5 = ListTraversals.slicing(5, 6);
+// Consider using Ixed type class for single-element access instead
+```
+
+### ✅ Do This Instead:
+
+```java
+// Efficient: Create traversal once, vary parameters
+Traversal<List<Product>, Product> takeN(int n) {
+    return ListTraversals.taking(n);
+}
+// Or store commonly used ones as constants
+static final Traversal<List<Product>, Product> FIRST_PAGE = ListTraversals.taking(10);
+
+// Clear: Keep operations at appropriate abstraction level
+List<Product> firstFive = Traversals.getAll(ListTraversals.taking(5), products);
+// If you need further processing, do it separately
+
+// Correct expectation: Use getAll for extraction, modify for transformation
+List<Product> onlyFirst5 = Traversals.getAll(first5, products);  // Extracts subset
+List<Product> allWithFirst5Updated = Traversals.modify(first5, p -> p.applyDiscount(0.1), products);  // Updates in place
+
+// Right tool: Use Ixed for single indexed access
+Optional<Product> fifth = IxedInstances.listIxed().ix(4).getOptional(products);
+```
+
+---
+
+## Performance Notes
+
+Limiting traversals are optimised for efficiency:
+
+* **Single pass**: No intermediate list creation—slicing happens during traversal
+* **Structural sharing**: Unchanged portions of the list are reused, not copied
+* **Lazy bounds checking**: Index calculations are minimal and performed once
+* **No boxing overhead**: Direct list operations without stream intermediaries
+* **Composable without penalty**: Chaining with other optics adds no extra iteration
+
+**Best Practice**: Store frequently-used limiting traversals as constants:
+
+```java
+public class CatalogueOptics {
+    // Pagination constants
+    public static final int PAGE_SIZE = 20;
+
+    public static Traversal<List<Product>, Product> page(int pageNum) {
+        return ListTraversals.slicing(pageNum * PAGE_SIZE, (pageNum + 1) * PAGE_SIZE);
+    }
+
+    // Featured products (first 5)
+    public static final Traversal<Catalogue, Product> FEATURED =
+        CatalogueLenses.products().asTraversal()
+            .andThen(ListTraversals.taking(5));
+
+    // Latest additions (last 10)
+    public static final Traversal<Catalogue, Product> LATEST =
+        CatalogueLenses.products().asTraversal()
+            .andThen(ListTraversals.takingLast(10));
+
+    // Exclude promotional items at end
+    public static final Traversal<Catalogue, Product> NON_PROMOTIONAL =
+        CatalogueLenses.products().asTraversal()
+            .andThen(ListTraversals.droppingLast(3));
+}
+```
+
+---
+
+## Real-World Example: E-Commerce Pagination
+
+Here's a comprehensive example demonstrating limiting traversals in a business context:
+
+```java
+package org.higherkindedj.example.optics;
+
+import org.higherkindedj.optics.*;
+import org.higherkindedj.optics.util.*;
+import java.util.*;
+
+public class PaginationExample {
+
+    public record Product(String sku, String name, double price, boolean featured) {
+        Product applyDiscount(double pct) {
+            return new Product(sku, name, price * (1 - pct), featured);
+        }
+    }
+
+    public static void main(String[] args) {
+        List<Product> catalogue = createCatalogue();
+
+        System.out.println("=== E-COMMERCE PAGINATION WITH LIMITING TRAVERSALS ===\n");
+
+        // --- Scenario 1: Basic Pagination ---
+        System.out.println("--- Scenario 1: Paginated Product Display ---");
+
+        int pageSize = 3;
+        int totalPages = (int) Math.ceil(catalogue.size() / (double) pageSize);
+
+        for (int page = 0; page < totalPages; page++) {
+            Traversal<List<Product>, Product> pageTraversal =
+                ListTraversals.slicing(page * pageSize, (page + 1) * pageSize);
+
+            List<Product> pageProducts = Traversals.getAll(pageTraversal, catalogue);
+            System.out.printf("Page %d: %s%n", page + 1,
+                pageProducts.stream().map(Product::name).toList());
+        }
+
+        // --- Scenario 2: Featured Products ---
+        System.out.println("\n--- Scenario 2: Featured Products (First 3) ---");
+
+        Traversal<List<Product>, Product> featured = ListTraversals.taking(3);
+        List<Product> featuredProducts = Traversals.getAll(featured, catalogue);
+        featuredProducts.forEach(p ->
+            System.out.printf("  ⭐ %s - £%.2f%n", p.name(), p.price()));
+
+        // --- Scenario 3: Apply Discount to Featured ---
+        System.out.println("\n--- Scenario 3: 10% Discount on Featured ---");
+
+        List<Product> withDiscount = Traversals.modify(featured, p -> p.applyDiscount(0.1), catalogue);
+        System.out.println("After discount on first 3:");
+        withDiscount.forEach(p -> System.out.printf("  %s: £%.2f%n", p.name(), p.price()));
+
+        // --- Scenario 4: Exclude Last Items ---
+        System.out.println("\n--- Scenario 4: All Except Last 2 (Clearance) ---");
+
+        Traversal<List<Product>, Product> nonClearance = ListTraversals.droppingLast(2);
+        List<Product> regularStock = Traversals.getAll(nonClearance, catalogue);
+        System.out.println("Regular stock: " + regularStock.stream().map(Product::name).toList());
+
+        System.out.println("\n=== PAGINATION COMPLETE ===");
+    }
+
+    private static List<Product> createCatalogue() {
+        return List.of(
+            new Product("SKU001", "Laptop", 999.99, true),
+            new Product("SKU002", "Mouse", 29.99, false),
+            new Product("SKU003", "Keyboard", 79.99, true),
+            new Product("SKU004", "Monitor", 349.99, true),
+            new Product("SKU005", "Webcam", 89.99, false),
+            new Product("SKU006", "Headset", 149.99, false),
+            new Product("SKU007", "USB Hub", 39.99, false),
+            new Product("SKU008", "Desk Lamp", 44.99, false)
+        );
+    }
+}
+```
+
+**Expected Output:**
+
+```
+=== E-COMMERCE PAGINATION WITH LIMITING TRAVERSALS ===
+
+--- Scenario 1: Paginated Product Display ---
+Page 1: [Laptop, Mouse, Keyboard]
+Page 2: [Monitor, Webcam, Headset]
+Page 3: [USB Hub, Desk Lamp]
+
+--- Scenario 2: Featured Products (First 3) ---
+  ⭐ Laptop - £999.99
+  ⭐ Mouse - £29.99
+  ⭐ Keyboard - £79.99
+
+--- Scenario 3: 10% Discount on Featured ---
+After discount on first 3:
+  Laptop: £899.99
+  Mouse: £26.99
+  Keyboard: £71.99
+  Monitor: £349.99
+  Webcam: £89.99
+  Headset: £149.99
+  USB Hub: £39.99
+  Desk Lamp: £44.99
+
+--- Scenario 4: All Except Last 2 (Clearance) ---
+Regular stock: [Laptop, Mouse, Keyboard, Monitor, Webcam, Headset]
+
+=== PAGINATION COMPLETE ===
+```
+
+---
+
+## The Relationship to Functional Programming Libraries
+
+For those familiar with functional programming, higher-kinded-j's limiting traversals are inspired by similar patterns in:
+
+### Haskell's Lens Library
+
+The [`Control.Lens.Traversal`](https://hackage.haskell.org/package/lens-5.2.3/docs/Control-Lens-Traversal.html) module provides:
+
+```haskell
+taking :: Int -> Traversal' [a] a
+dropping :: Int -> Traversal' [a] a
+```
+
+These create traversals that focus on the first/remaining elements—exactly what our `ListTraversals.taking()` and `dropping()` do.
+
+### Scala's Monocle Library
+
+[Monocle](https://www.optics.dev/Monocle/) provides similar index-based optics:
+
+```scala
+import monocle.function.Index._
+
+// Focus on element at index
+val atIndex: Optional[List[A], A] = index(3)
+
+// Take first n (via custom combinator)
+val firstN: Traversal[List[A], A] = ...
+```
+
+### Key Differences in Higher-Kinded-J
+
+* **Explicit Applicative instances** rather than implicit type class resolution
+* **Java's type system** requires more explicit composition steps
+* **Additional methods** like `takingLast` and `droppingLast` not standard in Haskell lens
+* **Edge case handling** follows Java conventions (no exceptions, graceful clamping)
+
+**Further Reading:**
+
+* [Haskell Lens Tutorial](https://hackage.haskell.org/package/lens-tutorial-1.0.4/docs/Control-Lens-Tutorial.html) - Original inspiration for optics
+* [Optics By Example](https://leanpub.com/optics-by-example) by Chris Penner - Comprehensive book on optics in Haskell
+* [Monocle Documentation](https://www.optics.dev/Monocle/) - Scala optics library with similar patterns
+* [Java Stream API](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/stream/Stream.html) - Comparison with `limit()` and `skip()`
+
+---
+
+## Summary: The Power of Limiting Traversals
+
+Limiting traversals bring **positional focus** into the heart of your optic compositions:
+
+* **`taking(n)`**: Focus on first n elements
+* **`dropping(n)`**: Skip first n, focus on rest
+* **`takingLast(n)`**: Focus on last n elements
+* **`droppingLast(n)`**: Focus on all except last n
+* **`slicing(from, to)`**: Focus on index range [from, to)
+
+These tools transform how you work with list portions in immutable data structures:
+
+| Before (Imperative) | After (Declarative) |
+|---------------------|---------------------|
+| Manual `subList()` with bounds checking | Single limiting traversal |
+| Index manipulation breaking composition | Positional focus as part of optic chain |
+| Explicit list reconstruction | Automatic structural preservation |
+| Mix of "what" and "how" | Pure expression of intent |
+
+By incorporating limiting traversals into your toolkit, you gain:
+
+* **Expressiveness**: Say "first 10 products" once, compose with other optics
+* **Safety**: No `IndexOutOfBoundsException`—graceful edge case handling
+* **Composability**: Chain with lenses, prisms, filtered traversals seamlessly
+* **Immutability**: Structure preserved, only focused elements transformed
+* **Clarity**: Business logic separate from index arithmetic
+
+Limiting traversals represent the natural evolution of optics for list manipulation—where Stream's `limit()` and `skip()` meet the composable, type-safe world of functional optics, all whilst maintaining full referential transparency and structural preservation.
+
+---
+
+**Previous:** [Filtered Optics: Predicate-Based Composition](filtered_optics.md)
+**Next:** [Getters: Composable Read-Only Access](getters.md)

--- a/hkj-core/src/main/java/org/higherkindedj/optics/util/ListTraversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/util/ListTraversals.java
@@ -1,0 +1,337 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A final utility class providing static factory methods for creating {@link Traversal}s that focus
+ * on specific portions of {@link List}s.
+ *
+ * <p>These combinators allow limiting which elements of a list are focused upon, enabling
+ * operations like "modify only the first 3 elements" or "transform elements from index 2 to 5".
+ *
+ * <p>All methods follow consistent edge-case handling:
+ *
+ * <ul>
+ *   <li>Negative indices are treated as 0 (identity behavior)
+ *   <li>Indices beyond list size are clamped to list bounds
+ *   <li>Empty lists always return identity (no modification)
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Modify only the first 3 users
+ * Traversal<List<User>, User> first3 = ListTraversals.taking(3);
+ * List<User> modified = Traversals.modify(first3, User::activate, users);
+ *
+ * // Get the last 2 items
+ * Traversal<List<Item>, Item> last2 = ListTraversals.takingLast(2);
+ * List<Item> items = Traversals.getAll(last2, allItems);
+ *
+ * // Slice elements from index 1 to 4 (exclusive)
+ * Traversal<List<String>, String> slice = ListTraversals.slicing(1, 4);
+ * List<String> sliced = Traversals.getAll(slice, strings);
+ * }</pre>
+ */
+@NullMarked
+public final class ListTraversals {
+
+  /** Private constructor to prevent instantiation. */
+  private ListTraversals() {}
+
+  /**
+   * Creates a {@code Traversal} that focuses on at most the first {@code n} elements of a list.
+   *
+   * <p>Elements beyond the first {@code n} are preserved unchanged during modifications but are not
+   * included in query operations like {@code getAll}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<List<Integer>, Integer> first3 = ListTraversals.taking(3);
+   *
+   * List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+   * List<Integer> doubled = Traversals.modify(first3, x -> x * 2, numbers);
+   * // Result: [2, 4, 6, 4, 5] - only first 3 doubled
+   *
+   * List<Integer> gotten = Traversals.getAll(first3, numbers);
+   * // Result: [1, 2, 3] - only first 3 returned
+   * }</pre>
+   *
+   * @param n The maximum number of elements to focus on. If {@code n <= 0}, returns an identity
+   *     traversal that focuses on no elements. If {@code n >= list.size()}, focuses on all
+   *     elements.
+   * @param <A> The element type of the list.
+   * @return A {@code Traversal} focusing on at most the first {@code n} elements.
+   */
+  public static <A> Traversal<List<A>, A> taking(final int n) {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, List<A>> modifyF(
+          final Function<A, Kind<F, A>> f, final List<A> source, final Applicative<F> applicative) {
+        if (n <= 0 || source.isEmpty()) {
+          return applicative.of(source);
+        }
+
+        final int splitPoint = Math.min(n, source.size());
+        final List<A> prefix = source.subList(0, splitPoint);
+        final List<A> suffix = source.subList(splitPoint, source.size());
+
+        // Traverse prefix with effects
+        final Kind<F, List<A>> modifiedPrefixF = Traversals.traverseList(prefix, f, applicative);
+
+        // Combine with unmodified suffix
+        return applicative.map(
+            newPrefix -> {
+              final List<A> result = new ArrayList<>(source.size());
+              result.addAll(newPrefix);
+              result.addAll(suffix);
+              return result;
+            },
+            modifiedPrefixF);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that focuses on all elements after skipping the first {@code n}.
+   *
+   * <p>The first {@code n} elements are preserved unchanged during modifications but are not
+   * included in query operations like {@code getAll}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<List<Integer>, Integer> afterFirst2 = ListTraversals.dropping(2);
+   *
+   * List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+   * List<Integer> doubled = Traversals.modify(afterFirst2, x -> x * 2, numbers);
+   * // Result: [1, 2, 6, 8, 10] - skipped first 2, doubled rest
+   *
+   * List<Integer> gotten = Traversals.getAll(afterFirst2, numbers);
+   * // Result: [3, 4, 5] - skipped first 2
+   * }</pre>
+   *
+   * @param n The number of elements to skip. If {@code n <= 0}, focuses on all elements. If {@code
+   *     n >= list.size()}, returns an identity traversal focusing on no elements.
+   * @param <A> The element type of the list.
+   * @return A {@code Traversal} focusing on elements after skipping the first {@code n}.
+   */
+  public static <A> Traversal<List<A>, A> dropping(final int n) {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, List<A>> modifyF(
+          final Function<A, Kind<F, A>> f, final List<A> source, final Applicative<F> applicative) {
+        if (n <= 0) {
+          // Drop nothing, focus on all elements
+          return Traversals.traverseList(source, f, applicative);
+        }
+
+        if (n >= source.size()) {
+          return applicative.of(source);
+        }
+
+        final List<A> prefix = source.subList(0, n);
+        final List<A> suffix = source.subList(n, source.size());
+
+        // Traverse suffix with effects
+        final Kind<F, List<A>> modifiedSuffixF = Traversals.traverseList(suffix, f, applicative);
+
+        // Combine with unmodified prefix
+        return applicative.map(
+            newSuffix -> {
+              final List<A> result = new ArrayList<>(source.size());
+              result.addAll(prefix);
+              result.addAll(newSuffix);
+              return result;
+            },
+            modifiedSuffixF);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that focuses on at most the last {@code n} elements of a list.
+   *
+   * <p>Elements before the last {@code n} are preserved unchanged during modifications but are not
+   * included in query operations like {@code getAll}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<List<Integer>, Integer> last3 = ListTraversals.takingLast(3);
+   *
+   * List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+   * List<Integer> doubled = Traversals.modify(last3, x -> x * 2, numbers);
+   * // Result: [1, 2, 6, 8, 10] - only last 3 doubled
+   *
+   * List<Integer> gotten = Traversals.getAll(last3, numbers);
+   * // Result: [3, 4, 5] - only last 3 returned
+   * }</pre>
+   *
+   * @param n The maximum number of elements from the end to focus on. If {@code n <= 0}, returns an
+   *     identity traversal that focuses on no elements. If {@code n >= list.size()}, focuses on all
+   *     elements.
+   * @param <A> The element type of the list.
+   * @return A {@code Traversal} focusing on at most the last {@code n} elements.
+   */
+  public static <A> Traversal<List<A>, A> takingLast(final int n) {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, List<A>> modifyF(
+          final Function<A, Kind<F, A>> f, final List<A> source, final Applicative<F> applicative) {
+        if (n <= 0 || source.isEmpty()) {
+          return applicative.of(source);
+        }
+
+        final int splitPoint = Math.max(0, source.size() - n);
+        final List<A> prefix = source.subList(0, splitPoint);
+        final List<A> suffix = source.subList(splitPoint, source.size());
+
+        // Traverse suffix (last n elements) with effects
+        final Kind<F, List<A>> modifiedSuffixF = Traversals.traverseList(suffix, f, applicative);
+
+        // Combine with unmodified prefix
+        return applicative.map(
+            newSuffix -> {
+              final List<A> result = new ArrayList<>(source.size());
+              result.addAll(prefix);
+              result.addAll(newSuffix);
+              return result;
+            },
+            modifiedSuffixF);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that focuses on all elements except the last {@code n}.
+   *
+   * <p>The last {@code n} elements are preserved unchanged during modifications but are not
+   * included in query operations like {@code getAll}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<List<Integer>, Integer> exceptLast2 = ListTraversals.droppingLast(2);
+   *
+   * List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+   * List<Integer> doubled = Traversals.modify(exceptLast2, x -> x * 2, numbers);
+   * // Result: [2, 4, 6, 4, 5] - doubled all except last 2
+   *
+   * List<Integer> gotten = Traversals.getAll(exceptLast2, numbers);
+   * // Result: [1, 2, 3] - all except last 2
+   * }</pre>
+   *
+   * @param n The number of elements from the end to exclude. If {@code n <= 0}, focuses on all
+   *     elements. If {@code n >= list.size()}, returns an identity traversal focusing on no
+   *     elements.
+   * @param <A> The element type of the list.
+   * @return A {@code Traversal} focusing on all elements except the last {@code n}.
+   */
+  public static <A> Traversal<List<A>, A> droppingLast(final int n) {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, List<A>> modifyF(
+          final Function<A, Kind<F, A>> f, final List<A> source, final Applicative<F> applicative) {
+        if (n <= 0) {
+          // Drop nothing from end, focus on all elements
+          return Traversals.traverseList(source, f, applicative);
+        }
+
+        if (n >= source.size()) {
+          return applicative.of(source);
+        }
+
+        final int splitPoint = source.size() - n;
+        final List<A> prefix = source.subList(0, splitPoint);
+        final List<A> suffix = source.subList(splitPoint, source.size());
+
+        // Traverse prefix with effects
+        final Kind<F, List<A>> modifiedPrefixF = Traversals.traverseList(prefix, f, applicative);
+
+        // Combine with unmodified suffix
+        return applicative.map(
+            newPrefix -> {
+              final List<A> result = new ArrayList<>(source.size());
+              result.addAll(newPrefix);
+              result.addAll(suffix);
+              return result;
+            },
+            modifiedPrefixF);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that focuses on elements within a specified index range.
+   *
+   * <p>Elements outside the range {@code [from, to)} are preserved unchanged during modifications
+   * but are not included in query operations like {@code getAll}.
+   *
+   * <p>The range is half-open: {@code from} is inclusive, {@code to} is exclusive (consistent with
+   * {@link List#subList}).
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, 4);
+   *
+   * List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+   * List<Integer> doubled = Traversals.modify(slice, x -> x * 2, numbers);
+   * // Result: [1, 4, 6, 8, 5] - doubled elements at indices 1, 2, 3
+   *
+   * List<Integer> gotten = Traversals.getAll(slice, numbers);
+   * // Result: [2, 3, 4] - elements at indices 1, 2, 3
+   * }</pre>
+   *
+   * @param from The starting index (inclusive). Clamped to 0 if negative.
+   * @param to The ending index (exclusive). Clamped to list size if beyond bounds. If {@code to <=
+   *     from}, returns an identity traversal focusing on no elements.
+   * @param <A> The element type of the list.
+   * @return A {@code Traversal} focusing on elements within the specified range.
+   */
+  public static <A> Traversal<List<A>, A> slicing(final int from, final int to) {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, List<A>> modifyF(
+          final Function<A, Kind<F, A>> f, final List<A> source, final Applicative<F> applicative) {
+        final int size = source.size();
+
+        // Clamp indices to valid bounds
+        final int effectiveFrom = Math.max(0, Math.min(from, size));
+        final int effectiveTo = Math.max(effectiveFrom, Math.min(to, size));
+
+        if (effectiveFrom >= effectiveTo || source.isEmpty()) {
+          return applicative.of(source);
+        }
+
+        final List<A> prefix = source.subList(0, effectiveFrom);
+        final List<A> middle = source.subList(effectiveFrom, effectiveTo);
+        final List<A> suffix = source.subList(effectiveTo, size);
+
+        // Traverse middle (sliced portion) with effects
+        final Kind<F, List<A>> modifiedMiddleF = Traversals.traverseList(middle, f, applicative);
+
+        // Combine all three parts
+        return applicative.map(
+            newMiddle -> {
+              final List<A> result = new ArrayList<>(source.size());
+              result.addAll(prefix);
+              result.addAll(newMiddle);
+              result.addAll(suffix);
+              return result;
+            },
+            modifiedMiddleF);
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/ListTraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/ListTraversalsTest.java
@@ -1,0 +1,726 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ListTraversals - Limiting Traversals for Lists")
+class ListTraversalsTest {
+
+  // Test Data Structure
+  record User(String name, int score) {
+    User doubleScore() {
+      return new User(name, score * 2);
+    }
+  }
+
+  @Nested
+  @DisplayName("taking(int n) - Focus on first n elements")
+  class TakingTests {
+
+    @Test
+    @DisplayName("taking() should modify only the first n elements")
+    void takingModifiesFirstN() {
+      Traversal<List<Integer>, Integer> first3 = ListTraversals.taking(3);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(first3, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6, 4, 5);
+    }
+
+    @Test
+    @DisplayName("taking() getAll should return only first n elements")
+    void takingGetAllReturnsFirstN() {
+      Traversal<List<Integer>, Integer> first3 = ListTraversals.taking(3);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(first3, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("taking() with n > size should focus on all elements")
+    void takingWithNGreaterThanSize() {
+      Traversal<List<Integer>, Integer> first10 = ListTraversals.taking(10);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(first10, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("taking() with n = 0 should focus on no elements")
+    void takingWithZero() {
+      Traversal<List<Integer>, Integer> first0 = ListTraversals.taking(0);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(first0, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+      assertThat(Traversals.getAll(first0, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("taking() with negative n should focus on no elements")
+    void takingWithNegative() {
+      Traversal<List<Integer>, Integer> negativeN = ListTraversals.taking(-5);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(negativeN, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+      assertThat(Traversals.getAll(negativeN, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("taking() with empty list should return empty list")
+    void takingWithEmptyList() {
+      Traversal<List<Integer>, Integer> first3 = ListTraversals.taking(3);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(first3, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("taking() with n=0 and empty list should return empty list")
+    void takingWithZeroAndEmptyList() {
+      Traversal<List<Integer>, Integer> first0 = ListTraversals.taking(0);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(first0, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(first0, emptyList)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("taking() should compose with other traversals")
+    void takingComposition() {
+      Traversal<List<User>, User> first2Users = ListTraversals.taking(2);
+      Lens<User, String> nameLens = Lens.of(User::name, (u, n) -> new User(n, u.score()));
+
+      Traversal<List<User>, String> first2Names = first2Users.andThen(nameLens.asTraversal());
+
+      List<User> users =
+          List.of(new User("Alice", 100), new User("Bob", 200), new User("Charlie", 150));
+
+      List<String> names = Traversals.getAll(first2Names, users);
+      assertThat(names).containsExactly("Alice", "Bob");
+
+      List<User> modified = Traversals.modify(first2Names, String::toUpperCase, users);
+      assertThat(modified)
+          .containsExactly(new User("ALICE", 100), new User("BOB", 200), new User("Charlie", 150));
+    }
+  }
+
+  @Nested
+  @DisplayName("dropping(int n) - Skip first n elements")
+  class DroppingTests {
+
+    @Test
+    @DisplayName("dropping() should modify only elements after first n")
+    void droppingModifiesAfterFirstN() {
+      Traversal<List<Integer>, Integer> drop2 = ListTraversals.dropping(2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(drop2, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 6, 8, 10);
+    }
+
+    @Test
+    @DisplayName("dropping() getAll should skip first n elements")
+    void droppingGetAllSkipsFirstN() {
+      Traversal<List<Integer>, Integer> drop2 = ListTraversals.dropping(2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(drop2, numbers);
+
+      assertThat(result).containsExactly(3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("dropping() with n >= size should focus on no elements")
+    void droppingWithNGreaterOrEqualToSize() {
+      Traversal<List<Integer>, Integer> drop10 = ListTraversals.dropping(10);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(drop10, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+      assertThat(Traversals.getAll(drop10, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("dropping() with n = 0 should focus on all elements")
+    void droppingWithZero() {
+      Traversal<List<Integer>, Integer> drop0 = ListTraversals.dropping(0);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(drop0, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("dropping() with negative n should focus on all elements")
+    void droppingWithNegative() {
+      Traversal<List<Integer>, Integer> dropNeg = ListTraversals.dropping(-5);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(dropNeg, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("dropping() with empty list should return empty list")
+    void droppingWithEmptyList() {
+      Traversal<List<Integer>, Integer> drop2 = ListTraversals.dropping(2);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(drop2, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("dropping() should compose with other traversals")
+    void droppingComposition() {
+      Traversal<List<User>, User> afterFirst = ListTraversals.dropping(1);
+      Lens<User, Integer> scoreLens = Lens.of(User::score, (u, s) -> new User(u.name(), s));
+
+      Traversal<List<User>, Integer> scoresAfterFirst = afterFirst.andThen(scoreLens.asTraversal());
+
+      List<User> users =
+          List.of(new User("Alice", 100), new User("Bob", 200), new User("Charlie", 150));
+
+      List<Integer> scores = Traversals.getAll(scoresAfterFirst, users);
+      assertThat(scores).containsExactly(200, 150);
+
+      List<User> modified = Traversals.modify(scoresAfterFirst, s -> s + 50, users);
+      assertThat(modified)
+          .containsExactly(new User("Alice", 100), new User("Bob", 250), new User("Charlie", 200));
+    }
+  }
+
+  @Nested
+  @DisplayName("takingLast(int n) - Focus on last n elements")
+  class TakingLastTests {
+
+    @Test
+    @DisplayName("takingLast() should modify only the last n elements")
+    void takingLastModifiesLastN() {
+      Traversal<List<Integer>, Integer> last3 = ListTraversals.takingLast(3);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(last3, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 6, 8, 10);
+    }
+
+    @Test
+    @DisplayName("takingLast() getAll should return only last n elements")
+    void takingLastGetAllReturnsLastN() {
+      Traversal<List<Integer>, Integer> last3 = ListTraversals.takingLast(3);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(last3, numbers);
+
+      assertThat(result).containsExactly(3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("takingLast() with n > size should focus on all elements")
+    void takingLastWithNGreaterThanSize() {
+      Traversal<List<Integer>, Integer> last10 = ListTraversals.takingLast(10);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(last10, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("takingLast() with n = 0 should focus on no elements")
+    void takingLastWithZero() {
+      Traversal<List<Integer>, Integer> last0 = ListTraversals.takingLast(0);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(last0, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+      assertThat(Traversals.getAll(last0, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("takingLast() with negative n should focus on no elements")
+    void takingLastWithNegative() {
+      Traversal<List<Integer>, Integer> lastNeg = ListTraversals.takingLast(-5);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(lastNeg, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+      assertThat(Traversals.getAll(lastNeg, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("takingLast() with empty list should return empty list")
+    void takingLastWithEmptyList() {
+      Traversal<List<Integer>, Integer> last3 = ListTraversals.takingLast(3);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(last3, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("takingLast() with n=0 and empty list should return empty list")
+    void takingLastWithZeroAndEmptyList() {
+      Traversal<List<Integer>, Integer> last0 = ListTraversals.takingLast(0);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(last0, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(last0, emptyList)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("takingLast() should compose with other traversals")
+    void takingLastComposition() {
+      Traversal<List<User>, User> last2Users = ListTraversals.takingLast(2);
+
+      List<User> users =
+          List.of(new User("Alice", 100), new User("Bob", 200), new User("Charlie", 150));
+
+      List<User> modified = Traversals.modify(last2Users, User::doubleScore, users);
+      assertThat(modified)
+          .containsExactly(new User("Alice", 100), new User("Bob", 400), new User("Charlie", 300));
+    }
+  }
+
+  @Nested
+  @DisplayName("droppingLast(int n) - Exclude last n elements")
+  class DroppingLastTests {
+
+    @Test
+    @DisplayName("droppingLast() should modify all except last n elements")
+    void droppingLastModifiesExceptLastN() {
+      Traversal<List<Integer>, Integer> dropLast2 = ListTraversals.droppingLast(2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(dropLast2, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6, 4, 5);
+    }
+
+    @Test
+    @DisplayName("droppingLast() getAll should exclude last n elements")
+    void droppingLastGetAllExcludesLastN() {
+      Traversal<List<Integer>, Integer> dropLast2 = ListTraversals.droppingLast(2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(dropLast2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("droppingLast() with n >= size should focus on no elements")
+    void droppingLastWithNGreaterOrEqualToSize() {
+      Traversal<List<Integer>, Integer> dropLast10 = ListTraversals.droppingLast(10);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(dropLast10, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+      assertThat(Traversals.getAll(dropLast10, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("droppingLast() with n = 0 should focus on all elements")
+    void droppingLastWithZero() {
+      Traversal<List<Integer>, Integer> dropLast0 = ListTraversals.droppingLast(0);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(dropLast0, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("droppingLast() with negative n should focus on all elements")
+    void droppingLastWithNegative() {
+      Traversal<List<Integer>, Integer> dropLastNeg = ListTraversals.droppingLast(-5);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(dropLastNeg, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("droppingLast() with empty list should return empty list")
+    void droppingLastWithEmptyList() {
+      Traversal<List<Integer>, Integer> dropLast2 = ListTraversals.droppingLast(2);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(dropLast2, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("droppingLast() should compose with other traversals")
+    void droppingLastComposition() {
+      Traversal<List<User>, User> exceptLast = ListTraversals.droppingLast(1);
+
+      List<User> users =
+          List.of(new User("Alice", 100), new User("Bob", 200), new User("Charlie", 150));
+
+      List<User> modified = Traversals.modify(exceptLast, User::doubleScore, users);
+      assertThat(modified)
+          .containsExactly(new User("Alice", 200), new User("Bob", 400), new User("Charlie", 150));
+    }
+  }
+
+  @Nested
+  @DisplayName("slicing(int from, int to) - Focus on index range")
+  class SlicingTests {
+
+    @Test
+    @DisplayName("slicing() should modify only elements in range [from, to)")
+    void slicingModifiesRange() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, 4);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 4, 6, 8, 5);
+    }
+
+    @Test
+    @DisplayName("slicing() getAll should return only elements in range")
+    void slicingGetAllReturnsRange() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, 4);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("slicing() from start should work like taking")
+    void slicingFromStart() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(0, 3);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("slicing() to end should work like dropping")
+    void slicingToEnd() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(2, 10);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("slicing() with from = to should focus on no elements")
+    void slicingWithEqualIndices() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(2, 2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3, 4, 5);
+      assertThat(Traversals.getAll(slice, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() with to < from should focus on no elements")
+    void slicingWithInvertedRange() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(4, 2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3, 4, 5);
+      assertThat(Traversals.getAll(slice, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() with negative from should clamp to 0")
+    void slicingWithNegativeFrom() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(-3, 2);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("slicing() with negative to parameter should clamp correctly")
+    void slicingWithNegativeTo() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, -5);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() with to beyond size should clamp to size")
+    void slicingWithToBeyondSize() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(3, 100);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(4, 5);
+    }
+
+    @Test
+    @DisplayName("slicing() with both indices out of bounds should clamp correctly")
+    void slicingWithBothOutOfBounds() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(-10, 100);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("slicing() with empty list should return empty list")
+    void slicingWithEmptyList() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, 4);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(slice, emptyList)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() with empty list and from=0 should return empty list")
+    void slicingWithEmptyListFromZero() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(0, 5);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(slice, emptyList)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() with empty list and both indices zero should return empty list")
+    void slicingWithEmptyListBothZero() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(0, 0);
+
+      List<Integer> emptyList = List.of();
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, emptyList);
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(slice, emptyList)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() should compose with other traversals")
+    void slicingComposition() {
+      Traversal<List<User>, User> middle = ListTraversals.slicing(1, 3);
+      Lens<User, String> nameLens = Lens.of(User::name, (u, n) -> new User(n, u.score()));
+
+      Traversal<List<User>, String> middleNames = middle.andThen(nameLens.asTraversal());
+
+      List<User> users =
+          List.of(
+              new User("Alice", 100),
+              new User("Bob", 200),
+              new User("Charlie", 150),
+              new User("Diana", 180));
+
+      List<String> names = Traversals.getAll(middleNames, users);
+      assertThat(names).containsExactly("Bob", "Charlie");
+
+      List<User> modified = Traversals.modify(middleNames, String::toLowerCase, users);
+      assertThat(modified)
+          .containsExactly(
+              new User("Alice", 100),
+              new User("bob", 200),
+              new User("charlie", 150),
+              new User("Diana", 180));
+    }
+
+    @Test
+    @DisplayName("slicing() single element should focus on one element")
+    void slicingSingleElement() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(2, 3);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(3);
+
+      List<Integer> modified = Traversals.modify(slice, x -> x * 10, numbers);
+      assertThat(modified).containsExactly(1, 2, 30, 4, 5);
+    }
+
+    @Test
+    @DisplayName("slicing() with from beyond size should focus on no elements")
+    void slicingWithFromBeyondSize() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(10, 20);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3); // No modifications
+      assertThat(Traversals.getAll(slice, numbers)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("slicing() with from equal to size should focus on no elements")
+    void slicingWithFromEqualToSize() {
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(5, 10);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.modify(slice, x -> x * 2, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3, 4, 5); // No modifications
+      assertThat(Traversals.getAll(slice, numbers)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition and Chaining")
+  class CompositionTests {
+
+    @Test
+    @DisplayName("taking() and dropping() can be combined")
+    void takingAndDropping() {
+      // Take first 4, then drop first 1 = elements at indices 1, 2, 3
+      Traversal<List<Integer>, Integer> take4 = ListTraversals.taking(4);
+      Traversal<List<Integer>, Integer> drop1 = ListTraversals.dropping(1);
+
+      // Apply take4 first, then within those results conceptually drop 1
+      // But these are List->element traversals, so we need nested structure
+      // Let's test a different approach: using slicing which is equivalent
+      Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, 4);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+      List<Integer> result = Traversals.getAll(slice, numbers);
+
+      assertThat(result).containsExactly(2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("Limiting traversals can be chained with filtered()")
+    void limitingWithFiltered() {
+      Traversal<List<Integer>, Integer> first4 = ListTraversals.taking(4);
+      Traversal<List<Integer>, Integer> first4Even = first4.filtered(n -> n % 2 == 0);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5, 6);
+      List<Integer> result = Traversals.getAll(first4Even, numbers);
+
+      // First 4 are [1, 2, 3, 4], of which evens are [2, 4]
+      assertThat(result).containsExactly(2, 4);
+
+      List<Integer> modified = Traversals.modify(first4Even, x -> x * 10, numbers);
+      assertThat(modified).containsExactly(1, 20, 3, 40, 5, 6);
+    }
+
+    @Test
+    @DisplayName("Multiple limiting traversals preserve structure")
+    void multipleTraversalsPreserveStructure() {
+      List<Integer> original = List.of(1, 2, 3, 4, 5);
+
+      // Apply taking(3) - should preserve [4, 5]
+      List<Integer> afterTaking = Traversals.modify(ListTraversals.taking(3), x -> x * 2, original);
+      assertThat(afterTaking).containsExactly(2, 4, 6, 4, 5);
+
+      // Apply dropping(2) to that result - should preserve [2, 4]
+      List<Integer> afterDropping =
+          Traversals.modify(ListTraversals.dropping(2), x -> x + 100, afterTaking);
+      assertThat(afterDropping).containsExactly(2, 4, 106, 104, 105);
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases and Boundary Conditions")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("Single element list with taking(1)")
+    void singleElementTaking() {
+      Traversal<List<String>, String> first1 = ListTraversals.taking(1);
+
+      List<String> single = List.of("only");
+      List<String> result = Traversals.modify(first1, String::toUpperCase, single);
+
+      assertThat(result).containsExactly("ONLY");
+    }
+
+    @Test
+    @DisplayName("Single element list with dropping(1)")
+    void singleElementDropping() {
+      Traversal<List<String>, String> drop1 = ListTraversals.dropping(1);
+
+      List<String> single = List.of("only");
+      List<String> result = Traversals.getAll(drop1, single);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Very large n values are handled gracefully")
+    void largeNValues() {
+      Traversal<List<Integer>, Integer> takeHuge = ListTraversals.taking(Integer.MAX_VALUE);
+
+      List<Integer> numbers = List.of(1, 2, 3);
+      List<Integer> result = Traversals.getAll(takeHuge, numbers);
+
+      assertThat(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("Traversals work with mutable operations but return new list")
+    void immutabilityCheck() {
+      Traversal<List<Integer>, Integer> first2 = ListTraversals.taking(2);
+
+      List<Integer> original = List.of(1, 2, 3, 4, 5);
+      List<Integer> modified = Traversals.modify(first2, x -> x * 2, original);
+
+      // Original should be unchanged
+      assertThat(original).containsExactly(1, 2, 3, 4, 5);
+      // Modified should be new list
+      assertThat(modified).containsExactly(2, 4, 3, 4, 5);
+      assertThat(original).isNotSameAs(modified);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/BatchProcessingExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/BatchProcessingExample.java
@@ -1,0 +1,335 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.ListTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A real-world example demonstrating limiting traversals for batch processing workflows.
+ *
+ * <p>This example simulates a data pipeline where:
+ *
+ * <ul>
+ *   <li>Records are processed in chunks (like Spring Batch)
+ *   <li>Different processing stages apply transformations to specific chunks
+ *   <li>Priority processing handles high-priority items first
+ *   <li>Failure recovery skips already-processed chunks
+ * </ul>
+ *
+ * <p>Key patterns demonstrated:
+ *
+ * <ul>
+ *   <li>Chunk-based processing using {@code slicing(from, to)}
+ *   <li>Priority handling using {@code taking(n)} and {@code dropping(n)}
+ *   <li>Progressive processing with state tracking
+ *   <li>Composing limiting traversals with domain transformations
+ * </ul>
+ */
+public class BatchProcessingExample {
+
+  // Domain models for a data processing pipeline
+  public record DataRecord(
+      String id,
+      String payload,
+      ProcessingStatus status,
+      int retryCount,
+      LocalDateTime processedAt) {
+    DataRecord markProcessed() {
+      return new DataRecord(
+          id, payload, ProcessingStatus.PROCESSED, retryCount, LocalDateTime.now());
+    }
+
+    DataRecord markFailed() {
+      return new DataRecord(id, payload, ProcessingStatus.FAILED, retryCount + 1, processedAt);
+    }
+
+    DataRecord markPending() {
+      return new DataRecord(id, payload, ProcessingStatus.PENDING, retryCount, processedAt);
+    }
+
+    DataRecord markProcessing() {
+      return new DataRecord(id, payload, ProcessingStatus.PROCESSING, retryCount, processedAt);
+    }
+
+    DataRecord transformPayload(String prefix) {
+      return new DataRecord(id, prefix + "_" + payload, status, retryCount, processedAt);
+    }
+  }
+
+  public enum ProcessingStatus {
+    PENDING,
+    PROCESSING,
+    PROCESSED,
+    FAILED
+  }
+
+  public record BatchResult(int chunkNumber, int processed, int failed, long durationMs) {}
+
+  // Constants
+  private static final int CHUNK_SIZE = 10;
+
+  public static void main(String[] args) {
+    List<DataRecord> records = createRecords(35);
+
+    System.out.println("=== Batch Processing with Limiting Traversals ===\n");
+    System.out.println("Total records: " + records.size());
+    System.out.println("Chunk size: " + CHUNK_SIZE);
+    System.out.println();
+
+    demonstrateChunkProcessing(records);
+    demonstratePriorityProcessing(records);
+    demonstrateProgressiveTransformation(records);
+    demonstrateFailureRecovery(records);
+    demonstrateParallelChunkPreparation(records);
+  }
+
+  private static void demonstrateChunkProcessing(List<DataRecord> records) {
+    System.out.println("--- Scenario 1: Chunk-Based Processing ---");
+
+    int totalChunks = (int) Math.ceil(records.size() / (double) CHUNK_SIZE);
+    System.out.printf("Processing %d records in %d chunks%n", records.size(), totalChunks);
+
+    List<DataRecord> processed = records;
+    List<BatchResult> results = new ArrayList<>();
+
+    for (int chunk = 0; chunk < totalChunks; chunk++) {
+      int start = chunk * CHUNK_SIZE;
+      int end = Math.min((chunk + 1) * CHUNK_SIZE, records.size());
+
+      Traversal<List<DataRecord>, DataRecord> chunkTraversal = ListTraversals.slicing(start, end);
+
+      long startTime = System.currentTimeMillis();
+
+      // Process this chunk - mark all as processed
+      processed = Traversals.modify(chunkTraversal, DataRecord::markProcessed, processed);
+
+      long duration = System.currentTimeMillis() - startTime;
+      int chunkSize = end - start;
+
+      results.add(new BatchResult(chunk + 1, chunkSize, 0, duration));
+      System.out.printf(
+          "  Chunk %d: Processed %d records (indices %d-%d) in %dms%n",
+          chunk + 1, chunkSize, start, end - 1, duration);
+    }
+
+    // Verify all processed
+    long processedCount =
+        processed.stream().filter(r -> r.status() == ProcessingStatus.PROCESSED).count();
+    System.out.printf("%nTotal processed: %d/%d records%n", processedCount, records.size());
+
+    System.out.println();
+  }
+
+  private static void demonstratePriorityProcessing(List<DataRecord> records) {
+    System.out.println("--- Scenario 2: Priority-Based Processing ---");
+
+    // High priority: First 5 records (urgent)
+    Traversal<List<DataRecord>, DataRecord> highPriority = ListTraversals.taking(5);
+
+    // Medium priority: Next 10 records
+    Traversal<List<DataRecord>, DataRecord> mediumPriority = ListTraversals.slicing(5, 15);
+
+    // Low priority: Remaining records
+    Traversal<List<DataRecord>, DataRecord> lowPriority = ListTraversals.dropping(15);
+
+    System.out.println("Priority distribution:");
+    System.out.println("  HIGH (first 5): " + Traversals.getAll(highPriority, records).size());
+    System.out.println("  MEDIUM (next 10): " + Traversals.getAll(mediumPriority, records).size());
+    System.out.println("  LOW (remaining): " + Traversals.getAll(lowPriority, records).size());
+
+    // Transform payloads based on priority
+    List<DataRecord> step1 =
+        Traversals.modify(highPriority, r -> r.transformPayload("URGENT"), records);
+    List<DataRecord> step2 =
+        Traversals.modify(mediumPriority, r -> r.transformPayload("NORMAL"), step1);
+    List<DataRecord> step3 =
+        Traversals.modify(lowPriority, r -> r.transformPayload("BATCH"), step2);
+
+    System.out.println("\nSample records after priority tagging:");
+    System.out.printf("  Record 1 (HIGH): %s%n", step3.get(0).payload());
+    System.out.printf("  Record 10 (MEDIUM): %s%n", step3.get(9).payload());
+    System.out.printf("  Record 20 (LOW): %s%n", step3.get(19).payload());
+
+    System.out.println();
+  }
+
+  private static void demonstrateProgressiveTransformation(List<DataRecord> records) {
+    System.out.println("--- Scenario 3: Progressive Transformation Pipeline ---");
+
+    // Simulate a multi-stage ETL pipeline
+    System.out.println("ETL Pipeline stages:");
+
+    // Stage 1: Extract - Mark first batch as processing
+    Traversal<List<DataRecord>, DataRecord> extractBatch = ListTraversals.taking(20);
+    List<DataRecord> afterExtract =
+        Traversals.modify(extractBatch, DataRecord::markProcessing, records);
+    System.out.println("  1. EXTRACT: First 20 records marked as PROCESSING");
+
+    // Stage 2: Transform - Apply transformation to extracted records
+    List<DataRecord> afterTransform =
+        Traversals.modify(extractBatch, r -> r.transformPayload("ETL"), afterExtract);
+    System.out.println("  2. TRANSFORM: Applied ETL prefix to payloads");
+
+    // Stage 3: Load - Mark as processed
+    List<DataRecord> afterLoad =
+        Traversals.modify(extractBatch, DataRecord::markProcessed, afterTransform);
+    System.out.println("  3. LOAD: Marked as PROCESSED with timestamp");
+
+    // Verify pipeline results
+    List<DataRecord> processed = Traversals.getAll(extractBatch, afterLoad);
+    boolean allProcessed =
+        processed.stream().allMatch(r -> r.status() == ProcessingStatus.PROCESSED);
+    boolean allTransformed = processed.stream().allMatch(r -> r.payload().startsWith("ETL_"));
+
+    System.out.println("\nPipeline verification:");
+    System.out.println("  All 20 records processed: " + allProcessed);
+    System.out.println("  All 20 records transformed: " + allTransformed);
+
+    // Check remaining records unchanged
+    Traversal<List<DataRecord>, DataRecord> remaining = ListTraversals.dropping(20);
+    List<DataRecord> unprocessed = Traversals.getAll(remaining, afterLoad);
+    boolean remainingPending =
+        unprocessed.stream().allMatch(r -> r.status() == ProcessingStatus.PENDING);
+    System.out.println(
+        "  Remaining " + unprocessed.size() + " records still PENDING: " + remainingPending);
+
+    System.out.println();
+  }
+
+  private static void demonstrateFailureRecovery(List<DataRecord> records) {
+    System.out.println("--- Scenario 4: Failure Recovery and Retry ---");
+
+    // Simulate partial processing with failures
+    // First 10: Successfully processed
+    // Next 5: Failed
+    // Remaining: Not yet attempted
+
+    Traversal<List<DataRecord>, DataRecord> successBatch = ListTraversals.taking(10);
+    Traversal<List<DataRecord>, DataRecord> failedBatch = ListTraversals.slicing(10, 15);
+    Traversal<List<DataRecord>, DataRecord> pendingBatch = ListTraversals.dropping(15);
+
+    List<DataRecord> step1 = Traversals.modify(successBatch, DataRecord::markProcessed, records);
+    List<DataRecord> step2 = Traversals.modify(failedBatch, DataRecord::markFailed, step1);
+
+    System.out.println("After initial processing attempt:");
+    System.out.printf(
+        "  PROCESSED: %d records%n",
+        step2.stream().filter(r -> r.status() == ProcessingStatus.PROCESSED).count());
+    System.out.printf(
+        "  FAILED: %d records%n",
+        step2.stream().filter(r -> r.status() == ProcessingStatus.FAILED).count());
+    System.out.printf(
+        "  PENDING: %d records%n",
+        step2.stream().filter(r -> r.status() == ProcessingStatus.PENDING).count());
+
+    // Recovery: Retry failed records
+    System.out.println("\nRetrying failed records...");
+
+    // Only modify the failed slice - attempt to process them again
+    List<DataRecord> afterRetry =
+        Traversals.modify(
+            failedBatch,
+            r -> {
+              // Simulate 80% success on retry
+              if (r.id().hashCode() % 5 != 0) {
+                return r.markProcessed();
+              } else {
+                return r.markFailed(); // Still fails
+              }
+            },
+            step2);
+
+    System.out.println("After retry:");
+    System.out.printf(
+        "  PROCESSED: %d records%n",
+        afterRetry.stream().filter(r -> r.status() == ProcessingStatus.PROCESSED).count());
+    System.out.printf(
+        "  FAILED: %d records (max retries exceeded)%n",
+        afterRetry.stream().filter(r -> r.status() == ProcessingStatus.FAILED).count());
+
+    // Show retry counts for failed records
+    List<DataRecord> stillFailed = Traversals.getAll(failedBatch, afterRetry);
+    stillFailed.stream()
+        .filter(r -> r.status() == ProcessingStatus.FAILED)
+        .forEach(r -> System.out.printf("    Record %s: %d retries%n", r.id(), r.retryCount()));
+
+    System.out.println();
+  }
+
+  private static void demonstrateParallelChunkPreparation(List<DataRecord> records) {
+    System.out.println("--- Scenario 5: Parallel Chunk Preparation ---");
+
+    // Prepare multiple chunks for parallel processing
+    System.out.println("Preparing 4 chunks for parallel execution:");
+
+    Traversal<List<DataRecord>, DataRecord> chunk1 = ListTraversals.slicing(0, 10);
+    Traversal<List<DataRecord>, DataRecord> chunk2 = ListTraversals.slicing(10, 20);
+    Traversal<List<DataRecord>, DataRecord> chunk3 = ListTraversals.slicing(20, 30);
+    Traversal<List<DataRecord>, DataRecord> chunk4 = ListTraversals.dropping(30);
+
+    List<List<DataRecord>> chunks =
+        List.of(
+            Traversals.getAll(chunk1, records),
+            Traversals.getAll(chunk2, records),
+            Traversals.getAll(chunk3, records),
+            Traversals.getAll(chunk4, records));
+
+    for (int i = 0; i < chunks.size(); i++) {
+      System.out.printf(
+          "  Chunk %d: %d records ready for Worker-%d%n", i + 1, chunks.get(i).size(), i + 1);
+    }
+
+    // Simulate parallel processing results
+    System.out.println("\nSimulated parallel processing results:");
+
+    List<DataRecord> finalResult = records;
+    String[] workerIds = {"WORKER_A", "WORKER_B", "WORKER_C", "WORKER_D"};
+    List<Traversal<List<DataRecord>, DataRecord>> chunkTraversals =
+        List.of(chunk1, chunk2, chunk3, chunk4);
+
+    for (int i = 0; i < chunkTraversals.size(); i++) {
+      String workerId = workerIds[i];
+      finalResult =
+          Traversals.modify(
+              chunkTraversals.get(i),
+              r -> r.transformPayload(workerId).markProcessed(),
+              finalResult);
+      System.out.printf("  %s completed chunk %d%n", workerId, i + 1);
+    }
+
+    // Verify all processed
+    long totalProcessed =
+        finalResult.stream().filter(r -> r.status() == ProcessingStatus.PROCESSED).count();
+    System.out.printf("%nAll %d records processed by parallel workers%n", totalProcessed);
+
+    // Sample verification
+    System.out.println("Sample transformed payloads:");
+    System.out.printf("  Record 5 (Chunk 1): %s%n", finalResult.get(4).payload());
+    System.out.printf("  Record 15 (Chunk 2): %s%n", finalResult.get(14).payload());
+    System.out.printf("  Record 25 (Chunk 3): %s%n", finalResult.get(24).payload());
+    System.out.printf("  Record 32 (Chunk 4): %s%n", finalResult.get(31).payload());
+
+    System.out.println();
+    System.out.println("=== Batch Processing Examples Complete ===");
+  }
+
+  // Helper method to create test records
+  private static List<DataRecord> createRecords(int count) {
+    List<DataRecord> records = new ArrayList<>();
+    IntStream.range(0, count)
+        .forEach(
+            i -> {
+              String id = UUID.randomUUID().toString().substring(0, 8);
+              String payload = "DATA_" + String.format("%03d", i + 1);
+              records.add(new DataRecord(id, payload, ProcessingStatus.PENDING, 0, null));
+            });
+    return records;
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/ListTraversalsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/ListTraversalsExample.java
@@ -1,0 +1,356 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.List;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.ListTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A comprehensive runnable example demonstrating limiting traversals for positional list focusing.
+ *
+ * <p>This example showcases five factory methods from {@code ListTraversals}:
+ *
+ * <ul>
+ *   <li><b>taking(n)</b>: Focus on first n elements
+ *   <li><b>dropping(n)</b>: Skip first n, focus on rest
+ *   <li><b>takingLast(n)</b>: Focus on last n elements
+ *   <li><b>droppingLast(n)</b>: Focus on all except last n
+ *   <li><b>slicing(from, to)</b>: Focus on index range [from, to)
+ * </ul>
+ *
+ * <p>Key semantics demonstrated:
+ *
+ * <ul>
+ *   <li>During <b>modification</b>: non-focused elements are <i>preserved unchanged</i> in the
+ *       structure
+ *   <li>During <b>queries</b> (like getAll): non-focused elements are <i>excluded</i> from results
+ *   <li>Edge cases are handled gracefully (negative n, n &gt; size, empty lists)
+ * </ul>
+ */
+public class ListTraversalsExample {
+
+  // Domain models for an e-commerce platform
+  public record Product(String sku, String name, double price, int stock) {
+    Product applyDiscount(double percentage) {
+      return new Product(sku, name, price * (1 - percentage), stock);
+    }
+
+    Product restock(int additional) {
+      return new Product(sku, name, price, stock + additional);
+    }
+  }
+
+  public record Category(String name, List<Product> products) {}
+
+  public static void main(String[] args) {
+    System.out.println("=== Limiting Traversals Examples ===\n");
+
+    demonstrateTaking();
+    demonstrateDropping();
+    demonstrateTakingLast();
+    demonstrateDroppingLast();
+    demonstrateSlicing();
+    demonstrateEdgeCases();
+    demonstrateComposition();
+    demonstrateChainedLimiting();
+    demonstrateWithFilteredTraversals();
+    demonstrateStructuralPreservation();
+  }
+
+  private static void demonstrateTaking() {
+    System.out.println("--- 1. taking(n) - Focus on First N Elements ---");
+
+    Traversal<List<Integer>, Integer> first3 = ListTraversals.taking(3);
+    List<Integer> numbers = List.of(10, 20, 30, 40, 50);
+
+    System.out.println("Original: " + numbers);
+
+    // Modify: Double first 3 elements
+    List<Integer> modified = Traversals.modify(first3, x -> x * 2, numbers);
+    System.out.println("After doubling first 3: " + modified);
+    // [20, 40, 60, 40, 50] - last 2 unchanged
+
+    // Query: Get first 3 elements
+    List<Integer> gotten = Traversals.getAll(first3, numbers);
+    System.out.println("getAll first 3: " + gotten);
+    // [10, 20, 30]
+
+    System.out.println();
+  }
+
+  private static void demonstrateDropping() {
+    System.out.println("--- 2. dropping(n) - Skip First N Elements ---");
+
+    Traversal<List<Integer>, Integer> drop2 = ListTraversals.dropping(2);
+    List<Integer> numbers = List.of(10, 20, 30, 40, 50);
+
+    System.out.println("Original: " + numbers);
+
+    // Modify: Triple elements after first 2
+    List<Integer> modified = Traversals.modify(drop2, x -> x * 3, numbers);
+    System.out.println("After tripling after first 2: " + modified);
+    // [10, 20, 90, 120, 150] - first 2 unchanged
+
+    // Query: Get elements after first 2
+    List<Integer> gotten = Traversals.getAll(drop2, numbers);
+    System.out.println("getAll after dropping 2: " + gotten);
+    // [30, 40, 50]
+
+    System.out.println();
+  }
+
+  private static void demonstrateTakingLast() {
+    System.out.println("--- 3. takingLast(n) - Focus on Last N Elements ---");
+
+    Traversal<List<Integer>, Integer> last3 = ListTraversals.takingLast(3);
+    List<Integer> numbers = List.of(10, 20, 30, 40, 50);
+
+    System.out.println("Original: " + numbers);
+
+    // Modify: Add 100 to last 3 elements
+    List<Integer> modified = Traversals.modify(last3, x -> x + 100, numbers);
+    System.out.println("After adding 100 to last 3: " + modified);
+    // [10, 20, 130, 140, 150] - first 2 unchanged
+
+    // Query: Get last 3 elements
+    List<Integer> gotten = Traversals.getAll(last3, numbers);
+    System.out.println("getAll last 3: " + gotten);
+    // [30, 40, 50]
+
+    System.out.println();
+  }
+
+  private static void demonstrateDroppingLast() {
+    System.out.println("--- 4. droppingLast(n) - Focus on All Except Last N ---");
+
+    Traversal<List<Integer>, Integer> dropLast2 = ListTraversals.droppingLast(2);
+    List<Integer> numbers = List.of(10, 20, 30, 40, 50);
+
+    System.out.println("Original: " + numbers);
+
+    // Modify: Negate all except last 2
+    List<Integer> modified = Traversals.modify(dropLast2, x -> -x, numbers);
+    System.out.println("After negating all except last 2: " + modified);
+    // [-10, -20, -30, 40, 50] - last 2 unchanged
+
+    // Query: Get all except last 2
+    List<Integer> gotten = Traversals.getAll(dropLast2, numbers);
+    System.out.println("getAll except last 2: " + gotten);
+    // [10, 20, 30]
+
+    System.out.println();
+  }
+
+  private static void demonstrateSlicing() {
+    System.out.println("--- 5. slicing(from, to) - Focus on Index Range ---");
+
+    Traversal<List<Integer>, Integer> slice = ListTraversals.slicing(1, 4);
+    List<Integer> numbers = List.of(10, 20, 30, 40, 50);
+
+    System.out.println("Original: " + numbers);
+    System.out.println("Slicing indices [1, 4) means indices 1, 2, 3");
+
+    // Modify: Square elements at indices 1, 2, 3
+    List<Integer> modified = Traversals.modify(slice, x -> x * x, numbers);
+    System.out.println("After squaring slice [1,4): " + modified);
+    // [10, 400, 900, 1600, 50] - indices 0 and 4 unchanged
+
+    // Query: Get elements at indices 1, 2, 3
+    List<Integer> gotten = Traversals.getAll(slice, numbers);
+    System.out.println("getAll slice [1,4): " + gotten);
+    // [20, 30, 40]
+
+    System.out.println();
+  }
+
+  private static void demonstrateEdgeCases() {
+    System.out.println("--- 6. Edge Case Handling ---");
+
+    List<Integer> numbers = List.of(1, 2, 3);
+    System.out.println("Test list: " + numbers);
+
+    // n > size: focuses on all available
+    List<Integer> takeMore = Traversals.getAll(ListTraversals.taking(100), numbers);
+    System.out.println("taking(100) on 3-element list: " + takeMore);
+    // [1, 2, 3]
+
+    // Negative n: identity (no focus)
+    List<Integer> takeNegative = Traversals.getAll(ListTraversals.taking(-5), numbers);
+    System.out.println("taking(-5): " + takeNegative);
+    // []
+
+    // n = 0: no focus
+    List<Integer> takeZero = Traversals.getAll(ListTraversals.taking(0), numbers);
+    System.out.println("taking(0): " + takeZero);
+    // []
+
+    // drop more than size: no focus
+    List<Integer> dropMore = Traversals.getAll(ListTraversals.dropping(10), numbers);
+    System.out.println("dropping(10): " + dropMore);
+    // []
+
+    // Inverted range: no focus
+    List<Integer> invertedSlice = Traversals.getAll(ListTraversals.slicing(3, 1), numbers);
+    System.out.println("slicing(3, 1) inverted range: " + invertedSlice);
+    // []
+
+    // Negative from in slice: clamps to 0
+    List<Integer> negativeFrom = Traversals.getAll(ListTraversals.slicing(-5, 2), numbers);
+    System.out.println("slicing(-5, 2) negative from: " + negativeFrom);
+    // [1, 2]
+
+    // Empty list: safe operation
+    List<Integer> emptyResult = Traversals.modify(ListTraversals.taking(3), x -> x * 2, List.of());
+    System.out.println("taking(3) on empty list: " + emptyResult);
+    // []
+
+    System.out.println();
+  }
+
+  private static void demonstrateComposition() {
+    System.out.println("--- 7. Composing with Lenses ---");
+
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 100),
+            new Product("SKU002", "Gadget", 25.0, 50),
+            new Product("SKU003", "Gizmo", 15.0, 75),
+            new Product("SKU004", "Doohickey", 30.0, 25),
+            new Product("SKU005", "Thingamajig", 20.0, 60));
+
+    System.out.println("Products: " + products.stream().map(Product::name).toList());
+
+    // Lens for product price
+    Lens<Product, Double> priceLens =
+        Lens.of(
+            Product::price, (p, newPrice) -> new Product(p.sku(), p.name(), newPrice, p.stock()));
+
+    // Compose: first 3 products → their prices
+    Traversal<List<Product>, Double> first3Prices =
+        ListTraversals.<Product>taking(3).andThen(priceLens.asTraversal());
+
+    // Apply 10% discount to first 3 products' prices
+    List<Product> discounted = Traversals.modify(first3Prices, price -> price * 0.9, products);
+
+    System.out.println("After 10% discount on first 3 products:");
+    for (Product p : discounted) {
+      System.out.printf("  %s: £%.2f%n", p.name(), p.price());
+    }
+    // Widget: £9.00, Gadget: £22.50, Gizmo: £13.50, Doohickey: £30.00, Thingamajig: £20.00
+
+    // Get prices of last 2 products
+    Traversal<List<Product>, Double> last2Prices =
+        ListTraversals.<Product>takingLast(2).andThen(priceLens.asTraversal());
+    List<Double> lastPrices = Traversals.getAll(last2Prices, products);
+    System.out.println("Prices of last 2 products: " + lastPrices);
+    // [30.0, 20.0]
+
+    System.out.println();
+  }
+
+  private static void demonstrateChainedLimiting() {
+    System.out.println("--- 8. Sequential Limiting Operations ---");
+
+    List<Integer> numbers = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    System.out.println("Original: " + numbers);
+
+    // Apply different operations to different slices
+    // First 3: double
+    List<Integer> step1 = Traversals.modify(ListTraversals.taking(3), x -> x * 2, numbers);
+    System.out.println("After doubling first 3: " + step1);
+    // [2, 4, 6, 4, 5, 6, 7, 8, 9, 10]
+
+    // Last 3: add 100
+    List<Integer> step2 = Traversals.modify(ListTraversals.takingLast(3), x -> x + 100, step1);
+    System.out.println("After adding 100 to last 3: " + step2);
+    // [2, 4, 6, 4, 5, 6, 7, 108, 109, 110]
+
+    // Middle slice [3, 7): negate
+    List<Integer> step3 = Traversals.modify(ListTraversals.slicing(3, 7), x -> -x, step2);
+    System.out.println("After negating slice [3,7): " + step3);
+    // [2, 4, 6, -4, -5, -6, -7, 108, 109, 110]
+
+    System.out.println();
+  }
+
+  private static void demonstrateWithFilteredTraversals() {
+    System.out.println("--- 9. Combining Limiting with Filtered Traversals ---");
+
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 20), // low stock
+            new Product("SKU002", "Gadget", 25.0, 150),
+            new Product("SKU003", "Gizmo", 15.0, 30), // low stock
+            new Product("SKU004", "Doohickey", 30.0, 200),
+            new Product("SKU005", "Thingamajig", 20.0, 10), // low stock
+            new Product("SKU006", "Whatsit", 35.0, 5), // low stock
+            new Product("SKU007", "Contraption", 40.0, 180));
+
+    System.out.println(
+        "Products with stock: "
+            + products.stream().map(p -> p.name() + "(" + p.stock() + ")").toList());
+
+    // First 5 products that are also low stock (< 50 units)
+    Traversal<List<Product>, Product> first5LowStock =
+        ListTraversals.<Product>taking(5).filtered(p -> p.stock() < 50);
+
+    List<Product> lowStockInFirst5 = Traversals.getAll(first5LowStock, products);
+    System.out.println(
+        "Low stock products in first 5: " + lowStockInFirst5.stream().map(Product::name).toList());
+    // [Widget, Gizmo, Thingamajig]
+
+    // Restock only the low-stock items in first 5
+    List<Product> restocked = Traversals.modify(first5LowStock, p -> p.restock(100), products);
+    System.out.println("After restocking low-stock items in first 5:");
+    for (Product p : restocked) {
+      System.out.printf("  %s: %d units%n", p.name(), p.stock());
+    }
+    // Widget: 120, Gadget: 150, Gizmo: 130, Doohickey: 200, Thingamajig: 110, Whatsit: 5,
+    // Contraption: 180
+    // Note: Whatsit (6th product) not restocked even though low stock
+
+    System.out.println();
+  }
+
+  private static void demonstrateStructuralPreservation() {
+    System.out.println("--- 10. Structural Preservation Semantics ---");
+
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 100),
+            new Product("SKU002", "Gadget", 25.0, 50),
+            new Product("SKU003", "Gizmo", 15.0, 75));
+
+    System.out.println("Original products: " + products.stream().map(Product::name).toList());
+    System.out.println("Original size: " + products.size());
+
+    Traversal<List<Product>, Product> first2 = ListTraversals.taking(2);
+
+    // MODIFY: Structure is preserved, only focused elements change
+    List<Product> modified = Traversals.modify(first2, p -> p.applyDiscount(0.2), products);
+    System.out.println("\nAfter 20% discount on first 2:");
+    System.out.println("Modified size: " + modified.size() + " (same as original!)");
+    System.out.println("Third product (unfocused) unchanged: " + modified.get(2).name());
+
+    // QUERY: Only focused elements returned
+    List<Product> gotten = Traversals.getAll(first2, products);
+    System.out.println("\ngetAll first 2:");
+    System.out.println("Result size: " + gotten.size() + " (only focused elements)");
+
+    // Original unchanged (immutability)
+    System.out.println(
+        "\nOriginal products unchanged: " + products.stream().map(Product::name).toList());
+    System.out.println(
+        "Original first product price: £"
+            + products.get(0).price()
+            + " (not £"
+            + modified.get(0).price()
+            + ")");
+
+    System.out.println();
+    System.out.println("=== All Limiting Traversal Examples Complete ===");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/PaginationExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/PaginationExample.java
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.ListTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A real-world example demonstrating limiting traversals for REST API pagination.
+ *
+ * <p>This example simulates a product catalogue API where:
+ *
+ * <ul>
+ *   <li>Products are paginated for efficient data transfer
+ *   <li>Featured products (first page) receive special treatment
+ *   <li>Clearance items (last few) have different pricing rules
+ *   <li>Bulk updates are applied to specific page ranges
+ * </ul>
+ *
+ * <p>Key patterns demonstrated:
+ *
+ * <ul>
+ *   <li>Paginated data access using {@code slicing(from, to)}
+ *   <li>Featured item highlighting using {@code taking(n)}
+ *   <li>Clearance handling using {@code takingLast(n)} and {@code droppingLast(n)}
+ *   <li>Composing limiting traversals with domain lenses
+ * </ul>
+ */
+public class PaginationExample {
+
+  // Domain models
+  public record Product(
+      String sku, String name, double price, int stock, boolean featured, String badge) {
+    Product withBadge(String newBadge) {
+      return new Product(sku, name, price, stock, featured, newBadge);
+    }
+
+    Product applyDiscount(double percentage) {
+      return new Product(sku, name, price * (1 - percentage), stock, featured, badge);
+    }
+
+    Product markFeatured() {
+      return new Product(sku, name, price, stock, true, badge);
+    }
+  }
+
+  public record PageInfo(int pageNumber, int pageSize, int totalItems, int totalPages) {}
+
+  public record PagedResponse(List<Product> items, PageInfo pageInfo) {}
+
+  // Constants
+  private static final int DEFAULT_PAGE_SIZE = 5;
+
+  public static void main(String[] args) {
+    List<Product> catalogue = createCatalogue();
+
+    System.out.println("=== REST API Pagination with Limiting Traversals ===\n");
+    System.out.println("Total products in catalogue: " + catalogue.size());
+    System.out.println("Page size: " + DEFAULT_PAGE_SIZE);
+    System.out.println();
+
+    demonstratePagination(catalogue);
+    demonstrateFeaturedProducts(catalogue);
+    demonstrateClearanceSection(catalogue);
+    demonstrateBulkPageUpdate(catalogue);
+    demonstratePageRangeQuery(catalogue);
+  }
+
+  private static void demonstratePagination(List<Product> catalogue) {
+    System.out.println("--- Scenario 1: Basic Pagination ---");
+
+    int totalPages = (int) Math.ceil(catalogue.size() / (double) DEFAULT_PAGE_SIZE);
+    System.out.println("Total pages: " + totalPages);
+    System.out.println();
+
+    for (int page = 0; page < totalPages; page++) {
+      PagedResponse response = getPage(catalogue, page, DEFAULT_PAGE_SIZE);
+      System.out.printf("Page %d of %d:%n", page + 1, response.pageInfo().totalPages());
+      for (Product p : response.items()) {
+        System.out.printf("  • %s - £%.2f (%d in stock)%n", p.name(), p.price(), p.stock());
+      }
+      System.out.println();
+    }
+  }
+
+  private static void demonstrateFeaturedProducts(List<Product> catalogue) {
+    System.out.println("--- Scenario 2: Featured Products (Hero Section) ---");
+
+    // First 3 products are featured on the hero section
+    Traversal<List<Product>, Product> heroProducts = ListTraversals.taking(3);
+
+    // Mark them as featured and add "HOT" badge
+    List<Product> withHeroSection =
+        Traversals.modify(heroProducts, p -> p.markFeatured().withBadge("HOT"), catalogue);
+
+    System.out.println("Hero section products:");
+    Traversals.getAll(heroProducts, withHeroSection)
+        .forEach(
+            p ->
+                System.out.printf(
+                    "  ⭐ %s [%s] - Featured: %s%n", p.name(), p.badge(), p.featured()));
+
+    // Apply special 15% discount to hero products
+    Lens<Product, Double> priceLens =
+        Lens.of(
+            Product::price,
+            (prod, newPrice) ->
+                new Product(
+                    prod.sku(),
+                    prod.name(),
+                    newPrice,
+                    prod.stock(),
+                    prod.featured(),
+                    prod.badge()));
+
+    Traversal<List<Product>, Double> heroPrices = heroProducts.andThen(priceLens.asTraversal());
+
+    List<Product> discountedHero = Traversals.modify(heroPrices, price -> price * 0.85, catalogue);
+
+    System.out.println("\nAfter 15% hero discount:");
+    for (int i = 0; i < 5; i++) {
+      Product original = catalogue.get(i);
+      Product discounted = discountedHero.get(i);
+      String marker = i < 3 ? "★" : " ";
+      System.out.printf(
+          "  %s %s: £%.2f → £%.2f%n",
+          marker, original.name(), original.price(), discounted.price());
+    }
+    System.out.println();
+  }
+
+  private static void demonstrateClearanceSection(List<Product> catalogue) {
+    System.out.println("--- Scenario 3: Clearance Section ---");
+
+    // Last 4 products are clearance items
+    Traversal<List<Product>, Product> clearanceItems = ListTraversals.takingLast(4);
+
+    System.out.println("Clearance items (last 4):");
+    List<Product> clearance = Traversals.getAll(clearanceItems, catalogue);
+    clearance.forEach(p -> System.out.printf("  🏷️ %s - £%.2f%n", p.name(), p.price()));
+
+    // Apply 30% clearance discount
+    List<Product> withClearance =
+        Traversals.modify(
+            clearanceItems, p -> p.applyDiscount(0.3).withBadge("CLEARANCE"), catalogue);
+
+    System.out.println("\nAfter 30% clearance discount:");
+    Traversals.getAll(clearanceItems, withClearance)
+        .forEach(p -> System.out.printf("  🏷️ %s [%s] - £%.2f%n", p.name(), p.badge(), p.price()));
+
+    // Regular items (all except clearance)
+    Traversal<List<Product>, Product> regularItems = ListTraversals.droppingLast(4);
+    List<Product> regular = Traversals.getAll(regularItems, catalogue);
+    System.out.println("\nRegular items (excluding clearance): " + regular.size() + " products");
+
+    System.out.println();
+  }
+
+  private static void demonstrateBulkPageUpdate(List<Product> catalogue) {
+    System.out.println("--- Scenario 4: Bulk Update Specific Pages ---");
+
+    // Apply different badges to different pages
+    System.out.println("Applying seasonal badges by page:");
+
+    // Page 1 (indices 0-4): "SPRING"
+    Traversal<List<Product>, Product> page1 = ListTraversals.slicing(0, 5);
+    List<Product> step1 = Traversals.modify(page1, p -> p.withBadge("SPRING"), catalogue);
+    System.out.println("  Page 1: SPRING badge");
+
+    // Page 2 (indices 5-9): "SUMMER"
+    Traversal<List<Product>, Product> page2 = ListTraversals.slicing(5, 10);
+    List<Product> step2 = Traversals.modify(page2, p -> p.withBadge("SUMMER"), step1);
+    System.out.println("  Page 2: SUMMER badge");
+
+    // Page 3 (indices 10-14): "AUTUMN"
+    Traversal<List<Product>, Product> page3 = ListTraversals.slicing(10, 15);
+    List<Product> step3 = Traversals.modify(page3, p -> p.withBadge("AUTUMN"), step2);
+    System.out.println("  Page 3: AUTUMN badge");
+
+    // Remaining (indices 15+): "WINTER"
+    Traversal<List<Product>, Product> remaining = ListTraversals.dropping(15);
+    List<Product> finalCatalogue = Traversals.modify(remaining, p -> p.withBadge("WINTER"), step3);
+    System.out.println("  Remaining: WINTER badge");
+
+    System.out.println("\nSample products after seasonal tagging:");
+    System.out.printf(
+        "  Product 1 (Page 1): %s [%s]%n",
+        finalCatalogue.get(0).name(), finalCatalogue.get(0).badge());
+    System.out.printf(
+        "  Product 6 (Page 2): %s [%s]%n",
+        finalCatalogue.get(5).name(), finalCatalogue.get(5).badge());
+    System.out.printf(
+        "  Product 11 (Page 3): %s [%s]%n",
+        finalCatalogue.get(10).name(), finalCatalogue.get(10).badge());
+    System.out.printf(
+        "  Product 16 (Page 4): %s [%s]%n",
+        finalCatalogue.get(15).name(), finalCatalogue.get(15).badge());
+
+    System.out.println();
+  }
+
+  private static void demonstratePageRangeQuery(List<Product> catalogue) {
+    System.out.println("--- Scenario 5: Query Specific Page Ranges ---");
+
+    // Get products from pages 2 and 3 (indices 5-14)
+    Traversal<List<Product>, Product> pages2And3 = ListTraversals.slicing(5, 15);
+    List<Product> middlePages = Traversals.getAll(pages2And3, catalogue);
+
+    System.out.println("Products from pages 2-3 (for bulk shipment):");
+    System.out.println("  Count: " + middlePages.size() + " products");
+
+    double totalValue = middlePages.stream().mapToDouble(p -> p.price() * p.stock()).sum();
+    System.out.printf("  Total inventory value: £%.2f%n", totalValue);
+
+    int totalStock = middlePages.stream().mapToInt(Product::stock).sum();
+    System.out.println("  Total units: " + totalStock);
+
+    // Calculate average price for middle pages
+    double avgPrice = middlePages.stream().mapToDouble(Product::price).average().orElse(0.0);
+    System.out.printf("  Average price: £%.2f%n", avgPrice);
+
+    System.out.println();
+    System.out.println("=== Pagination Examples Complete ===");
+  }
+
+  // Helper methods
+  private static PagedResponse getPage(List<Product> catalogue, int pageNumber, int pageSize) {
+    Traversal<List<Product>, Product> pageTraversal =
+        ListTraversals.slicing(pageNumber * pageSize, (pageNumber + 1) * pageSize);
+
+    List<Product> items = Traversals.getAll(pageTraversal, catalogue);
+
+    int totalPages = (int) Math.ceil(catalogue.size() / (double) pageSize);
+    PageInfo pageInfo = new PageInfo(pageNumber, pageSize, catalogue.size(), totalPages);
+
+    return new PagedResponse(items, pageInfo);
+  }
+
+  private static List<Product> createCatalogue() {
+    List<Product> products = new ArrayList<>();
+
+    String[] categories = {"Electronics", "Home", "Garden", "Sports", "Books"};
+    String[] adjectives = {"Premium", "Standard", "Budget", "Deluxe", "Basic"};
+
+    IntStream.range(1, 21)
+        .forEach(
+            i -> {
+              String category = categories[(i - 1) % categories.length];
+              String adjective = adjectives[(i - 1) % adjectives.length];
+              String name = adjective + " " + category + " Item " + i;
+              String sku = String.format("SKU%03d", i);
+              double price = 10.0 + (i * 5.0) + ((i % 3) * 2.5);
+              int stock = 50 + (i * 10) - ((i % 4) * 15);
+
+              products.add(new Product(sku, name, price, Math.max(5, stock), false, ""));
+            });
+
+    return products;
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/TimeSeriesWindowingExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/TimeSeriesWindowingExample.java
@@ -1,0 +1,345 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.ListTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A real-world example demonstrating limiting traversals for time-series data analysis.
+ *
+ * <p>This example simulates financial and operational analytics where:
+ *
+ * <ul>
+ *   <li>Recent data points (last N days) are analysed for trends
+ *   <li>Historical data (older periods) requires different treatment
+ *   <li>Rolling windows calculate moving averages
+ *   <li>Seasonal adjustments are applied to specific periods
+ * </ul>
+ *
+ * <p>Key patterns demonstrated:
+ *
+ * <ul>
+ *   <li>Recent period focus using {@code takingLast(n)}
+ *   <li>Historical data using {@code droppingLast(n)}
+ *   <li>Rolling window calculations using {@code slicing(from, to)}
+ *   <li>Trend analysis by comparing periods
+ * </ul>
+ */
+public class TimeSeriesWindowingExample {
+
+  // Domain models for time-series analytics
+  public record DailyMetric(
+      LocalDate date, double revenue, int transactions, double avgOrderValue, boolean adjusted) {
+    DailyMetric applySeasonalAdjustment(double factor) {
+      return new DailyMetric(date, revenue * factor, transactions, avgOrderValue * factor, true);
+    }
+
+    DailyMetric recalculateAvg() {
+      double newAvg = transactions > 0 ? revenue / transactions : 0.0;
+      return new DailyMetric(date, revenue, transactions, newAvg, adjusted);
+    }
+  }
+
+  public record TrendAnalysis(String period, double avgRevenue, double growth, String direction) {}
+
+  public record MovingAverage(LocalDate endDate, int windowSize, double average) {}
+
+  public static void main(String[] args) {
+    List<DailyMetric> metrics = generateMetrics(30);
+
+    System.out.println("=== Time-Series Windowing with Limiting Traversals ===\n");
+    System.out.println("Dataset: " + metrics.size() + " days of sales metrics");
+    System.out.println(
+        "Date range: " + metrics.get(0).date() + " to " + metrics.get(metrics.size() - 1).date());
+    System.out.println();
+
+    demonstrateRecentPeriodAnalysis(metrics);
+    demonstrateHistoricalComparison(metrics);
+    demonstrateRollingWindowCalculation(metrics);
+    demonstrateSeasonalAdjustment(metrics);
+    demonstrateTrendDetection(metrics);
+    demonstrateOutlierHandling(metrics);
+  }
+
+  private static void demonstrateRecentPeriodAnalysis(List<DailyMetric> metrics) {
+    System.out.println("--- Scenario 1: Recent Period Analysis (Last 7 Days) ---");
+
+    // Focus on last 7 days for recent performance
+    Traversal<List<DailyMetric>, DailyMetric> last7Days = ListTraversals.takingLast(7);
+
+    List<DailyMetric> recentMetrics = Traversals.getAll(last7Days, metrics);
+
+    System.out.println("Last 7 days performance:");
+    double totalRevenue = recentMetrics.stream().mapToDouble(DailyMetric::revenue).sum();
+    int totalTransactions = recentMetrics.stream().mapToInt(DailyMetric::transactions).sum();
+    double avgDailyRevenue = totalRevenue / 7;
+
+    System.out.printf("  Total Revenue: £%.2f%n", totalRevenue);
+    System.out.printf("  Total Transactions: %d%n", totalTransactions);
+    System.out.printf("  Average Daily Revenue: £%.2f%n", avgDailyRevenue);
+    System.out.printf("  Average Order Value: £%.2f%n", totalRevenue / totalTransactions);
+
+    // Highlight best and worst recent days
+    DailyMetric bestDay =
+        recentMetrics.stream()
+            .max((a, b) -> Double.compare(a.revenue(), b.revenue()))
+            .orElseThrow();
+    DailyMetric worstDay =
+        recentMetrics.stream()
+            .min((a, b) -> Double.compare(a.revenue(), b.revenue()))
+            .orElseThrow();
+
+    System.out.printf("%nBest recent day: %s with £%.2f%n", bestDay.date(), bestDay.revenue());
+    System.out.printf("Worst recent day: %s with £%.2f%n", worstDay.date(), worstDay.revenue());
+
+    System.out.println();
+  }
+
+  private static void demonstrateHistoricalComparison(List<DailyMetric> metrics) {
+    System.out.println("--- Scenario 2: Historical vs Recent Comparison ---");
+
+    // Historical: Everything except last 7 days
+    Traversal<List<DailyMetric>, DailyMetric> historical = ListTraversals.droppingLast(7);
+    // Recent: Last 7 days
+    Traversal<List<DailyMetric>, DailyMetric> recent = ListTraversals.takingLast(7);
+
+    List<DailyMetric> historicalData = Traversals.getAll(historical, metrics);
+    List<DailyMetric> recentData = Traversals.getAll(recent, metrics);
+
+    double historicalAvg =
+        historicalData.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+    double recentAvg = recentData.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+
+    double growthPercent = ((recentAvg - historicalAvg) / historicalAvg) * 100;
+
+    System.out.printf("Historical period (%d days):%n", historicalData.size());
+    System.out.printf("  Average daily revenue: £%.2f%n", historicalAvg);
+
+    System.out.printf("%nRecent period (7 days):%n");
+    System.out.printf("  Average daily revenue: £%.2f%n", recentAvg);
+
+    System.out.printf("%nGrowth: %+.1f%%%n", growthPercent);
+    String trend =
+        growthPercent > 5
+            ? "📈 Strong growth"
+            : growthPercent > 0 ? "📊 Moderate growth" : "📉 Decline";
+    System.out.println("Trend: " + trend);
+
+    System.out.println();
+  }
+
+  private static void demonstrateRollingWindowCalculation(List<DailyMetric> metrics) {
+    System.out.println("--- Scenario 3: Rolling Window (5-Day Moving Average) ---");
+
+    int windowSize = 5;
+    List<MovingAverage> movingAverages = new ArrayList<>();
+
+    // Calculate moving average for each possible window
+    for (int i = windowSize - 1; i < metrics.size(); i++) {
+      int start = i - windowSize + 1;
+      int end = i + 1;
+
+      Traversal<List<DailyMetric>, DailyMetric> window = ListTraversals.slicing(start, end);
+      List<DailyMetric> windowData = Traversals.getAll(window, metrics);
+
+      double avg = windowData.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+      LocalDate endDate = metrics.get(i).date();
+
+      movingAverages.add(new MovingAverage(endDate, windowSize, avg));
+    }
+
+    System.out.printf("%d-day moving averages (showing last 10):%n", windowSize);
+
+    // Show last 10 moving averages
+    Traversal<List<MovingAverage>, MovingAverage> lastTenMA = ListTraversals.takingLast(10);
+    List<MovingAverage> recentMAs = Traversals.getAll(lastTenMA, movingAverages);
+
+    for (MovingAverage ma : recentMAs) {
+      System.out.printf("  %s: £%.2f%n", ma.endDate(), ma.average());
+    }
+
+    // Detect trend in moving average
+    MovingAverage firstMA = recentMAs.get(0);
+    MovingAverage lastMA = recentMAs.get(recentMAs.size() - 1);
+    double maTrend = ((lastMA.average() - firstMA.average()) / firstMA.average()) * 100;
+
+    System.out.printf("%nMA Trend over last 10 periods: %+.1f%%%n", maTrend);
+
+    System.out.println();
+  }
+
+  private static void demonstrateSeasonalAdjustment(List<DailyMetric> metrics) {
+    System.out.println("--- Scenario 4: Seasonal Adjustment by Period ---");
+
+    // Apply different seasonal factors to different periods
+    // First week: Winter slowdown (0.9)
+    // Middle weeks: Normal (1.0)
+    // Last week: Holiday boost (1.15)
+
+    Traversal<List<DailyMetric>, DailyMetric> firstWeek = ListTraversals.taking(7);
+    Traversal<List<DailyMetric>, DailyMetric> middleWeeks = ListTraversals.slicing(7, 23);
+    Traversal<List<DailyMetric>, DailyMetric> lastWeek = ListTraversals.takingLast(7);
+
+    System.out.println("Applying seasonal adjustment factors:");
+    System.out.println("  First week (Winter): 0.9x");
+    System.out.println("  Middle weeks (Normal): 1.0x");
+    System.out.println("  Last week (Holiday): 1.15x");
+
+    List<DailyMetric> step1 =
+        Traversals.modify(firstWeek, m -> m.applySeasonalAdjustment(0.9), metrics);
+    List<DailyMetric> step2 =
+        Traversals.modify(middleWeeks, m -> m.applySeasonalAdjustment(1.0), step1);
+    List<DailyMetric> adjusted =
+        Traversals.modify(lastWeek, m -> m.applySeasonalAdjustment(1.15), step2);
+
+    // Compare unadjusted vs adjusted totals
+    double originalTotal = metrics.stream().mapToDouble(DailyMetric::revenue).sum();
+    double adjustedTotal = adjusted.stream().mapToDouble(DailyMetric::revenue).sum();
+
+    System.out.printf("%nOriginal total revenue: £%.2f%n", originalTotal);
+    System.out.printf("Seasonally adjusted total: £%.2f%n", adjustedTotal);
+    System.out.printf(
+        "Adjustment impact: %+.1f%%%n", ((adjustedTotal - originalTotal) / originalTotal) * 100);
+
+    // Verify adjustment flags
+    long adjustedCount = adjusted.stream().filter(DailyMetric::adjusted).count();
+    System.out.printf("%nRecords marked as adjusted: %d/%d%n", adjustedCount, adjusted.size());
+
+    System.out.println();
+  }
+
+  private static void demonstrateTrendDetection(List<DailyMetric> metrics) {
+    System.out.println("--- Scenario 5: Multi-Period Trend Detection ---");
+
+    // Divide data into equal periods for trend analysis
+    Traversal<List<DailyMetric>, DailyMetric> period1 = ListTraversals.taking(10);
+    Traversal<List<DailyMetric>, DailyMetric> period2 = ListTraversals.slicing(10, 20);
+    Traversal<List<DailyMetric>, DailyMetric> period3 = ListTraversals.takingLast(10);
+
+    List<DailyMetric> p1Data = Traversals.getAll(period1, metrics);
+    List<DailyMetric> p2Data = Traversals.getAll(period2, metrics);
+    List<DailyMetric> p3Data = Traversals.getAll(period3, metrics);
+
+    double p1Avg = p1Data.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+    double p2Avg = p2Data.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+    double p3Avg = p3Data.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+
+    double p2Growth = ((p2Avg - p1Avg) / p1Avg) * 100;
+    double p3Growth = ((p3Avg - p2Avg) / p2Avg) * 100;
+
+    System.out.println("Period analysis (10 days each):");
+    System.out.printf("  Period 1: £%.2f avg/day%n", p1Avg);
+    System.out.printf("  Period 2: £%.2f avg/day (%+.1f%% vs P1)%n", p2Avg, p2Growth);
+    System.out.printf("  Period 3: £%.2f avg/day (%+.1f%% vs P2)%n", p3Avg, p3Growth);
+
+    // Determine overall trend
+    String overallTrend;
+    if (p2Growth > 0 && p3Growth > 0) {
+      overallTrend = "📈 Consistent upward trend";
+    } else if (p2Growth < 0 && p3Growth < 0) {
+      overallTrend = "📉 Consistent downward trend";
+    } else if (p3Growth > p2Growth) {
+      overallTrend = "🔄 Recovering/accelerating";
+    } else {
+      overallTrend = "🔄 Decelerating/plateauing";
+    }
+
+    System.out.println("\nOverall trend: " + overallTrend);
+
+    System.out.println();
+  }
+
+  private static void demonstrateOutlierHandling(List<DailyMetric> metrics) {
+    System.out.println("--- Scenario 6: Outlier Detection and Smoothing ---");
+
+    // Use middle portion to calculate baseline (exclude first and last 5 days)
+    Traversal<List<DailyMetric>, DailyMetric> middlePortion =
+        ListTraversals.slicing(5, metrics.size() - 5);
+
+    List<DailyMetric> baseline = Traversals.getAll(middlePortion, metrics);
+
+    double mean = baseline.stream().mapToDouble(DailyMetric::revenue).average().orElse(0.0);
+    double variance =
+        baseline.stream().mapToDouble(m -> Math.pow(m.revenue() - mean, 2)).average().orElse(0.0);
+    double stdDev = Math.sqrt(variance);
+
+    System.out.printf("Baseline statistics (middle %d days):%n", baseline.size());
+    System.out.printf("  Mean revenue: £%.2f%n", mean);
+    System.out.printf("  Standard deviation: £%.2f%n", stdDev);
+
+    double lowerBound = mean - (2 * stdDev);
+    double upperBound = mean + (2 * stdDev);
+    System.out.printf("  Normal range: £%.2f - £%.2f%n", lowerBound, upperBound);
+
+    // Find outliers in entire dataset
+    long outlierCount =
+        metrics.stream().filter(m -> m.revenue() < lowerBound || m.revenue() > upperBound).count();
+    System.out.printf("%nOutliers detected: %d days%n", outlierCount);
+
+    // Smooth outliers by capping to bounds
+    Lens<DailyMetric, Double> revenueLens =
+        Lens.of(
+            DailyMetric::revenue,
+            (m, newRev) ->
+                new DailyMetric(
+                    m.date(), newRev, m.transactions(), m.avgOrderValue(), m.adjusted()));
+
+    Traversal<List<DailyMetric>, Double> allRevenues =
+        Traversals.<DailyMetric>forList().andThen(revenueLens.asTraversal());
+
+    List<DailyMetric> smoothed =
+        Traversals.modify(
+            allRevenues, rev -> Math.max(lowerBound, Math.min(upperBound, rev)), metrics);
+
+    double originalVariance =
+        metrics.stream().mapToDouble(m -> Math.pow(m.revenue() - mean, 2)).average().orElse(0.0);
+    double smoothedVariance =
+        smoothed.stream().mapToDouble(m -> Math.pow(m.revenue() - mean, 2)).average().orElse(0.0);
+
+    System.out.printf("Variance before smoothing: %.2f%n", originalVariance);
+    System.out.printf("Variance after smoothing: %.2f%n", smoothedVariance);
+    System.out.printf(
+        "Variance reduction: %.1f%%%n",
+        ((originalVariance - smoothedVariance) / originalVariance) * 100);
+
+    System.out.println();
+    System.out.println("=== Time-Series Windowing Examples Complete ===");
+  }
+
+  // Generate sample metrics with some variability
+  private static List<DailyMetric> generateMetrics(int days) {
+    List<DailyMetric> metrics = new ArrayList<>();
+    LocalDate startDate = LocalDate.now().minusDays(days - 1);
+
+    IntStream.range(0, days)
+        .forEach(
+            i -> {
+              LocalDate date = startDate.plusDays(i);
+
+              // Base revenue with growth trend
+              double baseRevenue = 1000.0 + (i * 15.0);
+
+              // Add weekly seasonality (weekends higher)
+              int dayOfWeek = date.getDayOfWeek().getValue();
+              double seasonalFactor = dayOfWeek >= 6 ? 1.3 : 1.0;
+
+              // Add some randomness
+              double noise = (Math.random() - 0.5) * 200;
+
+              double revenue = (baseRevenue * seasonalFactor) + noise;
+              int transactions = (int) (revenue / (15 + Math.random() * 10));
+              double avgOrder = revenue / transactions;
+
+              metrics.add(new DailyMetric(date, revenue, transactions, avgOrder, false));
+            });
+
+    return metrics;
+  }
+}


### PR DESCRIPTION
Introduces ListTraversals utility class with static factory methods for creating traversals that focus on specific portions of lists. This enables operations like "modify only the first 3 elements" or "transform elements from index 2 to 5" while preserving the rest of the structure unchanged.

New methods:
- taking(n): Focus on first n elements
- dropping(n): Skip first n elements
- takingLast(n): Focus on last n elements
- droppingLast(n): Exclude last n elements
- slicing(from, to): Focus on index range [from, to)

All methods handle edge cases consistently (negative indices treated as 0, indices beyond list size clamped to bounds) and integrate seamlessly with existing optics composition via andThen().



Fixes #167 
