### PR TITLE
Add comprehensive traversal enhancements for common data structures

### DIFF
--- a/hkj-book/src/optics/common_data_structure_traversals.md
+++ b/hkj-book/src/optics/common_data_structure_traversals.md
@@ -1,0 +1,598 @@
+# Common Data Structure Traversals
+
+## _Extending Traversal Power to Optional, Map, and Tuple Types_
+
+~~~admonish info title="What You'll Learn"
+- Traversing Optional values with affine traversals (0-1 cardinality)
+- Bulk transformations on Map values whilst preserving keys
+- Parallel operations on Tuple2 pairs when elements share a type
+- Composing structure traversals with lenses and filtered optics
+- Real-world patterns: configuration management, feature flags, coordinate transforms
+- When to use structure traversals vs direct access vs Stream API
+~~~
+
+~~~admonish title="Example Code"
+[OptionalMapTraversalsExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/OptionalMapTraversalsExample.java)
+
+[TupleTraversalsExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/TupleTraversalsExample.java)
+~~~
+
+So far, we've explored traversals for collections—lists, sets, and arrays. But Java applications work with many other data structures that benefit from traversal operations: Optional values that might be empty, Map collections where we need to transform values whilst preserving keys, and Tuple pairs that represent related data.
+
+These structures share a common need: **apply a transformation uniformly across their contents whilst maintaining structural integrity**. Higher-kinded-j's traversal combinators make this declarative, composable, and type-safe.
+
+---
+
+## Think of Structure Traversals Like...
+
+* **Java Stream's `Optional.map()`**: Like `optional.map(transform)` but composable with other optics
+* **Scala's for-comprehensions**: Similar to `for { x <- option } yield transform(x)`, but integrated into optic pipelines
+* **Database UPDATE statements**: Like `UPDATE config SET value = transform(value)`, preserving structure
+* **Functional map operations**: Like `fmap` in Haskell—lifting pure functions into wrapped contexts
+
+The key insight: these aren't special cases—they're **traversals with specific cardinality**:
+- `Optional<A>`: 0 or 1 element (affine traversal)
+- `Map<K, V>`: 0 to N values, preserving keys
+- `Tuple2<A, A>`: Exactly 2 elements (when same type)
+
+---
+
+## Three Categories of Structure Traversals
+
+Higher-kinded-j provides factory methods in `Traversals` and dedicated utility classes:
+
+| Structure | Method | Cardinality | Use Case |
+|-----------|--------|-------------|----------|
+| **Optional** | `Traversals.forOptional()` | 0 or 1 | Nullable fields, configuration values |
+| **Map Values** | `Traversals.forMapValues()` | 0 to N | Bulk value transforms, preserving keys |
+| **Tuple2 Pairs** | `TupleTraversals.both()` | Exactly 2 | Coordinate systems, min/max pairs |
+
+---
+
+## Optional Traversals: Handling Absent Values Declaratively
+
+### The Problem with Nested Optionals
+
+Traditional Optional handling becomes verbose when working with nested structures:
+
+```java
+@GenerateLenses
+public record ServerConfig(
+    String hostname,
+    Optional<Integer> port,
+    Optional<String> sslCertPath
+) {}
+
+@GenerateLenses
+public record ApplicationConfig(
+    String appName,
+    Optional<ServerConfig> server
+) {}
+
+// Traditional: Nested map() calls
+ApplicationConfig updated = config.server()
+    .map(server -> server.port()
+        .map(p -> server.withPort(Optional.of(p + 1000)))  // Offset ports
+        .orElse(server)
+    )
+    .map(newServer -> config.withServer(Optional.of(newServer)))
+    .orElse(config);
+```
+
+This pattern doesn't compose with other optics and mixes traversal logic with transformation logic.
+
+### The Solution: `forOptional()` Traversal
+
+The `forOptional()` method creates an **affine traversal**—focusing on 0 or 1 element.
+
+```java
+import org.higherkindedj.optics.util.Traversals;
+
+// Create an Optional traversal
+Traversal<Optional<Integer>, Integer> optTraversal = Traversals.forOptional();
+
+// Modify the value if present
+Optional<Integer> maybePort = Optional.of(8080);
+Optional<Integer> offsetPort = Traversals.modify(optTraversal, p -> p + 1000, maybePort);
+// Result: Optional.of(9080)
+
+// Empty Optional remains empty
+Optional<Integer> empty = Optional.empty();
+Optional<Integer> stillEmpty = Traversals.modify(optTraversal, p -> p + 1000, empty);
+// Result: Optional.empty()
+
+// Extract value as a list
+List<Integer> values = Traversals.getAll(optTraversal, maybePort);
+// Result: [8080]  (or [] for empty)
+```
+
+### Composing with Lenses for Nested Optionals
+
+```java
+// Compose Optional traversal with lens traversal
+Traversal<ApplicationConfig, Integer> serverPorts =
+    ApplicationConfigLenses.server().asTraversal()
+        .andThen(Traversals.forOptional())
+        .andThen(ServerConfigLenses.port().asTraversal())
+        .andThen(Traversals.forOptional());
+
+// Offset all server ports in one operation
+ApplicationConfig updated = Traversals.modify(serverPorts, p -> p + 1000, config);
+// Works whether server and port are present or absent
+```
+
+### Real-World Example: Feature Flag Management
+
+```java
+@GenerateLenses
+public record FeatureFlags(Map<String, Optional<Boolean>> flags) {}
+
+public class FeatureFlagService {
+
+    // Enable all flags that are currently set (respect absent flags)
+    public static FeatureFlags enableAllSet(FeatureFlags config) {
+        Traversal<Map<String, Optional<Boolean>>, Optional<Boolean>> allFlagValues =
+            Traversals.forMapValues();
+
+        Traversal<Map<String, Optional<Boolean>>, Boolean> presentFlags =
+            allFlagValues.andThen(Traversals.forOptional());
+
+        Map<String, Optional<Boolean>> updated = Traversals.modify(
+            presentFlags,
+            flag -> true,  // Enable all present flags
+            config.flags()
+        );
+
+        return new FeatureFlags(updated);
+    }
+}
+```
+
+---
+
+## Map Value Traversals: Bulk Transformations Preserving Keys
+
+### The Problem with Map Streams
+
+Transforming Map values whilst preserving keys requires ceremony:
+
+```java
+Map<String, Double> prices = Map.of(
+    "widget", 10.0,
+    "gadget", 25.0,
+    "gizmo", 15.0
+);
+
+// Traditional: Stream + collect
+Map<String, Double> inflated = prices.entrySet().stream()
+    .collect(Collectors.toMap(
+        Map.Entry::getKey,
+        e -> e.getValue() * 1.1  // 10% price increase
+    ));
+```
+
+This pattern doesn't compose and requires reconstructing the entire map.
+
+### The Solution: `forMapValues()` Traversal
+
+The `forMapValues()` method creates a traversal focusing on **all values** whilst preserving key structure.
+
+```java
+// Create a Map values traversal
+Traversal<Map<String, Double>, Double> priceTraversal = Traversals.forMapValues();
+
+// Apply 10% increase to all values
+Map<String, Double> inflated = Traversals.modify(priceTraversal, price -> price * 1.1, prices);
+// Result: {widget=11.0, gadget=27.5, gizmo=16.5}
+
+// Extract all values
+List<Double> allPrices = Traversals.getAll(priceTraversal, prices);
+// Result: [10.0, 25.0, 15.0]
+
+// Compose with filtered for conditional updates
+Traversal<Map<String, Double>, Double> expensiveItems =
+    priceTraversal.filtered(price -> price > 20.0);
+
+Map<String, Double> discounted = Traversals.modify(
+    expensiveItems,
+    price -> price * 0.9,  // 10% discount on expensive items only
+    prices
+);
+// Result: {widget=10.0, gadget=22.5, gizmo=15.0}
+```
+
+### Real-World Example: Configuration Value Normalisation
+
+```java
+@GenerateLenses
+public record DatabaseConfig(
+    Map<String, String> connectionProperties
+) {}
+
+public class ConfigNormaliser {
+
+    // Trim all connection property values
+    public static DatabaseConfig normaliseProperties(DatabaseConfig config) {
+        Traversal<Map<String, String>, String> allPropertyValues =
+            Traversals.forMapValues();
+
+        Map<String, String> trimmed = Traversals.modify(
+            allPropertyValues,
+            String::trim,
+            config.connectionProperties()
+        );
+
+        return new DatabaseConfig(trimmed);
+    }
+
+    // Redact sensitive values (password, token)
+    public static DatabaseConfig redactSensitive(DatabaseConfig config) {
+        // Use an indexed traversal to access both key and value during modification
+        IndexedTraversal<String, Map<String, String>, String> allProperties =
+            IndexedTraversals.forMap();
+
+        Map<String, String> redacted = IndexedTraversals.imodify(
+            allProperties,
+            (key, value) -> {
+                if (key.toLowerCase().contains("password") || key.toLowerCase().contains("token")) {
+                    return "***REDACTED***";
+                }
+                return value;
+            },
+            config.connectionProperties()
+        );
+
+        return new DatabaseConfig(redacted);
+    }
+}
+```
+
+### Composing Map Traversals with Nested Structures
+
+```java
+@GenerateLenses
+public record ServiceRegistry(
+    Map<String, ServerConfig> services
+) {}
+
+// Transform all server ports across all services
+Traversal<ServiceRegistry, Integer> allServicePorts =
+    ServiceRegistryLenses.services().asTraversal()
+        .andThen(Traversals.forMapValues())
+        .andThen(ServerConfigLenses.port().asTraversal())
+        .andThen(Traversals.forOptional());
+
+ServiceRegistry updated = Traversals.modify(
+    allServicePorts,
+    port -> port + 1000,  // Offset all ports
+    registry
+);
+```
+
+---
+
+## Tuple Traversals: Parallel Transformations on Pairs
+
+### The Problem with Manual Tuple Updates
+
+Applying the same operation to both elements of a tuple requires duplication:
+
+```java
+Tuple2<Integer, Integer> range = new Tuple2<>(10, 20);
+
+// Traditional: Manual, repetitive
+Tuple2<Integer, Integer> doubled = new Tuple2<>(
+    range._1() * 2,
+    range._2() * 2
+);
+```
+
+When tuples represent related data (coordinates, ranges, min/max pairs), we want to express "apply this transformation to both elements" declaratively.
+
+### The Solution: `TupleTraversals.both()`
+
+The `both()` method creates a traversal that focuses on **both elements** when they share a type.
+
+```java
+import org.higherkindedj.optics.util.TupleTraversals;
+import org.higherkindedj.hkt.tuple.Tuple2;
+
+// Create a tuple traversal (when both elements are same type)
+Traversal<Tuple2<Integer, Integer>, Integer> bothInts = TupleTraversals.both();
+
+// Double both elements
+Tuple2<Integer, Integer> range = new Tuple2<>(10, 20);
+Tuple2<Integer, Integer> doubled = Traversals.modify(bothInts, x -> x * 2, range);
+// Result: Tuple2(20, 40)
+
+// Extract both elements
+List<Integer> values = Traversals.getAll(bothInts, range);
+// Result: [10, 20]
+
+// Works with any shared type
+Traversal<Tuple2<String, String>, String> bothStrings = TupleTraversals.both();
+Tuple2<String, String> names = new Tuple2<>("alice", "bob");
+Tuple2<String, String> capitalised = Traversals.modify(
+    bothStrings,
+    s -> s.substring(0, 1).toUpperCase() + s.substring(1),
+    names
+);
+// Result: Tuple2("Alice", "Bob")
+```
+
+### Real-World Example: Geographic Coordinate Transformations
+
+```java
+@GenerateLenses
+public record Location(
+    String name,
+    Tuple2<Double, Double> coordinates  // (latitude, longitude)
+) {}
+
+public class CoordinateTransforms {
+
+    // Apply precision rounding to both lat/lon
+    public static Location roundCoordinates(Location location, int decimals) {
+        Traversal<Tuple2<Double, Double>, Double> bothCoords = TupleTraversals.both();
+
+        double factor = Math.pow(10, decimals);
+        Tuple2<Double, Double> rounded = Traversals.modify(
+            bothCoords,
+            coord -> Math.round(coord * factor) / factor,
+            location.coordinates()
+        );
+
+        return new Location(location.name(), rounded);
+    }
+
+    // Offset coordinates by a fixed delta
+    public static Location offsetCoordinates(Location location, double delta) {
+        Traversal<Tuple2<Double, Double>, Double> bothCoords = TupleTraversals.both();
+
+        Tuple2<Double, Double> offset = Traversals.modify(
+            bothCoords,
+            coord -> coord + delta,
+            location.coordinates()
+        );
+
+        return new Location(location.name(), offset);
+    }
+}
+```
+
+### Composing with Nested Structures
+
+```java
+@GenerateLenses
+public record BoundingBox(
+    Tuple2<Integer, Integer> topLeft,
+    Tuple2<Integer, Integer> bottomRight
+) {}
+
+// Scale coordinates in the top-left corner
+Traversal<BoundingBox, Integer> topLeftCoords =
+    BoundingBoxLenses.topLeft().asTraversal()
+        .andThen(TupleTraversals.both());
+
+BoundingBox scaled = Traversals.modify(topLeftCoords, coord -> coord * 2, box);
+
+// To scale all coordinates, you would compose traversals for each field separately
+// or create a custom traversal that focuses on all four coordinates
+```
+
+---
+
+## When to Use Structure Traversals vs Other Approaches
+
+### Use Structure Traversals When:
+
+* **Reusable transformations** - Define once, compose with other optics
+* **Nested optionals** - Avoiding `.map().map().map()` chains
+* **Bulk map updates** - Transforming all values whilst preserving keys
+* **Parallel tuple operations** - Same transformation to both elements
+* **Immutable updates** - Structure preserved, only focused elements transformed
+
+```java
+// Perfect: Declarative, composable, reusable
+Traversal<ServiceConfig, Integer> allTimeouts =
+    ServiceConfigLenses.endpoints().asTraversal()
+        .andThen(Traversals.forMapValues())
+        .andThen(EndpointLenses.timeout().asTraversal())
+        .andThen(Traversals.forOptional());
+
+ServiceConfig increased = Traversals.modify(allTimeouts, t -> t + 1000, config);
+```
+
+### Use Direct Access When:
+
+* **Single Optional** - Simple `map()` or `orElse()` is clearer
+* **Specific Map key** - `map.get(key)` is more direct
+* **Type-specific logic** - Different transformations per tuple element
+
+```java
+// Better with direct access: Single Optional
+Optional<Integer> port = config.port().map(p -> p + 1000);
+
+// Better with get: Specific key
+Double price = prices.getOrDefault("widget", 0.0) * 1.1;
+
+// Better with manual: Different operations per element
+Tuple2<Integer, String> result = new Tuple2<>(
+    tuple._1() * 2,        // Double the integer
+    tuple._2().toUpperCase()  // Uppercase the string
+);
+```
+
+### Use Stream API When:
+
+* **Complex filtering** - Multiple conditions
+* **Aggregations** - Collecting to new structures
+* **No structural preservation** - Extracting or transforming to different shape
+
+```java
+// Better with streams: Complex filtering
+List<Integer> values = map.values().stream()
+    .filter(v -> v > 10)
+    .filter(v -> v < 100)
+    .collect(toList());
+```
+
+---
+
+## Common Pitfalls
+
+### ❌ Don't Do This:
+
+```java
+// Inefficient: Creating traversals in loops
+for (Map.Entry<String, Double> entry : prices.entrySet()) {
+    Traversal<Map<String, Double>, Double> values = Traversals.forMapValues();
+    // Process each value... inefficient!
+}
+
+// Over-engineering: Using traversals for simple cases
+Traversal<Optional<String>, String> opt = Traversals.forOptional();
+String result = optional.map(s -> s.toUpperCase()).orElse("default");
+// Just use: optional.map(String::toUpperCase).orElse("default")
+
+// Type confusion: Trying to use both() with different types
+Tuple2<Integer, String> mixed = new Tuple2<>(42, "hello");
+// TupleTraversals.both() won't work here—types must match!
+```
+
+### ✅ Do This Instead:
+
+```java
+// Efficient: Create traversal once, apply to entire structure
+Traversal<Map<String, Double>, Double> priceTraversal = Traversals.forMapValues();
+Map<String, Double> updated = Traversals.modify(priceTraversal, p -> p * 1.1, prices);
+
+// Right tool: Use direct methods for simple cases
+String result = optional.map(String::toUpperCase).orElse("default");
+
+// Correct types: Use separate lenses for mixed tuples
+Lens<Tuple2<Integer, String>, Integer> first = Tuple2Lenses._1();
+Lens<Tuple2<Integer, String>, String> second = Tuple2Lenses._2();
+Tuple2<Integer, String> updated = new Tuple2<>(
+    first.get(mixed) * 2,
+    second.get(mixed).toUpperCase()
+);
+```
+
+---
+
+## Performance Notes
+
+Structure traversals are optimised for immutability:
+
+* **Single pass**: No intermediate collections
+* **Structural sharing**: Unchanged portions reuse original references
+* **No boxing overhead**: Direct map operations without streams
+* **Lazy evaluation**: Short-circuits on empty optionals
+
+**Best Practice**: Store commonly-used structure traversals as constants:
+
+```java
+public class ConfigOptics {
+    // Reusable structure traversals
+    public static final Traversal<Optional<String>, String> OPTIONAL_STRING =
+        Traversals.forOptional();
+
+    public static final Traversal<Map<String, Integer>, Integer> MAP_INT_VALUES =
+        Traversals.forMapValues();
+
+    public static final Traversal<Tuple2<Double, Double>, Double> COORDINATE_PAIR =
+        TupleTraversals.both();
+
+    // Domain-specific compositions
+    public static final Traversal<ServerConfig, Integer> ALL_PORTS =
+        ServerConfigLenses.endpoints().asTraversal()
+            .andThen(MAP_INT_VALUES);
+}
+```
+
+---
+
+## Integration with Functional Java Ecosystem
+
+### Vavr Integration
+
+```java
+import io.vavr.control.Option;
+
+// Note: higher-kinded-j uses java.util.Optional
+// For Vavr's Option, you'd need custom traversals
+// But the pattern is the same:
+
+Traversal<Option<Integer>, Integer> vavrOption = new Traversal<>() {
+    @Override
+    public <F> Kind<F, Option<Integer>> modifyF(
+        Function<Integer, Kind<F, Integer>> f,
+        Option<Integer> source,
+        Applicative<F> applicative
+    ) {
+        return source.isDefined()
+            ? applicative.map(Option::of, f.apply(source.get()))
+            : applicative.of(source);
+    }
+};
+```
+
+### Cyclops Integration
+
+```java
+import cyclops.control.Maybe;
+
+// Similar pattern for Cyclops Maybe
+// Higher-kinded-j's patterns extend naturally to other monadic types
+```
+
+---
+
+## Related Resources
+
+**Functional Java Libraries**:
+- [Vavr](https://www.vavr.io/) - Immutable collections with Option, Try, Either
+- [Cyclops](https://github.com/aol/cyclops) - Functional control structures
+- [Functional Java](https://www.functionaljava.org/) - Classic FP utilities
+
+**Further Reading**:
+- *Functional Programming in Java* by Venkat Subramaniam - Optional and immutable patterns
+- *Modern Java in Action* by Raoul-Gabriel Urma - Functional data processing
+- [Optics By Example](https://leanpub.com/optics-by-example) - Comprehensive optics guide (Haskell)
+
+**Type Theory Background**:
+- **Affine Traversals**: Focusing on 0 or 1 element (Optional)
+- **Bitraversable**: Traversing structures with two type parameters (Tuple2, Either)
+- [Profunctor Optics: Modular Data Accessors](https://arxiv.org/abs/1703.10857) - Theoretical foundation
+
+---
+
+## Summary
+
+Structure traversals extend the traversal pattern to common Java data types:
+
+| Structure | Traversal | Key Benefit |
+|-----------|-----------|-------------|
+| **Optional** | `forOptional()` | Null-safe composition without `.map()` chains |
+| **Map Values** | `forMapValues()` | Bulk value transformation preserving keys |
+| **Tuple2 Pairs** | `both()` | Parallel operations on homogeneous pairs |
+
+These tools transform how you work with wrapped and paired values:
+
+**Before** (Imperative):
+- Manual Optional chaining
+- Stream + collect for Maps
+- Repetitive tuple updates
+
+**After** (Declarative):
+- Composable Optional traversals
+- Direct map value transformations
+- Unified tuple operations
+
+By incorporating structure traversals into your optics toolkit, you gain the ability to express complex transformations declaratively, compose them seamlessly with other optics, and maintain type safety throughout—all whilst preserving the immutability and referential transparency that make functional programming powerful.
+
+---
+
+**Previous:** [String Traversals: Declarative Text Processing](string_traversals.md)
+**Next:** [Indexed Optics: Position-Aware Operations](indexed_optics.md)

--- a/hkj-book/src/optics/getters.md
+++ b/hkj-book/src/optics/getters.md
@@ -585,5 +585,5 @@ The key insight: **Getters make pure functions first-class composable citizens**
 
 ---
 
-**Previous:** [Limiting Traversals: Focusing on List Portions](limiting_traversals.md)
+**Previous:** [Indexed Optics: Position-Aware Operations](indexed_optics.md)
 **Next:** [Setters: Composable Write-Only Modifications](setters.md)

--- a/hkj-book/src/optics/indexed_optics.md
+++ b/hkj-book/src/optics/indexed_optics.md
@@ -1168,5 +1168,6 @@ Indexed optics represent the fusion of position awareness with functional compos
 
 ---
 
-**Previous:** [Filtered Optics: Predicate-Based Composition](filtered_optics.md)
-**Next:** [Limiting Traversals: Focusing on List Portions](limiting_traversals.md)
+**Previous:** [Common Data Structure Traversals](common_data_structure_traversals.md)
+**Next:** [Getters: Read-Only Optics](getters.md)
+

--- a/hkj-book/src/optics/string_traversals.md
+++ b/hkj-book/src/optics/string_traversals.md
@@ -1,0 +1,542 @@
+# String Traversals: Declarative Text Processing
+
+## _Type-Safe Text Manipulation Without Regex Complexity_
+
+~~~admonish info title="What You'll Learn"
+- Breaking strings into traversable units (characters, words, lines)
+- Declarative text normalisation and validation
+- Composing string traversals with filtered optics for pattern matching
+- Real-world text processing: logs, CSV, configuration files
+- When to use string traversals vs Stream API vs regex
+- Performance characteristics and best practices
+~~~
+
+~~~admonish title="Example Code"
+[StringTraversalsExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/StringTraversalsExample.java)
+~~~
+
+Working with text in Java often feels like choosing between extremes: verbose manual string manipulation with `substring()` and `indexOf()`, or cryptic regular expressions that become unmaintainable. String traversals offer a middle path—declarative, composable, and type-safe.
+
+Consider these common scenarios from enterprise Java applications:
+
+* **Configuration Management**: Normalising property values across `.properties` files
+* **Log Analysis**: Filtering and transforming log entries line-by-line
+* **Data Import**: Processing CSV files with per-field transformations
+* **API Integration**: Standardising email addresses from external systems
+* **Validation**: Checking character-level constraints (length, allowed characters)
+
+The traditional approach mixes parsing logic with transformation logic, making code difficult to test and reuse:
+
+```java
+// Traditional: Mixed concerns, hard to compose
+String normaliseEmail(String email) {
+    String[] parts = email.toLowerCase().split("@");
+    if (parts.length != 2) throw new IllegalArgumentException();
+    String domain = parts[1].trim();
+    return parts[0] + "@" + domain;
+}
+
+// What if we need to normalise just the domain? Or multiple emails in a document?
+// We'd need separate methods or complex parameters.
+```
+
+**String traversals** let you separate the "what" (the structure) from the "how" (the transformation), making your text processing logic reusable and composable.
+
+---
+
+## Think of String Traversals Like...
+
+* **Java Stream's split() + map()**: Like `text.lines().map(...)` but integrated into optic composition
+* **IntelliJ's "Replace in Selection"**: Focus on text units, transform them, reassemble automatically
+* **Unix text tools**: Similar to `awk` and `sed` pipelines, but type-safe and composable
+* **SQL's string functions**: Like `UPPER()`, `TRIM()`, `SPLIT_PART()`, but for immutable Java strings
+
+The key insight: text structure (characters, words, lines) becomes part of your optic's identity, not preprocessing before the real work.
+
+---
+
+## Three Ways to Decompose Text
+
+The `StringTraversals` utility class provides three fundamental decompositions:
+
+| Method | Unit | Example Input | Focused Elements |
+|--------|------|---------------|------------------|
+| **`chars()`** | Characters | `"hello"` | `['h', 'e', 'l', 'l', 'o']` |
+| **`worded()`** | Words (by `\s+`) | `"hello world"` | `["hello", "world"]` |
+| **`lined()`** | Lines (by `\n`, `\r\n`, `\r`) | `"line1\nline2"` | `["line1", "line2"]` |
+
+Each returns a `Traversal<String, ?>` that can be composed with other optics and applied via `Traversals.modify()` or `Traversals.getAll()`.
+
+---
+
+## A Step-by-Step Walkthrough
+
+### Step 1: Character-Level Processing with `chars()`
+
+The `chars()` traversal breaks a string into individual characters, allowing transformations at the finest granularity.
+
+```java
+import org.higherkindedj.optics.util.StringTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+// Create a character traversal
+Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+// Transform all characters to uppercase
+String uppercased = Traversals.modify(charTraversal, Character::toUpperCase, "hello world");
+// Result: "HELLO WORLD"
+
+// Extract all characters as a list
+List<Character> chars = Traversals.getAll(charTraversal, "abc");
+// Result: ['a', 'b', 'c']
+
+// Compose with filtered for selective transformation
+Traversal<String, Character> vowels = charTraversal.filtered(c ->
+    "aeiouAEIOU".indexOf(c) >= 0
+);
+String result = Traversals.modify(vowels, Character::toUpperCase, "hello world");
+// Result: "hEllO wOrld"  (only vowels uppercased)
+```
+
+**Use Cases**:
+- Character-level validation (alphanumeric checks)
+- ROT13 or Caesar cipher transformations
+- Character frequency analysis
+- Removing or replacing specific characters
+
+### Step 2: Word-Level Processing with `worded()`
+
+The `worded()` traversal splits by whitespace (`\s+`), focusing on each word independently.
+
+**Key Semantics**:
+- Multiple consecutive spaces are normalised to single spaces
+- Leading and trailing whitespace is removed
+- Empty strings or whitespace-only strings produce no words
+
+```java
+Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+// Capitalise each word
+String capitalised = Traversals.modify(
+    wordTraversal,
+    word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase(),
+    "hello WORLD from JAVA"
+);
+// Result: "Hello World From Java"
+
+// Extract all words (whitespace normalisation automatic)
+List<String> words = Traversals.getAll(wordTraversal, "foo  bar\t\tbaz");
+// Result: ["foo", "bar", "baz"]
+
+// Compose with filtered for conditional transformation
+Traversal<String, String> longWords = wordTraversal.filtered(w -> w.length() > 5);
+String emphasised = Traversals.modify(longWords, w -> w.toUpperCase(), "make software better");
+// Result: "make SOFTWARE BETTER"
+```
+
+**Use Cases**:
+- Title case formatting
+- Stop word filtering
+- Word-based text normalisation
+- Search query processing
+- Email domain extraction
+
+### Step 3: Line-Level Processing with `lined()`
+
+The `lined()` traversal splits by line separators (`\n`, `\r\n`, or `\r`), treating each line as a focus target.
+
+**Key Semantics**:
+- All line endings are normalised to `\n` in output
+- Empty strings produce no lines
+- Trailing newlines are preserved in individual line processing
+
+```java
+Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+// Prefix each line with a marker
+String prefixed = Traversals.modify(
+    lineTraversal,
+    line -> "> " + line,
+    "line1\nline2\nline3"
+);
+// Result: "> line1\n> line2\n> line3"
+
+// Extract all non-empty lines
+List<String> lines = Traversals.getAll(lineTraversal, "first\n\nthird");
+// Result: ["first", "", "third"]  (empty line preserved)
+
+// Filter lines by content
+Traversal<String, String> errorLines = lineTraversal.filtered(line ->
+    line.contains("ERROR")
+);
+String errors = Traversals.getAll(errorLines, logContent).stream()
+    .collect(Collectors.joining("\n"));
+```
+
+**Use Cases**:
+- Log file filtering and transformation
+- CSV row processing
+- Configuration file parsing
+- Code formatting (indentation, comments)
+- Multi-line text validation
+
+---
+
+## Real-World Example: Email Normalisation Service
+
+A common requirement in enterprise systems: normalise email addresses from various sources before storage.
+
+```java
+import org.higherkindedj.optics.util.StringTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+public class EmailNormaliser {
+
+    // Normalise the local part (before @) to lowercase
+    // Normalise the domain (after @) to lowercase and trim
+    public static String normalise(String email) {
+        Traversal<String, String> words = StringTraversals.worded();
+
+        // Split email by @ symbol (treated as whitespace separator for this example)
+        // In production, you'd want more robust parsing
+        String lowercased = Traversals.modify(words, String::toLowerCase, email);
+
+        return lowercased.trim();
+    }
+
+    // More sophisticated: normalise domain parts separately
+    public static String normaliseDomain(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex == -1) return email;
+
+        String local = email.substring(0, atIndex);
+        String domain = email.substring(atIndex + 1);
+
+        // Normalise domain components
+        Traversal<String, String> domainParts = StringTraversals.worded();
+        String normalisedDomain = Traversals.modify(
+            domainParts,
+            String::toLowerCase,
+            domain.replace(".", " ")  // Split domain by dots
+        ).replace(" ", ".");  // Rejoin
+
+        return local + "@" + normalisedDomain;
+    }
+}
+```
+
+---
+
+## Composing String Traversals
+
+The power emerges when combining string traversals with other optics:
+
+### With Filtered Traversals — Pattern Matching
+
+```java
+// Find and transform lines starting with a prefix
+Traversal<String, String> commentLines =
+    StringTraversals.lined().filtered(line -> line.trim().startsWith("#"));
+
+String withoutComments = Traversals.modify(
+    commentLines,
+    line -> "",  // Remove comment lines by replacing with empty
+    sourceCode
+);
+```
+
+### With Nested Structures — Bulk Text Processing
+
+```java
+@GenerateLenses
+public record Document(String title, List<String> paragraphs) {}
+
+// Capitalise first letter of each word in all paragraphs
+Traversal<Document, String> allWords =
+    DocumentLenses.paragraphs().asTraversal()
+        .andThen(Traversals.forList())
+        .andThen(StringTraversals.worded());
+
+Document formatted = Traversals.modify(
+    allWords,
+    word -> word.substring(0, 1).toUpperCase() + word.substring(1),
+    document
+);
+```
+
+### With Effectful Operations — Validation
+
+```java
+import org.higherkindedj.hkt.optional.OptionalMonad;
+
+// Validate that all words are alphanumeric
+Traversal<String, String> words = StringTraversals.worded();
+
+Function<String, Kind<OptionalKind.Witness, String>> validateWord = word -> {
+    boolean alphanumeric = word.chars().allMatch(Character::isLetterOrDigit);
+    return alphanumeric
+        ? OptionalKindHelper.OPTIONAL.widen(Optional.of(word))
+        : OptionalKindHelper.OPTIONAL.widen(Optional.empty());
+};
+
+Optional<String> validated = OptionalKindHelper.OPTIONAL.narrow(
+    words.modifyF(validateWord, input, OptionalMonad.INSTANCE)
+);
+// Returns Optional.empty() if any word contains non-alphanumeric characters
+```
+
+---
+
+## Common Patterns
+
+### Log File Processing
+
+```java
+// Extract ERROR lines from application logs
+Traversal<String, String> errorLines =
+    StringTraversals.lined().filtered(line -> line.contains("ERROR"));
+
+List<String> errors = Traversals.getAll(errorLines, logContent);
+
+// Add timestamps to each line
+Traversal<String, String> allLines = StringTraversals.lined();
+String timestamped = Traversals.modify(
+    allLines,
+    line -> LocalDateTime.now() + " " + line,
+    originalLog
+);
+```
+
+### CSV Processing
+
+```java
+// Process CSV by splitting into lines, then cells
+Traversal<String, String> rows = StringTraversals.lined();
+Traversal<String, String> cells = StringTraversals.worded();  // Simplified; use split(",") in production
+
+// Transform specific column (e.g., third column to uppercase)
+String processedCsv = Traversals.modify(
+    rows,
+    row -> {
+        List<String> parts = List.of(row.split(","));
+        if (parts.size() > 2) {
+            List<String> modified = new ArrayList<>(parts);
+            modified.set(2, parts.get(2).toUpperCase());
+            return String.join(",", modified);
+        }
+        return row;
+    },
+    csvContent
+);
+```
+
+### Configuration File Normalisation
+
+```java
+// Trim all property values in .properties format
+Traversal<String, String> propertyLines = StringTraversals.lined();
+
+String normalised = Traversals.modify(
+    propertyLines,
+    line -> {
+        if (line.contains("=")) {
+            String[] parts = line.split("=", 2);
+            return parts[0].trim() + "=" + parts[1].trim();
+        }
+        return line;
+    },
+    propertiesContent
+);
+```
+
+---
+
+## When to Use String Traversals vs Other Approaches
+
+### Use String Traversals When:
+
+* **Reusable text transformations** - Define once, apply across multiple strings
+* **Composable pipelines** - Building complex optic chains with lenses and prisms
+* **Type-safe operations** - Character/word/line transformations with compile-time safety
+* **Immutable updates** - Transforming text whilst keeping data immutable
+* **Declarative intent** - Express "what" without "how" (no manual indexing)
+
+```java
+// Perfect: Reusable, composable, declarative
+Traversal<Config, String> allPropertyValues =
+    ConfigLenses.properties().asTraversal()
+        .andThen(StringTraversals.lined())
+        .andThen(StringTraversals.worded());
+
+Config trimmed = Traversals.modify(allPropertyValues, String::trim, config);
+```
+
+### Use Stream API When:
+
+* **Complex filtering** - Multiple conditions with short-circuiting
+* **Aggregations** - Counting, collecting to new structures
+* **No structural preservation needed** - Extracting data, not updating in place
+* **One-time operations** - Not reused across different contexts
+
+```java
+// Better with streams: Complex aggregation
+long wordCount = text.lines()
+    .flatMap(line -> Arrays.stream(line.split("\\s+")))
+    .filter(word -> word.length() > 5)
+    .count();
+```
+
+### Use Regular Expressions When:
+
+* **Complex pattern matching** - Extracting structured data (emails, URLs, dates)
+* **Search and replace** - Simple find-and-replace operations
+* **Validation** - Checking format compliance (phone numbers, postal codes)
+
+```java
+// Sometimes regex is clearest
+Pattern emailPattern = Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
+Matcher matcher = emailPattern.matcher(text);
+while (matcher.find()) {
+    processEmail(matcher.group());
+}
+```
+
+---
+
+## Common Pitfalls
+
+### ❌ Don't Do This:
+
+```java
+// Inefficient: Creating traversals in loops
+for (String paragraph : document.paragraphs()) {
+    Traversal<String, String> words = StringTraversals.worded();
+    Traversals.modify(words, String::toUpperCase, paragraph);
+}
+
+// Over-engineering: Using traversals for simple operations
+Traversal<String, Character> chars = StringTraversals.chars();
+String upper = Traversals.modify(chars, Character::toUpperCase, "hello");
+// Just use: "hello".toUpperCase()
+
+// Wrong expectation: Thinking it changes string length
+Traversal<String, Character> chars = StringTraversals.chars();
+String result = Traversals.modify(chars.filtered(c -> c != 'a'), c -> c, "banana");
+// Result: "banana" (still 6 chars, 'a' positions unchanged)
+// Filtered traversals preserve structure!
+```
+
+### ✅ Do This Instead:
+
+```java
+// Efficient: Create traversal once, reuse
+Traversal<String, String> words = StringTraversals.worded();
+List<String> processed = document.paragraphs().stream()
+    .map(p -> Traversals.modify(words, String::toUpperCase, p))
+    .collect(toList());
+
+// Right tool: Use built-in methods for simple cases
+String upper = text.toUpperCase();  // Simple and clear
+
+// Correct expectation: Use getAll for extraction
+Traversal<String, Character> vowels = StringTraversals.chars()
+    .filtered(c -> "aeiou".indexOf(c) >= 0);
+List<Character> extracted = Traversals.getAll(vowels, "banana");
+// Result: ['a', 'a', 'a'] - extracts vowels without changing structure
+```
+
+---
+
+## Performance Notes
+
+String traversals are optimised for immutability:
+
+* **Single pass**: Text is decomposed and reconstructed in one traversal
+* **No intermediate strings**: Operates on character/word lists internally
+* **Structural sharing**: For filtered operations, unchanged portions reference original
+* **Lazy bounds checking**: Minimal overhead for validation
+
+**Best Practice**: For frequently used string transformations, create traversals as constants:
+
+```java
+public class TextProcessing {
+    // Reusable string traversals
+    public static final Traversal<String, String> WORDS =
+        StringTraversals.worded();
+
+    public static final Traversal<String, String> LINES =
+        StringTraversals.lined();
+
+    public static final Traversal<String, Character> VOWELS =
+        StringTraversals.chars().filtered(c -> "aeiouAEIOU".indexOf(c) >= 0);
+
+    // Domain-specific compositions
+    public static final Traversal<String, String> ERROR_LOG_LINES =
+        LINES.filtered(line -> line.contains("ERROR"));
+}
+```
+
+---
+
+## Integration with Functional Java Ecosystem
+
+String traversals complement existing functional libraries:
+
+### Vavr Integration
+
+```java
+import io.vavr.control.Try;
+
+// Process lines with error handling
+Traversal<String, String> lines = StringTraversals.lined();
+
+Try<String> processed = Try.of(() ->
+    Traversals.modify(lines, line -> {
+        if (line.startsWith("INVALID")) {
+            throw new IllegalStateException("Invalid line: " + line);
+        }
+        return line.toUpperCase();
+    }, content)
+);
+```
+
+### Cyclops Integration
+
+```java
+import cyclops.control.Validated;
+
+// Validate each word using Cyclops Validated
+Traversal<String, String> words = StringTraversals.worded();
+
+Function<String, Kind<ValidatedKind.Witness<List<String>>, String>> validateLength =
+    word -> word.length() <= 10
+        ? VALIDATED.widen(Validated.valid(word))
+        : VALIDATED.widen(Validated.invalid(List.of("Word too long: " + word)));
+
+Validated<List<String>, String> result = VALIDATED.narrow(
+    words.modifyF(validateLength, input, validatedApplicative)
+);
+```
+
+---
+
+## Related Resources
+
+**Functional Java Libraries**:
+- [Vavr](https://www.vavr.io/) - Functional data structures with pattern matching
+- [Cyclops](https://github.com/aol/cyclops) - Functional control structures and higher-kinded types
+- [jOOλ](https://github.com/jOOQ/jOOL) - Functional utilities complementing Java Streams
+
+**Further Reading**:
+- *Functional Programming in Java* by Venkat Subramaniam - Practical FP patterns
+- *Modern Java in Action* by Raoul-Gabriel Urma - Streams, lambdas, and functional style
+- [Optics By Example](https://leanpub.com/optics-by-example) by Chris Penner - Haskell optics comprehensive guide
+
+**Comparison with Other Languages**:
+- Haskell's [`Data.Text`](https://hackage.haskell.org/package/text-2.0.2/docs/Data-Text.html) - Similar text processing with optics
+- Scala's [Monocle](https://www.optics.dev/Monocle/) - String traversals via `Traversal[String, Char]`
+
+---
+
+**Previous:** [Limiting Traversals: Focusing on List Portions](limiting_traversals.md)
+**Next:** [Common Data Structure Traversals](common_data_structure_traversals.md)

--- a/hkj-core/src/main/java/org/higherkindedj/optics/util/StringTraversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/util/StringTraversals.java
@@ -1,0 +1,238 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A final utility class providing static factory methods for creating {@link Traversal}s for {@link
+ * String} types.
+ *
+ * <p>These combinators enable text processing operations by breaking strings into smaller units
+ * (characters, words, lines) that can be traversed and modified.
+ *
+ * <p>All traversals maintain referential transparency and preserve immutability.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Transform each character
+ * Traversal<String, Character> charTraversal = StringTraversals.chars();
+ * String uppercased = Traversals.modify(charTraversal, Character::toUpperCase, "hello");
+ * // Result: "HELLO"
+ *
+ * // Transform each word
+ * Traversal<String, String> wordTraversal = StringTraversals.worded();
+ * String result = Traversals.modify(wordTraversal, String::toUpperCase, "hello world");
+ * // Result: "HELLO WORLD"
+ *
+ * // Transform each line
+ * Traversal<String, String> lineTraversal = StringTraversals.lined();
+ * String prefixed = Traversals.modify(lineTraversal, line -> "> " + line, "line1\nline2");
+ * // Result: "> line1\n> line2"
+ * }</pre>
+ */
+@NullMarked
+public final class StringTraversals {
+
+  /** Private constructor to prevent instantiation. */
+  private StringTraversals() {}
+
+  /**
+   * Creates a {@code Traversal} that focuses on each character in a string.
+   *
+   * <p>The string is decomposed into individual characters, each of which can be transformed via an
+   * effectful function. The transformed characters are then recombined into a new string.
+   *
+   * <p>Empty strings produce an empty traversal (zero elements focused).
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<String, Character> charTraversal = StringTraversals.chars();
+   *
+   * // Uppercase all characters
+   * String result = Traversals.modify(charTraversal, Character::toUpperCase, "hello");
+   * // Result: "HELLO"
+   *
+   * // Get all characters
+   * List<Character> chars = Traversals.getAll(charTraversal, "abc");
+   * // Result: ['a', 'b', 'c']
+   *
+   * // Filter vowels and uppercase them (via composition)
+   * Traversal<String, Character> vowels = charTraversal.filtered(c ->
+   *     "aeiouAEIOU".indexOf(c) >= 0
+   * );
+   * String modified = Traversals.modify(vowels, Character::toUpperCase, "hello world");
+   * // Result: "hEllO wOrld"
+   * }</pre>
+   *
+   * @return A {@code Traversal} focusing on each character in a string.
+   */
+  public static Traversal<String, Character> chars() {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, String> modifyF(
+          final Function<Character, Kind<F, Character>> f,
+          final String source,
+          final Applicative<F> applicative) {
+
+        if (source.isEmpty()) {
+          return applicative.of(source);
+        }
+
+        // Convert string to list of characters
+        final List<Character> charList =
+            source.chars().mapToObj(c -> (char) c).collect(Collectors.toList());
+
+        // Traverse the character list
+        final Kind<F, List<Character>> traversedChars =
+            Traversals.traverseList(charList, f, applicative);
+
+        // Reconstruct string from characters
+        return applicative.map(
+            chars -> {
+              final StringBuilder sb = new StringBuilder(chars.size());
+              for (final Character ch : chars) {
+                sb.append(ch);
+              }
+              return sb.toString();
+            },
+            traversedChars);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that splits a string by whitespace and focuses on each word.
+   *
+   * <p>The string is split using {@code "\\s+"} (one or more whitespace characters), producing a
+   * list of words. Each word can be transformed via an effectful function. The transformed words
+   * are then joined back with single spaces.
+   *
+   * <p><b>Note:</b> Multiple consecutive whitespace characters are normalized to a single space in
+   * the output when words are present. Leading and trailing whitespace is removed when joining
+   * words.
+   *
+   * <p>Empty strings or strings containing only whitespace produce an empty traversal (focusing on
+   * zero words), and {@code modify} operations preserve the original string unchanged.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<String, String> wordTraversal = StringTraversals.worded();
+   *
+   * // Uppercase each word
+   * String result = Traversals.modify(wordTraversal, String::toUpperCase, "hello world");
+   * // Result: "HELLO WORLD"
+   *
+   * // Get all words
+   * List<String> words = Traversals.getAll(wordTraversal, "foo  bar\tbaz");
+   * // Result: ["foo", "bar", "baz"]
+   *
+   * // Capitalize first letter of each word
+   * String capitalized = Traversals.modify(
+   *     wordTraversal,
+   *     word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase(),
+   *     "hello WORLD"
+   * );
+   * // Result: "Hello World"
+   * }</pre>
+   *
+   * @return A {@code Traversal} focusing on each word in a string.
+   */
+  public static Traversal<String, String> worded() {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, String> modifyF(
+          final Function<String, Kind<F, String>> f,
+          final String source,
+          final Applicative<F> applicative) {
+
+        final String trimmed = source.trim();
+        if (trimmed.isEmpty()) {
+          return applicative.of(source);
+        }
+
+        // Split by whitespace (one or more whitespace characters)
+        final List<String> words =
+            Arrays.stream(trimmed.split("\\s+")).collect(Collectors.toList());
+
+        // Traverse the word list
+        final Kind<F, List<String>> traversedWords = Traversals.traverseList(words, f, applicative);
+
+        // Join words back with single spaces
+        return applicative.map(wordList -> String.join(" ", wordList), traversedWords);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that splits a string by line separators and focuses on each line.
+   *
+   * <p>The string is split using line separators ({@code \n}, {@code \r\n}, or {@code \r}). Each
+   * line can be transformed via an effectful function. The transformed lines are then joined back
+   * with {@code \n} (Unix-style line separator).
+   *
+   * <p><b>Note:</b> The output normalizes all line separators to {@code \n}. If you need to
+   * preserve the original line separator style, consider using a different approach.
+   *
+   * <p>Empty strings produce an empty traversal. Strings with no line separators focus on the
+   * entire string as a single line.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<String, String> lineTraversal = StringTraversals.lined();
+   *
+   * // Prefix each line
+   * String result = Traversals.modify(lineTraversal, line -> "> " + line, "foo\nbar\nbaz");
+   * // Result: "> foo\n> bar\n> baz"
+   *
+   * // Get all lines
+   * List<String> lines = Traversals.getAll(lineTraversal, "line1\nline2\nline3");
+   * // Result: ["line1", "line2", "line3"]
+   *
+   * // Number each line
+   * AtomicInteger counter = new AtomicInteger(1);
+   * String numbered = Traversals.modify(
+   *     lineTraversal,
+   *     line -> counter.getAndIncrement() + ". " + line,
+   *     "first\nsecond\nthird"
+   * );
+   * // Result: "1. first\n2. second\n3. third"
+   * }</pre>
+   *
+   * @return A {@code Traversal} focusing on each line in a string.
+   */
+  public static Traversal<String, String> lined() {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, String> modifyF(
+          final Function<String, Kind<F, String>> f,
+          final String source,
+          final Applicative<F> applicative) {
+
+        if (source.isEmpty()) {
+          return applicative.of(source);
+        }
+
+        // Split by line separators (\n, \r\n, or \r)
+        final List<String> lines = Arrays.asList(source.split("\\r?\\n|\\r"));
+
+        // Traverse the line list
+        final Kind<F, List<String>> traversedLines = Traversals.traverseList(lines, f, applicative);
+
+        // Join lines back with \n (Unix-style line separator)
+        return applicative.map(lineList -> String.join("\n", lineList), traversedLines);
+      }
+    };
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/util/TupleTraversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/util/TupleTraversals.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.tuple.Tuple2;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A final utility class providing static factory methods for creating {@link Traversal}s for {@link
+ * Tuple2} types.
+ *
+ * <p>These combinators allow traversing tuple structures when both elements share the same type,
+ * enabling operations like "modify both elements of a pair simultaneously".
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Modify both elements of a tuple
+ * Traversal<Tuple2<Integer, Integer>, Integer> bothInts = TupleTraversals.both();
+ * Tuple2<Integer, Integer> pair = new Tuple2<>(10, 20);
+ * Tuple2<Integer, Integer> doubled = Traversals.modify(bothInts, x -> x * 2, pair);
+ * // Result: Tuple2(20, 40)
+ *
+ * // Get both elements
+ * List<Integer> values = Traversals.getAll(bothInts, pair);
+ * // Result: [10, 20]
+ * }</pre>
+ */
+@NullMarked
+public final class TupleTraversals {
+
+  /** Private constructor to prevent instantiation. */
+  private TupleTraversals() {}
+
+  /**
+   * Creates a {@code Traversal} that focuses on both elements of a {@link Tuple2} when they share
+   * the same type.
+   *
+   * <p>This traversal has cardinality 2, focusing on both the first and second elements of the
+   * tuple. Effectful functions are applied to both positions, and the results are sequenced using
+   * the applicative's {@code map2} operation.
+   *
+   * <p>This is particularly useful for:
+   *
+   * <ul>
+   *   <li>Applying the same transformation to both tuple elements
+   *   <li>Collecting both values from a tuple
+   *   <li>Composing with other traversals for nested structures
+   * </ul>
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Traversal<Tuple2<String, String>, String> bothStrings = TupleTraversals.both();
+   *
+   * // Modify both elements
+   * Tuple2<String, String> names = new Tuple2<>("alice", "bob");
+   * Tuple2<String, String> capitalized = Traversals.modify(
+   *     bothStrings,
+   *     s -> s.substring(0, 1).toUpperCase() + s.substring(1),
+   *     names
+   * );
+   * // Result: Tuple2("Alice", "Bob")
+   *
+   * // Extract both elements
+   * List<String> allNames = Traversals.getAll(bothStrings, names);
+   * // Result: ["alice", "bob"]
+   *
+   * // Compose with other traversals
+   * Traversal<List<Tuple2<Integer, Integer>>, Integer> allInts =
+   *     Traversals.<Tuple2<Integer, Integer>>forList()
+   *         .andThen(TupleTraversals.both());
+   * }</pre>
+   *
+   * @param <A> The type of both elements in the tuple.
+   * @return A {@code Traversal} focusing on both elements of the tuple.
+   */
+  public static <A> Traversal<Tuple2<A, A>, A> both() {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, Tuple2<A, A>> modifyF(
+          final Function<A, Kind<F, A>> f,
+          final Tuple2<A, A> source,
+          final Applicative<F> applicative) {
+        return Traversals.traverseTuple2Both(source, f, applicative);
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/StringTraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/StringTraversalsTest.java
@@ -1,0 +1,679 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.higherkindedj.optics.Traversal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StringTraversals - String-specific Traversals")
+class StringTraversalsTest {
+
+  @Nested
+  @DisplayName("chars() - Focus on each character")
+  class CharsTests {
+
+    @Test
+    @DisplayName("chars() should modify each character")
+    void charsModifiesEachCharacter() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      String result = Traversals.modify(charTraversal, Character::toUpperCase, "hello");
+
+      assertThat(result).isEqualTo("HELLO");
+    }
+
+    @Test
+    @DisplayName("chars() getAll should return all characters")
+    void charsGetAllReturnsAllCharacters() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      List<Character> result = Traversals.getAll(charTraversal, "abc");
+
+      assertThat(result).containsExactly('a', 'b', 'c');
+    }
+
+    @Test
+    @DisplayName("chars() with empty string should return empty")
+    void charsWithEmptyString() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      String result = Traversals.modify(charTraversal, Character::toUpperCase, "");
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(charTraversal, "")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("chars() with single character")
+    void charsWithSingleCharacter() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      String result = Traversals.modify(charTraversal, c -> Character.toUpperCase(c), "a");
+
+      assertThat(result).isEqualTo("A");
+      assertThat(Traversals.getAll(charTraversal, "x")).containsExactly('x');
+    }
+
+    @Test
+    @DisplayName("chars() should preserve order")
+    void charsPreservesOrder() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      String result = Traversals.modify(charTraversal, c -> c, "abc123");
+
+      assertThat(result).isEqualTo("abc123");
+    }
+
+    @Test
+    @DisplayName("chars() should handle special characters")
+    void charsHandlesSpecialCharacters() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      List<Character> result = Traversals.getAll(charTraversal, "a!b@c#");
+
+      assertThat(result).containsExactly('a', '!', 'b', '@', 'c', '#');
+    }
+
+    @Test
+    @DisplayName("chars() should compose with filtered")
+    void charsComposesWithFiltered() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+      Traversal<String, Character> vowelsOnly =
+          charTraversal.filtered(c -> "aeiouAEIOU".indexOf(c) >= 0);
+
+      String result = Traversals.modify(vowelsOnly, Character::toUpperCase, "hello world");
+
+      assertThat(result).isEqualTo("hEllO wOrld");
+    }
+
+    @Test
+    @DisplayName("chars() should transform to different characters")
+    void charsTransformsToDifferentCharacters() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      String result = Traversals.modify(charTraversal, c -> c == 'a' ? 'z' : c, "banana");
+
+      assertThat(result).isEqualTo("bznznz");
+    }
+
+    @Test
+    @DisplayName("chars() with effectful operation should produce all combinations")
+    void charsWithEffectfulOperation() {
+      Traversal<String, Character> charTraversal = StringTraversals.chars();
+
+      Kind<ListKind.Witness, String> result =
+          charTraversal.modifyF(
+              c -> ListKindHelper.LIST.widen(List.of(c, Character.toUpperCase(c))),
+              "ab",
+              ListMonad.INSTANCE);
+
+      List<String> resultList = ListKindHelper.LIST.narrow(result);
+
+      // Should produce all combinations: 2^2 = 4 results
+      // Order depends on applicative sequencing (left-to-right, inner choices vary fastest)
+      assertThat(resultList).containsExactly("ab", "aB", "Ab", "AB");
+    }
+  }
+
+  @Nested
+  @DisplayName("worded() - Focus on each word")
+  class WordedTests {
+
+    @Test
+    @DisplayName("worded() should modify each word")
+    void wordedModifiesEachWord() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, "hello world");
+
+      assertThat(result).isEqualTo("HELLO WORLD");
+    }
+
+    @Test
+    @DisplayName("worded() getAll should return all words")
+    void wordedGetAllReturnsAllWords() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      List<String> result = Traversals.getAll(wordTraversal, "foo bar baz");
+
+      assertThat(result).containsExactly("foo", "bar", "baz");
+    }
+
+    @Test
+    @DisplayName("worded() with empty string should return empty")
+    void wordedWithEmptyString() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, "");
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(wordTraversal, "")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("worded() with whitespace-only string should return original")
+    void wordedWithWhitespaceOnly() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, "   \t  ");
+
+      assertThat(result).isEqualTo("   \t  ");
+      assertThat(Traversals.getAll(wordTraversal, "   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("worded() should normalize multiple spaces to single space")
+    void wordedNormalizesWhitespace() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, w -> w, "foo  bar\t\tbaz");
+
+      assertThat(result).isEqualTo("foo bar baz");
+    }
+
+    @Test
+    @DisplayName("worded() with single word")
+    void wordedWithSingleWord() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, "hello");
+
+      assertThat(result).isEqualTo("HELLO");
+      assertThat(Traversals.getAll(wordTraversal, "world")).containsExactly("world");
+    }
+
+    @Test
+    @DisplayName("worded() should handle leading and trailing whitespace")
+    void wordedHandlesLeadingTrailingWhitespace() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, "  hello world  ");
+
+      assertThat(result).isEqualTo("HELLO WORLD");
+    }
+
+    @Test
+    @DisplayName("worded() should capitalize first letter of each word")
+    void wordedCapitalizesWords() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result =
+          Traversals.modify(
+              wordTraversal,
+              word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase(),
+              "hello WORLD");
+
+      assertThat(result).isEqualTo("Hello World");
+    }
+
+    @Test
+    @DisplayName("worded() should compose with filtered")
+    void wordedComposesWithFiltered() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+      Traversal<String, String> longWords = wordTraversal.filtered(w -> w.length() > 3);
+
+      String result = Traversals.modify(longWords, String::toUpperCase, "hi hello world ok");
+
+      assertThat(result).isEqualTo("hi HELLO WORLD ok");
+    }
+
+    @Test
+    @DisplayName("worded() should handle tab characters")
+    void wordedHandlesTabs() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      List<String> result = Traversals.getAll(wordTraversal, "foo\tbar\tbaz");
+
+      assertThat(result).containsExactly("foo", "bar", "baz");
+    }
+
+    @Test
+    @DisplayName("worded() should handle string with many consecutive whitespace types")
+    void wordedHandlesVariousWhitespace() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String input = "  \t\n  word1  \t  word2   \n\t  word3  ";
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, input);
+
+      assertThat(result).isEqualTo("WORD1 WORD2 WORD3");
+    }
+
+    @Test
+    @DisplayName("worded() should handle string after splitting with effectful operation")
+    void wordedWithEffectfulOperation() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String input = "a b c";
+      Kind<ListKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> ListKindHelper.LIST.widen(List.of(word, word.toUpperCase())),
+              input,
+              ListMonad.INSTANCE);
+
+      List<String> resultList = ListKindHelper.LIST.narrow(result);
+
+      // Should produce all combinations: 2^3 = 8 results
+      assertThat(resultList).hasSize(8);
+      assertThat(resultList).contains("a b c", "A B C", "a B c", "A b C");
+    }
+
+    @Test
+    @DisplayName("worded() with single whitespace character")
+    void wordedWithSingleSpace() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, " ");
+
+      assertThat(result).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("worded() should preserve original when only whitespace")
+    void wordedPreservesWhitespaceOnlySource() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String source = "   \t  \n  ";
+      List<String> words = Traversals.getAll(wordTraversal, source);
+
+      assertThat(words).isEmpty();
+    }
+
+    @Test
+    @DisplayName("worded() with modifyF on whitespace-only source should preserve it")
+    void wordedModifyFWithWhitespaceOnlySource() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String source = "   \t  \n  ";
+      Kind<OptionalKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              source,
+              OptionalMonad.INSTANCE);
+
+      Optional<String> optResult = OptionalKindHelper.OPTIONAL.narrow(result);
+
+      // Should preserve original when no words to process
+      assertThat(optResult).contains(source);
+    }
+
+    @Test
+    @DisplayName("worded() with modifyF on empty trimmed source")
+    void wordedModifyFWithEmptyTrimmedSource() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String source = "";
+      Kind<OptionalKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              source,
+              OptionalMonad.INSTANCE);
+
+      Optional<String> optResult = OptionalKindHelper.OPTIONAL.narrow(result);
+
+      assertThat(optResult).contains("");
+    }
+
+    @Test
+    @DisplayName("worded() with modifyF using ListMonad on whitespace-only source")
+    void wordedModifyFListMonadWhitespaceOnly() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String source = "   ";
+      Kind<ListKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> ListKindHelper.LIST.widen(List.of(word, word.toUpperCase())),
+              source,
+              ListMonad.INSTANCE);
+
+      List<String> resultList = ListKindHelper.LIST.narrow(result);
+
+      // Should preserve original when no words
+      assertThat(resultList).containsExactly(source);
+    }
+
+    @Test
+    @DisplayName("worded() with Optional applicative should succeed for all words")
+    void wordedWithOptionalApplicative() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String input = "hello world";
+      Kind<OptionalKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              input,
+              OptionalMonad.INSTANCE);
+
+      Optional<String> optResult = OptionalKindHelper.OPTIONAL.narrow(result);
+
+      assertThat(optResult).contains("HELLO WORLD");
+    }
+
+    @Test
+    @DisplayName("worded() with Optional applicative should fail if transformation fails")
+    void wordedWithOptionalApplicativeFails() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String input = "hello world";
+      Kind<OptionalKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word ->
+                  word.equals("world")
+                      ? OptionalKindHelper.OPTIONAL.widen(Optional.empty())
+                      : OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              input,
+              OptionalMonad.INSTANCE);
+
+      Optional<String> optResult = OptionalKindHelper.OPTIONAL.narrow(result);
+
+      assertThat(optResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName(
+        "worded() with modifyF on trimmed-empty source using different applicative contexts")
+    void wordedTrimmedEmptyWithVariousApplicatives() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      // Empty string with OptionalMonad should preserve empty
+      String emptySource = "";
+      Kind<OptionalKind.Witness, String> optResult =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              emptySource,
+              OptionalMonad.INSTANCE);
+      assertThat(OptionalKindHelper.OPTIONAL.narrow(optResult)).contains("");
+
+      // Empty string with ListMonad should preserve empty
+      Kind<ListKind.Witness, String> listResult =
+          wordTraversal.modifyF(
+              word -> ListKindHelper.LIST.widen(List.of(word.toUpperCase())),
+              emptySource,
+              ListMonad.INSTANCE);
+      assertThat(ListKindHelper.LIST.narrow(listResult)).containsExactly("");
+    }
+
+    @Test
+    @DisplayName(
+        "worded() with single space character should return original preserving whitespace")
+    void wordedSingleSpacePreserved() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      // Single space trims to empty
+      String singleSpace = " ";
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, singleSpace);
+
+      assertThat(result).isEqualTo(" ");
+
+      // Verify with modifyF using OptionalMonad
+      Kind<OptionalKind.Witness, String> optResult =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              singleSpace,
+              OptionalMonad.INSTANCE);
+      assertThat(OptionalKindHelper.OPTIONAL.narrow(optResult)).contains(" ");
+    }
+
+    @Test
+    @DisplayName("worded() with tabs and spaces only should preserve structure")
+    void wordedTabsAndSpacesOnly() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String tabsAndSpaces = "\t  \t  ";
+
+      // With modify
+      String modifyResult = Traversals.modify(wordTraversal, String::toUpperCase, tabsAndSpaces);
+      assertThat(modifyResult).isEqualTo(tabsAndSpaces);
+
+      // With modifyF using ListMonad
+      Kind<ListKind.Witness, String> listResult =
+          wordTraversal.modifyF(
+              word -> ListKindHelper.LIST.widen(List.of(word, word.toUpperCase())),
+              tabsAndSpaces,
+              ListMonad.INSTANCE);
+      assertThat(ListKindHelper.LIST.narrow(listResult)).containsExactly(tabsAndSpaces);
+
+      // Verify getAll returns empty
+      List<String> words = Traversals.getAll(wordTraversal, tabsAndSpaces);
+      assertThat(words).isEmpty();
+    }
+
+    @Test
+    @DisplayName("worded() with newlines only should preserve structure")
+    void wordedNewlinesOnly() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String newlinesOnly = "\n\n\n";
+
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, newlinesOnly);
+      assertThat(result).isEqualTo(newlinesOnly);
+
+      // Verify with modifyF
+      Kind<OptionalKind.Witness, String> optResult =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              newlinesOnly,
+              OptionalMonad.INSTANCE);
+      assertThat(OptionalKindHelper.OPTIONAL.narrow(optResult)).contains(newlinesOnly);
+    }
+
+    @Test
+    @DisplayName("worded() with mixed whitespace characters should preserve when empty")
+    void wordedMixedWhitespacePreserved() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      String mixed = " \t\n\r ";
+
+      // With modify
+      String result = Traversals.modify(wordTraversal, String::toUpperCase, mixed);
+      assertThat(result).isEqualTo(mixed);
+
+      // With modifyF using both applicatives
+      Kind<OptionalKind.Witness, String> optResult =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              mixed,
+              OptionalMonad.INSTANCE);
+      assertThat(OptionalKindHelper.OPTIONAL.narrow(optResult)).contains(mixed);
+
+      Kind<ListKind.Witness, String> listResult =
+          wordTraversal.modifyF(
+              word -> ListKindHelper.LIST.widen(List.of(word.toUpperCase())),
+              mixed,
+              ListMonad.INSTANCE);
+      assertThat(ListKindHelper.LIST.narrow(listResult)).containsExactly(mixed);
+    }
+
+    @Test
+    @DisplayName("worded() normal traversal path with OptionalMonad transformation")
+    void wordedNormalPathOptionalMonad() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      // Ensure we go through the normal traversal path (not early returns)
+      String input = "alpha beta gamma";
+      Kind<OptionalKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> OptionalKindHelper.OPTIONAL.widen(Optional.of(word.toUpperCase())),
+              input,
+              OptionalMonad.INSTANCE);
+
+      Optional<String> optResult = OptionalKindHelper.OPTIONAL.narrow(result);
+      assertThat(optResult).contains("ALPHA BETA GAMMA");
+    }
+
+    @Test
+    @DisplayName("worded() normal traversal path with ListMonad non-determinism")
+    void wordedNormalPathListMonad() {
+      Traversal<String, String> wordTraversal = StringTraversals.worded();
+
+      // Ensure we go through the normal traversal path with effectful transformation
+      String input = "x y";
+      Kind<ListKind.Witness, String> result =
+          wordTraversal.modifyF(
+              word -> ListKindHelper.LIST.widen(List.of(word, word.toUpperCase())),
+              input,
+              ListMonad.INSTANCE);
+
+      List<String> resultList = ListKindHelper.LIST.narrow(result);
+
+      // Should produce 2^2 = 4 combinations
+      assertThat(resultList).hasSize(4);
+      assertThat(resultList).containsExactly("x y", "x Y", "X y", "X Y");
+    }
+  }
+
+  @Nested
+  @DisplayName("lined() - Focus on each line")
+  class LinedTests {
+
+    @Test
+    @DisplayName("lined() should modify each line")
+    void linedModifiesEachLine() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      String result = Traversals.modify(lineTraversal, line -> "> " + line, "foo\nbar\nbaz");
+
+      assertThat(result).isEqualTo("> foo\n> bar\n> baz");
+    }
+
+    @Test
+    @DisplayName("lined() getAll should return all lines")
+    void linedGetAllReturnsAllLines() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      List<String> result = Traversals.getAll(lineTraversal, "line1\nline2\nline3");
+
+      assertThat(result).containsExactly("line1", "line2", "line3");
+    }
+
+    @Test
+    @DisplayName("lined() with empty string should return empty")
+    void linedWithEmptyString() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      String result = Traversals.modify(lineTraversal, line -> "> " + line, "");
+
+      assertThat(result).isEmpty();
+      assertThat(Traversals.getAll(lineTraversal, "")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("lined() with single line (no newlines)")
+    void linedWithSingleLine() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      String result = Traversals.modify(lineTraversal, String::toUpperCase, "hello");
+
+      assertThat(result).isEqualTo("HELLO");
+      assertThat(Traversals.getAll(lineTraversal, "world")).containsExactly("world");
+    }
+
+    @Test
+    @DisplayName("lined() should normalize \\r\\n to \\n")
+    void linedNormalizesWindowsLineEndings() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      String result = Traversals.modify(lineTraversal, line -> line, "foo\r\nbar\r\nbaz");
+
+      assertThat(result).isEqualTo("foo\nbar\nbaz");
+    }
+
+    @Test
+    @DisplayName("lined() should handle \\r line endings")
+    void linedHandlesMacLineEndings() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      String result = Traversals.modify(lineTraversal, line -> line, "foo\rbar\rbaz");
+
+      assertThat(result).isEqualTo("foo\nbar\nbaz");
+    }
+
+    @Test
+    @DisplayName("lined() should number each line")
+    void linedNumbersLines() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+      AtomicInteger counter = new AtomicInteger(1);
+
+      String result =
+          Traversals.modify(
+              lineTraversal,
+              line -> counter.getAndIncrement() + ". " + line,
+              "first\nsecond\nthird");
+
+      assertThat(result).isEqualTo("1. first\n2. second\n3. third");
+    }
+
+    @Test
+    @DisplayName("lined() should compose with filtered")
+    void linedComposesWithFiltered() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+      Traversal<String, String> nonEmptyLines = lineTraversal.filtered(line -> !line.isEmpty());
+
+      String result = Traversals.modify(nonEmptyLines, String::toUpperCase, "foo\n\nbar\nbaz");
+
+      assertThat(result).isEqualTo("FOO\n\nBAR\nBAZ");
+    }
+
+    @Test
+    @DisplayName("lined() should handle empty lines")
+    void linedHandlesEmptyLines() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      List<String> result = Traversals.getAll(lineTraversal, "foo\n\nbar");
+
+      assertThat(result).containsExactly("foo", "", "bar");
+    }
+
+    @Test
+    @DisplayName("lined() should handle trailing newline")
+    void linedHandlesTrailingNewline() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      // Trailing newline doesn't create an extra empty line (standard split behavior)
+      List<String> result = Traversals.getAll(lineTraversal, "foo\nbar\n");
+
+      assertThat(result).containsExactly("foo", "bar");
+    }
+
+    @Test
+    @DisplayName("lined() should indent each line")
+    void linedIndentsLines() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      String result = Traversals.modify(lineTraversal, line -> "  " + line, "foo\nbar");
+
+      assertThat(result).isEqualTo("  foo\n  bar");
+    }
+
+    @Test
+    @DisplayName("lined() with effectful operation should produce all combinations")
+    void linedWithEffectfulOperation() {
+      Traversal<String, String> lineTraversal = StringTraversals.lined();
+
+      Kind<ListKind.Witness, String> result =
+          lineTraversal.modifyF(
+              line -> ListKindHelper.LIST.widen(List.of(line, line.toUpperCase())),
+              "a\nb",
+              ListMonad.INSTANCE);
+
+      List<String> resultList = ListKindHelper.LIST.narrow(result);
+
+      // Should produce all combinations: 2^2 = 4 results
+      // Order depends on applicative sequencing (left-to-right, inner choices vary fastest)
+      assertThat(resultList).containsExactly("a\nb", "a\nB", "A\nb", "A\nB");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/TupleTraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/TupleTraversalsTest.java
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.hkt.tuple.Tuple2;
+import org.higherkindedj.optics.Traversal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TupleTraversals - Tuple-specific Traversals")
+class TupleTraversalsTest {
+
+  @Nested
+  @DisplayName("both() - Focus on both elements of Tuple2<A, A>")
+  class BothTests {
+
+    @Test
+    @DisplayName("both() should modify both elements")
+    void bothModifiesBothElements() {
+      Traversal<Tuple2<Integer, Integer>, Integer> bothTraversal = TupleTraversals.both();
+
+      Tuple2<Integer, Integer> pair = new Tuple2<>(10, 20);
+      Tuple2<Integer, Integer> result = Traversals.modify(bothTraversal, x -> x * 2, pair);
+
+      assertThat(result).isEqualTo(new Tuple2<>(20, 40));
+    }
+
+    @Test
+    @DisplayName("both() getAll should return both elements")
+    void bothGetAllReturnsBothElements() {
+      Traversal<Tuple2<Integer, Integer>, Integer> bothTraversal = TupleTraversals.both();
+
+      Tuple2<Integer, Integer> pair = new Tuple2<>(10, 20);
+      List<Integer> result = Traversals.getAll(bothTraversal, pair);
+
+      assertThat(result).containsExactly(10, 20);
+    }
+
+    @Test
+    @DisplayName("both() with strings should apply transformation to both")
+    void bothWithStrings() {
+      Traversal<Tuple2<String, String>, String> bothTraversal = TupleTraversals.both();
+
+      Tuple2<String, String> pair = new Tuple2<>("alice", "bob");
+      Tuple2<String, String> result = Traversals.modify(bothTraversal, String::toUpperCase, pair);
+
+      assertThat(result).isEqualTo(new Tuple2<>("ALICE", "BOB"));
+    }
+
+    @Test
+    @DisplayName("both() should preserve order")
+    void bothPreservesOrder() {
+      Traversal<Tuple2<String, String>, String> bothTraversal = TupleTraversals.both();
+
+      Tuple2<String, String> pair = new Tuple2<>("first", "second");
+      List<String> result = Traversals.getAll(bothTraversal, pair);
+
+      assertThat(result).containsExactly("first", "second");
+    }
+
+    @Test
+    @DisplayName("both() with identity function should return unchanged tuple")
+    void bothWithIdentity() {
+      Traversal<Tuple2<Integer, Integer>, Integer> bothTraversal = TupleTraversals.both();
+
+      Tuple2<Integer, Integer> pair = new Tuple2<>(42, 99);
+      Tuple2<Integer, Integer> result = Traversals.modify(bothTraversal, x -> x, pair);
+
+      assertThat(result).isEqualTo(pair);
+    }
+
+    @Test
+    @DisplayName("both() should compose with list traversal")
+    void bothComposesWithListTraversal() {
+      Traversal<List<Tuple2<Integer, Integer>>, Integer> composedTraversal =
+          Traversals.<Tuple2<Integer, Integer>>forList().andThen(TupleTraversals.both());
+
+      List<Tuple2<Integer, Integer>> pairs =
+          List.of(new Tuple2<>(1, 2), new Tuple2<>(3, 4), new Tuple2<>(5, 6));
+
+      List<Integer> allInts = Traversals.getAll(composedTraversal, pairs);
+
+      assertThat(allInts).containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    @DisplayName("both() should compose with list traversal for modification")
+    void bothComposesWithListTraversalForModification() {
+      Traversal<List<Tuple2<Integer, Integer>>, Integer> composedTraversal =
+          Traversals.<Tuple2<Integer, Integer>>forList().andThen(TupleTraversals.both());
+
+      List<Tuple2<Integer, Integer>> pairs = List.of(new Tuple2<>(1, 2), new Tuple2<>(3, 4));
+
+      List<Tuple2<Integer, Integer>> result =
+          Traversals.modify(composedTraversal, x -> x * 10, pairs);
+
+      assertThat(result).containsExactly(new Tuple2<>(10, 20), new Tuple2<>(30, 40));
+    }
+
+    @Test
+    @DisplayName("both() with same values should modify both to same new value")
+    void bothWithSameValues() {
+      Traversal<Tuple2<Integer, Integer>, Integer> bothTraversal = TupleTraversals.both();
+
+      Tuple2<Integer, Integer> pair = new Tuple2<>(5, 5);
+      Tuple2<Integer, Integer> result = Traversals.modify(bothTraversal, x -> x + 1, pair);
+
+      assertThat(result).isEqualTo(new Tuple2<>(6, 6));
+    }
+
+    @Test
+    @DisplayName("both() should handle complex transformations")
+    void bothHandlesComplexTransformations() {
+      Traversal<Tuple2<Integer, Integer>, Integer> bothTraversal = TupleTraversals.both();
+
+      Tuple2<Integer, Integer> pair = new Tuple2<>(3, 5);
+      Tuple2<Integer, Integer> result = Traversals.modify(bothTraversal, x -> x * x + 1, pair);
+
+      assertThat(result).isEqualTo(new Tuple2<>(10, 26)); // 3^2+1=10, 5^2+1=26
+    }
+
+    @Test
+    @DisplayName("both() with filtered should apply predicate to both")
+    void bothComposesWithFiltered() {
+      Traversal<Tuple2<Integer, Integer>, Integer> bothTraversal = TupleTraversals.both();
+      Traversal<Tuple2<Integer, Integer>, Integer> evenOnly =
+          bothTraversal.filtered(x -> x % 2 == 0);
+
+      Tuple2<Integer, Integer> pair = new Tuple2<>(2, 3);
+      Tuple2<Integer, Integer> result = Traversals.modify(evenOnly, x -> x * 10, pair);
+
+      assertThat(result).isEqualTo(new Tuple2<>(20, 3)); // Only 2 is even, so only it gets modified
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/OptionalMapTraversalsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/OptionalMapTraversalsExample.java
@@ -1,0 +1,296 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * Demonstrates Optional and Map value traversals for declarative handling of nullable fields and
+ * bulk map transformations.
+ *
+ * <p>This example shows:
+ *
+ * <ul>
+ *   <li>{@code Traversals.forOptional()} - Affine traversals for Optional values (0-1 cardinality)
+ *   <li>{@code Traversals.forMapValues()} - Bulk value transformations preserving keys
+ *   <li>Composing structure traversals with other optics
+ *   <li>Avoiding nested Optional.map() chains
+ * </ul>
+ *
+ * <p>Scenarios covered:
+ *
+ * <ul>
+ *   <li>Feature flag management
+ *   <li>Configuration value normalisation
+ *   <li>Server registry operations
+ *   <li>Nullable field handling
+ *   <li>Service endpoint transformations
+ * </ul>
+ */
+public class OptionalMapTraversalsExample {
+
+  // Domain models
+  record ServerConfig(String hostname, Optional<Integer> port, Optional<String> sslCertPath) {
+    @Override
+    public String toString() {
+      return String.format(
+          "Server[host=%s, port=%s, ssl=%s]",
+          hostname, port.map(String::valueOf).orElse("default"), sslCertPath.orElse("none"));
+    }
+  }
+
+  record ApplicationConfig(
+      String appName, Optional<ServerConfig> server, Map<String, String> properties) {
+    @Override
+    public String toString() {
+      return String.format(
+          "App[name=%s, server=%s, props=%d]",
+          appName, server.map(s -> "configured").orElse("none"), properties.size());
+    }
+  }
+
+  record FeatureFlags(Map<String, Optional<Boolean>> flags) {
+    @Override
+    public String toString() {
+      long enabled = flags.values().stream().filter(opt -> opt.orElse(false)).count();
+      long disabled = flags.values().stream().filter(opt -> !opt.orElse(false)).count();
+      long unset = flags.values().stream().filter(Optional::isEmpty).count();
+      return String.format("Features[enabled=%d, disabled=%d, unset=%d]", enabled, disabled, unset);
+    }
+  }
+
+  record ServiceRegistry(Map<String, ServerConfig> services) {
+    @Override
+    public String toString() {
+      return "Registry[services=" + services.size() + "]";
+    }
+  }
+
+  public static void main(String[] args) {
+    System.out.println("=== OPTIONAL AND MAP TRAVERSALS EXAMPLE ===\n");
+
+    demonstrateOptionalTraversals();
+    demonstrateMapValueTraversals();
+    demonstrateComposedTraversals();
+    demonstrateFeatureFlagManagement();
+
+    System.out.println("\n=== OPTIONAL AND MAP TRAVERSALS COMPLETE ===");
+  }
+
+  private static void demonstrateOptionalTraversals() {
+    System.out.println("--- SCENARIO 1: Optional Traversals ---\n");
+
+    // Basic Optional traversal
+    Traversal<Optional<Integer>, Integer> optTraversal = Traversals.forOptional();
+
+    Optional<Integer> maybePort = Optional.of(8080);
+    Optional<Integer> offsetPort = Traversals.modify(optTraversal, p -> p + 1000, maybePort);
+
+    System.out.println("Original port: " + maybePort);
+    System.out.println("Offset port:   " + offsetPort);
+
+    // Empty Optional remains empty
+    Optional<Integer> empty = Optional.empty();
+    Optional<Integer> stillEmpty = Traversals.modify(optTraversal, p -> p + 1000, empty);
+
+    System.out.println("\nEmpty optional: " + empty);
+    System.out.println("After modify:   " + stillEmpty);
+
+    // Extract as list
+    List<Integer> values = Traversals.getAll(optTraversal, maybePort);
+    System.out.println("\nExtracted values: " + values);
+
+    // ServerConfig with optional fields
+    ServerConfig server =
+        new ServerConfig("localhost", Optional.of(8080), Optional.of("/etc/ssl/cert.pem"));
+
+    System.out.println("\n--- Server Configuration ---");
+    System.out.println("Original:  " + server);
+
+    // Modify port if present
+    ServerConfig offsetServer =
+        new ServerConfig(
+            server.hostname(),
+            Traversals.modify(optTraversal, p -> p + 1000, server.port()),
+            server.sslCertPath());
+
+    System.out.println("Offset:    " + offsetServer);
+
+    // Handle server with no port
+    ServerConfig serverNoPort =
+        new ServerConfig("api.example.com", Optional.empty(), Optional.empty());
+    System.out.println("\nServer without port: " + serverNoPort);
+
+    ServerConfig attemptOffset =
+        new ServerConfig(
+            serverNoPort.hostname(),
+            Traversals.modify(optTraversal, p -> p + 1000, serverNoPort.port()),
+            serverNoPort.sslCertPath());
+
+    System.out.println("After offset:        " + attemptOffset);
+    System.out.println();
+  }
+
+  private static void demonstrateMapValueTraversals() {
+    System.out.println("--- SCENARIO 2: Map Value Traversals ---\n");
+
+    // Basic Map values traversal
+    Traversal<Map<String, Double>, Double> priceTraversal = Traversals.forMapValues();
+
+    Map<String, Double> prices = new HashMap<>();
+    prices.put("widget", 10.0);
+    prices.put("gadget", 25.0);
+    prices.put("gizmo", 15.0);
+
+    System.out.println("Original prices:");
+    prices.forEach((k, v) -> System.out.println("  " + k + ": $" + v));
+
+    // Apply 10% increase to all prices
+    Map<String, Double> inflated = Traversals.modify(priceTraversal, price -> price * 1.1, prices);
+
+    System.out.println("\nAfter 10% increase:");
+    inflated.forEach((k, v) -> System.out.printf("  %s: $%.2f%n", k, v));
+
+    // Extract all values
+    List<Double> allPrices = Traversals.getAll(priceTraversal, prices);
+    System.out.println("\nAll prices: " + allPrices);
+
+    // Conditional update with filtered
+    Traversal<Map<String, Double>, Double> expensiveItems =
+        priceTraversal.filtered(price -> price > 20.0);
+
+    Map<String, Double> discounted =
+        Traversals.modify(expensiveItems, price -> price * 0.9, prices);
+
+    System.out.println("\n10% discount on expensive items (>$20):");
+    discounted.forEach((k, v) -> System.out.printf("  %s: $%.2f%n", k, v));
+
+    // Configuration properties
+    Map<String, String> config = new HashMap<>();
+    config.put("db.host", "  localhost  ");
+    config.put("db.port", "  5432  ");
+    config.put("db.name", "  mydb  ");
+
+    Traversal<Map<String, String>, String> stringValues = Traversals.forMapValues();
+
+    System.out.println("\n--- Configuration Properties ---");
+    System.out.println("Original:");
+    config.forEach((k, v) -> System.out.println("  " + k + "='" + v + "'"));
+
+    // Trim all values
+    Map<String, String> trimmed = Traversals.modify(stringValues, String::trim, config);
+
+    System.out.println("\nAfter trimming:");
+    trimmed.forEach((k, v) -> System.out.println("  " + k + "='" + v + "'"));
+    System.out.println();
+  }
+
+  private static void demonstrateComposedTraversals() {
+    System.out.println("--- SCENARIO 3: Composed Traversals ---\n");
+
+    // Service registry with multiple servers
+    Map<String, ServerConfig> services = new HashMap<>();
+    services.put("api", new ServerConfig("api.example.com", Optional.of(8080), Optional.empty()));
+    services.put(
+        "db",
+        new ServerConfig("db.example.com", Optional.of(5432), Optional.of("/etc/ssl/db.pem")));
+    services.put(
+        "cache", new ServerConfig("cache.example.com", Optional.empty(), Optional.empty()));
+
+    ServiceRegistry registry = new ServiceRegistry(services);
+
+    System.out.println("Original registry:");
+    services.forEach((name, config) -> System.out.println("  " + name + ": " + config));
+
+    // Compose: Map values -> Optional -> modify ports
+    Traversal<Map<String, ServerConfig>, ServerConfig> allServices = Traversals.forMapValues();
+    Traversal<Optional<Integer>, Integer> optPort = Traversals.forOptional();
+
+    // Transform all service ports (where present)
+    Map<String, ServerConfig> offsetServices = new HashMap<>();
+    services.forEach(
+        (name, config) -> {
+          Optional<Integer> newPort = Traversals.modify(optPort, p -> p + 1000, config.port());
+          offsetServices.put(
+              name, new ServerConfig(config.hostname(), newPort, config.sslCertPath()));
+        });
+
+    System.out.println("\nAfter port offset (+1000):");
+    offsetServices.forEach((name, config) -> System.out.println("  " + name + ": " + config));
+
+    // Extract all configured ports
+    List<Integer> configuredPorts =
+        services.values().stream().flatMap(config -> config.port().stream()).toList();
+
+    System.out.println("\nAll configured ports: " + configuredPorts);
+    System.out.println();
+  }
+
+  private static void demonstrateFeatureFlagManagement() {
+    System.out.println("--- SCENARIO 4: Feature Flag Management ---\n");
+
+    Map<String, Optional<Boolean>> flags = new HashMap<>();
+    flags.put("dark-mode", Optional.of(true));
+    flags.put("new-ui", Optional.of(false));
+    flags.put("beta-features", Optional.empty()); // Not yet configured
+    flags.put("analytics", Optional.of(true));
+
+    FeatureFlags config = new FeatureFlags(flags);
+
+    System.out.println("Original flags:");
+    System.out.println("  " + config);
+    flags.forEach(
+        (name, value) ->
+            System.out.println("    " + name + ": " + value.map(String::valueOf).orElse("unset")));
+
+    // Enable all flags that are currently set (respect unset flags)
+    Traversal<Map<String, Optional<Boolean>>, Optional<Boolean>> allFlagValues =
+        Traversals.forMapValues();
+    Traversal<Optional<Boolean>, Boolean> presentFlags = Traversals.forOptional();
+
+    Map<String, Optional<Boolean>> allEnabled = new HashMap<>(flags);
+    allFlagValues = Traversals.forMapValues();
+
+    // Manual transformation for nested Optional (simplified)
+    Map<String, Optional<Boolean>> enabled = new HashMap<>();
+    flags.forEach(
+        (name, value) -> {
+          if (value.isPresent()) {
+            enabled.put(name, Optional.of(true));
+          } else {
+            enabled.put(name, value); // Keep unset flags as unset
+          }
+        });
+
+    FeatureFlags allEnabledConfig = new FeatureFlags(enabled);
+
+    System.out.println("\nAfter enabling all set flags:");
+    System.out.println("  " + allEnabledConfig);
+    enabled.forEach(
+        (name, value) ->
+            System.out.println("    " + name + ": " + value.map(String::valueOf).orElse("unset")));
+
+    // Disable specific flags
+    Map<String, Optional<Boolean>> selective = new HashMap<>(flags);
+    selective.put("beta-features", Optional.of(false)); // Explicitly disable
+
+    System.out.println("\nWith beta-features explicitly disabled:");
+    selective.forEach(
+        (name, value) ->
+            System.out.println("    " + name + ": " + value.map(String::valueOf).orElse("unset")));
+
+    // Extract enabled feature names
+    List<String> enabledFeatures =
+        flags.entrySet().stream()
+            .filter(e -> e.getValue().orElse(false))
+            .map(Map.Entry::getKey)
+            .toList();
+
+    System.out.println("\nCurrently enabled features: " + enabledFeatures);
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/PredicateListTraversalsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/PredicateListTraversalsExample.java
@@ -1,0 +1,373 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.ListTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * Demonstrates predicate-based list traversals for conditional focusing on list portions.
+ *
+ * <p>Predicate-based traversals enable runtime-determined focusing where the number of elements in
+ * focus depends on data conditions rather than fixed indices:
+ *
+ * <ul>
+ *   <li>{@code takingWhile(Predicate)} - Focus on longest prefix where predicate holds
+ *   <li>{@code droppingWhile(Predicate)} - Skip prefix whilst predicate holds
+ *   <li>{@code element(int)} - Safe single-element access (affine traversal)
+ * </ul>
+ *
+ * <p>Scenarios covered:
+ *
+ * <ul>
+ *   <li>Time-series data processing with thresholds
+ *   <li>Priority queue handling
+ *   <li>Log file analysis (skipping headers, extracting sections)
+ *   <li>Batch processing with conditional boundaries
+ *   <li>Safe indexed access without exceptions
+ * </ul>
+ */
+public class PredicateListTraversalsExample {
+
+  // Domain models
+  record Transaction(String id, LocalDateTime timestamp, double amount, String status) {
+    @Override
+    public String toString() {
+      return String.format(
+          "Transaction[%s, %s, $%.2f, %s]",
+          id, timestamp.truncatedTo(ChronoUnit.SECONDS), amount, status);
+    }
+  }
+
+  record LogEntry(LocalDateTime timestamp, String level, String message) {
+    boolean isWarmup() {
+      return message.contains("WARMUP") || message.contains("INIT");
+    }
+
+    @Override
+    public String toString() {
+      return String.format(
+          "[%s] %s: %s", timestamp.truncatedTo(ChronoUnit.SECONDS), level, message);
+    }
+  }
+
+  record Task(String id, int priority, String status) {
+    @Override
+    public String toString() {
+      return String.format("Task[%s, P%d, %s]", id, priority, status);
+    }
+  }
+
+  record Product(String sku, String name, double price, int stock) {
+    @Override
+    public String toString() {
+      return String.format("%s (%s): $%.2f, stock=%d", name, sku, price, stock);
+    }
+  }
+
+  public static void main(String[] args) {
+    System.out.println("=== PREDICATE-BASED LIST TRAVERSALS EXAMPLE ===\n");
+
+    demonstrateTakingWhile();
+    demonstrateDroppingWhile();
+    demonstrateElement();
+    demonstrateComposedPredicateTraversals();
+    demonstrateRealWorldScenarios();
+
+    System.out.println("\n=== PREDICATE-BASED TRAVERSALS COMPLETE ===");
+  }
+
+  private static void demonstrateTakingWhile() {
+    System.out.println("--- SCENARIO 1: takingWhile() - Prefix Processing ---\n");
+
+    // Process products while price < $20
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 100),
+            new Product("SKU002", "Gadget", 15.0, 50),
+            new Product("SKU003", "Gizmo", 25.0, 75), // Stops here
+            new Product("SKU004", "Thing", 12.0, 25) // Not included
+            );
+
+    Traversal<List<Product>, Product> affordablePrefix =
+        ListTraversals.takingWhile(p -> p.price() < 20.0);
+
+    System.out.println("Original products:");
+    products.forEach(p -> System.out.println("  " + p));
+
+    // Discount affordable prefix
+    List<Product> discounted =
+        Traversals.modify(
+            affordablePrefix,
+            p -> new Product(p.sku(), p.name(), p.price() * 0.9, p.stock()),
+            products);
+
+    System.out.println("\nAfter 10% discount on affordable prefix (price < $20):");
+    discounted.forEach(p -> System.out.println("  " + p));
+
+    // Extract the prefix
+    List<Product> affordable = Traversals.getAll(affordablePrefix, products);
+    System.out.println("\nAffordable prefix: " + affordable.size() + " products");
+    affordable.forEach(p -> System.out.println("  " + p));
+
+    // Sorted list example
+    List<Integer> sorted = List.of(1, 2, 3, 4, 10, 11, 12);
+    Traversal<List<Integer>, Integer> lessThan5 = ListTraversals.takingWhile(n -> n < 5);
+
+    List<Integer> prefix = Traversals.getAll(lessThan5, sorted);
+    System.out.println("\nNumbers less than 5 (prefix): " + prefix);
+    System.out.println();
+  }
+
+  private static void demonstrateDroppingWhile() {
+    System.out.println("--- SCENARIO 2: droppingWhile() - Skip Prefix ---\n");
+
+    // Skip low-stock items
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 20),
+            new Product("SKU002", "Gadget", 25.0, 30),
+            new Product("SKU003", "Gizmo", 15.0, 75), // First well-stocked
+            new Product("SKU004", "Thing", 12.0, 25)); // Included
+
+    Traversal<List<Product>, Product> wellStocked =
+        ListTraversals.droppingWhile(p -> p.stock() < 50);
+
+    System.out.println("Original products:");
+    products.forEach(p -> System.out.println("  " + p));
+
+    // Restock well-stocked items (and everything after first well-stocked)
+    List<Product> restocked =
+        Traversals.modify(
+            wellStocked, p -> new Product(p.sku(), p.name(), p.price(), p.stock() + 50), products);
+
+    System.out.println("\nAfter restocking (skip stock < 50 prefix):");
+    restocked.forEach(p -> System.out.println("  " + p));
+
+    // Extract focused portion
+    List<Product> focused = Traversals.getAll(wellStocked, products);
+    System.out.println("\nFocused products (after skipping): " + focused.size());
+    focused.forEach(p -> System.out.println("  " + p));
+
+    // Log processing example
+    List<String> logLines =
+        List.of(
+            "[CONFIG] Loading application.properties",
+            "[CONFIG] Initialising database pool",
+            "[INFO] Application started",
+            "[WARN] High memory usage",
+            "[ERROR] Connection timeout");
+
+    Traversal<List<String>, String> runtimeLogs =
+        ListTraversals.droppingWhile(line -> line.startsWith("[CONFIG]"));
+
+    List<String> runtime = Traversals.getAll(runtimeLogs, logLines);
+    System.out.println("\nRuntime logs (skipping config preamble):");
+    runtime.forEach(line -> System.out.println("  " + line));
+    System.out.println();
+  }
+
+  private static void demonstrateElement() {
+    System.out.println("--- SCENARIO 3: element() - Safe Single Element Access ---\n");
+
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 100),
+            new Product("SKU002", "Gadget", 25.0, 50),
+            new Product("SKU003", "Gizmo", 15.0, 75));
+
+    // Access third product
+    Traversal<List<Product>, Product> thirdProduct = ListTraversals.element(2);
+
+    System.out.println("All products:");
+    for (int i = 0; i < products.size(); i++) {
+      System.out.println("  [" + i + "] " + products.get(i));
+    }
+
+    // Modify only the third product
+    List<Product> updated =
+        Traversals.modify(
+            thirdProduct,
+            p -> new Product(p.sku(), p.name(), p.price() * 0.8, p.stock()),
+            products);
+
+    System.out.println("\nAfter 20% discount on element at index 2:");
+    for (int i = 0; i < updated.size(); i++) {
+      System.out.println("  [" + i + "] " + updated.get(i));
+    }
+
+    // Extract the element
+    List<Product> element = Traversals.getAll(thirdProduct, products);
+    System.out.println("\nExtracted element [2]: " + element);
+
+    // Out of bounds: gracefully returns empty
+    Traversal<List<Product>, Product> outOfBounds = ListTraversals.element(10);
+    List<Product> empty = Traversals.getAll(outOfBounds, products);
+    System.out.println("Element at index 10 (out of bounds): " + empty);
+
+    // Compose with nested lists
+    List<List<Integer>> nested =
+        List.of(List.of(1, 2, 3), List.of(10, 20, 30), List.of(100, 200, 300));
+
+    Traversal<List<List<Integer>>, List<Integer>> secondList = ListTraversals.element(1);
+    Traversal<List<List<Integer>>, Integer> secondListFirstElement =
+        secondList.andThen(ListTraversals.element(0));
+
+    List<Integer> extracted = Traversals.getAll(secondListFirstElement, nested);
+    System.out.println("\nNested list access [1][0]: " + extracted);
+    System.out.println();
+  }
+
+  private static void demonstrateComposedPredicateTraversals() {
+    System.out.println("--- SCENARIO 4: Composed Predicate Traversals ---\n");
+
+    List<Product> products =
+        List.of(
+            new Product("SKU001", "Widget", 10.0, 0), // No stock
+            new Product("SKU002", "Gadget", 15.0, 50),
+            new Product("SKU003", "Gizmo", 25.0, 75),
+            new Product("SKU004", "Thing", 12.0, 100),
+            new Product("SKU005", "Doodad", 30.0, 25),
+            new Product("SKU006", "Thingamajig", 8.0, 80));
+
+    // Combine taking with filtering - take first 4, then filter by stock and price
+    Traversal<List<Product>, Product> topAffordableInStock =
+        ListTraversals.<Product>taking(4)
+            .filtered(p -> p.stock() > 0)
+            .filtered(p -> p.price() < 20.0);
+
+    System.out.println("All products:");
+    for (int i = 0; i < products.size(); i++) {
+      System.out.println(String.format("  [%d] %s", i, products.get(i)));
+    }
+
+    List<Product> focused = Traversals.getAll(topAffordableInStock, products);
+    System.out.println("\nFocused (take 4, where stock > 0 and price < $20):");
+    focused.forEach(p -> System.out.println("  " + p));
+
+    // Apply discount to focused products
+    List<Product> discounted =
+        Traversals.modify(
+            topAffordableInStock,
+            p -> new Product(p.sku(), p.name(), p.price() * 0.85, p.stock()),
+            products);
+
+    System.out.println("\nAfter 15% discount on focused products:");
+    for (int i = 0; i < discounted.size(); i++) {
+      System.out.println(String.format("  [%d] %s", i, discounted.get(i)));
+    }
+    System.out.println();
+  }
+
+  private static void demonstrateRealWorldScenarios() {
+    System.out.println("--- SCENARIO 5: Real-World Use Cases ---\n");
+
+    demonstrateTimeSeriesProcessing();
+    demonstratePriorityQueueHandling();
+    demonstrateBatchProcessing();
+  }
+
+  private static void demonstrateTimeSeriesProcessing() {
+    System.out.println("Use Case 1: Time-Series Processing with Threshold");
+    System.out.println("--------------------------------------------------");
+
+    LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
+    LocalDateTime now = LocalDateTime.now();
+
+    List<Transaction> transactions =
+        List.of(
+            new Transaction("TX001", now.minusHours(48), 100.0, "COMPLETED"),
+            new Transaction("TX002", now.minusHours(36), 200.0, "COMPLETED"),
+            new Transaction("TX003", now.minusHours(12), 150.0, "PENDING"),
+            new Transaction("TX004", now.minusHours(6), 300.0, "PENDING"),
+            new Transaction("TX005", now.minusHours(1), 250.0, "PENDING"));
+
+    Traversal<List<Transaction>, Transaction> beforeCutoff =
+        ListTraversals.takingWhile(t -> t.timestamp().isBefore(cutoff));
+
+    System.out.println("All transactions:");
+    transactions.forEach(t -> System.out.println("  " + t));
+
+    // Process old transactions
+    List<Transaction> processed =
+        Traversals.modify(
+            beforeCutoff,
+            t -> new Transaction(t.id(), t.timestamp(), t.amount(), "ARCHIVED"),
+            transactions);
+
+    System.out.println("\nAfter archiving transactions before cutoff:");
+    processed.forEach(t -> System.out.println("  " + t));
+    System.out.println();
+  }
+
+  private static void demonstratePriorityQueueHandling() {
+    System.out.println("Use Case 2: Priority Queue Processing");
+    System.out.println("--------------------------------------");
+
+    List<Task> tasks =
+        List.of(
+            new Task("T1", 1, "PENDING"),
+            new Task("T2", 1, "PENDING"),
+            new Task("T3", 2, "PENDING"), // Priority changes here
+            new Task("T4", 2, "PENDING"),
+            new Task("T5", 3, "PENDING"));
+
+    Traversal<List<Task>, Task> highPriority = ListTraversals.takingWhile(t -> t.priority() == 1);
+
+    System.out.println("All tasks:");
+    tasks.forEach(t -> System.out.println("  " + t));
+
+    // Process high-priority tasks
+    List<Task> processed =
+        Traversals.modify(highPriority, t -> new Task(t.id(), t.priority(), "COMPLETED"), tasks);
+
+    System.out.println("\nAfter processing priority 1 tasks:");
+    processed.forEach(t -> System.out.println("  " + t));
+
+    // Remaining tasks
+    Traversal<List<Task>, Task> remaining = ListTraversals.droppingWhile(t -> t.priority() == 1);
+
+    List<Task> remainingTasks = Traversals.getAll(remaining, tasks);
+    System.out.println("\nRemaining tasks: " + remainingTasks.size());
+    remainingTasks.forEach(t -> System.out.println("  " + t));
+    System.out.println();
+  }
+
+  private static void demonstrateBatchProcessing() {
+    System.out.println("Use Case 3: Batch Processing with Warmup Skip");
+    System.out.println("----------------------------------------------");
+
+    LocalDateTime now = LocalDateTime.now();
+    List<LogEntry> logs =
+        List.of(
+            new LogEntry(now.minusMinutes(10), "INFO", "WARMUP: Initialising cache"),
+            new LogEntry(now.minusMinutes(9), "INFO", "WARMUP: Loading data"),
+            new LogEntry(now.minusMinutes(8), "INFO", "INIT: System ready"),
+            new LogEntry(now.minusMinutes(7), "INFO", "Processing request 1"),
+            new LogEntry(now.minusMinutes(6), "WARN", "High latency detected"),
+            new LogEntry(now.minusMinutes(5), "ERROR", "Connection timeout"));
+
+    Traversal<List<LogEntry>, LogEntry> steadyState =
+        ListTraversals.droppingWhile(LogEntry::isWarmup);
+
+    System.out.println("All log entries:");
+    logs.forEach(e -> System.out.println("  " + e));
+
+    // Process only steady-state logs
+    List<LogEntry> steadyStateLogs = Traversals.getAll(steadyState, logs);
+
+    System.out.println("\nSteady-state logs (skipping warmup):");
+    steadyStateLogs.forEach(e -> System.out.println("  " + e));
+
+    // To combine droppingWhile with taking, apply sequentially
+    // First drop warmup, then take first N from the result
+    Traversal<List<LogEntry>, LogEntry> takingFirst = ListTraversals.<LogEntry>taking(100);
+
+    List<LogEntry> batchLogs = Traversals.getAll(takingFirst, steadyStateLogs);
+    System.out.println("\nFirst batch (skip warmup, take 100): " + batchLogs.size() + " entries");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/StringTraversalsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/StringTraversalsExample.java
@@ -1,0 +1,316 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.StringTraversals;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * Demonstrates string traversals for declarative text processing using {@link StringTraversals}.
+ *
+ * <p>String traversals provide composable, type-safe text manipulation by breaking strings into
+ * traversable units:
+ *
+ * <ul>
+ *   <li>{@code chars()} - Focus on individual characters
+ *   <li>{@code worded()} - Focus on whitespace-delimited words
+ *   <li>{@code lined()} - Focus on line-separated content
+ * </ul>
+ *
+ * <p>This example covers:
+ *
+ * <ul>
+ *   <li>Email normalisation for data consistency
+ *   <li>Log file filtering and transformation
+ *   <li>CSV data processing
+ *   <li>Configuration file sanitisation
+ *   <li>Character-level validation and transformation
+ * </ul>
+ */
+public class StringTraversalsExample {
+
+  public static void main(String[] args) {
+    System.out.println("=== STRING TRAVERSALS EXAMPLE ===\n");
+
+    demonstrateCharacterTraversals();
+    demonstrateWordTraversals();
+    demonstrateLineTraversals();
+    demonstrateRealWorldScenarios();
+
+    System.out.println("\n=== STRING TRAVERSALS COMPLETE ===");
+  }
+
+  private static void demonstrateCharacterTraversals() {
+    System.out.println("--- SCENARIO 1: Character-Level Operations ---\n");
+
+    // Basic character transformation
+    Traversal<String, Character> chars = StringTraversals.chars();
+
+    String input = "Hello World";
+    String uppercased = Traversals.modify(chars, Character::toUpperCase, input);
+    System.out.println("Original:    " + input);
+    System.out.println("Uppercased:  " + uppercased);
+
+    // Selective character transformation using filtered
+    Traversal<String, Character> vowels = chars.filtered(c -> "aeiouAEIOU".indexOf(c) >= 0);
+
+    String vowelsUppercased = Traversals.modify(vowels, Character::toUpperCase, input);
+    System.out.println("Vowels only: " + vowelsUppercased);
+
+    // Character frequency analysis
+    String text = "banana";
+    List<Character> allChars = Traversals.getAll(chars, text);
+    System.out.println("\nCharacters in '" + text + "': " + allChars);
+    System.out.println(
+        "Character 'a' frequency: " + allChars.stream().filter(c -> c == 'a').count() + " times");
+
+    // ROT13 cipher demonstration
+    Traversal<String, Character> letters = chars.filtered(c -> Character.isLetter(c));
+
+    String secret = "hello";
+    String encoded =
+        Traversals.modify(
+            letters,
+            c -> {
+              if (Character.isLowerCase(c)) {
+                return (char) ('a' + (c - 'a' + 13) % 26);
+              } else {
+                return (char) ('A' + (c - 'A' + 13) % 26);
+              }
+            },
+            secret);
+    System.out.println("\nROT13 encoding:");
+    System.out.println("Original: " + secret);
+    System.out.println("Encoded:  " + encoded);
+    System.out.println();
+  }
+
+  private static void demonstrateWordTraversals() {
+    System.out.println("--- SCENARIO 2: Word-Level Operations ---\n");
+
+    Traversal<String, String> words = StringTraversals.worded();
+
+    // Title case formatting
+    String rawTitle = "functional programming in java";
+    String titleCase =
+        Traversals.modify(
+            words,
+            word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase(),
+            rawTitle);
+    System.out.println("Raw title:    " + rawTitle);
+    System.out.println("Title case:   " + titleCase);
+
+    // Email domain normalisation
+    String email = "  User.Name@EXAMPLE.COM  ";
+    String normalised = Traversals.modify(words, String::toLowerCase, email.trim());
+    System.out.println("\nEmail normalisation:");
+    System.out.println("Input:       '" + email + "'");
+    System.out.println("Normalised:  '" + normalised + "'");
+
+    // Word filtering and extraction
+    String sentence = "The quick brown fox jumps over the lazy dog";
+    Traversal<String, String> longWords = words.filtered(w -> w.length() > 4);
+
+    List<String> extracted = Traversals.getAll(longWords, sentence);
+    System.out.println("\nLong words (>4 chars) in: " + sentence);
+    System.out.println("Result: " + extracted);
+
+    // Emphasis transformation
+    String emphasised = Traversals.modify(longWords, String::toUpperCase, sentence);
+    System.out.println("Emphasised: " + emphasised);
+
+    // Whitespace normalisation
+    String messyText = "  inconsistent   whitespace\t\there  ";
+    List<String> normalizedWords = Traversals.getAll(words, messyText);
+    String cleaned = String.join(" ", normalizedWords);
+    System.out.println("\nWhitespace normalisation:");
+    System.out.println("Input:  '" + messyText + "'");
+    System.out.println("Output: '" + cleaned + "'");
+    System.out.println();
+  }
+
+  private static void demonstrateLineTraversals() {
+    System.out.println("--- SCENARIO 3: Line-Level Operations ---\n");
+
+    Traversal<String, String> lines = StringTraversals.lined();
+
+    // Application log processing
+    String logContent =
+        """
+        [2025-01-15 10:00:00] INFO Application started
+        [2025-01-15 10:00:01] INFO Loading configuration
+        [2025-01-15 10:00:02] ERROR Failed to connect to database
+        [2025-01-15 10:00:03] WARN Retrying connection
+        [2025-01-15 10:00:04] INFO Connected successfully
+        """;
+
+    System.out.println("--- Original Log ---");
+    System.out.println(logContent);
+
+    // Extract ERROR lines only
+    Traversal<String, String> errorLines = lines.filtered(line -> line.contains("ERROR"));
+
+    List<String> errors = Traversals.getAll(errorLines, logContent);
+    System.out.println("--- ERROR Lines Only ---");
+    errors.forEach(System.out::println);
+
+    // Add prefixes to each line
+    String prefixed = Traversals.modify(lines, line -> "> " + line, logContent);
+    System.out.println("\n--- Prefixed Log ---");
+    System.out.println(prefixed);
+
+    // Number lines
+    final int[] lineNumber = {1};
+    String numbered = Traversals.modify(lines, line -> lineNumber[0]++ + ". " + line, logContent);
+    System.out.println("--- Numbered Log ---");
+    System.out.println(numbered);
+
+    // Filter and transform
+    String warningsAndErrors =
+        Traversals.modify(
+            lines.filtered(line -> line.contains("ERROR") || line.contains("WARN")),
+            String::toUpperCase,
+            logContent);
+    System.out.println("--- Emphasised Warnings and Errors ---");
+    System.out.println(warningsAndErrors);
+    System.out.println();
+  }
+
+  private static void demonstrateRealWorldScenarios() {
+    System.out.println("--- SCENARIO 4: Real-World Use Cases ---\n");
+
+    demonstrateEmailNormalisation();
+    demonstrateCsvProcessing();
+    demonstrateConfigurationSanitisation();
+  }
+
+  private static void demonstrateEmailNormalisation() {
+    System.out.println("Use Case 1: Email Normalisation Service");
+    System.out.println("----------------------------------------");
+
+    String[] emails = {
+      "  User.Name@EXAMPLE.COM  ", "admin@TEST-DOMAIN.org", "contact@My-Company.CO.UK  "
+    };
+
+    Traversal<String, String> words = StringTraversals.worded();
+
+    System.out.println("\nNormalising email addresses:");
+    for (String email : emails) {
+      String normalised = Traversals.modify(words, String::toLowerCase, email.trim());
+      System.out.println("  " + email + " -> " + normalised);
+    }
+    System.out.println();
+  }
+
+  private static void demonstrateCsvProcessing() {
+    System.out.println("Use Case 2: CSV Data Processing");
+    System.out.println("--------------------------------");
+
+    String csvData =
+        """
+        Product,Price,Stock
+        Widget,10.50,100
+        Gadget,25.00,50
+        Gizmo,15.75,75
+        """;
+
+    Traversal<String, String> lines = StringTraversals.lined();
+
+    // Extract header
+    List<String> allLines = Traversals.getAll(lines, csvData);
+    String header = allLines.get(0);
+    System.out.println("Header: " + header);
+
+    // Process data rows (skip header)
+    Traversal<String, String> dataLines = lines.filtered(line -> !line.startsWith("Product"));
+
+    System.out.println("\nData rows:");
+    List<String> dataRows = Traversals.getAll(dataLines, csvData);
+    dataRows.forEach(row -> System.out.println("  " + row));
+
+    // Transform: uppercase product names (first column)
+    String transformed =
+        Traversals.modify(
+            dataLines,
+            line -> {
+              String[] parts = line.split(",");
+              if (parts.length >= 3) {
+                parts[0] = parts[0].toUpperCase();
+                return String.join(",", parts);
+              }
+              return line;
+            },
+            csvData);
+
+    System.out.println("\nTransformed (uppercase product names):");
+    System.out.println(transformed);
+  }
+
+  private static void demonstrateConfigurationSanitisation() {
+    System.out.println("Use Case 3: Configuration File Sanitisation");
+    System.out.println("--------------------------------------------");
+
+    String configFile =
+        """
+        # Database Configuration
+        db.host=localhost
+        db.port=5432
+        db.username=admin
+        db.password=secret123
+
+        # Application Settings
+        app.name=MyApplication
+        app.version=1.0.0
+        app.debug=true
+        """;
+
+    Traversal<String, String> lines = StringTraversals.lined();
+
+    // Remove comments
+    Traversal<String, String> nonCommentLines =
+        lines.filtered(line -> !line.trim().startsWith("#") && !line.trim().isEmpty());
+
+    String withoutComments =
+        Traversals.getAll(nonCommentLines, configFile).stream().collect(Collectors.joining("\n"));
+
+    System.out.println("Without comments:");
+    System.out.println(withoutComments);
+
+    // Redact sensitive values
+    String redacted =
+        Traversals.modify(
+            lines,
+            line -> {
+              if (line.contains("password")) {
+                int equalsIndex = line.indexOf('=');
+                if (equalsIndex != -1) {
+                  return line.substring(0, equalsIndex + 1) + "***REDACTED***";
+                }
+              }
+              return line;
+            },
+            configFile);
+
+    System.out.println("\nWith redacted passwords:");
+    System.out.println(redacted);
+
+    // Trim all property values
+    String trimmed =
+        Traversals.modify(
+            nonCommentLines,
+            line -> {
+              String[] parts = line.split("=", 2);
+              if (parts.length == 2) {
+                return parts[0].trim() + "=" + parts[1].trim();
+              }
+              return line;
+            },
+            configFile);
+
+    System.out.println("\nWith trimmed values:");
+    System.out.println(trimmed);
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/TupleTraversalsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/TupleTraversalsExample.java
@@ -1,0 +1,321 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.List;
+import org.higherkindedj.hkt.tuple.Tuple2;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.higherkindedj.optics.util.TupleTraversals;
+
+/**
+ * Demonstrates tuple traversals for parallel operations on Tuple2 pairs using {@link
+ * TupleTraversals}.
+ *
+ * <p>The {@code both()} traversal focuses on both elements of a Tuple2 when they share the same
+ * type, enabling:
+ *
+ * <ul>
+ *   <li>Parallel transformations on paired data
+ *   <li>Coordinate system operations (latitude/longitude, x/y)
+ *   <li>Range and boundary manipulations (min/max, start/end)
+ *   <li>Simultaneous updates to homogeneous pairs
+ * </ul>
+ *
+ * <p>This example covers:
+ *
+ * <ul>
+ *   <li>Geographic coordinate transformations
+ *   <li>Statistical range operations
+ *   <li>Bounding box calculations
+ *   <li>Time period adjustments
+ *   <li>Normalisation and scaling
+ * </ul>
+ */
+public class TupleTraversalsExample {
+
+  public static void main(String[] args) {
+    System.out.println("=== TUPLE TRAVERSALS EXAMPLE ===\n");
+
+    demonstrateBasicTupleOperations();
+    demonstrateGeographicCoordinates();
+    demonstrateStatisticalRanges();
+    demonstrateBoundingBoxes();
+    demonstrateTimePeriods();
+
+    System.out.println("\n=== TUPLE TRAVERSALS COMPLETE ===");
+  }
+
+  private static void demonstrateBasicTupleOperations() {
+    System.out.println("--- SCENARIO 1: Basic Tuple Operations ---\n");
+
+    // Create a tuple traversal
+    Traversal<Tuple2<Integer, Integer>, Integer> both = TupleTraversals.both();
+
+    // Basic transformation
+    Tuple2<Integer, Integer> range = new Tuple2<>(10, 20);
+    Tuple2<Integer, Integer> doubled = Traversals.modify(both, x -> x * 2, range);
+
+    System.out.println("Original range: " + range);
+    System.out.println("Doubled:        " + doubled);
+
+    // Extract both elements
+    List<Integer> values = Traversals.getAll(both, range);
+    System.out.println("Extracted:      " + values);
+
+    // String tuple transformation
+    Traversal<Tuple2<String, String>, String> bothStrings = TupleTraversals.both();
+    Tuple2<String, String> names = new Tuple2<>("alice", "bob");
+    Tuple2<String, String> capitalised =
+        Traversals.modify(
+            bothStrings, s -> s.substring(0, 1).toUpperCase() + s.substring(1), names);
+
+    System.out.println("\nOriginal names:  " + names);
+    System.out.println("Capitalised:     " + capitalised);
+    System.out.println();
+  }
+
+  private static void demonstrateGeographicCoordinates() {
+    System.out.println("--- SCENARIO 2: Geographic Coordinates ---\n");
+
+    record Location(String name, Tuple2<Double, Double> coordinates) {
+      // coordinates: (latitude, longitude)
+      @Override
+      public String toString() {
+        return String.format("%s (lat: %.6f, lon: %.6f)", name, coordinates._1(), coordinates._2());
+      }
+    }
+
+    Traversal<Tuple2<Double, Double>, Double> bothCoords = TupleTraversals.both();
+
+    Location london = new Location("London", new Tuple2<>(51.5074, -0.1278));
+    Location paris = new Location("Paris", new Tuple2<>(48.8566, 2.3522));
+
+    System.out.println("Original locations:");
+    System.out.println("  " + london);
+    System.out.println("  " + paris);
+
+    // Round coordinates to 2 decimal places
+    double roundingFactor = 100.0;
+    Location londonRounded =
+        new Location(
+            london.name(),
+            Traversals.modify(
+                bothCoords,
+                coord -> Math.round(coord * roundingFactor) / roundingFactor,
+                london.coordinates()));
+
+    Location parisRounded =
+        new Location(
+            paris.name(),
+            Traversals.modify(
+                bothCoords,
+                coord -> Math.round(coord * roundingFactor) / roundingFactor,
+                paris.coordinates()));
+
+    System.out.println("\nRounded to 2 decimals:");
+    System.out.println("  " + londonRounded);
+    System.out.println("  " + parisRounded);
+
+    // Apply offset to both coordinates (e.g., coordinate system adjustment)
+    double offset = 0.001; // Small offset
+    Location londonOffset =
+        new Location(
+            london.name() + " (offset)",
+            Traversals.modify(bothCoords, coord -> coord + offset, london.coordinates()));
+
+    System.out.println("\nWith offset +0.001:");
+    System.out.println("  " + londonOffset);
+
+    // Scale coordinates (useful for projection transformations)
+    double scale = 1000000.0; // Convert to microDegrees
+    Tuple2<Double, Double> scaled =
+        Traversals.modify(bothCoords, coord -> coord * scale, london.coordinates());
+
+    System.out.println("\nScaled to microDegrees:");
+    System.out.println("  " + scaled);
+    System.out.println();
+  }
+
+  private static void demonstrateStatisticalRanges() {
+    System.out.println("--- SCENARIO 3: Statistical Ranges ---\n");
+
+    record DataRange(String metric, Tuple2<Double, Double> range) {
+      // range: (min, max)
+      double spread() {
+        return range._2() - range._1();
+      }
+
+      @Override
+      public String toString() {
+        return String.format(
+            "%s: [%.2f, %.2f] (spread: %.2f)", metric, range._1(), range._2(), spread());
+      }
+    }
+
+    Traversal<Tuple2<Double, Double>, Double> bothValues = TupleTraversals.both();
+
+    DataRange temperature = new DataRange("Temperature (°C)", new Tuple2<>(-5.0, 35.0));
+    DataRange humidity = new DataRange("Humidity (%)", new Tuple2<>(20.0, 95.0));
+
+    System.out.println("Original ranges:");
+    System.out.println("  " + temperature);
+    System.out.println("  " + humidity);
+
+    // Convert temperature to Fahrenheit
+    DataRange tempFahrenheit =
+        new DataRange(
+            "Temperature (°F)",
+            Traversals.modify(
+                bothValues, celsius -> celsius * 9.0 / 5.0 + 32.0, temperature.range()));
+
+    System.out.println("\nConverted to Fahrenheit:");
+    System.out.println("  " + tempFahrenheit);
+
+    // Normalise range to [0, 1]
+    double minTemp = temperature.range._1();
+    double maxTemp = temperature.range._2();
+    double range = maxTemp - minTemp;
+
+    Tuple2<Double, Double> normalised =
+        Traversals.modify(bothValues, temp -> (temp - minTemp) / range, temperature.range());
+
+    System.out.println("\nNormalised temperature range:");
+    System.out.println("  " + normalised);
+
+    // Expand range by 10% on both sides
+    DataRange expanded =
+        new DataRange(
+            humidity.metric() + " (expanded)",
+            Traversals.modify(
+                bothValues,
+                value -> {
+                  double spread = humidity.range._2() - humidity.range._1();
+                  return value == humidity.range._1()
+                      ? value - spread * 0.1 // Expand min
+                      : value + spread * 0.1; // Expand max
+                },
+                humidity.range()));
+
+    System.out.println("\nExpanded humidity range by 10%:");
+    System.out.println("  " + humidity);
+    System.out.println("  " + expanded);
+    System.out.println();
+  }
+
+  private static void demonstrateBoundingBoxes() {
+    System.out.println("--- SCENARIO 4: Bounding Box Operations ---\n");
+
+    record BoundingBox(Tuple2<Integer, Integer> topLeft, Tuple2<Integer, Integer> bottomRight) {
+      int width() {
+        return bottomRight._1() - topLeft._1();
+      }
+
+      int height() {
+        return bottomRight._2() - topLeft._2();
+      }
+
+      @Override
+      public String toString() {
+        return String.format(
+            "Box[TL:(%d,%d), BR:(%d,%d), Size:%dx%d]",
+            topLeft._1(), topLeft._2(), bottomRight._1(), bottomRight._2(), width(), height());
+      }
+    }
+
+    Traversal<Tuple2<Integer, Integer>, Integer> bothCoords = TupleTraversals.both();
+
+    BoundingBox box = new BoundingBox(new Tuple2<>(10, 10), new Tuple2<>(100, 50));
+
+    System.out.println("Original bounding box:");
+    System.out.println("  " + box);
+
+    // Scale top-left corner
+    Tuple2<Integer, Integer> scaledTopLeft =
+        Traversals.modify(bothCoords, coord -> coord * 2, box.topLeft());
+    BoundingBox scaledBox = new BoundingBox(scaledTopLeft, box.bottomRight());
+
+    System.out.println("\nTop-left corner scaled 2x:");
+    System.out.println("  " + scaledBox);
+
+    // Offset entire box
+    int offsetX = 50;
+    int offsetY = 20;
+    BoundingBox offsetBox =
+        new BoundingBox(
+            Traversals.modify(bothCoords, coord -> coord + offsetX, box.topLeft()),
+            Traversals.modify(bothCoords, coord -> coord + offsetX, box.bottomRight()));
+
+    System.out.println("\nOffset by (50, 50):");
+    System.out.println("  " + offsetBox);
+
+    // Clamp coordinates to positive values
+    Tuple2<Integer, Integer> negativeCoords = new Tuple2<>(-5, -10);
+    Tuple2<Integer, Integer> clamped =
+        Traversals.modify(bothCoords, coord -> Math.max(0, coord), negativeCoords);
+
+    System.out.println("\nClamping negative coordinates:");
+    System.out.println("  Original: " + negativeCoords);
+    System.out.println("  Clamped:  " + clamped);
+    System.out.println();
+  }
+
+  private static void demonstrateTimePeriods() {
+    System.out.println("--- SCENARIO 5: Time Period Operations ---\n");
+
+    record TimePeriod(String name, Tuple2<Integer, Integer> hourRange) {
+      // hourRange: (startHour, endHour) in 24-hour format
+      int duration() {
+        return hourRange._2() - hourRange._1();
+      }
+
+      @Override
+      public String toString() {
+        return String.format(
+            "%s: %02d:00-%02d:00 (%d hours)", name, hourRange._1(), hourRange._2(), duration());
+      }
+    }
+
+    Traversal<Tuple2<Integer, Integer>, Integer> bothHours = TupleTraversals.both();
+
+    TimePeriod workHours = new TimePeriod("Work Hours", new Tuple2<>(9, 17));
+    TimePeriod eveningShift = new TimePeriod("Evening Shift", new Tuple2<>(17, 23));
+
+    System.out.println("Original time periods:");
+    System.out.println("  " + workHours);
+    System.out.println("  " + eveningShift);
+
+    // Shift work hours forward by 2 hours
+    TimePeriod shiftedWork =
+        new TimePeriod(
+            "Shifted Work Hours",
+            Traversals.modify(bothHours, hour -> hour + 2, workHours.hourRange()));
+
+    System.out.println("\nShifted forward 2 hours:");
+    System.out.println("  " + shiftedWork);
+
+    // Extend both periods by 1 hour
+    TimePeriod extendedWork =
+        new TimePeriod(
+            "Extended Work",
+            Traversals.modify(
+                bothHours,
+                hour -> {
+                  // Extend start earlier, end later
+                  return hour == workHours.hourRange._1() ? hour - 1 : hour + 1;
+                },
+                workHours.hourRange()));
+
+    System.out.println("\nExtended by 1 hour on both ends:");
+    System.out.println("  " + workHours);
+    System.out.println("  " + extendedWork);
+
+    // Modulo 24 for wrap-around
+    Tuple2<Integer, Integer> late = new Tuple2<>(22, 26); // 26 should wrap to 2
+    Tuple2<Integer, Integer> wrapped = Traversals.modify(bothHours, hour -> hour % 24, late);
+
+    System.out.println("\nWrap-around for 24-hour format:");
+    System.out.println("  Original: " + late);
+    System.out.println("  Wrapped:  " + wrapped);
+  }
+}


### PR DESCRIPTION
This commit adds several categories of traversal enhancements following higher-kinded-j patterns:

**Core Data Structure Traversals (Traversals.java):**
- forOptional(): Affine traversal for Optional<A> (0-1 cardinality)
- forMapValues(): Traverse all values in Map<K,V> preserving keys
- Helper methods: traverseOptional(), traverseMapValues(), traverseTuple2Both()

**Tuple Traversals (new TupleTraversals.java):**
- both(): Traverse both elements of Tuple2<A,A> when same type
- Enables parallel transformations on tuple pairs

**String Traversals (new StringTraversals.java):**
- chars(): Focus on each character in a string
- worded(): Split by whitespace, focus on each word
- lined(): Split by line separators, focus on each line
- All maintain immutability and normalize output formatting

**List Position Traversals (ListTraversals.java):**
- takingWhile(Predicate): Focus on prefix while predicate holds
- droppingWhile(Predicate): Skip prefix while predicate holds, focus on rest
- element(int): Affine traversal for single element at index (0-1 cardinality)

All enhancements:
- Follow existing higher-kinded-j patterns and conventions
- Use wildcards for maximum flexibility
- Include comprehensive JavaDoc with examples
- Preserve immutability and referential transparency
- Support composition with existing traversals



Fixes #172 
