### PR TITLE
Claude/add indexed optics 

### DIFF
--- a/hkj-api/src/main/java/module-info.java
+++ b/hkj-api/src/main/java/module-info.java
@@ -6,4 +6,5 @@ module org.higherkindedj.api {
   exports org.higherkindedj.hkt;
   exports org.higherkindedj.hkt.function;
   exports org.higherkindedj.optics;
+  exports org.higherkindedj.optics.indexed;
 }

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedFold.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedFold.java
@@ -1,0 +1,417 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.optics.Fold;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An indexed fold for read-only querying and extraction with access to indices.
+ *
+ * <p>An {@code IndexedFold} is the indexed equivalent of a {@link Fold}. While a regular fold
+ * allows you to query and extract multiple elements from a structure, an indexed fold also provides
+ * the index/position of each element, enabling position-aware queries.
+ *
+ * <p>Common use cases include:
+ *
+ * <ul>
+ *   <li>Extracting elements with their positions: {@code toIndexedList()}
+ *   <li>Finding elements by position-aware criteria
+ *   <li>Aggregating with position weighting
+ *   <li>Debugging: tracking which positions contain certain values
+ * </ul>
+ *
+ * @param <I> The index type (e.g., Integer for lists, K for Map&lt;K, V&gt;)
+ * @param <S> The source structure type
+ * @param <A> The focused element type
+ */
+@NullMarked
+public interface IndexedFold<I, S, A> extends IndexedOptic<I, S, A> {
+
+  /**
+   * Folds all focused parts into a summary value using a {@link Monoid}, with access to both index
+   * and value.
+   *
+   * <p>This is the fundamental operation of an IndexedFold. It maps each focused part {@code A}
+   * along with its index {@code I} to a monoidal value {@code M}, then combines all these values
+   * using the monoid's {@code combine} operation.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * // Weight prices by position (earlier items cost more)
+   * Monoid<Double> sumMonoid = Monoid.of(0.0, Double::sum);
+   * double weightedTotal = itemsFold.ifoldMap(
+   *     sumMonoid,
+   *     (index, item) -> item.price() * (1.0 - index * 0.1),
+   *     order
+   * );
+   * }</pre>
+   *
+   * @param monoid The {@link Monoid} used to combine the mapped values
+   * @param f The function to map each index-value pair to the monoidal type {@code M}
+   * @param source The source structure
+   * @param <M> The monoidal type
+   * @return The aggregated result of type {@code M}
+   */
+  <M> M ifoldMap(Monoid<M> monoid, BiFunction<? super I, ? super A, ? extends M> f, S source);
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Default implementation that uses ifoldMap to apply the effectful function to each element.
+   */
+  @Override
+  default <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app) {
+    // For IndexedFold, we traverse and apply effects but don't modify the structure
+    Monoid<Kind<F, Void>> effectMonoid =
+        new Monoid<>() {
+          @Override
+          public Kind<F, Void> empty() {
+            return app.of(null);
+          }
+
+          @Override
+          public Kind<F, Void> combine(Kind<F, Void> a, Kind<F, Void> b) {
+            return app.map2(a, b, (v1, v2) -> null);
+          }
+        };
+
+    Kind<F, Void> effects =
+        ifoldMap(effectMonoid, (i, a) -> app.map(ignored -> null, f.apply(i, a)), source);
+
+    return app.map(ignored -> source, effects);
+  }
+
+  /**
+   * Extracts all focused parts along with their indices into a list of pairs.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedFold<Integer, List<String>, String> ifold = IndexedTraversals.forList();
+   * List<Pair<Integer, String>> indexed = ifold.toIndexedList(List.of("a", "b", "c"));
+   * // [Pair(0, "a"), Pair(1, "b"), Pair(2, "c")]
+   * }</pre>
+   *
+   * @param source The source structure
+   * @return A list of index-value pairs in traversal order
+   */
+  default List<Pair<I, A>> toIndexedList(S source) {
+    final List<Pair<I, A>> result = new ArrayList<>();
+    Monoid<Void> accumulatorMonoid =
+        new Monoid<>() {
+          @Override
+          public Void empty() {
+            return null;
+          }
+
+          @Override
+          public Void combine(Void a, Void b) {
+            return null;
+          }
+        };
+
+    ifoldMap(
+        accumulatorMonoid,
+        (i, a) -> {
+          result.add(new Pair<>(i, a));
+          return null;
+        },
+        source);
+    return result;
+  }
+
+  /**
+   * Extracts all focused parts, discarding index information.
+   *
+   * @param source The source structure
+   * @return A list of all focused values
+   */
+  default List<A> getAll(S source) {
+    final List<A> result = new ArrayList<>();
+    Monoid<Void> accumulatorMonoid =
+        new Monoid<>() {
+          @Override
+          public Void empty() {
+            return null;
+          }
+
+          @Override
+          public Void combine(Void a, Void b) {
+            return null;
+          }
+        };
+
+    ifoldMap(
+        accumulatorMonoid,
+        (i, a) -> {
+          result.add(a);
+          return null;
+        },
+        source);
+    return result;
+  }
+
+  /**
+   * Finds the first element that satisfies a predicate based on both index and value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * // Find first element at an even position with value > 10
+   * Optional<Pair<Integer, Integer>> found = ifold.findWithIndex(
+   *     (index, value) -> index % 2 == 0 && value > 10,
+   *     source
+   * );
+   * }</pre>
+   *
+   * @param predicate Predicate that takes both index and value
+   * @param source The source structure
+   * @return The first matching index-value pair, or empty if none found
+   */
+  default Optional<Pair<I, A>> findWithIndex(
+      BiPredicate<? super I, ? super A> predicate, S source) {
+    return ifoldMap(
+        firstOptionalMonoid(),
+        (i, a) -> predicate.test(i, a) ? Optional.of(new Pair<>(i, a)) : Optional.empty(),
+        source);
+  }
+
+  /**
+   * Finds the first element that satisfies a predicate on the value.
+   *
+   * @param predicate Predicate on the focused value
+   * @param source The source structure
+   * @return The first matching index-value pair, or empty if none found
+   */
+  default Optional<Pair<I, A>> find(Predicate<? super A> predicate, S source) {
+    return findWithIndex((i, a) -> predicate.test(a), source);
+  }
+
+  /**
+   * Checks if any element satisfies a predicate based on both index and value.
+   *
+   * @param predicate Predicate that takes both index and value
+   * @param source The source structure
+   * @return true if any element matches, false otherwise
+   */
+  default boolean existsWithIndex(BiPredicate<? super I, ? super A> predicate, S source) {
+    return ifoldMap(anyBooleanMonoid(), (i, a) -> predicate.test(i, a), source);
+  }
+
+  /**
+   * Checks if any element satisfies a predicate on the value.
+   *
+   * @param predicate Predicate on the focused value
+   * @param source The source structure
+   * @return true if any element matches, false otherwise
+   */
+  default boolean exists(Predicate<? super A> predicate, S source) {
+    return existsWithIndex((i, a) -> predicate.test(a), source);
+  }
+
+  /**
+   * Checks if all elements satisfy a predicate based on both index and value.
+   *
+   * @param predicate Predicate that takes both index and value
+   * @param source The source structure
+   * @return true if all elements match (or if empty), false otherwise
+   */
+  default boolean allWithIndex(BiPredicate<? super I, ? super A> predicate, S source) {
+    return ifoldMap(allBooleanMonoid(), (i, a) -> predicate.test(i, a), source);
+  }
+
+  /**
+   * Checks if all elements satisfy a predicate on the value.
+   *
+   * @param predicate Predicate on the focused value
+   * @param source The source structure
+   * @return true if all elements match (or if empty), false otherwise
+   */
+  default boolean all(Predicate<? super A> predicate, S source) {
+    return allWithIndex((i, a) -> predicate.test(a), source);
+  }
+
+  /**
+   * Counts the number of focused parts in the structure.
+   *
+   * @param source The source structure
+   * @return The number of focused parts
+   */
+  default int length(S source) {
+    return ifoldMap(sumIntMonoid(), (i, a) -> 1, source);
+  }
+
+  /**
+   * Checks if there are no focused parts in the structure.
+   *
+   * @param source The source structure
+   * @return true if no focused parts, false otherwise
+   */
+  default boolean isEmpty(S source) {
+    return length(source) == 0;
+  }
+
+  /**
+   * Composes this {@code IndexedFold<I, S, A>} with another {@code IndexedFold<J, A, B>} to create
+   * a new {@code IndexedFold<Pair<I, J>, S, B>} with paired indices.
+   *
+   * @param other The {@link IndexedFold} to compose with
+   * @param <J> The index type of the other fold
+   * @param <B> The focus type of the other fold
+   * @return A new {@link IndexedFold} with paired indices
+   */
+  default <J, B> IndexedFold<Pair<I, J>, S, B> iandThen(IndexedFold<J, A, B> other) {
+    IndexedFold<I, S, A> self = this;
+    return new IndexedFold<>() {
+      @Override
+      public <M> M ifoldMap(
+          Monoid<M> monoid, BiFunction<? super Pair<I, J>, ? super B, ? extends M> f, S source) {
+        return self.ifoldMap(
+            monoid,
+            (i, a) -> other.ifoldMap(monoid, (j, b) -> f.apply(new Pair<>(i, j), b), a),
+            source);
+      }
+    };
+  }
+
+  /**
+   * Composes this {@code IndexedFold<I, S, A>} with a regular {@code Fold<A, B>} to create a new
+   * {@code IndexedFold<I, S, B>} that preserves the outer index.
+   *
+   * @param other The {@link Fold} to compose with
+   * @param <B> The focus type of the other fold
+   * @return A new {@link IndexedFold} preserving the outer index
+   */
+  default <B> IndexedFold<I, S, B> andThen(Fold<A, B> other) {
+    IndexedFold<I, S, A> self = this;
+    return new IndexedFold<>() {
+      @Override
+      public <M> M ifoldMap(
+          Monoid<M> monoid, BiFunction<? super I, ? super B, ? extends M> f, S source) {
+        return self.ifoldMap(
+            monoid, (i, a) -> other.foldMap(monoid, b -> f.apply(i, b), a), source);
+      }
+    };
+  }
+
+  /**
+   * Filters elements based on their index.
+   *
+   * @param predicate Predicate on the index
+   * @return A new indexed fold that only focuses on matching indices
+   */
+  default IndexedFold<I, S, A> filterIndex(Predicate<? super I> predicate) {
+    IndexedFold<I, S, A> self = this;
+    return new IndexedFold<>() {
+      @Override
+      public <M> M ifoldMap(
+          Monoid<M> monoid, BiFunction<? super I, ? super A, ? extends M> f, S source) {
+        return self.ifoldMap(
+            monoid, (i, a) -> predicate.test(i) ? f.apply(i, a) : monoid.empty(), source);
+      }
+    };
+  }
+
+  /**
+   * Filters elements based on their value.
+   *
+   * @param predicate Predicate on the focused value
+   * @return A new indexed fold that only focuses on matching values
+   */
+  default IndexedFold<I, S, A> filtered(Predicate<? super A> predicate) {
+    IndexedFold<I, S, A> self = this;
+    return new IndexedFold<>() {
+      @Override
+      public <M> M ifoldMap(
+          Monoid<M> monoid, BiFunction<? super I, ? super A, ? extends M> f, S source) {
+        return self.ifoldMap(
+            monoid, (i, a) -> predicate.test(a) ? f.apply(i, a) : monoid.empty(), source);
+      }
+    };
+  }
+
+  /**
+   * Views this {@code IndexedFold} as a regular (non-indexed) {@link Fold}.
+   *
+   * @return A {@link Fold} that ignores index information
+   */
+  default Fold<S, A> asFold() {
+    IndexedFold<I, S, A> self = this;
+    return new Fold<>() {
+      @Override
+      public <M> M foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f, S source) {
+        return self.ifoldMap(monoid, (i, a) -> f.apply(a), source);
+      }
+    };
+  }
+
+  // Private helper monoids
+
+  private static <T> Monoid<Optional<T>> firstOptionalMonoid() {
+    return new Monoid<>() {
+      @Override
+      public Optional<T> empty() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<T> combine(Optional<T> a, Optional<T> b) {
+        return a.isPresent() ? a : b;
+      }
+    };
+  }
+
+  private static Monoid<Integer> sumIntMonoid() {
+    return new Monoid<>() {
+      @Override
+      public Integer empty() {
+        return 0;
+      }
+
+      @Override
+      public Integer combine(Integer a, Integer b) {
+        return a + b;
+      }
+    };
+  }
+
+  private static Monoid<Boolean> anyBooleanMonoid() {
+    return new Monoid<>() {
+      @Override
+      public Boolean empty() {
+        return false;
+      }
+
+      @Override
+      public Boolean combine(Boolean a, Boolean b) {
+        return a || b;
+      }
+    };
+  }
+
+  private static Monoid<Boolean> allBooleanMonoid() {
+    return new Monoid<>() {
+      @Override
+      public Boolean empty() {
+        return true;
+      }
+
+      @Override
+      public Boolean combine(Boolean a, Boolean b) {
+        return a && b;
+      }
+    };
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedLens.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedLens.java
@@ -1,0 +1,329 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.optics.Lens;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An indexed lens that provides focused access to a single field along with its index/key.
+ *
+ * <p>An {@code IndexedLens} is the indexed equivalent of a {@link Lens}. While a regular lens
+ * focuses on exactly one field that is guaranteed to exist, an indexed lens also provides index
+ * information, which can represent:
+ *
+ * <ul>
+ *   <li>A field name (for introspection/debugging)
+ *   <li>A map key
+ *   <li>A position in a fixed-size structure
+ *   <li>A path component
+ * </ul>
+ *
+ * <p>Common use cases include:
+ *
+ * <ul>
+ *   <li>Tracking field names during transformations
+ *   <li>Building audit trails with field provenance
+ *   <li>Conditional logic based on which field is being accessed
+ *   <li>Generic field processing with field identification
+ * </ul>
+ *
+ * @param <I> The index type (e.g., String for field names, K for Map keys)
+ * @param <S> The source/target structure type
+ * @param <A> The focused element type
+ */
+@NullMarked
+public interface IndexedLens<I, S, A> extends IndexedOptic<I, S, A> {
+
+  /**
+   * Gets the index associated with this lens.
+   *
+   * <p>Unlike traversals where each element has its own index, a lens has a single fixed index
+   * representing the field or key being focused on.
+   *
+   * @return The index value
+   */
+  I index();
+
+  /**
+   * Gets the focused part {@code A} from the whole structure {@code S}.
+   *
+   * @param source The whole structure
+   * @return The focused part
+   */
+  A get(S source);
+
+  /**
+   * Sets a new value for the focused part {@code A}, returning a new, updated structure {@code S}.
+   *
+   * <p>This operation is immutable; the original {@code source} object is not changed.
+   *
+   * @param newValue The new value for the focused part
+   * @param source The original structure
+   * @return A new structure with the focused part updated
+   */
+  S set(A newValue, S source);
+
+  /**
+   * Gets the focused part along with its index as a pair.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedLens<String, User, Integer> ageLens = IndexedLens.of("age", User::age, User::withAge);
+   * Pair<String, Integer> indexed = ageLens.iget(user);
+   * // Pair("age", 25)
+   * }</pre>
+   *
+   * @param source The whole structure
+   * @return A pair of (index, value)
+   */
+  default Pair<I, A> iget(S source) {
+    return new Pair<>(index(), get(source));
+  }
+
+  /**
+   * Modifies the focused part using a function that receives both index and value.
+   *
+   * @param modifier The function to apply, receiving both index and value
+   * @param source The whole structure
+   * @return A new structure with the modified part
+   */
+  default S imodify(BiFunction<I, A, A> modifier, S source) {
+    return set(modifier.apply(index(), get(source)), source);
+  }
+
+  /**
+   * Modifies the focused part using a pure function (ignoring the index).
+   *
+   * @param modifier The function to apply to the focused part
+   * @param source The whole structure
+   * @return A new structure with the modified part
+   */
+  default S modify(Function<A, A> modifier, S source) {
+    return set(modifier.apply(get(source)), source);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Modifies the focused part with an effectful function that receives both index and value.
+   */
+  @Override
+  default <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app) {
+    Kind<F, A> fa = f.apply(index(), get(source));
+    return app.map(a -> set(a, source), fa);
+  }
+
+  /**
+   * Modifies the focused part with an effectful function that receives only the value.
+   *
+   * @param f The effectful function to apply
+   * @param source The whole structure
+   * @param functor The Functor instance for the context F
+   * @param <F> The witness type for the Functor context
+   * @return The updated structure wrapped in the context F
+   */
+  default <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S source, Functor<F> functor) {
+    Kind<F, A> fa = f.apply(get(source));
+    return functor.map(a -> set(a, source), fa);
+  }
+
+  /**
+   * Composes this {@code IndexedLens<I, S, A>} with another {@code IndexedLens<J, A, B>} to create
+   * a new {@code IndexedLens<Pair<I, J>, S, B>} with paired indices.
+   *
+   * @param other The {@link IndexedLens} to compose with
+   * @param <J> The index type of the other lens
+   * @param <B> The focus type of the other lens
+   * @return A new {@link IndexedLens} with paired indices
+   */
+  default <J, B> IndexedLens<Pair<I, J>, S, B> iandThen(IndexedLens<J, A, B> other) {
+    IndexedLens<I, S, A> self = this;
+    return new IndexedLens<>() {
+      @Override
+      public Pair<I, J> index() {
+        return new Pair<>(self.index(), other.index());
+      }
+
+      @Override
+      public B get(S source) {
+        return other.get(self.get(source));
+      }
+
+      @Override
+      public S set(B newValue, S source) {
+        return self.set(other.set(newValue, self.get(source)), source);
+      }
+    };
+  }
+
+  /**
+   * Composes this {@code IndexedLens<I, S, A>} with a regular {@code Lens<A, B>} to create a new
+   * {@code IndexedLens<I, S, B>} that preserves the outer index.
+   *
+   * @param other The {@link Lens} to compose with
+   * @param <B> The focus type of the other lens
+   * @return A new {@link IndexedLens} preserving the outer index
+   */
+  default <B> IndexedLens<I, S, B> andThen(Lens<A, B> other) {
+    IndexedLens<I, S, A> self = this;
+    return new IndexedLens<>() {
+      @Override
+      public I index() {
+        return self.index();
+      }
+
+      @Override
+      public B get(S source) {
+        return other.get(self.get(source));
+      }
+
+      @Override
+      public S set(B newValue, S source) {
+        return self.set(other.set(newValue, self.get(source)), source);
+      }
+    };
+  }
+
+  /**
+   * Views this {@code IndexedLens} as a regular (non-indexed) {@link Lens}.
+   *
+   * @return A {@link Lens} that ignores index information
+   */
+  default Lens<S, A> asLens() {
+    IndexedLens<I, S, A> self = this;
+    return new Lens<>() {
+      @Override
+      public A get(S source) {
+        return self.get(source);
+      }
+
+      @Override
+      public S set(A newValue, S source) {
+        return self.set(newValue, source);
+      }
+
+      @Override
+      public <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S source, Functor<F> functor) {
+        return self.modifyF(f, source, functor);
+      }
+    };
+  }
+
+  /**
+   * Views this {@code IndexedLens} as an {@link IndexedTraversal}.
+   *
+   * <p>This is always possible because a lens is a traversal that focuses on exactly one element.
+   *
+   * @return An {@link IndexedTraversal} that represents this lens
+   */
+  default IndexedTraversal<I, S, A> asIndexedTraversal() {
+    IndexedLens<I, S, A> self = this;
+    return self::imodifyF;
+  }
+
+  /**
+   * Views this {@code IndexedLens} as an {@link IndexedFold}.
+   *
+   * @return An {@link IndexedFold} that represents this lens
+   */
+  default IndexedFold<I, S, A> asIndexedFold() {
+    IndexedLens<I, S, A> self = this;
+    return new IndexedFold<I, S, A>() {
+      @Override
+      public <M> M ifoldMap(
+          Monoid<M> monoid, BiFunction<? super I, ? super A, ? extends M> f, S source) {
+        return f.apply(self.index(), self.get(source));
+      }
+    };
+  }
+
+  /**
+   * Creates an {@code IndexedLens} from its components: an index, a getter, and a setter.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedLens<String, User, String> nameLens = IndexedLens.of(
+   *     "name",                           // Index (field name)
+   *     User::name,                       // Getter
+   *     (user, name) -> user.withName(name)  // Setter
+   * );
+   *
+   * // Use with index awareness
+   * String fieldName = nameLens.index();        // "name"
+   * Pair<String, String> indexed = nameLens.iget(user);  // Pair("name", "Alice")
+   * User updated = nameLens.imodify((field, value) -> value.toUpperCase(), user);
+   * }</pre>
+   *
+   * @param index The index value for this lens
+   * @param getter A function to extract the part from the structure
+   * @param setter A function to immutably update the part within the structure
+   * @param <I> The index type
+   * @param <S> The structure type
+   * @param <A> The focused part type
+   * @return A new {@code IndexedLens} instance
+   */
+  static <I, S, A> IndexedLens<I, S, A> of(
+      I index, Function<S, A> getter, BiFunction<S, A, S> setter) {
+    return new IndexedLens<>() {
+      @Override
+      public I index() {
+        return index;
+      }
+
+      @Override
+      public A get(S source) {
+        return getter.apply(source);
+      }
+
+      @Override
+      public S set(A newValue, S source) {
+        return setter.apply(source, newValue);
+      }
+    };
+  }
+
+  /**
+   * Creates an {@code IndexedLens} from an existing {@link Lens} plus an index.
+   *
+   * <p>This is useful when you have an existing lens and want to add index tracking to it.
+   *
+   * @param index The index value for this lens
+   * @param lens The underlying lens
+   * @param <I> The index type
+   * @param <S> The structure type
+   * @param <A> The focused part type
+   * @return A new {@code IndexedLens} wrapping the provided lens
+   */
+  static <I, S, A> IndexedLens<I, S, A> from(I index, Lens<S, A> lens) {
+    return new IndexedLens<>() {
+      @Override
+      public I index() {
+        return index;
+      }
+
+      @Override
+      public A get(S source) {
+        return lens.get(source);
+      }
+
+      @Override
+      public S set(A newValue, S source) {
+        return lens.set(newValue, source);
+      }
+
+      @Override
+      public <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S source, Functor<F> functor) {
+        return lens.modifyF(f, source, functor);
+      }
+    };
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedOptic.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedOptic.java
@@ -1,0 +1,149 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.Optic;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An abstract representation of an indexed optic that provides access to both the index and value
+ * during modifications. This is the base interface for all indexed optics (IndexedLens,
+ * IndexedTraversal, IndexedFold).
+ *
+ * <p>Indexed optics are crucial for position-aware operations where you need to know the location
+ * of each element being processed. Common use cases include:
+ *
+ * <ul>
+ *   <li>Position-aware transformations (e.g., numbering items)
+ *   <li>Debugging and tracking which elements are modified
+ *   <li>Conditional logic based on position
+ *   <li>Maintaining element provenance
+ * </ul>
+ *
+ * <p>The index type {@code I} can be any type appropriate for the structure:
+ *
+ * <ul>
+ *   <li>{@code Integer} for lists/arrays
+ *   <li>{@code K} for {@code Map<K, V>}
+ *   <li>{@code String} for named fields
+ *   <li>{@code Tuple2<I, J>} for composed indexed optics
+ * </ul>
+ *
+ * @param <I> The index type
+ * @param <S> The source/target structure type
+ * @param <A> The focused element type
+ */
+@NullMarked
+public interface IndexedOptic<I, S, A> {
+
+  /**
+   * The fundamental operation of any indexed optic. It applies a function to the focused parts,
+   * providing both the index and value, and returns the updated structure wrapped in an Applicative
+   * context.
+   *
+   * <p>This operation enables position-aware transformations where the modification function can
+   * use the index to determine how to transform each element.
+   *
+   * @param f The function to apply to each focused part, receiving both index and value
+   * @param source The source structure
+   * @param app The Applicative instance for the context 'F'
+   * @param <F> The witness type for the Applicative context
+   * @return The updated structure 'S' wrapped in the context 'F'
+   */
+  <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app);
+
+  /**
+   * Converts this indexed optic to a regular (non-indexed) optic by discarding the index
+   * information.
+   *
+   * <p>This is useful when you want to use an indexed optic in a context that expects a regular
+   * optic, or when the index information is not needed for a particular operation.
+   *
+   * @return A regular {@link Optic} that ignores index information
+   */
+  default Optic<S, S, A, A> unindexed() {
+    IndexedOptic<I, S, A> self = this;
+    return new Optic<>() {
+      @Override
+      public <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S s, Applicative<F> app) {
+        return self.imodifyF((i, a) -> f.apply(a), s, app);
+      }
+    };
+  }
+
+  /**
+   * Composes this indexed optic with another indexed optic to create a new indexed optic with
+   * paired indices.
+   *
+   * <p>When composing two indexed optics, the resulting optic tracks both indices using a {@link
+   * Pair}. This allows you to maintain full provenance information through the composition.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<Map<String, User>>, Map<String, User>> listTraversal = ...;
+   * IndexedTraversal<String, Map<String, User>, User> mapTraversal = ...;
+   *
+   * IndexedTraversal<Pair<Integer, String>, List<Map<String, User>>, User> composed =
+   *     listTraversal.iandThen(mapTraversal);
+   *
+   * // Access both indices during modification
+   * composed.imodifyF((indices, user) -> {
+   *     int listIndex = indices.first();
+   *     String mapKey = indices.second();
+   *     // ... position-aware transformation
+   * }, source, app);
+   * }</pre>
+   *
+   * @param other The indexed optic to compose with
+   * @param <J> The index type of the other optic
+   * @param <B> The focus type of the other optic
+   * @return A new indexed optic with paired indices
+   */
+  default <J, B> IndexedOptic<Pair<I, J>, S, B> iandThen(IndexedOptic<J, A, B> other) {
+    IndexedOptic<I, S, A> self = this;
+    return new IndexedOptic<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(
+          BiFunction<Pair<I, J>, B, Kind<F, B>> f, S source, Applicative<F> app) {
+        return self.imodifyF(
+            (i, a) -> other.imodifyF((j, b) -> f.apply(new Pair<>(i, j), b), a, app), source, app);
+      }
+    };
+  }
+
+  /**
+   * Composes this indexed optic with a regular (non-indexed) optic, preserving the index from this
+   * optic.
+   *
+   * <p>This is useful when you want to focus deeper into a structure but only need the index from
+   * the outer level.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<User>, User> users = ...;
+   * Traversal<User, String> email = ...;
+   *
+   * IndexedTraversal<Integer, List<User>, String> userEmails = users.andThen(email);
+   * // Index represents user position in list, not email position
+   * }</pre>
+   *
+   * @param other The regular optic to compose with
+   * @param <B> The focus type of the other optic
+   * @return A new indexed optic that preserves this optic's index
+   */
+  default <B> IndexedOptic<I, S, B> andThen(Optic<A, A, B, B> other) {
+    IndexedOptic<I, S, A> self = this;
+    return new IndexedOptic<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(BiFunction<I, B, Kind<F, B>> f, S source, Applicative<F> app) {
+        return self.imodifyF((i, a) -> other.modifyF(b -> f.apply(i, b), a, app), source, app);
+      }
+    };
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedTraversal.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedTraversal.java
@@ -1,0 +1,294 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An indexed traversal that focuses on zero or more elements within a structure, providing access
+ * to both the index and value for each focused element.
+ *
+ * <p>An {@code IndexedTraversal} is the indexed equivalent of a {@link Traversal}. While a regular
+ * traversal allows you to modify multiple elements in a structure, an indexed traversal also
+ * provides the index/position of each element, enabling position-aware transformations.
+ *
+ * <p>Common use cases include:
+ *
+ * <ul>
+ *   <li>Numbering items: {@code (i, item) -> item + " #" + i}
+ *   <li>Position-based filtering: {@code filterIndex(i -> i % 2 == 0)} for even positions
+ *   <li>Weighted modifications: {@code (i, value) -> value * weights[i]}
+ *   <li>Debugging: Tracking which elements are being modified
+ * </ul>
+ *
+ * <p>Like regular traversals, indexed traversals compose naturally with other optics, allowing you
+ * to build complex indexed access patterns.
+ *
+ * @param <I> The index type (e.g., Integer for lists, K for Map&lt;K, V&gt;)
+ * @param <S> The source/target structure type
+ * @param <A> The focused element type
+ */
+@NullMarked
+public interface IndexedTraversal<I, S, A> extends IndexedOptic<I, S, A> {
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This is the core operation of an {@code IndexedTraversal}. It modifies all focused parts
+   * {@code A} within a structure {@code S} by applying a function that receives both the index and
+   * value, returning a value in an {@link Applicative} context {@code F}.
+   *
+   * @param <F> The witness type for the {@link Applicative} context
+   * @param f The effectful function to apply to each focused part, receiving both index and value
+   * @param source The whole structure to operate on
+   * @param app The {@link Applicative} instance for the context {@code F}
+   * @return The updated structure {@code S}, itself wrapped in the context {@code F}
+   */
+  @Override
+  <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app);
+
+  /**
+   * Composes this {@code IndexedTraversal<I, S, A>} with another {@code IndexedTraversal<J, A, B>}
+   * to create a new {@code IndexedTraversal<Pair<I, J>, S, B>} with paired indices.
+   *
+   * <p>This specialized overload ensures the result is correctly typed as an {@code
+   * IndexedTraversal} with paired indices.
+   *
+   * @param other The {@link IndexedTraversal} to compose with
+   * @param <J> The index type of the other traversal
+   * @param <B> The focus type of the other traversal
+   * @return A new {@link IndexedTraversal} with paired indices
+   */
+  default <J, B> IndexedTraversal<Pair<I, J>, S, B> iandThen(IndexedTraversal<J, A, B> other) {
+    IndexedTraversal<I, S, A> self = this;
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(
+          BiFunction<Pair<I, J>, B, Kind<F, B>> f, S source, Applicative<F> app) {
+        return self.imodifyF(
+            (i, a) -> other.imodifyF((j, b) -> f.apply(new Pair<>(i, j), b), a, app), source, app);
+      }
+    };
+  }
+
+  /**
+   * Composes this {@code IndexedTraversal<I, S, A>} with a regular {@code Traversal<A, B>} to
+   * create a new {@code IndexedTraversal<I, S, B>} that preserves the outer index.
+   *
+   * <p>This is useful when you want to focus deeper into a structure but only care about the index
+   * from the outer level. For example, focusing on user emails while tracking user positions.
+   *
+   * @param other The {@link Traversal} to compose with
+   * @param <B> The type of the final focused parts
+   * @return A new {@link IndexedTraversal} preserving the outer index
+   */
+  default <B> IndexedTraversal<I, S, B> andThen(Traversal<A, B> other) {
+    IndexedTraversal<I, S, A> self = this;
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(BiFunction<I, B, Kind<F, B>> f, S source, Applicative<F> app) {
+        return self.imodifyF((i, a) -> other.modifyF(b -> f.apply(i, b), a, app), source, app);
+      }
+    };
+  }
+
+  /**
+   * Filters elements based on their index, creating a new indexed traversal that only focuses on
+   * elements whose indices match the predicate.
+   *
+   * <p>This is particularly useful for position-based filtering:
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+   *
+   * // Focus on even positions only
+   * IndexedTraversal<Integer, List<String>, String> evens =
+   *     ilist.filterIndex(i -> i % 2 == 0);
+   *
+   * // Focus on first 3 elements
+   * IndexedTraversal<Integer, List<String>, String> firstThree =
+   *     ilist.filterIndex(i -> i < 3);
+   *
+   * // Focus on specific indices
+   * Set<Integer> indices = Set.of(0, 2, 5);
+   * IndexedTraversal<Integer, List<String>, String> specific =
+   *     ilist.filterIndex(indices::contains);
+   * }</pre>
+   *
+   * @param predicate Predicate on the index
+   * @return A new indexed traversal that only focuses on matching indices
+   */
+  default IndexedTraversal<I, S, A> filterIndex(Predicate<? super I> predicate) {
+    IndexedTraversal<I, S, A> self = this;
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app) {
+        return self.imodifyF((i, a) -> predicate.test(i) ? f.apply(i, a) : app.of(a), source, app);
+      }
+    };
+  }
+
+  /**
+   * Filters elements based on their value, creating a new indexed traversal that only focuses on
+   * elements matching the predicate while preserving their indices.
+   *
+   * <p>This is similar to {@link Traversal#filtered(Predicate)} but maintains the index
+   * information.
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<User>, User> iusers = IndexedTraversals.forList();
+   *
+   * // Focus on active users only, preserving their list positions
+   * IndexedTraversal<Integer, List<User>, User> activeUsers =
+   *     iusers.filtered(User::isActive);
+   *
+   * // Modify active users with position awareness
+   * imodify(activeUsers, (index, user) -> user.withLabel("Active #" + index), users);
+   * }</pre>
+   *
+   * @param predicate Predicate on the focused value
+   * @return A new indexed traversal that only focuses on matching values
+   */
+  default IndexedTraversal<I, S, A> filtered(Predicate<? super A> predicate) {
+    IndexedTraversal<I, S, A> self = this;
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app) {
+        return self.imodifyF((i, a) -> predicate.test(a) ? f.apply(i, a) : app.of(a), source, app);
+      }
+    };
+  }
+
+  /**
+   * Filters elements based on both index and value, providing maximum flexibility in element
+   * selection.
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<Item>, Item> items = IndexedTraversals.forList();
+   *
+   * // Focus on items that are both in first half and marked as important
+   * IndexedTraversal<Integer, List<Item>, Item> filtered =
+   *     items.filteredWithIndex((index, item) -> index < items.size() / 2 && item.isImportant());
+   * }</pre>
+   *
+   * @param predicate Predicate that takes both index and value
+   * @return A new indexed traversal that only focuses on matching elements
+   */
+  default IndexedTraversal<I, S, A> filteredWithIndex(
+      BiFunction<? super I, ? super A, Boolean> predicate) {
+    IndexedTraversal<I, S, A> self = this;
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, S> imodifyF(BiFunction<I, A, Kind<F, A>> f, S source, Applicative<F> app) {
+        return self.imodifyF(
+            (i, a) -> predicate.apply(i, a) ? f.apply(i, a) : app.of(a), source, app);
+      }
+    };
+  }
+
+  /**
+   * Views this {@code IndexedTraversal} as a regular (non-indexed) {@link Traversal} by discarding
+   * index information.
+   *
+   * <p>This is useful when you need to pass an indexed traversal to code that expects a regular
+   * traversal.
+   *
+   * @return A {@link Traversal} that ignores index information
+   */
+  default Traversal<S, A> asTraversal() {
+    IndexedTraversal<I, S, A> self = this;
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, S> modifyF(
+          java.util.function.Function<A, Kind<F, A>> f, S source, Applicative<F> app) {
+        return self.imodifyF((i, a) -> f.apply(a), source, app);
+      }
+    };
+  }
+
+  /**
+   * Views this {@code IndexedTraversal} as an {@link IndexedFold} for read-only indexed operations.
+   *
+   * @return An {@link IndexedFold} that provides read-only indexed access
+   */
+  default IndexedFold<I, S, A> asIndexedFold() {
+    IndexedTraversal<I, S, A> self = this;
+    return new IndexedFold<I, S, A>() {
+      @Override
+      public <M> M ifoldMap(
+          org.higherkindedj.hkt.Monoid<M> monoid,
+          BiFunction<? super I, ? super A, ? extends M> f,
+          S source) {
+        // We need to traverse all elements and fold them using the monoid.
+        // Since we can't reference Id/IdMonad from hkj-core, we define a minimal
+        // identity-like applicative inline.
+        final java.util.List<Pair<I, A>> collected = new java.util.ArrayList<>();
+
+        // Define a simple identity wrapper that implements Kind
+        // This is a local class to avoid circular dependencies
+        @SuppressWarnings("rawtypes")
+        final class IdWrapper implements Kind {
+          final Object value;
+
+          IdWrapper(Object value) {
+            this.value = value;
+          }
+        }
+
+        // Create a minimal Applicative for IdWrapper
+        Applicative<IdWrapper> idApp =
+            new Applicative<>() {
+              @Override
+              @SuppressWarnings("unchecked")
+              public <A1> Kind<IdWrapper, A1> of(A1 a) {
+                return (Kind<IdWrapper, A1>) new IdWrapper(a);
+              }
+
+              @Override
+              @SuppressWarnings("unchecked")
+              public <A1, B1> Kind<IdWrapper, B1> map(
+                  java.util.function.Function<? super A1, ? extends B1> fn,
+                  Kind<IdWrapper, A1> fa) {
+                IdWrapper wrapper = (IdWrapper) fa;
+                return (Kind<IdWrapper, B1>) new IdWrapper(fn.apply((A1) wrapper.value));
+              }
+
+              @Override
+              @SuppressWarnings("unchecked")
+              public <A1, B1> Kind<IdWrapper, B1> ap(
+                  Kind<IdWrapper, ? extends java.util.function.Function<A1, B1>> ff,
+                  Kind<IdWrapper, A1> fa) {
+                IdWrapper wrapperF = (IdWrapper) ff;
+                IdWrapper wrapperA = (IdWrapper) fa;
+                java.util.function.Function<A1, B1> fn =
+                    (java.util.function.Function<A1, B1>) wrapperF.value;
+                return (Kind<IdWrapper, B1>) new IdWrapper(fn.apply((A1) wrapperA.value));
+              }
+            };
+
+        // Use the traversal to collect all index-value pairs
+        self.imodifyF(
+            (i, a) -> {
+              collected.add(new Pair<>(i, a));
+              @SuppressWarnings("unchecked")
+              Kind<IdWrapper, A> result = (Kind<IdWrapper, A>) new IdWrapper(a);
+              return result;
+            },
+            source,
+            idApp);
+
+        // Fold over the collected pairs using the provided monoid
+        M result = monoid.empty();
+        for (Pair<I, A> pair : collected) {
+          result = monoid.combine(result, f.apply(pair.first(), pair.second()));
+        }
+        return result;
+      }
+    };
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/Pair.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/Pair.java
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A simple immutable pair of two values, used for composing indices in indexed optics.
+ *
+ * <p>When two indexed optics are composed (e.g., an indexed traversal over a list composed with an
+ * indexed traversal over a map), the resulting optic tracks both indices as a {@code Pair}.
+ *
+ * <p>This is a minimal record type designed for use within the optics API. For more feature-rich
+ * tuple operations in hkj-core, see {@code org.higherkindedj.hkt.tuple.Tuple2} which provides
+ * bifunctor operations and validation.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * IndexedTraversal<Integer, List<Map<String, User>>, Map<String, User>> ilist = ...;
+ * IndexedTraversal<String, Map<String, User>, User> imap = ...;
+ *
+ * IndexedTraversal<Pair<Integer, String>, List<Map<String, User>>, User> composed =
+ *     ilist.iandThen(imap);
+ *
+ * // Access the paired indices
+ * composed.imodifyF((indices, user) -> {
+ *     int listIndex = indices.first();
+ *     String mapKey = indices.second();
+ *     // ... position-aware transformation
+ * }, source, app);
+ * }</pre>
+ *
+ * @param <A> The type of the first element (typically the outer index)
+ * @param <B> The type of the second element (typically the inner index)
+ * @param first The first element of the pair
+ * @param second The second element of the pair
+ */
+@NullMarked
+public record Pair<A, B>(A first, B second) {
+
+  /**
+   * Creates a new pair with the first element transformed.
+   *
+   * @param newFirst The new first element
+   * @param <C> The type of the new first element
+   * @return A new pair with the transformed first element
+   */
+  public <C> Pair<C, B> withFirst(C newFirst) {
+    return new Pair<>(newFirst, second);
+  }
+
+  /**
+   * Creates a new pair with the second element transformed.
+   *
+   * @param newSecond The new second element
+   * @param <C> The type of the new second element
+   * @return A new pair with the transformed second element
+   */
+  public <C> Pair<A, C> withSecond(C newSecond) {
+    return new Pair<>(first, newSecond);
+  }
+
+  /**
+   * Swaps the elements of this pair.
+   *
+   * @return A new pair with elements swapped
+   */
+  public Pair<B, A> swap() {
+    return new Pair<>(second, first);
+  }
+
+  /**
+   * Creates a pair from two values.
+   *
+   * @param first The first element
+   * @param second The second element
+   * @param <A> The type of the first element
+   * @param <B> The type of the second element
+   * @return A new pair
+   */
+  public static <A, B> Pair<A, B> of(A first, B second) {
+    return new Pair<>(first, second);
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/package-info.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/package-info.java
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+/**
+ * Indexed optics that track the index/position of each focused element.
+ *
+ * <p>This package provides indexed variants of the standard optics, enabling position-aware
+ * operations. Unlike regular optics that only provide access to values, indexed optics pass both
+ * the index and value to modification functions.
+ *
+ * <h2>Key Features</h2>
+ *
+ * <ul>
+ *   <li><b>Position-Aware:</b> Know where each element came from
+ *   <li><b>Debugging:</b> Track which elements are being modified
+ *   <li><b>Conditional Logic:</b> Apply different logic based on position
+ *   <li><b>Index Composition:</b> Compose indexed optics with paired indices using {@link
+ *       org.higherkindedj.optics.indexed.Pair}
+ * </ul>
+ *
+ * <h2>Core Types</h2>
+ *
+ * <dl>
+ *   <dt>{@link org.higherkindedj.optics.indexed.IndexedOptic}
+ *   <dd>Base interface for all indexed optics
+ *   <dt>{@link org.higherkindedj.optics.indexed.IndexedTraversal}
+ *   <dd>Zero or more elements with position tracking
+ *   <dt>{@link org.higherkindedj.optics.indexed.IndexedFold}
+ *   <dd>Read-only indexed aggregation
+ *   <dt>{@link org.higherkindedj.optics.indexed.IndexedLens}
+ *   <dd>Single indexed field access
+ * </dl>
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>{@code
+ * // Create an indexed traversal for lists
+ * IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+ *
+ * // Number each element
+ * List<String> numbered = IndexedTraversals.imodify(
+ *     ilist,
+ *     (index, value) -> value + " #" + index,
+ *     List.of("a", "b", "c")
+ * );
+ * // Result: ["a #0", "b #1", "c #2"]
+ *
+ * // Filter by index
+ * IndexedTraversal<Integer, List<String>, String> evens = ilist.filterIndex(i -> i % 2 == 0);
+ *
+ * // Compose with regular optics
+ * IndexedTraversal<Integer, List<User>, String> userNames =
+ *     IndexedTraversals.<User>forList().andThen(userNameLens.asTraversal());
+ *
+ * // Compose two indexed optics (paired indices)
+ * IndexedTraversal<Integer, List<Map<String, User>>, Map<String, User>> ilistMap =
+ *     IndexedTraversals.forList();
+ * IndexedTraversal<String, Map<String, User>, User> imap = IndexedTraversals.forMap();
+ * IndexedTraversal<Pair<Integer, String>, List<Map<String, User>>, User> composed =
+ *     ilistMap.iandThen(imap);
+ * // Index is Pair(listIndex, mapKey)
+ * }</pre>
+ *
+ * @see org.higherkindedj.optics.Optic
+ * @see org.higherkindedj.optics.Traversal
+ * @see org.higherkindedj.optics.Fold
+ * @see org.higherkindedj.optics.Lens
+ */
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.optics.indexed;

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -61,6 +61,7 @@
   - [Traversals](optics/traversals.md)
   - [Folds](optics/folds.md)
   - [Filtered Optics](optics/filtered_optics.md)
+  - [Indexed Optics](optics/indexed_optics.md)
   - [Limiting Traversals](optics/limiting_traversals.md)
   - [Getters](optics/getters.md)
   - [Setters](optics/setters.md)

--- a/hkj-book/src/optics/indexed_optics.md
+++ b/hkj-book/src/optics/indexed_optics.md
@@ -1,0 +1,1172 @@
+# Indexed Optics: Position-Aware Operations
+
+## _Tracking Indices During Transformations_
+
+![indexed-optics.jpg](../images/indexed-optics.jpg)
+
+~~~admonish info title="What You'll Learn"
+- How to access both index and value during optic operations
+- Using IndexedTraversal for position-aware bulk updates
+- Using IndexedFold for queries that need position information
+- Using IndexedLens for field name tracking and debugging
+- Creating indexed traversals for Lists and Maps with IndexedTraversals utility
+- Composing indexed optics with paired indices (Pair<I, J>)
+- Converting between indexed and non-indexed optics
+- When to use indexed optics vs standard optics
+- Real-world patterns for debugging, audit trails, and position-based logic
+~~~
+
+~~~admonish title="Example Code"
+[IndexedOpticsExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/IndexedOpticsExample.java)
+~~~
+
+In our journey through optics, we've mastered how to focus on parts of immutable data structures—whether it's a single field with **Lens**, an optional value with **Prism**, or multiple elements with **Traversal**. But sometimes, knowing *where* you are is just as important as knowing *what* you're looking at.
+
+Consider these scenarios:
+- **Numbering items** in a packing list: "Item 1: Laptop, Item 2: Mouse..."
+- **Tracking field names** for audit logs: "User modified field 'email' from..."
+- **Processing map entries** where both key and value matter: "For metadata key 'priority', set value to..."
+- **Debugging nested updates** by seeing the complete path: "Changed scores[2] from 100 to 150"
+
+Standard optics give you the *value*. **Indexed optics** give you both the *index* and the *value*.
+
+---
+
+## The Scenario: E-Commerce Order Processing
+
+Imagine building an order fulfilment system where position information drives business logic.
+
+**The Data Model:**
+
+```java
+@GenerateLenses
+public record LineItem(String productName, int quantity, double price) {}
+
+@GenerateLenses
+@GenerateTraversals
+public record Order(String orderId, List<LineItem> items, Map<String, String> metadata) {}
+
+@GenerateLenses
+public record Customer(String name, String email) {}
+```
+
+**Business Requirements:**
+
+1. **Generate packing slips** with numbered items: "Item 1: Laptop (£999.99)"
+2. **Process metadata** with key awareness: "Set shipping method based on 'priority' key"
+3. **Audit trail** showing which fields were modified: "Updated Customer.email at 2025-01-15 10:30"
+4. **Position-based pricing** for bulk orders: "Items at even positions get 10% discount"
+
+**The Traditional Approach:**
+
+```java
+// Verbose: Manual index tracking
+List<String> packingSlip = new ArrayList<>();
+for (int i = 0; i < order.items().size(); i++) {
+    LineItem item = order.items().get(i);
+    packingSlip.add("Item " + (i + 1) + ": " + item.productName());
+}
+
+// Or with streams, losing type-safety
+AtomicInteger counter = new AtomicInteger(1);
+order.items().stream()
+    .map(item -> "Item " + counter.getAndIncrement() + ": " + item.productName())
+    .collect(toList());
+
+// Map processing requires breaking into entries
+order.metadata().entrySet().stream()
+    .map(entry -> processWithKey(entry.getKey(), entry.getValue()))
+    .collect(toMap(Entry::getKey, Entry::getValue));
+```
+
+This approach forces manual index management, mixing the *what* (transformation logic) with the *how* (index tracking). **Indexed optics** provide a declarative, type-safe solution.
+
+---
+
+## Think of Indexed Optics Like...
+
+* **GPS coordinates**: Not just the destination, but the latitude and longitude
+* **Line numbers in an editor**: Every line knows its position in the file
+* **Map.Entry**: Provides both key and value instead of just the value
+* **Breadcrumbs in a file system**: Showing the complete path to each file
+* **A numbered list**: Each element has both content and a position
+* **Spreadsheet cells**: Both the cell reference (A1, B2) and the value
+
+The key insight: indexed optics make *position* a first-class citizen, accessible during every operation.
+
+---
+
+## Part I: The Basics
+
+### The Three Indexed Optics
+
+Higher-kinded-j provides three indexed optics that mirror their standard counterparts:
+
+| Standard Optic | Indexed Variant | Index Type | Use Case |
+|----------------|-----------------|------------|----------|
+| **Traversal\<S, A>** | **IndexedTraversal\<I, S, A>** | `I` (any type) | Position-aware bulk updates (List indices, Map keys) |
+| **Fold\<S, A>** | **IndexedFold\<I, S, A>** | `I` (any type) | Position-aware read-only queries |
+| **Lens\<S, A>** | **IndexedLens\<I, S, A>** | `I` (any type) | Field name tracking for single-field access |
+
+The additional type parameter `I` represents the **index type**:
+- For `List<A>`: `I` is `Integer` (position 0, 1, 2...)
+- For `Map<K, V>`: `I` is `K` (the key type)
+- For record fields: `I` is `String` (field name)
+- Custom: Any type that makes sense for your domain
+
+---
+
+## A Step-by-Step Walkthrough
+
+### Step 1: Creating Indexed Traversals
+
+The `IndexedTraversals` utility class provides factory methods for common cases.
+
+#### For Lists: Integer Indices
+
+```java
+import org.higherkindedj.optics.indexed.IndexedTraversal;
+import org.higherkindedj.optics.util.IndexedTraversals;
+
+// Create an indexed traversal for List elements
+IndexedTraversal<Integer, List<LineItem>, LineItem> itemsWithIndex =
+    IndexedTraversals.forList();
+
+List<LineItem> items = List.of(
+    new LineItem("Laptop", 1, 999.99),
+    new LineItem("Mouse", 2, 24.99),
+    new LineItem("Keyboard", 1, 79.99)
+);
+```
+
+The `forList()` factory creates a traversal where each element is paired with its zero-based index.
+
+#### For Maps: Key-Based Indices
+
+```java
+// Create an indexed traversal for Map values
+IndexedTraversal<String, Map<String, String>, String> metadataWithKeys =
+    IndexedTraversals.forMap();
+
+Map<String, String> metadata = Map.of(
+    "priority", "express",
+    "gift-wrap", "true",
+    "delivery-note", "Leave at door"
+);
+```
+
+The `forMap()` factory creates a traversal where each value is paired with its key.
+
+---
+
+### Step 2: Accessing Index-Value Pairs
+
+Indexed optics provide specialized methods that give you access to both the index and the value.
+
+#### Extracting All Index-Value Pairs
+
+```java
+import org.higherkindedj.optics.indexed.Pair;
+
+// Get list of (index, item) pairs
+List<Pair<Integer, LineItem>> indexedItems = itemsWithIndex.toIndexedList(items);
+
+for (Pair<Integer, LineItem> pair : indexedItems) {
+    int position = pair.first();
+    LineItem item = pair.second();
+    System.out.println("Position " + position + ": " + item.productName());
+}
+// Output:
+// Position 0: Laptop
+// Position 1: Mouse
+// Position 2: Keyboard
+```
+
+#### Using IndexedFold for Queries
+
+```java
+import org.higherkindedj.optics.indexed.IndexedFold;
+
+// Convert to read-only indexed fold
+IndexedFold<Integer, List<LineItem>, LineItem> itemsFold =
+    itemsWithIndex.asIndexedFold();
+
+// Find item at a specific position
+Pair<Integer, LineItem> found = itemsFold.findWithIndex(
+    (index, item) -> index == 1,
+    items
+).orElse(null);
+
+System.out.println("Item at index 1: " + found.second().productName());
+// Output: Item at index 1: Mouse
+
+// Check if any even-positioned item is expensive
+boolean hasExpensiveEven = itemsFold.existsWithIndex(
+    (index, item) -> index % 2 == 0 && item.price() > 500,
+    items
+);
+```
+
+---
+
+### Step 3: Position-Aware Modifications
+
+The real power emerges when you modify elements based on their position.
+
+#### Numbering Items in a Packing Slip
+
+```java
+// Modify product names to include position numbers
+List<LineItem> numbered = IndexedTraversals.imodify(
+    itemsWithIndex,
+    (index, item) -> new LineItem(
+        "Item " + (index + 1) + ": " + item.productName(),
+        item.quantity(),
+        item.price()
+    ),
+    items
+);
+
+for (LineItem item : numbered) {
+    System.out.println(item.productName());
+}
+// Output:
+// Item 1: Laptop
+// Item 2: Mouse
+// Item 3: Keyboard
+```
+
+#### Position-Based Discount Logic
+
+```java
+// Apply 10% discount to items at even positions (0, 2, 4...)
+List<LineItem> discounted = IndexedTraversals.imodify(
+    itemsWithIndex,
+    (index, item) -> {
+        if (index % 2 == 0) {
+            double discountedPrice = item.price() * 0.9;
+            return new LineItem(item.productName(), item.quantity(), discountedPrice);
+        }
+        return item;
+    },
+    items
+);
+
+// Position 0 (Laptop): £999.99 → £899.99
+// Position 1 (Mouse): £24.99 (unchanged)
+// Position 2 (Keyboard): £79.99 → £71.99
+```
+
+#### Map Processing with Key Awareness
+
+```java
+IndexedTraversal<String, Map<String, String>, String> metadataTraversal =
+    IndexedTraversals.forMap();
+
+Map<String, String> processed = IndexedTraversals.imodify(
+    metadataTraversal,
+    (key, value) -> {
+        // Add key prefix to all values for debugging
+        return "[" + key + "] " + value;
+    },
+    metadata
+);
+
+// Results:
+// "priority" → "[priority] express"
+// "gift-wrap" → "[gift-wrap] true"
+// "delivery-note" → "[delivery-note] Leave at door"
+```
+
+---
+
+### Step 4: Filtering with Index Awareness
+
+Indexed traversals support filtering, allowing you to focus on specific positions or keys.
+
+#### Filter by Index
+
+```java
+// Focus only on even-positioned items
+IndexedTraversal<Integer, List<LineItem>, LineItem> evenPositions =
+    itemsWithIndex.filterIndex(index -> index % 2 == 0);
+
+List<Pair<Integer, LineItem>> evenItems =
+    IndexedTraversals.toIndexedList(evenPositions, items);
+// Returns: [(0, Laptop), (2, Keyboard)]
+
+// Modify only even-positioned items
+List<LineItem> result = IndexedTraversals.imodify(
+    evenPositions,
+    (index, item) -> new LineItem(
+        item.productName() + " [SALE]",
+        item.quantity(),
+        item.price()
+    ),
+    items
+);
+// Laptop and Keyboard get "[SALE]" suffix, Mouse unchanged
+```
+
+#### Filter by Value with Index Available
+
+```java
+// Focus on expensive items, but still track their original positions
+IndexedTraversal<Integer, List<LineItem>, LineItem> expensiveItems =
+    itemsWithIndex.filteredWithIndex((index, item) -> item.price() > 50);
+
+List<Pair<Integer, LineItem>> expensive =
+    IndexedTraversals.toIndexedList(expensiveItems, items);
+// Returns: [(0, Laptop), (2, Keyboard)]
+// Notice: indices are preserved (0 and 2), not renumbered
+```
+
+#### Filter Map by Key Pattern
+
+```java
+// Focus on metadata keys starting with "delivery"
+IndexedTraversal<String, Map<String, String>, String> deliveryMetadata =
+    metadataTraversal.filterIndex(key -> key.startsWith("delivery"));
+
+List<Pair<String, String>> deliveryEntries =
+    deliveryMetadata.toIndexedList(metadata);
+// Returns: [("delivery-note", "Leave at door")]
+```
+
+---
+
+### Step 5: IndexedLens for Field Tracking
+
+An `IndexedLens` focuses on exactly one field whilst providing its name or identifier.
+
+```java
+import org.higherkindedj.optics.indexed.IndexedLens;
+
+// Create an indexed lens for the customer email field
+IndexedLens<String, Customer, String> emailLens = IndexedLens.of(
+    "email",                 // The index: field name
+    Customer::email,         // Getter
+    (customer, newEmail) -> new Customer(customer.name(), newEmail)  // Setter
+);
+
+Customer customer = new Customer("Alice", "alice@example.com");
+
+// Get both field name and value
+Pair<String, String> fieldInfo = emailLens.iget(customer);
+System.out.println("Field: " + fieldInfo.first());      // email
+System.out.println("Value: " + fieldInfo.second());     // alice@example.com
+
+// Modify with field name awareness
+Customer updated = emailLens.imodify(
+    (fieldName, oldValue) -> {
+        System.out.println("Updating field '" + fieldName + "' from " + oldValue);
+        return "alice.smith@example.com";
+    },
+    customer
+);
+// Output: Updating field 'email' from alice@example.com
+```
+
+**Use case**: Audit logging that records *which* field changed, not just the new value.
+
+---
+
+### Step 6: Converting Between Indexed and Non-Indexed
+
+Every indexed optic can be converted to its standard (non-indexed) counterpart.
+
+```java
+import org.higherkindedj.optics.Traversal;
+
+// Start with indexed traversal
+IndexedTraversal<Integer, List<LineItem>, LineItem> indexed =
+    IndexedTraversals.forList();
+
+// Drop the index to get a standard traversal
+Traversal<List<LineItem>, LineItem> standard = indexed.unindexed();
+
+// Now you can use standard traversal methods
+List<LineItem> uppercased = Traversals.modify(
+    standard.andThen(Lens.of(
+        LineItem::productName,
+        (item, name) -> new LineItem(name, item.quantity(), item.price())
+    ).asTraversal()),
+    String::toUpperCase,
+    items
+);
+```
+
+**When to convert**: When you need the index for *some* operations but not others, start indexed and convert as needed.
+
+---
+
+### When to Use Indexed Optics vs Standard Optics
+
+Understanding when indexed optics add value is crucial for writing clear, maintainable code.
+
+#### Use Indexed Optics When:
+
+* **Position-based logic** - Different behaviour for even/odd indices, first/last elements
+* **Numbering or labelling** - Adding sequence numbers, prefixes, or position markers
+* **Map operations** - Both key and value are needed during transformation
+* **Audit trails** - Recording which field or position was modified
+* **Debugging complex updates** - Tracking the path to each change
+* **Index-based filtering** - Operating on specific positions or key patterns
+
+```java
+// Perfect: Position drives the logic
+IndexedTraversal<Integer, List<Product>, Product> productsIndexed =
+    IndexedTraversals.forList();
+
+List<Product> prioritised = productsIndexed.imodify(
+    (index, product) -> {
+        // First 3 products get express shipping
+        String shipping = index < 3 ? "express" : "standard";
+        return product.withShipping(shipping);
+    },
+    products
+);
+```
+
+#### Use Standard Optics When:
+
+* **Position irrelevant** - Pure value transformations
+* **Simpler code** - Index tracking adds unnecessary complexity
+* **Performance critical** - Minimal overhead needed (though indexed optics are optimised)
+* **No positional logic** - All elements treated identically
+
+```java
+// Better with standard optics: Index not needed
+Traversal<List<Product>, Double> prices =
+    Traversals.<Product>forList()
+        .andThen(ProductLenses.price().asTraversal());
+
+List<Product> inflated = Traversals.modify(prices, price -> price * 1.1, products);
+// All prices increased by 10%, position doesn't matter
+```
+
+---
+
+### Common Patterns: Position-Based Operations
+
+#### Pattern 1: Adding Sequence Numbers
+
+```java
+// Generate a numbered list for display
+IndexedTraversal<Integer, List<String>, String> indexed = IndexedTraversals.forList();
+
+List<String> tasks = List.of("Review PR", "Update docs", "Run tests");
+
+List<String> numbered = IndexedTraversals.imodify(
+    indexed,
+    (i, task) -> (i + 1) + ". " + task,
+    tasks
+);
+// ["1. Review PR", "2. Update docs", "3. Run tests"]
+```
+
+#### Pattern 2: First/Last Element Special Handling
+
+```java
+IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+    IndexedTraversals.forList();
+
+List<LineItem> items = List.of(/* ... */);
+int lastIndex = items.size() - 1;
+
+List<LineItem> marked = IndexedTraversals.imodify(
+    itemsIndexed,
+    (index, item) -> {
+        String marker = "";
+        if (index == 0) marker = "[FIRST] ";
+        if (index == lastIndex) marker = "[LAST] ";
+        return new LineItem(
+            marker + item.productName(),
+            item.quantity(),
+            item.price()
+        );
+    },
+    items
+);
+```
+
+#### Pattern 3: Map Key-Value Transformations
+
+```java
+IndexedTraversal<String, Map<String, Integer>, Integer> mapIndexed =
+    IndexedTraversals.forMap();
+
+Map<String, Integer> scores = Map.of(
+    "alice", 100,
+    "bob", 85,
+    "charlie", 92
+);
+
+// Create display strings incorporating both key and value
+List<String> results = IndexedTraversals.toIndexedList(mapIndexed, scores).stream()
+    .map(pair -> pair.first() + " scored " + pair.second())
+    .toList();
+// ["alice scored 100", "bob scored 85", "charlie scored 92"]
+```
+
+#### Pattern 4: Position-Based Filtering
+
+```java
+IndexedTraversal<Integer, List<String>, String> indexed = IndexedTraversals.forList();
+
+List<String> values = List.of("a", "b", "c", "d", "e", "f");
+
+// Take only odd positions (1, 3, 5)
+IndexedTraversal<Integer, List<String>, String> oddPositions =
+    indexed.filterIndex(i -> i % 2 == 1);
+
+List<String> odd = IndexedTraversals.getAll(oddPositions, values);
+// ["b", "d", "f"]
+```
+
+---
+
+### Common Pitfalls
+
+#### ❌ Don't Do This:
+
+```java
+// Inefficient: Recreating indexed traversals in loops
+for (Order order : orders) {
+    var indexed = IndexedTraversals.<LineItem>forList();
+    IndexedTraversals.imodify(indexed, (i, item) -> numberItem(i, item), order.items());
+}
+
+// Over-engineering: Using indexed optics when index isn't needed
+IndexedTraversal<Integer, List<String>, String> indexed = IndexedTraversals.forList();
+List<String> upper = IndexedTraversals.imodify(indexed, (i, s) -> s.toUpperCase(), list);
+// Index parameter 'i' is never used! Use standard Traversals.modify()
+
+// Confusing: Manual index tracking alongside indexed optics
+AtomicInteger counter = new AtomicInteger(0);
+IndexedTraversals.imodify(indexed, (i, item) -> {
+    int myIndex = counter.getAndIncrement(); // Redundant!
+    return process(myIndex, item);
+}, items);
+
+// Wrong: Expecting indices to be renumbered after filtering
+IndexedTraversal<Integer, List<String>, String> evenOnly =
+    indexed.filterIndex(i -> i % 2 == 0);
+List<Pair<Integer, String>> pairs = IndexedTraversals.toIndexedList(evenOnly, list);
+// Indices are [0, 2, 4], NOT [0, 1, 2] - original positions preserved!
+```
+
+#### ✅ Do This Instead:
+
+```java
+// Efficient: Create indexed traversal once, reuse many times
+IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+    IndexedTraversals.forList();
+
+for (Order order : orders) {
+    IndexedTraversals.imodify(itemsIndexed, (i, item) -> numberItem(i, item), order.items());
+}
+
+// Simple: Use standard traversals when index isn't needed
+Traversal<List<String>, String> standard = Traversals.forList();
+List<String> upper = Traversals.modify(standard, String::toUpperCase, list);
+
+// Clear: Trust the indexed optic to provide correct indices
+IndexedTraversals.imodify(indexed, (providedIndex, item) -> {
+    // Use providedIndex directly, it's correct
+    return process(providedIndex, item);
+}, items);
+
+// Understand: Filtered indexed traversals preserve original indices
+IndexedTraversal<Integer, List<String>, String> evenOnly =
+    indexed.filterIndex(i -> i % 2 == 0);
+List<Pair<Integer, String>> pairs = IndexedTraversals.toIndexedList(evenOnly, list);
+// If you need renumbered indices, transform after extraction:
+List<Pair<Integer, String>> renumbered = IntStream.range(0, pairs.size())
+    .mapToObj(newIndex -> new Pair<>(newIndex, pairs.get(newIndex).second()))
+    .toList();
+```
+
+---
+
+### Performance Notes
+
+Indexed optics are designed to be efficient:
+
+* **No additional traversals** - Index computed during normal iteration
+* **Lazy index creation** - `Pair<I, A>` objects only created when needed
+* **Minimal overhead** - Index tracking adds negligible cost
+* **Reusable compositions** - Indexed optics can be composed and cached
+* **No boxing for primitives** - When using integer indices directly
+
+**Best Practice**: Create indexed optics once and store as constants:
+
+```java
+public class OrderOptics {
+    public static final IndexedTraversal<Integer, List<LineItem>, LineItem>
+        ITEMS_WITH_INDEX = IndexedTraversals.forList();
+
+    public static final IndexedTraversal<String, Map<String, String>, String>
+        METADATA_WITH_KEYS = IndexedTraversals.forMap();
+
+    // Compose with filtering
+    public static final IndexedTraversal<Integer, List<LineItem>, LineItem>
+        EVEN_POSITIONED_ITEMS = ITEMS_WITH_INDEX.filterIndex(i -> i % 2 == 0);
+}
+```
+
+---
+
+## Part II: Advanced Topics
+
+### Composing Indexed Optics with Paired Indices
+
+When you compose two indexed optics, the indices form a **pair** representing the path through nested structures.
+
+```java
+import org.higherkindedj.optics.indexed.Pair;
+
+// Nested structure: List of Orders, each with List of Items
+record Order(String id, List<LineItem> items) {}
+
+// First level: indexed traversal for orders
+IndexedTraversal<Integer, List<Order>, Order> ordersIndexed =
+    IndexedTraversals.forList();
+
+// Second level: lens to items field
+Lens<Order, List<LineItem>> itemsLens =
+    Lens.of(Order::items, (order, items) -> new Order(order.id(), items));
+
+// Third level: indexed traversal for items
+IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+    IndexedTraversals.forList();
+
+// Compose: orders → items field → each item with PAIRED indices
+IndexedTraversal<Pair<Integer, Integer>, List<Order>, LineItem> composed =
+    ordersIndexed
+        .iandThen(itemsLens)
+        .iandThen(itemsIndexed);
+
+List<Order> orders = List.of(
+    new Order("ORD-1", List.of(
+        new LineItem("Laptop", 1, 999.99),
+        new LineItem("Mouse", 1, 24.99)
+    )),
+    new Order("ORD-2", List.of(
+        new LineItem("Keyboard", 1, 79.99),
+        new LineItem("Monitor", 1, 299.99)
+    ))
+);
+
+// Access with paired indices: (order index, item index)
+List<Pair<Pair<Integer, Integer>, LineItem>> all = composed.toIndexedList(orders);
+
+for (Pair<Pair<Integer, Integer>, LineItem> entry : all) {
+    Pair<Integer, Integer> indices = entry.first();
+    LineItem item = entry.second();
+    System.out.printf("Order %d, Item %d: %s%n",
+        indices.first(), indices.second(), item.productName());
+}
+// Output:
+// Order 0, Item 0: Laptop
+// Order 0, Item 1: Mouse
+// Order 1, Item 0: Keyboard
+// Order 1, Item 1: Monitor
+```
+
+**Use case**: Generating globally unique identifiers like "Order 3, Item 5" or "Row 2, Column 7".
+
+---
+
+### Index Transformation and Mapping
+
+You can transform indices whilst preserving the optic composition.
+
+```java
+// Start with integer indices (0, 1, 2...)
+IndexedTraversal<Integer, List<LineItem>, LineItem> zeroIndexed =
+    IndexedTraversals.forList();
+
+// Transform to 1-based indices (1, 2, 3...)
+IndexedTraversal<Integer, List<LineItem>, LineItem> oneIndexed =
+    zeroIndexed.reindex(i -> i + 1);
+
+List<LineItem> items = List.of(/* ... */);
+
+List<String> numbered = oneIndexed.imodify(
+    (index, item) -> "Item " + index + ": " + item.productName(),
+    items
+).stream()
+    .map(LineItem::productName)
+    .toList();
+// ["Item 1: Laptop", "Item 2: Mouse", "Item 3: Keyboard"]
+```
+
+**Note**: The `reindex` method is conceptual. In practice, you'd transform indices in your `imodify` function:
+
+```java
+zeroIndexed.imodify((zeroBasedIndex, item) -> {
+    int oneBasedIndex = zeroBasedIndex + 1;
+    return new LineItem("Item " + oneBasedIndex + ": " + item.productName(),
+                        item.quantity(), item.price());
+}, items);
+```
+
+---
+
+### Combining Index Filtering with Value Filtering
+
+You can layer multiple filters for precise control.
+
+```java
+IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+    IndexedTraversals.forList();
+
+// Filter: even positions AND expensive items
+IndexedTraversal<Integer, List<LineItem>, LineItem> targeted =
+    itemsIndexed
+        .filterIndex(i -> i % 2 == 0)              // Even positions only
+        .filtered(item -> item.price() > 50);       // Expensive items only
+
+List<LineItem> items = List.of(
+    new LineItem("Laptop", 1, 999.99),    // Index 0, expensive ✓
+    new LineItem("Pen", 1, 2.99),         // Index 1, cheap ✗
+    new LineItem("Keyboard", 1, 79.99),   // Index 2, expensive ✓
+    new LineItem("Mouse", 1, 24.99),      // Index 3, cheap ✗
+    new LineItem("Monitor", 1, 299.99)    // Index 4, expensive ✓
+);
+
+List<Pair<Integer, LineItem>> results = targeted.toIndexedList(items);
+// Returns: [(0, Laptop), (2, Keyboard), (4, Monitor)]
+// All at even positions AND expensive
+```
+
+---
+
+### Audit Trail Pattern: Field Change Tracking
+
+A powerful real-world pattern is tracking *which* fields change in your domain objects.
+
+```java
+// Generic field audit logger
+public class AuditLog {
+    public record FieldChange<A>(
+        String fieldName,
+        A oldValue,
+        A newValue,
+        Instant timestamp
+    ) {}
+
+    public static <A> Function<Pair<String, A>, A> loggedModification(
+        Function<A, A> transformation,
+        List<FieldChange<?>> auditLog
+    ) {
+        return pair -> {
+            String fieldName = pair.first();
+            A oldValue = pair.second();
+            A newValue = transformation.apply(oldValue);
+
+            if (!oldValue.equals(newValue)) {
+                auditLog.add(new FieldChange<>(
+                    fieldName,
+                    oldValue,
+                    newValue,
+                    Instant.now()
+                ));
+            }
+
+            return newValue;
+        };
+    }
+}
+
+// Usage with indexed lens
+IndexedLens<String, Customer, String> emailLens = IndexedLens.of(
+    "email",
+    Customer::email,
+    (c, email) -> new Customer(c.name(), email)
+);
+
+List<AuditLog.FieldChange<?>> audit = new ArrayList<>();
+
+Customer customer = new Customer("Alice", "alice@old.com");
+
+Customer updated = emailLens.imodify(
+    AuditLog.loggedModification(
+        email -> "alice@new.com",
+        audit
+    ),
+    customer
+);
+
+// Check audit log
+for (AuditLog.FieldChange<?> change : audit) {
+    System.out.printf("Field '%s' changed from %s to %s at %s%n",
+        change.fieldName(),
+        change.oldValue(),
+        change.newValue(),
+        change.timestamp()
+    );
+}
+// Output: Field 'email' changed from alice@old.com to alice@new.com at 2025-01-15T10:30:00Z
+```
+
+---
+
+### Debugging Pattern: Path Tracking in Nested Updates
+
+When debugging complex nested updates, indexed optics reveal the complete path to each modification.
+
+```java
+// Nested structure with multiple levels
+record Item(String name, double price) {}
+record Order(List<Item> items) {}
+record Customer(String name, List<Order> orders) {}
+
+// Build an indexed path through the structure
+IndexedTraversal<Integer, List<Customer>, Customer> customersIdx =
+    IndexedTraversals.forList();
+
+Lens<Customer, List<Order>> ordersLens =
+    Lens.of(Customer::orders, (c, o) -> new Customer(c.name(), o));
+
+IndexedTraversal<Integer, List<Order>, Order> ordersIdx =
+    IndexedTraversals.forList();
+
+Lens<Order, List<Item>> itemsLens =
+    Lens.of(Order::items, (order, items) -> new Order(items));
+
+IndexedTraversal<Integer, List<Item>, Item> itemsIdx =
+    IndexedTraversals.forList();
+
+Lens<Item, Double> priceLens =
+    Lens.of(Item::price, (item, price) -> new Item(item.name(), price));
+
+// Compose the full indexed path
+IndexedTraversal<Pair<Pair<Integer, Integer>, Integer>, List<Customer>, Double> fullPath =
+    customersIdx
+        .iandThen(ordersLens)
+        .iandThen(ordersIdx)
+        .iandThen(itemsLens)
+        .iandThen(itemsIdx)
+        .iandThen(priceLens);
+
+List<Customer> customers = List.of(/* ... */);
+
+// Modify with full path visibility
+List<Customer> updated = fullPath.imodify(
+    (indices, price) -> {
+        int customerIdx = indices.first().first();
+        int orderIdx = indices.first().second();
+        int itemIdx = indices.second();
+
+        System.out.printf(
+            "Updating price at [customer=%d, order=%d, item=%d]: %.2f → %.2f%n",
+            customerIdx, orderIdx, itemIdx, price, price * 1.1
+        );
+
+        return price * 1.1;  // 10% increase
+    },
+    customers
+);
+// Output shows complete path to every modified price:
+// Updating price at [customer=0, order=0, item=0]: 999.99 → 1099.99
+// Updating price at [customer=0, order=0, item=1]: 24.99 → 27.49
+// Updating price at [customer=0, order=1, item=0]: 79.99 → 87.99
+// ...
+```
+
+---
+
+### Working with Pair Utilities
+
+The `Pair<A, B>` type provides utility methods for manipulation.
+
+```java
+import org.higherkindedj.optics.indexed.Pair;
+
+Pair<Integer, String> pair = new Pair<>(1, "Hello");
+
+// Access components
+int first = pair.first();       // 1
+String second = pair.second();  // "Hello"
+
+// Transform components
+Pair<Integer, String> modified = pair.withSecond("World");
+// Result: Pair(1, "World")
+
+Pair<String, String> transformed = pair.withFirst("One");
+// Result: Pair("One", "Hello")
+
+// Swap
+Pair<String, Integer> swapped = pair.swap();
+// Result: Pair("Hello", 1)
+
+// Factory method
+Pair<String, Integer> created = Pair.of("Key", 42);
+```
+
+For converting to/from `Tuple2` (when working with hkj-core utilities):
+
+```java
+import org.higherkindedj.hkt.Tuple2;
+import org.higherkindedj.optics.util.IndexedTraversals;
+
+Pair<String, Integer> pair = Pair.of("key", 100);
+
+// Convert to Tuple2
+Tuple2<String, Integer> tuple = IndexedTraversals.pairToTuple2(pair);
+
+// Convert back to Pair
+Pair<String, Integer> converted = IndexedTraversals.tuple2ToPair(tuple);
+```
+
+---
+
+### Real-World Example: Order Fulfilment Dashboard
+
+Here's a comprehensive example demonstrating indexed optics in a business context.
+
+```java
+package org.higherkindedj.example.optics;
+
+import java.time.Instant;
+import java.util.*;
+import org.higherkindedj.optics.indexed.*;
+import org.higherkindedj.optics.util.IndexedTraversals;
+
+public class OrderFulfilmentDashboard {
+
+    public record LineItem(String productName, int quantity, double price) {}
+
+    public record Order(
+        String orderId,
+        List<LineItem> items,
+        Map<String, String> metadata
+    ) {}
+
+    public static void main(String[] args) {
+        Order order = new Order(
+            "ORD-12345",
+            List.of(
+                new LineItem("Laptop", 1, 999.99),
+                new LineItem("Mouse", 2, 24.99),
+                new LineItem("Keyboard", 1, 79.99),
+                new LineItem("Monitor", 1, 299.99)
+            ),
+            new LinkedHashMap<>(Map.of(
+                "priority", "express",
+                "gift-wrap", "true",
+                "delivery-note", "Leave at door"
+            ))
+        );
+
+        System.out.println("=== ORDER FULFILMENT DASHBOARD ===\n");
+
+        // --- Task 1: Generate Packing Slip ---
+        System.out.println("--- Packing Slip ---");
+        generatePackingSlip(order);
+
+        // --- Task 2: Apply Position-Based Discounts ---
+        System.out.println("\n--- Position-Based Discounts ---");
+        Order discounted = applyPositionDiscounts(order);
+        System.out.println("Original total: £" + calculateTotal(order));
+        System.out.println("Discounted total: £" + calculateTotal(discounted));
+
+        // --- Task 3: Process Metadata with Key Awareness ---
+        System.out.println("\n--- Metadata Processing ---");
+        processMetadata(order);
+
+        // --- Task 4: Identify High-Value Positions ---
+        System.out.println("\n--- High-Value Items ---");
+        identifyHighValuePositions(order);
+
+        System.out.println("\n=== END OF DASHBOARD ===");
+    }
+
+    private static void generatePackingSlip(Order order) {
+        IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+            IndexedTraversals.forList();
+
+        List<Pair<Integer, LineItem>> indexedItems =
+            itemsIndexed.toIndexedList(order.items());
+
+        System.out.println("Order: " + order.orderId());
+        for (Pair<Integer, LineItem> pair : indexedItems) {
+            int position = pair.first() + 1;  // 1-based for display
+            LineItem item = pair.second();
+            System.out.printf("  Item %d: %s (Qty: %d) - £%.2f%n",
+                position,
+                item.productName(),
+                item.quantity(),
+                item.price() * item.quantity()
+            );
+        }
+    }
+
+    private static Order applyPositionDiscounts(Order order) {
+        IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+            IndexedTraversals.forList();
+
+        // Every 3rd item gets 15% off (positions 2, 5, 8...)
+        List<LineItem> discounted = itemsIndexed.imodify(
+            (index, item) -> {
+                if ((index + 1) % 3 == 0) {
+                    double newPrice = item.price() * 0.85;
+                    System.out.printf("  Position %d (%s): £%.2f → £%.2f (15%% off)%n",
+                        index + 1, item.productName(), item.price(), newPrice);
+                    return new LineItem(item.productName(), item.quantity(), newPrice);
+                }
+                return item;
+            },
+            order.items()
+        );
+
+        return new Order(order.orderId(), discounted, order.metadata());
+    }
+
+    private static void processMetadata(Order order) {
+        IndexedTraversal<String, Map<String, String>, String> metadataIndexed =
+            IndexedTraversals.forMap();
+
+        IndexedFold<String, Map<String, String>, String> fold =
+            metadataIndexed.asIndexedFold();
+
+        List<Pair<String, String>> entries = fold.toIndexedList(order.metadata());
+
+        for (Pair<String, String> entry : entries) {
+            String key = entry.first();
+            String value = entry.second();
+
+            // Process based on key
+            switch (key) {
+                case "priority" ->
+                    System.out.println("  Shipping priority: " + value.toUpperCase());
+                case "gift-wrap" ->
+                    System.out.println("  Gift wrapping: " +
+                        (value.equals("true") ? "Required" : "Not required"));
+                case "delivery-note" ->
+                    System.out.println("  Special instructions: " + value);
+                default ->
+                    System.out.println("  " + key + ": " + value);
+            }
+        }
+    }
+
+    private static void identifyHighValuePositions(Order order) {
+        IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed =
+            IndexedTraversals.forList();
+
+        // Filter to items over £100
+        IndexedTraversal<Integer, List<LineItem>, LineItem> highValue =
+            itemsIndexed.filteredWithIndex((index, item) -> item.price() > 100);
+
+        List<Pair<Integer, LineItem>> expensive = highValue.toIndexedList(order.items());
+
+        System.out.println("  Items over £100 (require special handling):");
+        for (Pair<Integer, LineItem> pair : expensive) {
+            System.out.printf("    Position %d: %s (£%.2f)%n",
+                pair.first() + 1,
+                pair.second().productName(),
+                pair.second().price()
+            );
+        }
+    }
+
+    private static double calculateTotal(Order order) {
+        return order.items().stream()
+            .mapToDouble(item -> item.price() * item.quantity())
+            .sum();
+    }
+}
+```
+
+**Expected Output:**
+
+```
+=== ORDER FULFILMENT DASHBOARD ===
+
+--- Packing Slip ---
+Order: ORD-12345
+  Item 1: Laptop (Qty: 1) - £999.99
+  Item 2: Mouse (Qty: 2) - £49.98
+  Item 3: Keyboard (Qty: 1) - £79.99
+  Item 4: Monitor (Qty: 1) - £299.99
+
+--- Position-Based Discounts ---
+  Position 3 (Keyboard): £79.99 → £67.99 (15% off)
+Original total: £1429.95
+Discounted total: £1417.95
+
+--- Metadata Processing ---
+  Shipping priority: EXPRESS
+  Gift wrapping: Required
+  Special instructions: Leave at door
+
+--- High-Value Items ---
+  Items over £100 (require special handling):
+    Position 1: Laptop (£999.99)
+    Position 4: Monitor (£299.99)
+
+=== END OF DASHBOARD ===
+```
+
+---
+
+## The Relationship to Haskell's Lens Library
+
+For those familiar with functional programming, higher-kinded-j's indexed optics are inspired by Haskell's [lens library](https://hackage.haskell.org/package/lens), specifically indexed traversals and indexed folds.
+
+In Haskell:
+```haskell
+itraversed :: IndexedTraversal Int ([] a) a
+```
+
+This creates an indexed traversal over lists where the index is an integer—exactly what our `IndexedTraversals.forList()` provides.
+
+**Key differences:**
+- Higher-kinded-j uses explicit `Applicative` instances rather than implicit type class resolution
+- Java's type system requires explicit `Pair<I, A>` for index-value pairs
+- The `imodify` and `iget` methods provide a more Java-friendly API
+- Map-based traversals (`forMap`) are a practical extension for Java's collection library
+
+**Further Reading:**
+- [Haskell Lens Tutorial: Indexed Optics](https://hackage.haskell.org/package/lens-tutorial-1.0.4/docs/Control-Lens-Tutorial.html) - Original inspiration
+- [Optics By Example](https://leanpub.com/optics-by-example) by Chris Penner - Chapter on indexed optics
+- [Monocle (Scala)](https://www.optics.dev/Monocle/) - Similar indexed optics for Scala
+
+---
+
+## Summary: The Power of Indexed Optics
+
+Indexed optics bring **position awareness** into your functional data transformations:
+
+* **IndexedTraversal\<I, S, A>**: Bulk operations with index tracking
+* **IndexedFold\<I, S, A>**: Read-only queries with position information
+* **IndexedLens\<I, S, A>**: Single-field access with field name tracking
+
+These tools transform how you work with collections and records:
+
+| Before (Manual Index Tracking) | After (Declarative Indexed Optics) |
+|-------------------------------|-----------------------------------|
+| Manual loop counters | Built-in index access |
+| AtomicInteger for streams | Type-safe `imodify` |
+| Breaking into Map.entrySet() | Direct key-value processing |
+| Complex audit logging logic | Field tracking with `IndexedLens` |
+| Scattered position logic | Composable indexed transformations |
+
+By incorporating indexed optics into your toolkit, you gain:
+
+* **Expressiveness**: Say "numbered list items" declaratively
+* **Type safety**: Compile-time checked index types
+* **Composability**: Chain indexed optics, filter by position, compose with standard optics
+* **Debugging power**: Track complete paths through nested structures
+* **Audit trails**: Record which fields changed, not just values
+* **Performance**: Minimal overhead, lazy index computation
+
+Indexed optics represent the fusion of position awareness with functional composition—enabling you to write code that is simultaneously more declarative, more powerful, and more maintainable than traditional index-tracking approaches.
+
+---
+
+**Previous:** [Limiting Traversals: Focusing on List Portions](limiting_traversals.md)
+**Next:** [Getters: Read-Only Optics](getters.md)

--- a/hkj-core/src/main/java/org/higherkindedj/optics/util/IndexedTraversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/util/IndexedTraversals.java
@@ -1,0 +1,398 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
+import org.higherkindedj.hkt.id.IdMonad;
+import org.higherkindedj.hkt.tuple.Tuple2;
+import org.higherkindedj.optics.indexed.IndexedFold;
+import org.higherkindedj.optics.indexed.IndexedTraversal;
+import org.higherkindedj.optics.indexed.Pair;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A final utility class providing static helper methods and factory functions for working with
+ * indexed optics.
+ *
+ * <p>This class provides:
+ *
+ * <ul>
+ *   <li>Factory methods for creating indexed traversals for common data structures
+ *   <li>Convenience methods for modifying and extracting data with index awareness
+ *   <li>Composition helpers for building complex indexed optics
+ * </ul>
+ */
+@NullMarked
+public final class IndexedTraversals {
+
+  /** Private constructor to prevent instantiation. */
+  private IndexedTraversals() {}
+
+  /**
+   * Creates an {@link IndexedTraversal} that focuses on every element within a {@link List}, with
+   * the element's index as the key.
+   *
+   * <p>This is the canonical indexed traversal for lists, providing zero-based integer indices.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+   *
+   * // Number each element
+   * List<String> numbered = imodify(ilist, (i, s) -> s + " #" + i, List.of("a", "b", "c"));
+   * // ["a #0", "b #1", "c #2"]
+   *
+   * // Process only even positions
+   * IndexedTraversal<Integer, List<String>, String> evens = ilist.filterIndex(i -> i % 2 == 0);
+   * List<String> modified = imodify(evens, (i, s) -> s.toUpperCase(), List.of("a", "b", "c", "d"));
+   * // ["A", "b", "C", "d"]
+   * }</pre>
+   *
+   * @param <A> The element type of the list
+   * @return An {@link IndexedTraversal} for list elements with their indices
+   */
+  public static <A> IndexedTraversal<Integer, List<A>, A> forList() {
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, List<A>> imodifyF(
+          BiFunction<Integer, A, Kind<F, A>> f, List<A> source, Applicative<F> app) {
+        if (source.isEmpty()) {
+          return app.of(source);
+        }
+
+        // Apply f to each element with its index, collecting the results
+        List<Kind<F, A>> modifiedEffects = new ArrayList<>(source.size());
+        for (int i = 0; i < source.size(); i++) {
+          modifiedEffects.add(f.apply(i, source.get(i)));
+        }
+
+        // Sequence the effects into a single effect containing the list
+        return sequenceList(modifiedEffects, app);
+      }
+    };
+  }
+
+  /**
+   * Creates an {@link IndexedTraversal} that focuses on every value within a {@link Map}, with the
+   * entry's key as the index.
+   *
+   * <p>This traversal provides access to all map values along with their keys.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedTraversal<String, Map<String, Integer>, Integer> imap = IndexedTraversals.forMap();
+   *
+   * Map<String, Integer> scores = Map.of("alice", 85, "bob", 92, "carol", 78);
+   *
+   * // Add prefix based on key
+   * Map<String, String> labeled = imodify(
+   *     IndexedTraversals.<String, Integer>forMap().andThen(intToStringTraversal),
+   *     (key, score) -> key + ": " + score,
+   *     scores
+   * );
+   *
+   * // Get all key-value pairs
+   * List<Pair<String, Integer>> indexed = toIndexedList(imap, scores);
+   * // [Pair("alice", 85), Pair("bob", 92), Pair("carol", 78)]
+   * }</pre>
+   *
+   * @param <K> The key type of the map
+   * @param <V> The value type of the map
+   * @return An {@link IndexedTraversal} for map values with their keys as indices
+   */
+  public static <K, V> IndexedTraversal<K, Map<K, V>, V> forMap() {
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, Map<K, V>> imodifyF(
+          BiFunction<K, V, Kind<F, V>> f, Map<K, V> source, Applicative<F> app) {
+        if (source.isEmpty()) {
+          return app.of(source);
+        }
+
+        // Collect keys and effects separately
+        List<K> keys = new ArrayList<>(source.size());
+        List<Kind<F, V>> effects = new ArrayList<>(source.size());
+        for (Map.Entry<K, V> entry : source.entrySet()) {
+          keys.add(entry.getKey());
+          effects.add(f.apply(entry.getKey(), entry.getValue()));
+        }
+
+        // Sequence all effects into a single Kind<F, List<V>>
+        Kind<F, List<V>> sequencedValues = sequenceList(effects, app);
+
+        // Build the final map in one step
+        return app.map(
+            newValues -> {
+              Map<K, V> newMap = new HashMap<>(keys.size());
+              for (int i = 0; i < keys.size(); i++) {
+                newMap.put(keys.get(i), newValues.get(i));
+              }
+              return newMap;
+            },
+            sequencedValues);
+      }
+    };
+  }
+
+  /**
+   * Creates an {@link IndexedFold} that focuses on every element within a {@link List}, with the
+   * element's index as the key.
+   *
+   * <p>This is the read-only version of {@link #forList()}.
+   *
+   * @param <A> The element type of the list
+   * @return An {@link IndexedFold} for list elements with their indices
+   */
+  public static <A> IndexedFold<Integer, List<A>, A> foldList() {
+    return IndexedTraversals.<A>forList().asIndexedFold();
+  }
+
+  /**
+   * Creates an {@link IndexedFold} that focuses on every value within a {@link Map}, with the
+   * entry's key as the index.
+   *
+   * <p>This is the read-only version of {@link #forMap()}.
+   *
+   * @param <K> The key type of the map
+   * @param <V> The value type of the map
+   * @return An {@link IndexedFold} for map values with their keys as indices
+   */
+  public static <K, V> IndexedFold<K, Map<K, V>, V> foldMap() {
+    return IndexedTraversals.<K, V>forMap().asIndexedFold();
+  }
+
+  /**
+   * Modifies all targets of an {@link IndexedTraversal} using a pure function that receives both
+   * index and value.
+   *
+   * <p>This is a convenience method that wraps the function in the {@link Id} monad and immediately
+   * unwraps the result.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+   * List<String> result = IndexedTraversals.imodify(
+   *     ilist,
+   *     (index, value) -> value + " at " + index,
+   *     List.of("a", "b", "c")
+   * );
+   * // ["a at 0", "b at 1", "c at 2"]
+   * }</pre>
+   *
+   * @param traversal The indexed traversal to use
+   * @param f A function that takes index and value, returning the new value
+   * @param source The source structure
+   * @param <I> The index type
+   * @param <S> The structure type
+   * @param <A> The element type
+   * @return A new, updated source structure
+   */
+  public static <I, S, A> @Nullable S imodify(
+      final IndexedTraversal<I, S, A> traversal, final BiFunction<I, A, A> f, final S source) {
+    BiFunction<I, A, Kind<IdKind.Witness, A>> fId = (i, a) -> Id.of(f.apply(i, a));
+    Kind<IdKind.Witness, S> resultInId = traversal.imodifyF(fId, source, IdMonad.instance());
+    return IdKindHelper.ID.narrow(resultInId).value();
+  }
+
+  /**
+   * Extracts all targets of an {@link IndexedTraversal} along with their indices.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+   * List<Pair<Integer, String>> indexed = IndexedTraversals.toIndexedList(
+   *     ilist,
+   *     List.of("a", "b", "c")
+   * );
+   * // [Pair(0, "a"), Pair(1, "b"), Pair(2, "c")]
+   * }</pre>
+   *
+   * @param traversal The indexed traversal to use
+   * @param source The source structure
+   * @param <I> The index type
+   * @param <S> The structure type
+   * @param <A> The element type
+   * @return A list of index-value pairs
+   */
+  public static <I, S, A> List<Pair<I, A>> toIndexedList(
+      final IndexedTraversal<I, S, A> traversal, final S source) {
+    final List<Pair<I, A>> results = new ArrayList<>();
+    traversal.imodifyF(
+        (i, a) -> {
+          results.add(new Pair<>(i, a));
+          return Id.of(a);
+        },
+        source,
+        IdMonad.instance());
+    return results;
+  }
+
+  /**
+   * Extracts all targets of an {@link IndexedTraversal}, discarding index information.
+   *
+   * @param traversal The indexed traversal to use
+   * @param source The source structure
+   * @param <I> The index type
+   * @param <S> The structure type
+   * @param <A> The element type
+   * @return A list of all focused values
+   */
+  public static <I, S, A> List<A> getAll(
+      final IndexedTraversal<I, S, A> traversal, final S source) {
+    final List<A> results = new ArrayList<>();
+    traversal.imodifyF(
+        (i, a) -> {
+          results.add(a);
+          return Id.of(a);
+        },
+        source,
+        IdMonad.instance());
+    return results;
+  }
+
+  /**
+   * Counts the number of focused elements in the structure.
+   *
+   * @param traversal The indexed traversal to use
+   * @param source The source structure
+   * @param <I> The index type
+   * @param <S> The structure type
+   * @param <A> The element type
+   * @return The count of focused elements
+   */
+  public static <I, S, A> int length(final IndexedTraversal<I, S, A> traversal, final S source) {
+    return toIndexedList(traversal, source).size();
+  }
+
+  /**
+   * Sequences a list of effects into a single effect containing a list.
+   *
+   * <p>This is a helper method for implementing indexed traversals over collections.
+   *
+   * @param effects List of effects to sequence
+   * @param app The Applicative instance
+   * @param <F> The effect type
+   * @param <A> The element type
+   * @return A single effect containing the list of results
+   */
+  public static <F, A> Kind<F, List<A>> sequenceList(
+      final List<Kind<F, A>> effects, final Applicative<F> app) {
+    Kind<F, List<A>> result = app.of(new ArrayList<>());
+
+    for (Kind<F, A> effect : effects) {
+      result =
+          app.map2(
+              result,
+              effect,
+              (list, a) -> {
+                List<A> newList = new ArrayList<>(list);
+                newList.add(a);
+                return newList;
+              });
+    }
+
+    return result;
+  }
+
+  /**
+   * Creates an affine {@link IndexedTraversal} that focuses on a single value only if it matches
+   * the given index predicate.
+   *
+   * <p>This is useful for creating conditional indexed access patterns.
+   *
+   * @param indexPredicate Predicate on the index to determine if focusing should occur
+   * @param <I> The index type
+   * @param <A> The element type
+   * @return An indexed traversal that focuses based on index condition
+   */
+  public static <I, A> IndexedTraversal<I, Pair<I, A>, A> filteredByIndex(
+      final java.util.function.Predicate<? super I> indexPredicate) {
+    return new IndexedTraversal<>() {
+      @Override
+      public <F> Kind<F, Pair<I, A>> imodifyF(
+          BiFunction<I, A, Kind<F, A>> f, Pair<I, A> source, Applicative<F> app) {
+        if (indexPredicate.test(source.first())) {
+          return app.map(
+              newA -> new Pair<>(source.first(), newA), f.apply(source.first(), source.second()));
+        } else {
+          return app.of(source);
+        }
+      }
+    };
+  }
+
+  /**
+   * Converts a {@link Pair} to a {@link Tuple2}.
+   *
+   * <p>This is useful when you need to use the richer Tuple2 API from hkj-core after working with
+   * indexed optics.
+   *
+   * @param pair The pair to convert
+   * @param <A> The type of the first element
+   * @param <B> The type of the second element
+   * @return A Tuple2 with the same elements
+   */
+  public static <A, B> Tuple2<A, B> pairToTuple2(Pair<A, B> pair) {
+    return new Tuple2<>(pair.first(), pair.second());
+  }
+
+  /**
+   * Converts a {@link Tuple2} to a {@link Pair}.
+   *
+   * <p>This is useful when you need to work with indexed optics APIs that use Pair.
+   *
+   * @param tuple The tuple to convert
+   * @param <A> The type of the first element
+   * @param <B> The type of the second element
+   * @return A Pair with the same elements
+   */
+  public static <A, B> Pair<A, B> tuple2ToPair(Tuple2<A, B> tuple) {
+    return new Pair<>(tuple._1(), tuple._2());
+  }
+
+  /**
+   * Converts a list of {@link Pair}s to a list of {@link Tuple2}s.
+   *
+   * @param pairs The list of pairs to convert
+   * @param <A> The type of the first element
+   * @param <B> The type of the second element
+   * @return A list of Tuple2s
+   */
+  public static <A, B> List<Tuple2<A, B>> pairsToTuple2s(List<Pair<A, B>> pairs) {
+    List<Tuple2<A, B>> result = new ArrayList<>(pairs.size());
+    for (Pair<A, B> pair : pairs) {
+      result.add(pairToTuple2(pair));
+    }
+    return result;
+  }
+
+  /**
+   * Converts a list of {@link Tuple2}s to a list of {@link Pair}s.
+   *
+   * @param tuples The list of tuples to convert
+   * @param <A> The type of the first element
+   * @param <B> The type of the second element
+   * @return A list of Pairs
+   */
+  public static <A, B> List<Pair<A, B>> tuple2sToPairs(List<Tuple2<A, B>> tuples) {
+    List<Pair<A, B>> result = new ArrayList<>(tuples.size());
+    for (Tuple2<A, B> tuple : tuples) {
+      result.add(tuple2ToPair(tuple));
+    }
+    return result;
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/indexed/IndexedFoldTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/indexed/IndexedFoldTest.java
@@ -1,0 +1,388 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.util.IndexedTraversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IndexedFold<I, S, A> Tests")
+class IndexedFoldTest {
+
+  // Test Data Structures
+  record Item(String name, int price, int quantity) {}
+
+  record Order(List<Item> items) {}
+
+  // Helper to create IndexedFold for List
+  private <A> IndexedFold<Integer, List<A>, A> listFold() {
+    return IndexedTraversals.<A>forList().asIndexedFold();
+  }
+
+  @Nested
+  @DisplayName("ifoldMap() - Core indexed folding operation")
+  class IFoldMapTests {
+
+    @Test
+    @DisplayName("should fold with access to indices")
+    void foldWithIndices() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(10, 20, 30);
+
+      // Sum each value weighted by its position
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      int result = ifold.ifoldMap(sumMonoid, (i, v) -> v * (i + 1), source);
+
+      // 10*1 + 20*2 + 30*3 = 10 + 40 + 90 = 140
+      assertThat(result).isEqualTo(140);
+    }
+
+    @Test
+    @DisplayName("should handle empty collections")
+    void emptyCollection() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of();
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      int result = ifold.ifoldMap(sumMonoid, (i, v) -> v * i, source);
+
+      assertThat(result).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  @DisplayName("toIndexedList() - Extract elements with indices")
+  class ToIndexedListTests {
+
+    @Test
+    @DisplayName("should extract all elements with their indices")
+    void extractWithIndices() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      List<String> source = List.of("a", "b", "c");
+
+      List<Pair<Integer, String>> indexed = ifold.toIndexedList(source);
+
+      assertThat(indexed)
+          .containsExactly(new Pair<>(0, "a"), new Pair<>(1, "b"), new Pair<>(2, "c"));
+    }
+
+    @Test
+    @DisplayName("should return empty list for empty source")
+    void emptySource() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      List<String> source = List.of();
+
+      List<Pair<Integer, String>> indexed = ifold.toIndexedList(source);
+
+      assertThat(indexed).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("getAll() - Extract values ignoring indices")
+  class GetAllTests {
+
+    @Test
+    @DisplayName("should extract all values")
+    void extractAllValues() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      List<String> source = List.of("x", "y", "z");
+
+      List<String> values = ifold.getAll(source);
+
+      assertThat(values).containsExactly("x", "y", "z");
+    }
+  }
+
+  @Nested
+  @DisplayName("findWithIndex() - Find elements by index-value predicate")
+  class FindWithIndexTests {
+
+    @Test
+    @DisplayName("should find first matching element with index")
+    void findFirstMatch() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(5, 15, 25, 35);
+
+      // Find first element where index is even AND value > 10
+      Optional<Pair<Integer, Integer>> found =
+          ifold.findWithIndex((i, v) -> i % 2 == 0 && v > 10, source);
+
+      assertThat(found).isPresent();
+      assertThat(found.get()).isEqualTo(new Pair<>(2, 25));
+    }
+
+    @Test
+    @DisplayName("should return empty when no match")
+    void noMatch() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(5, 15, 25);
+
+      Optional<Pair<Integer, Integer>> found = ifold.findWithIndex((i, v) -> v > 100, source);
+
+      assertThat(found).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("find() - Find elements by value predicate")
+  class FindTests {
+
+    @Test
+    @DisplayName("should find first matching element with its index")
+    void findByValue() {
+      IndexedFold<Integer, List<Item>, Item> ifold = listFold();
+      List<Item> source =
+          List.of(
+              new Item("Apple", 100, 5), new Item("Banana", 50, 10), new Item("Cherry", 150, 3));
+
+      Optional<Pair<Integer, Item>> found = ifold.find(item -> item.price() > 100, source);
+
+      assertThat(found).isPresent();
+      assertThat(found.get().first()).isEqualTo(2); // Index of Cherry
+      assertThat(found.get().second().name()).isEqualTo("Cherry");
+    }
+  }
+
+  @Nested
+  @DisplayName("existsWithIndex() - Check existence by index-value predicate")
+  class ExistsWithIndexTests {
+
+    @Test
+    @DisplayName("should return true when condition is met")
+    void conditionMet() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(1, 2, 3, 4, 5);
+
+      boolean exists = ifold.existsWithIndex((i, v) -> i == v - 1, source);
+
+      assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("should return false when condition is not met")
+    void conditionNotMet() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(10, 20, 30);
+
+      boolean exists = ifold.existsWithIndex((i, v) -> i > v, source);
+
+      assertThat(exists).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("allWithIndex() - Check all elements by index-value predicate")
+  class AllWithIndexTests {
+
+    @Test
+    @DisplayName("should return true when all match")
+    void allMatch() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(0, 10, 20, 30);
+
+      // Each value should be index * 10
+      boolean all = ifold.allWithIndex((i, v) -> v == i * 10, source);
+
+      assertThat(all).isTrue();
+    }
+
+    @Test
+    @DisplayName("should return false when not all match")
+    void notAllMatch() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of(0, 10, 25, 30);
+
+      boolean all = ifold.allWithIndex((i, v) -> v == i * 10, source);
+
+      assertThat(all).isFalse();
+    }
+
+    @Test
+    @DisplayName("should return true for empty collection")
+    void emptyCollection() {
+      IndexedFold<Integer, List<Integer>, Integer> ifold = listFold();
+      List<Integer> source = List.of();
+
+      boolean all = ifold.allWithIndex((i, v) -> false, source);
+
+      assertThat(all).isTrue(); // Vacuous truth
+    }
+  }
+
+  @Nested
+  @DisplayName("length() and isEmpty() - Count operations")
+  class CountTests {
+
+    @Test
+    @DisplayName("length should count elements")
+    void lengthCount() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      List<String> source = List.of("a", "b", "c", "d");
+
+      int count = ifold.length(source);
+
+      assertThat(count).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("isEmpty should return true for empty")
+    void isEmptyTrue() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      List<String> source = List.of();
+
+      boolean empty = ifold.isEmpty(source);
+
+      assertThat(empty).isTrue();
+    }
+
+    @Test
+    @DisplayName("isEmpty should return false for non-empty")
+    void isEmptyFalse() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      List<String> source = List.of("x");
+
+      boolean empty = ifold.isEmpty(source);
+
+      assertThat(empty).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("iandThen() - Composition with indexed folds")
+  class IAndThenTests {
+
+    @Test
+    @DisplayName("should compose with paired indices")
+    void composeIndexedFolds() {
+      IndexedFold<Integer, List<Map<String, Integer>>, Map<String, Integer>> listFold =
+          IndexedTraversals.<Map<String, Integer>>forList().asIndexedFold();
+      IndexedFold<String, Map<String, Integer>, Integer> mapFold =
+          IndexedTraversals.<String, Integer>forMap().asIndexedFold();
+
+      IndexedFold<Pair<Integer, String>, List<Map<String, Integer>>, Integer> composed =
+          listFold.iandThen(mapFold);
+
+      List<Map<String, Integer>> source = List.of(Map.of("a", 1), Map.of("b", 2, "c", 3));
+
+      List<Pair<Pair<Integer, String>, Integer>> indexed = composed.toIndexedList(source);
+
+      assertThat(indexed).hasSize(3);
+      assertThat(
+              indexed.stream()
+                  .anyMatch(t -> t.first().equals(new Pair<>(0, "a")) && t.second() == 1))
+          .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("andThen() - Composition with regular folds")
+  class AndThenTests {
+
+    @Test
+    @DisplayName("should compose with regular fold preserving index")
+    void composeWithRegularFold() {
+      IndexedFold<Integer, List<Order>, Order> ordersFold = listFold();
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+
+      IndexedFold<Integer, List<Order>, Item> composed = ordersFold.andThen(itemsFold);
+
+      List<Order> source =
+          List.of(
+              new Order(List.of(new Item("A", 10, 1), new Item("B", 20, 2))),
+              new Order(List.of(new Item("C", 30, 3))));
+
+      List<Pair<Integer, Item>> indexed = composed.toIndexedList(source);
+
+      // All items have the order's index
+      assertThat(indexed).hasSize(3);
+      assertThat(indexed.get(0).first()).isEqualTo(0);
+      assertThat(indexed.get(1).first()).isEqualTo(0);
+      assertThat(indexed.get(2).first()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("filterIndex() - Index-based filtering")
+  class FilterIndexTests {
+
+    @Test
+    @DisplayName("should filter by index predicate")
+    void filterByIndex() {
+      IndexedFold<Integer, List<String>, String> ifold = listFold();
+      IndexedFold<Integer, List<String>, String> evens = ifold.filterIndex(i -> i % 2 == 0);
+      List<String> source = List.of("a", "b", "c", "d", "e");
+
+      List<Pair<Integer, String>> indexed = evens.toIndexedList(source);
+
+      assertThat(indexed)
+          .containsExactly(new Pair<>(0, "a"), new Pair<>(2, "c"), new Pair<>(4, "e"));
+    }
+  }
+
+  @Nested
+  @DisplayName("asFold() - Conversion to regular fold")
+  class AsFoldTests {
+
+    @Test
+    @DisplayName("should convert to regular fold ignoring indices")
+    void convertToFold() {
+      IndexedFold<Integer, List<Item>, Item> ifold = listFold();
+      Fold<List<Item>, Item> fold = ifold.asFold();
+
+      List<Item> source =
+          List.of(new Item("A", 100, 1), new Item("B", 200, 2), new Item("C", 150, 3));
+
+      // Use regular fold operations
+      int totalPrice =
+          fold.foldMap(
+              new Monoid<>() {
+                @Override
+                public Integer empty() {
+                  return 0;
+                }
+
+                @Override
+                public Integer combine(Integer a, Integer b) {
+                  return a + b;
+                }
+              },
+              Item::price,
+              source);
+
+      assertThat(totalPrice).isEqualTo(450);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/indexed/IndexedLensTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/indexed/IndexedLensTest.java
@@ -1,0 +1,419 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.util.IndexedTraversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IndexedLens<I, S, A> Tests")
+class IndexedLensTest {
+
+  // Test Data Structures
+  record User(String name, int age, String email) {
+    User withName(String newName) {
+      return new User(newName, age, email);
+    }
+
+    User withAge(int newAge) {
+      return new User(name, newAge, email);
+    }
+
+    User withEmail(String newEmail) {
+      return new User(name, age, newEmail);
+    }
+  }
+
+  record Address(String street, String city, String zip) {
+    Address withStreet(String newStreet) {
+      return new Address(newStreet, city, zip);
+    }
+
+    Address withCity(String newCity) {
+      return new Address(street, newCity, zip);
+    }
+  }
+
+  record Person(String id, User user, Address address) {
+    Person withUser(User newUser) {
+      return new Person(id, newUser, address);
+    }
+
+    Person withAddress(Address newAddress) {
+      return new Person(id, user, newAddress);
+    }
+  }
+
+  @Nested
+  @DisplayName("of() - Factory method")
+  class OfTests {
+
+    @Test
+    @DisplayName("should create indexed lens with correct index")
+    void createWithIndex() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+
+      assertThat(nameLens.index()).isEqualTo("name");
+    }
+
+    @Test
+    @DisplayName("should get value correctly")
+    void getValue() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      String name = nameLens.get(user);
+
+      assertThat(name).isEqualTo("Alice");
+    }
+
+    @Test
+    @DisplayName("should set value correctly")
+    void setValue() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      User updated = nameLens.set("Bob", user);
+
+      assertThat(updated.name()).isEqualTo("Bob");
+      assertThat(updated.age()).isEqualTo(30);
+      assertThat(updated.email()).isEqualTo("alice@example.com");
+    }
+  }
+
+  @Nested
+  @DisplayName("iget() - Get with index")
+  class IGetTests {
+
+    @Test
+    @DisplayName("should return index-value pair")
+    void getIndexValuePair() {
+      IndexedLens<String, User, Integer> ageLens = IndexedLens.of("age", User::age, User::withAge);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      Pair<String, Integer> indexed = ageLens.iget(user);
+
+      assertThat(indexed.first()).isEqualTo("age");
+      assertThat(indexed.second()).isEqualTo(30);
+    }
+  }
+
+  @Nested
+  @DisplayName("imodify() - Modify with index")
+  class IModifyTests {
+
+    @Test
+    @DisplayName("should modify using both index and value")
+    void modifyWithIndex() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      User updated = nameLens.imodify((fieldName, value) -> value + " [" + fieldName + "]", user);
+
+      assertThat(updated.name()).isEqualTo("Alice [name]");
+    }
+
+    @Test
+    @DisplayName("should use index for conditional logic")
+    void conditionalModifyByIndex() {
+      IndexedLens<String, User, String> emailLens =
+          IndexedLens.of("email", User::email, User::withEmail);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      User updated =
+          emailLens.imodify(
+              (field, value) -> {
+                if (field.equals("email")) {
+                  return value.toUpperCase();
+                }
+                return value;
+              },
+              user);
+
+      assertThat(updated.email()).isEqualTo("ALICE@EXAMPLE.COM");
+    }
+  }
+
+  @Nested
+  @DisplayName("modify() - Modify without index")
+  class ModifyTests {
+
+    @Test
+    @DisplayName("should modify value ignoring index")
+    void modifyWithoutIndex() {
+      IndexedLens<String, User, Integer> ageLens = IndexedLens.of("age", User::age, User::withAge);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      User updated = ageLens.modify(age -> age + 1, user);
+
+      assertThat(updated.age()).isEqualTo(31);
+    }
+  }
+
+  @Nested
+  @DisplayName("imodifyF() - Effectful modification with index")
+  class IModifyFTests {
+
+    @Test
+    @DisplayName("should modify with effectful function using index")
+    void effectfulModifyWithIndex() {
+      IndexedLens<String, User, Integer> ageLens = IndexedLens.of("age", User::age, User::withAge);
+      User user = new User("Alice", 30, "alice@example.com");
+
+      // Use Optional as effect - fail if field is "age" and value > 100
+      Kind<OptionalKind.Witness, User> result =
+          ageLens.imodifyF(
+              (field, age) -> {
+                if (field.equals("age") && age > 100) {
+                  return OptionalKindHelper.OPTIONAL.widen(Optional.empty());
+                }
+                return OptionalKindHelper.OPTIONAL.widen(Optional.of(age + 1));
+              },
+              user,
+              OptionalMonad.INSTANCE);
+
+      Optional<User> unwrapped = OptionalKindHelper.OPTIONAL.narrow(result);
+      assertThat(unwrapped).isPresent();
+      assertThat(unwrapped.get().age()).isEqualTo(31);
+    }
+
+    @Test
+    @DisplayName("should propagate effect failure")
+    void effectFailure() {
+      IndexedLens<String, User, Integer> ageLens = IndexedLens.of("age", User::age, User::withAge);
+      User user = new User("Alice", 150, "alice@example.com");
+
+      Kind<OptionalKind.Witness, User> result =
+          ageLens.imodifyF(
+              (field, age) -> {
+                if (age > 100) {
+                  return OptionalKindHelper.OPTIONAL.widen(Optional.empty());
+                }
+                return OptionalKindHelper.OPTIONAL.widen(Optional.of(age + 1));
+              },
+              user,
+              OptionalMonad.INSTANCE);
+
+      Optional<User> unwrapped = OptionalKindHelper.OPTIONAL.narrow(result);
+      assertThat(unwrapped).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("from() - Create from existing Lens")
+  class FromTests {
+
+    @Test
+    @DisplayName("should wrap existing lens with index")
+    void wrapExistingLens() {
+      Lens<User, String> regularNameLens = Lens.of(User::name, User::withName);
+      IndexedLens<String, User, String> indexedNameLens =
+          IndexedLens.from("userName", regularNameLens);
+
+      User user = new User("Alice", 30, "alice@example.com");
+
+      assertThat(indexedNameLens.index()).isEqualTo("userName");
+      assertThat(indexedNameLens.get(user)).isEqualTo("Alice");
+      assertThat(indexedNameLens.set("Bob", user).name()).isEqualTo("Bob");
+    }
+  }
+
+  @Nested
+  @DisplayName("iandThen() - Composition with paired indices")
+  class IAndThenTests {
+
+    @Test
+    @DisplayName("should compose indexed lenses with paired indices")
+    void composeWithPairedIndices() {
+      IndexedLens<String, Person, User> userLens =
+          IndexedLens.of("user", Person::user, Person::withUser);
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+
+      IndexedLens<Pair<String, String>, Person, String> composed = userLens.iandThen(nameLens);
+
+      Person person =
+          new Person(
+              "p1",
+              new User("Alice", 30, "alice@example.com"),
+              new Address("Main St", "NYC", "10001"));
+
+      assertThat(composed.index()).isEqualTo(new Pair<>("user", "name"));
+      assertThat(composed.get(person)).isEqualTo("Alice");
+
+      Person updated = composed.set("Bob", person);
+      assertThat(updated.user().name()).isEqualTo("Bob");
+    }
+
+    @Test
+    @DisplayName("should preserve full path in paired index")
+    void preserveFullPath() {
+      IndexedLens<String, Person, Address> addressLens =
+          IndexedLens.of("address", Person::address, Person::withAddress);
+      IndexedLens<String, Address, String> cityLens =
+          IndexedLens.of("city", Address::city, Address::withCity);
+
+      IndexedLens<Pair<String, String>, Person, String> personCityLens =
+          addressLens.iandThen(cityLens);
+
+      Pair<String, String> fullPath = personCityLens.index();
+      assertThat(fullPath.first()).isEqualTo("address");
+      assertThat(fullPath.second()).isEqualTo("city");
+    }
+  }
+
+  @Nested
+  @DisplayName("andThen() - Composition with regular lens")
+  class AndThenTests {
+
+    @Test
+    @DisplayName("should compose with regular lens preserving outer index")
+    void composeWithRegularLens() {
+      IndexedLens<String, Person, User> userLens =
+          IndexedLens.of("user", Person::user, Person::withUser);
+      Lens<User, String> nameLens = Lens.of(User::name, User::withName);
+
+      IndexedLens<String, Person, String> composed = userLens.andThen(nameLens);
+
+      Person person =
+          new Person(
+              "p1",
+              new User("Alice", 30, "alice@example.com"),
+              new Address("Main St", "NYC", "10001"));
+
+      assertThat(composed.index()).isEqualTo("user");
+      assertThat(composed.get(person)).isEqualTo("Alice");
+
+      Person updated = composed.set("Carol", person);
+      assertThat(updated.user().name()).isEqualTo("Carol");
+    }
+  }
+
+  @Nested
+  @DisplayName("asLens() - Conversion to regular lens")
+  class AsLensTests {
+
+    @Test
+    @DisplayName("should convert to regular lens ignoring index")
+    void convertToLens() {
+      IndexedLens<String, User, Integer> indexedAgeLens =
+          IndexedLens.of("age", User::age, User::withAge);
+      Lens<User, Integer> regularLens = indexedAgeLens.asLens();
+
+      User user = new User("Alice", 30, "alice@example.com");
+
+      assertThat(regularLens.get(user)).isEqualTo(30);
+
+      User updated = regularLens.modify(age -> age * 2, user);
+      assertThat(updated.age()).isEqualTo(60);
+    }
+  }
+
+  @Nested
+  @DisplayName("asIndexedTraversal() - Conversion to indexed traversal")
+  class AsIndexedTraversalTests {
+
+    @Test
+    @DisplayName("should convert to indexed traversal")
+    void convertToTraversal() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+      IndexedTraversal<String, User, String> traversal = nameLens.asIndexedTraversal();
+
+      User user = new User("Alice", 30, "alice@example.com");
+
+      User updated =
+          IndexedTraversals.imodify(traversal, (field, value) -> value + " (" + field + ")", user);
+
+      assertThat(updated.name()).isEqualTo("Alice (name)");
+    }
+  }
+
+  @Nested
+  @DisplayName("asIndexedFold() - Conversion to indexed fold")
+  class AsIndexedFoldTests {
+
+    @Test
+    @DisplayName("should convert to indexed fold")
+    void convertToFold() {
+      IndexedLens<String, User, String> emailLens =
+          IndexedLens.of("email", User::email, User::withEmail);
+      IndexedFold<String, User, String> fold = emailLens.asIndexedFold();
+
+      User user = new User("Alice", 30, "alice@example.com");
+
+      Pair<String, String> indexed = fold.toIndexedList(user).get(0);
+      assertThat(indexed.first()).isEqualTo("email");
+      assertThat(indexed.second()).isEqualTo("alice@example.com");
+    }
+  }
+
+  @Nested
+  @DisplayName("Practical use cases")
+  class PracticalUseCasesTests {
+
+    @Test
+    @DisplayName("should track field modifications for audit")
+    void auditFieldModifications() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+      IndexedLens<String, User, Integer> ageLens = IndexedLens.of("age", User::age, User::withAge);
+
+      User user = new User("Alice", 30, "alice@example.com");
+
+      // Audit log
+      StringBuilder audit = new StringBuilder();
+
+      Function<IndexedLens<String, User, ?>, User> auditingModifier =
+          lens -> {
+            Object oldValue = lens.get(user);
+            User modified = lens.imodify((field, value) -> value, user);
+            audit
+                .append("Modified ")
+                .append(lens.index())
+                .append(": ")
+                .append(oldValue)
+                .append("\n");
+            return modified;
+          };
+
+      auditingModifier.apply(nameLens);
+      auditingModifier.apply(ageLens);
+
+      assertThat(audit.toString()).contains("Modified name: Alice");
+      assertThat(audit.toString()).contains("Modified age: 30");
+    }
+
+    @Test
+    @DisplayName("should support generic field processing with identification")
+    void genericFieldProcessing() {
+      IndexedLens<String, User, String> nameLens =
+          IndexedLens.of("name", User::name, User::withName);
+      IndexedLens<String, User, String> emailLens =
+          IndexedLens.of("email", User::email, User::withEmail);
+
+      User user = new User("Alice", 30, "alice@example.com");
+
+      // Process all string fields the same way but with field-specific labeling
+      User updated = nameLens.imodify((field, value) -> "[" + field + "=" + value + "]", user);
+      updated = emailLens.imodify((field, value) -> "[" + field + "=" + value + "]", updated);
+
+      assertThat(updated.name()).isEqualTo("[name=Alice]");
+      assertThat(updated.email()).isEqualTo("[email=alice@example.com]");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/indexed/IndexedTraversalTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/indexed/IndexedTraversalTest.java
@@ -1,0 +1,423 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.IndexedTraversals;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IndexedTraversal<I, S, A> Tests")
+class IndexedTraversalTest {
+
+  // Test Data Structures
+  record User(String name, int age, boolean active) {
+    User withName(String newName) {
+      return new User(newName, age, active);
+    }
+
+    User withAge(int newAge) {
+      return new User(name, newAge, active);
+    }
+  }
+
+  record Team(String name, List<User> members) {}
+
+  @Nested
+  @DisplayName("forList() - List indexed traversal")
+  class ForListTests {
+
+    @Test
+    @DisplayName("should modify elements with access to their indices")
+    void modifyWithIndex() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      List<String> source = List.of("a", "b", "c");
+
+      List<String> result = IndexedTraversals.imodify(ilist, (i, s) -> s + "#" + i, source);
+
+      assertThat(result).containsExactly("a#0", "b#1", "c#2");
+    }
+
+    @Test
+    @DisplayName("should handle empty lists")
+    void emptyList() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      List<String> source = List.of();
+
+      List<String> result = IndexedTraversals.imodify(ilist, (i, s) -> s + "#" + i, source);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should extract elements with their indices")
+    void toIndexedList() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      List<String> source = List.of("a", "b", "c");
+
+      List<Pair<Integer, String>> indexed = IndexedTraversals.toIndexedList(ilist, source);
+
+      assertThat(indexed)
+          .containsExactly(new Pair<>(0, "a"), new Pair<>(1, "b"), new Pair<>(2, "c"));
+    }
+
+    @Test
+    @DisplayName("should extract values ignoring indices")
+    void getAll() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      List<String> source = List.of("x", "y", "z");
+
+      List<String> values = IndexedTraversals.getAll(ilist, source);
+
+      assertThat(values).containsExactly("x", "y", "z");
+    }
+
+    @Test
+    @DisplayName("should count elements correctly")
+    void length() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      List<String> source = List.of("a", "b", "c", "d", "e");
+
+      int count = IndexedTraversals.length(ilist, source);
+
+      assertThat(count).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("should work with effectful modifications")
+    void modifyWithEffect() {
+      IndexedTraversal<Integer, List<Integer>, Integer> ilist = IndexedTraversals.forList();
+      List<Integer> source = List.of(10, 20, 30);
+
+      // Use Optional as the effect - fail if index is 1 and value is 20
+      Applicative<OptionalKind.Witness> optionalApp = OptionalMonad.INSTANCE;
+      Kind<OptionalKind.Witness, List<Integer>> result =
+          ilist.imodifyF(
+              (i, v) -> {
+                if (i == 1 && v == 20) {
+                  return OptionalKindHelper.OPTIONAL.widen(Optional.empty());
+                }
+                return OptionalKindHelper.OPTIONAL.widen(Optional.of(v * (i + 1)));
+              },
+              source,
+              optionalApp);
+
+      Optional<List<Integer>> unwrapped = OptionalKindHelper.OPTIONAL.narrow(result);
+      assertThat(unwrapped).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("forMap() - Map indexed traversal")
+  class ForMapTests {
+
+    @Test
+    @DisplayName("should modify values with access to their keys")
+    void modifyWithKey() {
+      IndexedTraversal<String, Map<String, Integer>, Integer> imap = IndexedTraversals.forMap();
+      Map<String, Integer> source = new HashMap<>();
+      source.put("a", 1);
+      source.put("b", 2);
+      source.put("c", 3);
+
+      Map<String, Integer> result =
+          IndexedTraversals.imodify(imap, (key, value) -> value * key.length(), source);
+
+      assertThat(result).containsEntry("a", 1).containsEntry("b", 2).containsEntry("c", 3);
+    }
+
+    @Test
+    @DisplayName("should handle empty maps")
+    void emptyMap() {
+      IndexedTraversal<String, Map<String, Integer>, Integer> imap = IndexedTraversals.forMap();
+      Map<String, Integer> source = Map.of();
+
+      Map<String, Integer> result =
+          IndexedTraversals.imodify(imap, (key, value) -> value * 2, source);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should extract key-value pairs")
+    void toIndexedListFromMap() {
+      IndexedTraversal<String, Map<String, Integer>, Integer> imap = IndexedTraversals.forMap();
+      Map<String, Integer> source = Map.of("x", 10, "y", 20);
+
+      List<Pair<String, Integer>> indexed = IndexedTraversals.toIndexedList(imap, source);
+
+      assertThat(indexed).hasSize(2);
+      assertThat(indexed).anyMatch(t -> t.first().equals("x") && t.second().equals(10));
+      assertThat(indexed).anyMatch(t -> t.first().equals("y") && t.second().equals(20));
+    }
+  }
+
+  @Nested
+  @DisplayName("filterIndex() - Index-based filtering")
+  class FilterIndexTests {
+
+    @Test
+    @DisplayName("should filter by even indices")
+    void filterEvenIndices() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      IndexedTraversal<Integer, List<String>, String> evens = ilist.filterIndex(i -> i % 2 == 0);
+      List<String> source = List.of("a", "b", "c", "d", "e");
+
+      List<String> result = IndexedTraversals.imodify(evens, (i, s) -> s.toUpperCase(), source);
+
+      assertThat(result).containsExactly("A", "b", "C", "d", "E");
+    }
+
+    @Test
+    @DisplayName("should filter first N elements")
+    void filterFirstN() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      IndexedTraversal<Integer, List<String>, String> firstThree = ilist.filterIndex(i -> i < 3);
+      List<String> source = List.of("a", "b", "c", "d", "e");
+
+      List<String> result = IndexedTraversals.imodify(firstThree, (i, s) -> s + "!", source);
+
+      assertThat(result).containsExactly("a!", "b!", "c!", "d", "e");
+    }
+
+    @Test
+    @DisplayName("should filter by specific indices set")
+    void filterSpecificIndices() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      var indices = java.util.Set.of(0, 2, 4);
+      IndexedTraversal<Integer, List<String>, String> specific =
+          ilist.filterIndex(indices::contains);
+      List<String> source = List.of("a", "b", "c", "d", "e");
+
+      List<Pair<Integer, String>> indexed = IndexedTraversals.toIndexedList(specific, source);
+
+      // Only focused indices are returned (0, 2, 4)
+      assertThat(indexed).hasSize(3);
+      assertThat(indexed.get(0).first()).isEqualTo(0);
+      assertThat(indexed.get(0).second()).isEqualTo("a");
+      assertThat(indexed.get(1).first()).isEqualTo(2);
+      assertThat(indexed.get(1).second()).isEqualTo("c");
+      assertThat(indexed.get(2).first()).isEqualTo(4);
+      assertThat(indexed.get(2).second()).isEqualTo("e");
+    }
+  }
+
+  @Nested
+  @DisplayName("filtered() - Value-based filtering with index preservation")
+  class FilteredTests {
+
+    @Test
+    @DisplayName("should filter by value while preserving indices")
+    void filterByValue() {
+      IndexedTraversal<Integer, List<User>, User> iusers = IndexedTraversals.forList();
+      IndexedTraversal<Integer, List<User>, User> active = iusers.filtered(User::active);
+      List<User> source =
+          List.of(
+              new User("Alice", 30, true), new User("Bob", 25, false), new User("Carol", 35, true));
+
+      List<Pair<Integer, User>> indexed = IndexedTraversals.toIndexedList(active, source);
+
+      // Only active users returned with their original indices preserved
+      assertThat(indexed).hasSize(2);
+      assertThat(indexed.get(0).first()).isEqualTo(0);
+      assertThat(indexed.get(0).second().name()).isEqualTo("Alice");
+      assertThat(indexed.get(1).first()).isEqualTo(2);
+      assertThat(indexed.get(1).second().name()).isEqualTo("Carol");
+    }
+
+    @Test
+    @DisplayName("should modify only matching elements")
+    void modifyFilteredElements() {
+      IndexedTraversal<Integer, List<User>, User> iusers = IndexedTraversals.forList();
+      IndexedTraversal<Integer, List<User>, User> active = iusers.filtered(User::active);
+      List<User> source =
+          List.of(
+              new User("Alice", 30, true), new User("Bob", 25, false), new User("Carol", 35, true));
+
+      List<User> result =
+          IndexedTraversals.imodify(
+              active, (i, u) -> u.withName(u.name() + " [" + i + "]"), source);
+
+      assertThat(result.get(0).name()).isEqualTo("Alice [0]");
+      assertThat(result.get(1).name()).isEqualTo("Bob"); // Unchanged
+      assertThat(result.get(2).name()).isEqualTo("Carol [2]");
+    }
+  }
+
+  @Nested
+  @DisplayName("filteredWithIndex() - Combined index and value filtering")
+  class FilteredWithIndexTests {
+
+    @Test
+    @DisplayName("should filter by both index and value")
+    void filterByIndexAndValue() {
+      IndexedTraversal<Integer, List<Integer>, Integer> ilist = IndexedTraversals.forList();
+      // Focus on elements where index is even AND value > 10
+      IndexedTraversal<Integer, List<Integer>, Integer> combined =
+          ilist.filteredWithIndex((i, v) -> i % 2 == 0 && v > 10);
+      List<Integer> source = List.of(5, 20, 15, 30, 25);
+
+      List<Integer> result = IndexedTraversals.imodify(combined, (i, v) -> v * 2, source);
+
+      assertThat(result)
+          .containsExactly(
+              5, // index 0 even, but 5 <= 10, not modified
+              20, // index 1 odd, not modified
+              30, // index 2 even AND 15 > 10, modified to 30
+              30, // index 3 odd, not modified
+              50 // index 4 even AND 25 > 10, modified to 50
+              );
+    }
+  }
+
+  @Nested
+  @DisplayName("andThen() - Composition with regular optics")
+  class AndThenTests {
+
+    @Test
+    @DisplayName("should compose with Traversal preserving index")
+    void composeWithTraversal() {
+      IndexedTraversal<Integer, List<User>, User> iusers = IndexedTraversals.forList();
+      Lens<User, String> nameLens = Lens.of(User::name, User::withName);
+      Traversal<User, String> nameTraversal = nameLens.asTraversal();
+
+      IndexedTraversal<Integer, List<User>, String> userNames = iusers.andThen(nameTraversal);
+
+      List<User> source = List.of(new User("Alice", 30, true), new User("Bob", 25, false));
+
+      List<User> result =
+          IndexedTraversals.imodify(userNames, (i, name) -> name + " #" + i, source);
+
+      assertThat(result.get(0).name()).isEqualTo("Alice #0");
+      assertThat(result.get(1).name()).isEqualTo("Bob #1");
+    }
+
+    @Test
+    @DisplayName("should preserve outer index through multiple compositions")
+    void multipleCompositions() {
+      IndexedTraversal<Integer, List<Team>, Team> iteams = IndexedTraversals.forList();
+      Lens<Team, List<User>> membersLens = Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+      Traversal<List<User>, User> usersTraversal = Traversals.forList();
+      Lens<User, String> nameLens = Lens.of(User::name, User::withName);
+
+      // Compose: Teams (indexed) -> members (list) -> users -> names
+      IndexedTraversal<Integer, List<Team>, String> teamUserNames =
+          iteams
+              .andThen(membersLens.asTraversal())
+              .andThen(usersTraversal)
+              .andThen(nameLens.asTraversal());
+
+      List<Team> source =
+          List.of(
+              new Team("Alpha", List.of(new User("Alice", 30, true), new User("Bob", 25, false))),
+              new Team("Beta", List.of(new User("Carol", 35, true))));
+
+      // All user names get the team index (outer index)
+      List<Team> result =
+          IndexedTraversals.imodify(
+              teamUserNames, (teamIndex, name) -> name + "@Team" + teamIndex, source);
+
+      assertThat(result.get(0).members().get(0).name()).isEqualTo("Alice@Team0");
+      assertThat(result.get(0).members().get(1).name()).isEqualTo("Bob@Team0");
+      assertThat(result.get(1).members().get(0).name()).isEqualTo("Carol@Team1");
+    }
+  }
+
+  @Nested
+  @DisplayName("iandThen() - Composition with indexed optics (paired indices)")
+  class IAndThenTests {
+
+    @Test
+    @DisplayName("should pair indices when composing indexed optics")
+    void pairIndices() {
+      IndexedTraversal<Integer, List<Map<String, Integer>>, Map<String, Integer>> ilist =
+          IndexedTraversals.forList();
+      IndexedTraversal<String, Map<String, Integer>, Integer> imap = IndexedTraversals.forMap();
+
+      IndexedTraversal<Pair<Integer, String>, List<Map<String, Integer>>, Integer> composed =
+          ilist.iandThen(imap);
+
+      List<Map<String, Integer>> source = List.of(Map.of("a", 1, "b", 2), Map.of("x", 10, "y", 20));
+
+      List<Pair<Pair<Integer, String>, Integer>> indexed =
+          IndexedTraversals.toIndexedList(composed, source);
+
+      assertThat(indexed).hasSize(4);
+      // Check that we have paired indices
+      assertThat(
+              indexed.stream()
+                  .anyMatch(t -> t.first().first().equals(0) && t.first().second().equals("a")))
+          .isTrue();
+      assertThat(
+              indexed.stream()
+                  .anyMatch(t -> t.first().first().equals(1) && t.first().second().equals("x")))
+          .isTrue();
+    }
+
+    @Test
+    @DisplayName("should allow modification using paired indices")
+    void modifyWithPairedIndices() {
+      IndexedTraversal<Integer, List<Map<String, String>>, Map<String, String>> ilist =
+          IndexedTraversals.forList();
+      IndexedTraversal<String, Map<String, String>, String> imap = IndexedTraversals.forMap();
+
+      IndexedTraversal<Pair<Integer, String>, List<Map<String, String>>, String> composed =
+          ilist.iandThen(imap);
+
+      List<Map<String, String>> source =
+          List.of(new HashMap<>(Map.of("name", "Alice")), new HashMap<>(Map.of("name", "Bob")));
+
+      List<Map<String, String>> result =
+          IndexedTraversals.imodify(
+              composed,
+              (indices, value) -> value + "[" + indices.first() + ":" + indices.second() + "]",
+              source);
+
+      assertThat(result.get(0).get("name")).isEqualTo("Alice[0:name]");
+      assertThat(result.get(1).get("name")).isEqualTo("Bob[1:name]");
+    }
+  }
+
+  @Nested
+  @DisplayName("asTraversal() - Conversion to regular traversal")
+  class AsTraversalTests {
+
+    @Test
+    @DisplayName("should convert to regular traversal ignoring indices")
+    void convertToTraversal() {
+      IndexedTraversal<Integer, List<String>, String> ilist = IndexedTraversals.forList();
+      Traversal<List<String>, String> traversal = ilist.asTraversal();
+
+      List<String> source = List.of("a", "b", "c");
+      List<String> result = Traversals.modify(traversal, String::toUpperCase, source);
+
+      assertThat(result).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("should work with Traversals utility methods")
+    void useWithTraversalsUtility() {
+      IndexedTraversal<Integer, List<Integer>, Integer> ilist = IndexedTraversals.forList();
+      Traversal<List<Integer>, Integer> traversal = ilist.asTraversal();
+
+      List<Integer> source = List.of(1, 2, 3, 4, 5);
+      List<Integer> values = Traversals.getAll(traversal, source);
+
+      assertThat(values).containsExactly(1, 2, 3, 4, 5);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/IndexedTraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/IndexedTraversalsTest.java
@@ -1,0 +1,286 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.higherkindedj.hkt.tuple.Tuple2;
+import org.higherkindedj.optics.indexed.IndexedFold;
+import org.higherkindedj.optics.indexed.IndexedTraversal;
+import org.higherkindedj.optics.indexed.Pair;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IndexedTraversals Utility Tests")
+class IndexedTraversalsTest {
+
+  @Nested
+  @DisplayName("filteredByIndex() - Conditional indexed access")
+  class FilteredByIndexTests {
+
+    @Test
+    @DisplayName("should focus when predicate matches")
+    void focusWhenPredicateMatches() {
+      IndexedTraversal<String, Pair<String, Integer>, Integer> filtered =
+          IndexedTraversals.filteredByIndex((String index) -> index.equals("target"));
+
+      Pair<String, Integer> source = new Pair<>("target", 42);
+      Pair<String, Integer> result =
+          IndexedTraversals.imodify(filtered, (idx, val) -> val * 2, source);
+
+      assertThat(result.first()).isEqualTo("target");
+      assertThat(result.second()).isEqualTo(84);
+    }
+
+    @Test
+    @DisplayName("should not focus when predicate does not match")
+    void doNotFocusWhenPredicateDoesNotMatch() {
+      IndexedTraversal<String, Pair<String, Integer>, Integer> filtered =
+          IndexedTraversals.filteredByIndex((String index) -> index.equals("target"));
+
+      Pair<String, Integer> source = new Pair<>("other", 42);
+      Pair<String, Integer> result =
+          IndexedTraversals.imodify(filtered, (idx, val) -> val * 2, source);
+
+      assertThat(result.first()).isEqualTo("other");
+      assertThat(result.second()).isEqualTo(42); // Unchanged
+    }
+
+    @Test
+    @DisplayName("should work with numeric indices")
+    void workWithNumericIndices() {
+      IndexedTraversal<Integer, Pair<Integer, String>, String> evenOnly =
+          IndexedTraversals.filteredByIndex((Integer i) -> i % 2 == 0);
+
+      Pair<Integer, String> even = new Pair<>(2, "even");
+      Pair<Integer, String> odd = new Pair<>(3, "odd");
+
+      Pair<Integer, String> evenResult =
+          IndexedTraversals.imodify(evenOnly, (i, s) -> s.toUpperCase(), even);
+      Pair<Integer, String> oddResult =
+          IndexedTraversals.imodify(evenOnly, (i, s) -> s.toUpperCase(), odd);
+
+      assertThat(evenResult.second()).isEqualTo("EVEN");
+      assertThat(oddResult.second()).isEqualTo("odd"); // Unchanged
+    }
+
+    @Test
+    @DisplayName("should extract indexed values only when predicate matches")
+    void extractOnlyWhenMatches() {
+      IndexedTraversal<String, Pair<String, Integer>, Integer> filtered =
+          IndexedTraversals.filteredByIndex((String index) -> index.startsWith("a"));
+
+      Pair<String, Integer> matching = new Pair<>("abc", 10);
+      Pair<String, Integer> notMatching = new Pair<>("xyz", 20);
+
+      List<Pair<String, Integer>> matchingList =
+          IndexedTraversals.toIndexedList(filtered, matching);
+      List<Pair<String, Integer>> notMatchingList =
+          IndexedTraversals.toIndexedList(filtered, notMatching);
+
+      assertThat(matchingList).hasSize(1);
+      assertThat(matchingList.get(0).first()).isEqualTo("abc");
+      assertThat(matchingList.get(0).second()).isEqualTo(10);
+
+      assertThat(notMatchingList).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Pair/Tuple2 conversion methods")
+  class ConversionTests {
+
+    @Test
+    @DisplayName("pairToTuple2() should convert correctly")
+    void pairToTuple2() {
+      Pair<String, Integer> pair = new Pair<>("hello", 42);
+      Tuple2<String, Integer> tuple = IndexedTraversals.pairToTuple2(pair);
+
+      assertThat(tuple._1()).isEqualTo("hello");
+      assertThat(tuple._2()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("tuple2ToPair() should convert correctly")
+    void tuple2ToPair() {
+      Tuple2<String, Integer> tuple = new Tuple2<>("world", 99);
+      Pair<String, Integer> pair = IndexedTraversals.tuple2ToPair(tuple);
+
+      assertThat(pair.first()).isEqualTo("world");
+      assertThat(pair.second()).isEqualTo(99);
+    }
+
+    @Test
+    @DisplayName("pairToTuple2() and tuple2ToPair() should be inverses")
+    void roundTripConversion() {
+      Pair<String, Integer> original = new Pair<>("test", 123);
+      Pair<String, Integer> roundTrip =
+          IndexedTraversals.tuple2ToPair(IndexedTraversals.pairToTuple2(original));
+
+      assertThat(roundTrip).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("pairsToTuple2s() should convert list of pairs")
+    void pairsToTuple2s() {
+      List<Pair<String, Integer>> pairs =
+          List.of(new Pair<>("a", 1), new Pair<>("b", 2), new Pair<>("c", 3));
+
+      List<Tuple2<String, Integer>> tuples = IndexedTraversals.pairsToTuple2s(pairs);
+
+      assertThat(tuples).hasSize(3);
+      assertThat(tuples.get(0)._1()).isEqualTo("a");
+      assertThat(tuples.get(0)._2()).isEqualTo(1);
+      assertThat(tuples.get(1)._1()).isEqualTo("b");
+      assertThat(tuples.get(1)._2()).isEqualTo(2);
+      assertThat(tuples.get(2)._1()).isEqualTo("c");
+      assertThat(tuples.get(2)._2()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("tuple2sToPairs() should convert list of tuples")
+    void tuple2sToPairs() {
+      List<Tuple2<String, Integer>> tuples =
+          List.of(new Tuple2<>("x", 10), new Tuple2<>("y", 20), new Tuple2<>("z", 30));
+
+      List<Pair<String, Integer>> pairs = IndexedTraversals.tuple2sToPairs(tuples);
+
+      assertThat(pairs).hasSize(3);
+      assertThat(pairs.get(0).first()).isEqualTo("x");
+      assertThat(pairs.get(0).second()).isEqualTo(10);
+      assertThat(pairs.get(1).first()).isEqualTo("y");
+      assertThat(pairs.get(1).second()).isEqualTo(20);
+      assertThat(pairs.get(2).first()).isEqualTo("z");
+      assertThat(pairs.get(2).second()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("should handle empty lists")
+    void handleEmptyLists() {
+      List<Pair<String, Integer>> emptyPairs = List.of();
+      List<Tuple2<String, Integer>> emptyTuples = List.of();
+
+      assertThat(IndexedTraversals.pairsToTuple2s(emptyPairs)).isEmpty();
+      assertThat(IndexedTraversals.tuple2sToPairs(emptyTuples)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("foldList() and foldMap() - IndexedFold factory methods")
+  class FoldFactoryTests {
+
+    @Test
+    @DisplayName("foldList() should create read-only indexed fold for lists")
+    void foldListCreation() {
+      IndexedFold<Integer, List<String>, String> fold = IndexedTraversals.foldList();
+      List<String> source = List.of("a", "b", "c");
+
+      List<Pair<Integer, String>> indexed = fold.toIndexedList(source);
+
+      assertThat(indexed)
+          .containsExactly(new Pair<>(0, "a"), new Pair<>(1, "b"), new Pair<>(2, "c"));
+    }
+
+    @Test
+    @DisplayName("foldList() should handle empty lists")
+    void foldListEmpty() {
+      IndexedFold<Integer, List<String>, String> fold = IndexedTraversals.foldList();
+      List<String> source = List.of();
+
+      List<Pair<Integer, String>> indexed = fold.toIndexedList(source);
+
+      assertThat(indexed).isEmpty();
+    }
+
+    @Test
+    @DisplayName("foldMap() should create read-only indexed fold for maps")
+    void foldMapCreation() {
+      IndexedFold<String, Map<String, Integer>, Integer> fold = IndexedTraversals.foldMap();
+      Map<String, Integer> source = Map.of("a", 1, "b", 2);
+
+      List<Pair<String, Integer>> indexed = fold.toIndexedList(source);
+
+      assertThat(indexed).hasSize(2);
+      assertThat(indexed).anyMatch(p -> p.first().equals("a") && p.second().equals(1));
+      assertThat(indexed).anyMatch(p -> p.first().equals("b") && p.second().equals(2));
+    }
+
+    @Test
+    @DisplayName("foldMap() should handle empty maps")
+    void foldMapEmpty() {
+      IndexedFold<String, Map<String, Integer>, Integer> fold = IndexedTraversals.foldMap();
+      Map<String, Integer> source = Map.of();
+
+      List<Pair<String, Integer>> indexed = fold.toIndexedList(source);
+
+      assertThat(indexed).isEmpty();
+    }
+
+    @Test
+    @DisplayName("foldList() should support all IndexedFold operations")
+    void foldListOperations() {
+      IndexedFold<Integer, List<Integer>, Integer> fold = IndexedTraversals.foldList();
+      List<Integer> source = List.of(10, 20, 30, 40);
+
+      // Test exists
+      assertThat(fold.exists(v -> v > 25, source)).isTrue();
+      assertThat(fold.exists(v -> v > 100, source)).isFalse();
+
+      // Test all
+      assertThat(fold.all(v -> v > 0, source)).isTrue();
+      assertThat(fold.all(v -> v > 25, source)).isFalse();
+
+      // Test length
+      assertThat(fold.length(source)).isEqualTo(4);
+
+      // Test isEmpty
+      assertThat(fold.isEmpty(source)).isFalse();
+      assertThat(fold.isEmpty(List.of())).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge cases and special scenarios")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("should handle null values in pairs")
+    void handleNullInPairs() {
+      Pair<String, Integer> pairWithNull = new Pair<>(null, 42);
+      Tuple2<String, Integer> tuple = IndexedTraversals.pairToTuple2(pairWithNull);
+
+      assertThat(tuple._1()).isNull();
+      assertThat(tuple._2()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("filteredByIndex should work with complex predicates")
+    void complexPredicates() {
+      IndexedTraversal<Integer, Pair<Integer, String>, String> multipleOfThree =
+          IndexedTraversals.filteredByIndex((Integer i) -> i % 3 == 0 && i > 0);
+
+      Pair<Integer, String> match = new Pair<>(6, "six");
+      Pair<Integer, String> noMatch1 = new Pair<>(0, "zero"); // 0 is not > 0
+      Pair<Integer, String> noMatch2 = new Pair<>(5, "five"); // 5 is not multiple of 3
+
+      assertThat(IndexedTraversals.toIndexedList(multipleOfThree, match)).hasSize(1);
+      assertThat(IndexedTraversals.toIndexedList(multipleOfThree, noMatch1)).isEmpty();
+      assertThat(IndexedTraversals.toIndexedList(multipleOfThree, noMatch2)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("conversion methods should preserve types correctly")
+    void typePreservation() {
+      // Test with different types
+      Pair<Long, Double> pair = new Pair<>(123L, 45.67);
+      Tuple2<Long, Double> tuple = IndexedTraversals.pairToTuple2(pair);
+      Pair<Long, Double> backToPair = IndexedTraversals.tuple2ToPair(tuple);
+
+      assertThat(backToPair.first()).isInstanceOf(Long.class).isEqualTo(123L);
+      assertThat(backToPair.second()).isInstanceOf(Double.class).isEqualTo(45.67);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/IndexedOpticsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/IndexedOpticsExample.java
@@ -1,0 +1,467 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.time.Instant;
+import java.util.*;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.indexed.IndexedLens;
+import org.higherkindedj.optics.indexed.IndexedTraversal;
+import org.higherkindedj.optics.indexed.Pair;
+import org.higherkindedj.optics.util.IndexedTraversals;
+
+/**
+ * A runnable example demonstrating indexed optics for position-aware operations.
+ *
+ * <p>This example showcases:
+ *
+ * <ul>
+ *   <li><b>IndexedTraversal</b> for list and map operations with position tracking
+ *   <li><b>IndexedFold</b> for position-aware queries
+ *   <li><b>IndexedLens</b> for field name tracking
+ *   <li>Practical use cases: numbering, labelling, audit trails, debugging
+ * </ul>
+ *
+ * <p>Key concepts demonstrated:
+ *
+ * <ul>
+ *   <li>Creating indexed traversals with {@code IndexedTraversals.forList()} and {@code
+ *       IndexedTraversals.forMap()}
+ *   <li>Accessing index-value pairs with {@code toIndexedList()}
+ *   <li>Position-aware modifications with {@code imodify()}
+ *   <li>Filtering by index with {@code filterIndex()} and {@code filteredWithIndex()}
+ *   <li>Composing indexed optics for nested structures
+ *   <li>Field tracking for audit logs with {@code IndexedLens}
+ * </ul>
+ */
+public class IndexedOpticsExample {
+
+  // Domain models for e-commerce order processing
+  public record LineItem(String productName, int quantity, double price) {}
+
+  public record Order(String orderId, List<LineItem> items, Map<String, String> metadata) {}
+
+  public record Customer(String name, String email) {}
+
+  public static void main(String[] args) {
+    System.out.println("=== Indexed Optics Examples ===\n");
+
+    demonstrateListIndexing();
+    demonstrateMapIndexing();
+    demonstratePositionBasedLogic();
+    demonstrateIndexedFiltering();
+    demonstrateLensIndexing();
+    demonstrateAuditTrail();
+    demonstrateComposition();
+    demonstrateRealWorldScenario();
+  }
+
+  /** Demonstrates basic list indexing with integer indices. */
+  private static void demonstrateListIndexing() {
+    System.out.println("--- List Indexing with Integer Indices ---");
+
+    IndexedTraversal<Integer, List<String>, String> indexed = IndexedTraversals.forList();
+
+    List<String> tasks = List.of("Review PR", "Update docs", "Run tests", "Deploy");
+
+    // Extract all index-value pairs
+    List<Pair<Integer, String>> indexedTasks = IndexedTraversals.toIndexedList(indexed, tasks);
+
+    System.out.println("Tasks with indices:");
+    for (Pair<Integer, String> pair : indexedTasks) {
+      System.out.println("  Index " + pair.first() + ": " + pair.second());
+    }
+
+    // Add sequence numbers (1-based for display)
+    List<String> numbered =
+        IndexedTraversals.imodify(indexed, (index, task) -> (index + 1) + ". " + task, tasks);
+
+    System.out.println("\nNumbered tasks:");
+    for (String task : numbered) {
+      System.out.println("  " + task);
+    }
+
+    System.out.println();
+  }
+
+  /** Demonstrates map indexing where the key is the index. */
+  private static void demonstrateMapIndexing() {
+    System.out.println("--- Map Indexing with Key-Based Indices ---");
+
+    IndexedTraversal<String, Map<String, Integer>, Integer> indexed = IndexedTraversals.forMap();
+
+    Map<String, Integer> scores = new LinkedHashMap<>();
+    scores.put("alice", 100);
+    scores.put("bob", 85);
+    scores.put("charlie", 92);
+
+    // Extract key-value pairs
+    List<Pair<String, Integer>> entries = IndexedTraversals.toIndexedList(indexed, scores);
+
+    System.out.println("Scores with keys:");
+    for (Pair<String, Integer> pair : entries) {
+      System.out.println("  " + pair.first() + " scored " + pair.second());
+    }
+
+    // Transform values with key awareness
+    Map<String, Integer> withBonus =
+        IndexedTraversals.imodify(
+            indexed,
+            (key, score) -> {
+              // Alice gets a 10-point bonus
+              if (key.equals("alice")) {
+                return score + 10;
+              }
+              return score;
+            },
+            scores);
+
+    System.out.println("\nScores after bonus:");
+    for (var entry : withBonus.entrySet()) {
+      System.out.println("  " + entry.getKey() + ": " + entry.getValue());
+    }
+
+    System.out.println();
+  }
+
+  /** Demonstrates position-based conditional logic. */
+  private static void demonstratePositionBasedLogic() {
+    System.out.println("--- Position-Based Logic ---");
+
+    IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed = IndexedTraversals.forList();
+
+    List<LineItem> items =
+        List.of(
+            new LineItem("Laptop", 1, 999.99),
+            new LineItem("Mouse", 2, 24.99),
+            new LineItem("Keyboard", 1, 79.99),
+            new LineItem("Monitor", 1, 299.99),
+            new LineItem("Webcam", 1, 59.99),
+            new LineItem("Headphones", 1, 149.99));
+
+    System.out.println("Original items:");
+    for (int i = 0; i < items.size(); i++) {
+      System.out.printf(
+          "  Position %d: %s - £%.2f%n", i, items.get(i).productName(), items.get(i).price());
+    }
+
+    // Apply 10% discount to items at even positions (0, 2, 4...)
+    List<LineItem> discounted =
+        IndexedTraversals.imodify(
+            itemsIndexed,
+            (index, item) -> {
+              if (index % 2 == 0) {
+                double newPrice = item.price() * 0.9;
+                return new LineItem(item.productName(), item.quantity(), newPrice);
+              }
+              return item;
+            },
+            items);
+
+    System.out.println("\nAfter even-position discount (10% off):");
+    for (int i = 0; i < discounted.size(); i++) {
+      LineItem item = discounted.get(i);
+      System.out.printf("  Position %d: %s - £%.2f", i, item.productName(), item.price());
+      if (i % 2 == 0) {
+        System.out.print(" (discounted)");
+      }
+      System.out.println();
+    }
+
+    // Mark first and last items specially
+    int lastIndex = items.size() - 1;
+    List<LineItem> marked =
+        IndexedTraversals.imodify(
+            itemsIndexed,
+            (index, item) -> {
+              String prefix = "";
+              if (index == 0) prefix = "[FIRST] ";
+              if (index == lastIndex) prefix = "[LAST] ";
+              return new LineItem(prefix + item.productName(), item.quantity(), item.price());
+            },
+            items);
+
+    System.out.println("\nWith first/last markers:");
+    for (LineItem item : marked) {
+      System.out.println("  " + item.productName());
+    }
+
+    System.out.println();
+  }
+
+  /** Demonstrates filtering by index and by value with index. */
+  private static void demonstrateIndexedFiltering() {
+    System.out.println("--- Indexed Filtering ---");
+
+    IndexedTraversal<Integer, List<String>, String> indexed = IndexedTraversals.forList();
+
+    List<String> values = List.of("a", "b", "c", "d", "e", "f", "g", "h");
+
+    // Filter to odd positions only (1, 3, 5, 7)
+    IndexedTraversal<Integer, List<String>, String> oddPositions =
+        indexed.filterIndex(i -> i % 2 == 1);
+
+    List<Pair<Integer, String>> oddPairs = IndexedTraversals.toIndexedList(oddPositions, values);
+    System.out.println("Odd positions (indices preserved):");
+    for (Pair<Integer, String> pair : oddPairs) {
+      System.out.println("  Index " + pair.first() + ": " + pair.second());
+    }
+
+    // Filter by both index and value
+    List<LineItem> items =
+        List.of(
+            new LineItem("Laptop", 1, 999.99), // Index 0, expensive
+            new LineItem("Pen", 1, 2.99), // Index 1, cheap
+            new LineItem("Keyboard", 1, 79.99), // Index 2, mid-range
+            new LineItem("Mouse", 1, 24.99), // Index 3, cheap
+            new LineItem("Monitor", 1, 299.99)); // Index 4, expensive
+
+    IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed = IndexedTraversals.forList();
+
+    // Filter: even positions AND price > £50
+    IndexedTraversal<Integer, List<LineItem>, LineItem> evenAndExpensive =
+        itemsIndexed.filterIndex(i -> i % 2 == 0).filtered(item -> item.price() > 50);
+
+    List<Pair<Integer, LineItem>> filtered =
+        IndexedTraversals.toIndexedList(evenAndExpensive, items);
+
+    System.out.println("\nEven positions AND price > £50:");
+    for (Pair<Integer, LineItem> pair : filtered) {
+      System.out.printf(
+          "  Position %d: %s (£%.2f)%n",
+          pair.first(), pair.second().productName(), pair.second().price());
+    }
+
+    System.out.println();
+  }
+
+  /** Demonstrates IndexedLens for field name tracking. */
+  private static void demonstrateLensIndexing() {
+    System.out.println("--- IndexedLens for Field Tracking ---");
+
+    // Create indexed lens for customer email field
+    IndexedLens<String, Customer, String> emailLens =
+        IndexedLens.of(
+            "email", // The index: field name
+            Customer::email, // Getter
+            (customer, newEmail) -> new Customer(customer.name(), newEmail) // Setter
+            );
+
+    Customer customer = new Customer("Alice", "alice@example.com");
+
+    // Get both field name and value
+    Pair<String, String> fieldInfo = emailLens.iget(customer);
+    System.out.println("Field name: " + fieldInfo.first());
+    System.out.println("Field value: " + fieldInfo.second());
+
+    // Modify with field name awareness
+    Customer updated =
+        emailLens.imodify(
+            (fieldName, oldValue) -> {
+              System.out.println("\nModifying field '" + fieldName + "' from '" + oldValue + "'");
+              return "alice.smith@example.com";
+            },
+            customer);
+
+    System.out.println("Updated customer: " + updated);
+
+    System.out.println();
+  }
+
+  /** Demonstrates audit trail pattern with field change tracking. */
+  private static void demonstrateAuditTrail() {
+    System.out.println("--- Audit Trail Pattern ---");
+
+    // Field change record
+    record FieldChange(String fieldName, Object oldValue, Object newValue, Instant timestamp) {}
+
+    List<FieldChange> auditLog = new ArrayList<>();
+
+    // Create indexed lens with audit logging
+    IndexedLens<String, Customer, String> emailLens =
+        IndexedLens.of("email", Customer::email, (c, email) -> new Customer(c.name(), email));
+
+    Customer customer = new Customer("Bob", "bob@old.com");
+
+    // Modify with audit logging
+    Customer updated =
+        emailLens.imodify(
+            (fieldName, oldValue) -> {
+              String newValue = "bob@new.com";
+
+              if (!oldValue.equals(newValue)) {
+                auditLog.add(new FieldChange(fieldName, oldValue, newValue, Instant.now()));
+              }
+
+              return newValue;
+            },
+            customer);
+
+    System.out.println("Original: " + customer);
+    System.out.println("Updated: " + updated);
+    System.out.println("\nAudit log:");
+    for (FieldChange change : auditLog) {
+      System.out.printf(
+          "  Field '%s' changed from '%s' to '%s' at %s%n",
+          change.fieldName(), change.oldValue(), change.newValue(), change.timestamp());
+    }
+
+    System.out.println();
+  }
+
+  /** Demonstrates composing indexed optics for nested structures. */
+  private static void demonstrateComposition() {
+    System.out.println("--- Composing Indexed Optics ---");
+
+    // Nested structure: List of Orders, each with List of LineItems
+    record OrderWithItems(String id, List<LineItem> items) {}
+
+    // First level: indexed traversal for orders
+    IndexedTraversal<Integer, List<OrderWithItems>, OrderWithItems> ordersIndexed =
+        IndexedTraversals.forList();
+
+    // Second level: lens to items field
+    Lens<OrderWithItems, List<LineItem>> itemsLens =
+        Lens.of(OrderWithItems::items, (order, items) -> new OrderWithItems(order.id(), items));
+
+    // Third level: indexed traversal for items
+    IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed = IndexedTraversals.forList();
+
+    // Compose: orders → items field → each item with PAIRED indices
+    IndexedTraversal<Pair<Integer, Integer>, List<OrderWithItems>, LineItem> composed =
+        ordersIndexed.andThen(itemsLens.asTraversal()).iandThen(itemsIndexed);
+
+    List<OrderWithItems> orders =
+        List.of(
+            new OrderWithItems(
+                "ORD-1",
+                List.of(new LineItem("Laptop", 1, 999.99), new LineItem("Mouse", 1, 24.99))),
+            new OrderWithItems(
+                "ORD-2",
+                List.of(new LineItem("Keyboard", 1, 79.99), new LineItem("Monitor", 1, 299.99))));
+
+    // Access with paired indices: (order index, item index)
+    List<Pair<Pair<Integer, Integer>, LineItem>> all =
+        IndexedTraversals.toIndexedList(composed, orders);
+
+    System.out.println("All items with paired indices:");
+    for (Pair<Pair<Integer, Integer>, LineItem> entry : all) {
+      Pair<Integer, Integer> indices = entry.first();
+      LineItem item = entry.second();
+      System.out.printf(
+          "  Order %d, Item %d: %s%n", indices.first(), indices.second(), item.productName());
+    }
+
+    // Modify with full path visibility
+    List<OrderWithItems> updated =
+        IndexedTraversals.imodify(
+            composed,
+            (indices, item) -> {
+              int orderIdx = indices.first();
+              int itemIdx = indices.second();
+              System.out.printf(
+                  "Processing [order=%d, item=%d]: %s%n", orderIdx, itemIdx, item.productName());
+              return item;
+            },
+            orders);
+
+    System.out.println();
+  }
+
+  /** Demonstrates a comprehensive real-world order fulfilment scenario. */
+  private static void demonstrateRealWorldScenario() {
+    System.out.println("--- Real-World: Order Fulfilment Dashboard ---");
+
+    Order order =
+        new Order(
+            "ORD-12345",
+            List.of(
+                new LineItem("Laptop", 1, 999.99),
+                new LineItem("Mouse", 2, 24.99),
+                new LineItem("Keyboard", 1, 79.99),
+                new LineItem("Monitor", 1, 299.99)),
+            new LinkedHashMap<>(
+                Map.of(
+                    "priority", "express",
+                    "gift-wrap", "true",
+                    "delivery-note", "Leave at door")));
+
+    // Task 1: Generate packing slip
+    System.out.println("Packing Slip for " + order.orderId() + ":");
+    IndexedTraversal<Integer, List<LineItem>, LineItem> itemsIndexed = IndexedTraversals.forList();
+
+    List<Pair<Integer, LineItem>> indexedItems =
+        IndexedTraversals.toIndexedList(itemsIndexed, order.items());
+
+    for (Pair<Integer, LineItem> pair : indexedItems) {
+      int position = pair.first() + 1; // 1-based for display
+      LineItem item = pair.second();
+      System.out.printf(
+          "  Item %d: %s (Qty: %d) - £%.2f%n",
+          position, item.productName(), item.quantity(), item.price() * item.quantity());
+    }
+
+    // Task 2: Apply position-based discount (every 3rd item gets 15% off)
+    System.out.println("\nApplying position-based discounts:");
+    List<LineItem> discounted =
+        IndexedTraversals.imodify(
+            itemsIndexed,
+            (index, item) -> {
+              if ((index + 1) % 3 == 0) {
+                double newPrice = item.price() * 0.85;
+                System.out.printf(
+                    "  Position %d (%s): £%.2f → £%.2f (15%% off)%n",
+                    index + 1, item.productName(), item.price(), newPrice);
+                return new LineItem(item.productName(), item.quantity(), newPrice);
+              }
+              return item;
+            },
+            order.items());
+
+    double originalTotal =
+        order.items().stream().mapToDouble(item -> item.price() * item.quantity()).sum();
+    double discountedTotal =
+        discounted.stream().mapToDouble(item -> item.price() * item.quantity()).sum();
+
+    System.out.printf("Original total: £%.2f%n", originalTotal);
+    System.out.printf("Discounted total: £%.2f%n", discountedTotal);
+
+    // Task 3: Process metadata with key awareness
+    System.out.println("\nProcessing metadata:");
+    IndexedTraversal<String, Map<String, String>, String> metadataIndexed =
+        IndexedTraversals.forMap();
+
+    List<Pair<String, String>> metadataEntries =
+        IndexedTraversals.toIndexedList(metadataIndexed, order.metadata());
+
+    for (Pair<String, String> entry : metadataEntries) {
+      String key = entry.first();
+      String value = entry.second();
+
+      switch (key) {
+        case "priority" -> System.out.println("  Shipping priority: " + value.toUpperCase());
+        case "gift-wrap" ->
+            System.out.println(
+                "  Gift wrapping: " + (value.equals("true") ? "Required" : "Not required"));
+        case "delivery-note" -> System.out.println("  Special instructions: " + value);
+        default -> System.out.println("  " + key + ": " + value);
+      }
+    }
+
+    // Task 4: Identify high-value positions (items > £100)
+    System.out.println("\nHigh-value items (require special handling):");
+    IndexedTraversal<Integer, List<LineItem>, LineItem> highValue =
+        itemsIndexed.filteredWithIndex((index, item) -> item.price() > 100);
+
+    List<Pair<Integer, LineItem>> expensive =
+        IndexedTraversals.toIndexedList(highValue, order.items());
+
+    for (Pair<Integer, LineItem> pair : expensive) {
+      System.out.printf(
+          "  Position %d: %s (£%.2f)%n",
+          pair.first() + 1, pair.second().productName(), pair.second().price());
+    }
+
+    System.out.println("\n=== Indexed optics enable position-aware business logic ===");
+  }
+}


### PR DESCRIPTION
    Add indexed optics for position-aware transformations
    
    Implements indexed optics that track the index/position of each focused
    element, enabling position-aware operations:
    
    - IndexedOptic: Base interface with imodifyF for index-aware modifications
    - IndexedTraversal: Zero or more elements with index tracking
    - IndexedFold: Read-only indexed aggregation with ifoldMap
    - IndexedLens: Single indexed field access
    - IndexedTraversals: Utility class with factory methods for List/Map
    
    Key features:
    - Index composition using Tuple2 (paired indices)
    - Filter by index with filterIndex()
    - Filter by value preserving indices with filtered()
    - Combined index-value filtering with filteredWithIndex()
    - Composition with regular optics preserving outer index
    - Conversion to non-indexed variants (asTraversal, asFold, asLens)


Fixes #169 


