### PR TITLE
Add ArchUnit architecture tests for pattern enforcement

### DIFF
--- a/hkj-core/build.gradle.kts
+++ b/hkj-core/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   testImplementation("org.assertj:assertj-core:3.27.3")
   testImplementation("net.jqwik:jqwik:1.9.2")
   testImplementation("net.jqwik:jqwik-engine:1.9.2")
+  testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }
 
 

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/ArchitectureTestBase.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/ArchitectureTestBase.java
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+
+/**
+ * Base class providing shared class imports for architecture tests.
+ *
+ * <p>This class provides a cached import of all production classes using {@link ClassFileImporter}
+ * directly, which works reliably in multi-module Gradle projects where the {@code @AnalyzeClasses}
+ * annotation may not find all classes.
+ */
+public final class ArchitectureTestBase {
+
+  /** The base package for all higher-kinded-j code. */
+  public static final String BASE_PACKAGE = "org.higherkindedj";
+
+  /** Cached import of all production classes (no test classes). */
+  private static volatile JavaClasses productionClasses;
+
+  /** Cached import of all test classes only. */
+  private static volatile JavaClasses testClasses;
+
+  private ArchitectureTestBase() {
+    // Utility class
+  }
+
+  /**
+   * Returns all production classes in the higher-kinded-j packages.
+   *
+   * <p>This method imports classes programmatically using {@link ClassFileImporter}, which provides
+   * reliable class discovery in multi-module projects. The result is cached for performance.
+   *
+   * @return the imported production classes
+   */
+  public static JavaClasses getProductionClasses() {
+    if (productionClasses == null) {
+      synchronized (ArchitectureTestBase.class) {
+        if (productionClasses == null) {
+          productionClasses =
+              new ClassFileImporter()
+                  .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                  .importPackages(BASE_PACKAGE);
+        }
+      }
+    }
+    return productionClasses;
+  }
+
+  /**
+   * Returns all test classes in the higher-kinded-j packages.
+   *
+   * <p>This method imports only test classes programmatically using {@link ClassFileImporter}. The
+   * result is cached for performance.
+   *
+   * @return the imported test classes
+   */
+  public static JavaClasses getTestClasses() {
+    if (testClasses == null) {
+      synchronized (ArchitectureTestBase.class) {
+        if (testClasses == null) {
+          testClasses =
+              new ClassFileImporter()
+                  .withImportOption(ImportOption.Predefined.ONLY_INCLUDE_TESTS)
+                  .importPackages(BASE_PACKAGE);
+        }
+      }
+    }
+    return testClasses;
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/DependencyLayerRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/DependencyLayerRules.java
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing dependency layers between packages.
+ *
+ * <p>These rules ensure proper layering and prevent inappropriate dependencies:
+ *
+ * <ul>
+ *   <li>Core types shouldn't depend on transformers
+ *   <li>Optics shouldn't depend on specific monad implementations
+ *   <li>API types shouldn't depend on implementation details
+ * </ul>
+ */
+@DisplayName("Dependency Layer Rules")
+class DependencyLayerRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Core Maybe type should not depend on MaybeT transformer.
+   *
+   * <p>The base Maybe monad should be independent of its transformer variant.
+   */
+  @Test
+  @DisplayName("Maybe package should not depend on MaybeT transformer")
+  void maybe_should_not_depend_on_maybe_t() {
+    noClasses()
+        .that()
+        .resideInAPackage("..hkt.maybe..")
+        .and()
+        .haveSimpleNameNotContaining("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.maybe_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Core Either type should not depend on EitherT transformer.
+   *
+   * <p>The base Either monad should be independent of its transformer variant.
+   */
+  @Test
+  @DisplayName("Either package should not depend on EitherT transformer")
+  void either_should_not_depend_on_either_t() {
+    noClasses()
+        .that()
+        .resideInAPackage("..hkt.either..")
+        .and()
+        .haveSimpleNameNotContaining("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.either_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Core State type should not depend on StateT transformer.
+   *
+   * <p>The base State monad should be independent of its transformer variant.
+   */
+  @Test
+  @DisplayName("State package should not depend on StateT transformer")
+  void state_should_not_depend_on_state_t() {
+    noClasses()
+        .that()
+        .resideInAPackage("..hkt.state..")
+        .and()
+        .haveSimpleNameNotContaining("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.state_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Core Optional type should not depend on OptionalT transformer.
+   *
+   * <p>The base Optional wrapper should be independent of its transformer variant.
+   */
+  @Test
+  @DisplayName("Optional package should not depend on OptionalT transformer")
+  void optional_should_not_depend_on_optional_t() {
+    noClasses()
+        .that()
+        .resideInAPackage("..hkt.optional..")
+        .and()
+        .haveSimpleNameNotContaining("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.optional_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Optics core should not depend on specific monad implementations.
+   *
+   * <p>Optics should work with any monad through the type class interfaces, not concrete types.
+   */
+  @Test
+  @DisplayName("Optics should not depend on State monad implementation")
+  void optics_should_not_depend_on_state_implementation() {
+    noClasses()
+        .that()
+        .resideInAPackage("..optics..")
+        .and()
+        .haveSimpleNameNotContaining("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.state..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Optics core should not depend on IO monad implementation.
+   *
+   * <p>Optics should work through abstractions, not concrete IO types.
+   */
+  @Test
+  @DisplayName("Optics should not depend on IO monad implementation")
+  void optics_should_not_depend_on_io_implementation() {
+    noClasses()
+        .that()
+        .resideInAPackage("..optics..")
+        .and()
+        .haveSimpleNameNotContaining("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.io..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * HKT implementations should depend on the API module interfaces.
+   *
+   * <p>All HKT types should implement the core interfaces from the API.
+   */
+  @Test
+  @DisplayName("HKT implementations should use Kind interface")
+  void hkt_implementations_should_use_kind_interface() {
+    classes()
+        .that()
+        .resideInAPackage("..hkt..")
+        .and()
+        .haveSimpleNameEndingWith("Kind")
+        .and()
+        .areInterfaces()
+        .should()
+        .beAssignableTo(org.higherkindedj.hkt.Kind.class)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Transformer packages should depend on their base types.
+   *
+   * <p>EitherT should depend on Either, MaybeT on Maybe, etc.
+   */
+  @Test
+  @DisplayName("EitherT should depend on Either")
+  void either_t_should_depend_on_either() {
+    classes()
+        .that()
+        .resideInAPackage("..hkt.either_t..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.either..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** MaybeT should depend on Maybe. */
+  @Test
+  @DisplayName("MaybeT should depend on Maybe")
+  void maybe_t_should_depend_on_maybe() {
+    classes()
+        .that()
+        .resideInAPackage("..hkt.maybe_t..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..hkt.maybe..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/ImmutabilityRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/ImmutabilityRules.java
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.higherkindedj.hkt.Kind;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing immutability patterns.
+ *
+ * <p>Functional programming relies heavily on immutability. These rules ensure:
+ *
+ * <ul>
+ *   <li>HKT data types (Kind implementations) are immutable
+ *   <li>Fields in functional types are final
+ *   <li>Records are used where appropriate for data types
+ * </ul>
+ */
+@DisplayName("Immutability Rules")
+class ImmutabilityRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Kind implementations should have only final fields.
+   *
+   * <p>HKT types like Either, Maybe, Try should be immutable to support referential transparency.
+   *
+   * <p>Note: This excludes interfaces (which have no fields) and inner/nested classes that may have
+   * synthetic fields.
+   */
+  @Test
+  @DisplayName("Kind implementations should have only final fields (immutability)")
+  void kind_implementations_should_have_final_fields() {
+    classes()
+        .that()
+        .implement(Kind.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotAnonymousClasses()
+        .and()
+        .areNotMemberClasses() // Exclude inner classes with potential synthetic fields
+        .should(haveOnlyFinalInstanceFields())
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Custom condition checking that all instance fields are final.
+   *
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveOnlyFinalInstanceFields() {
+    return new ArchCondition<>("have only final instance fields") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        javaClass.getFields().stream()
+            .filter(field -> !field.getModifiers().contains(JavaModifier.STATIC))
+            .filter(field -> !field.getModifiers().contains(JavaModifier.FINAL))
+            .filter(field -> !field.getName().startsWith("this$")) // Exclude synthetic outer refs
+            .forEach(
+                field ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            javaClass,
+                            String.format(
+                                "Class %s has non-final instance field '%s' (should be immutable)",
+                                javaClass.getName(), field.getName()))));
+      }
+    };
+  }
+
+  /**
+   * Classes representing values should be final or sealed.
+   *
+   * <p>Value types should not be extended arbitrarily to maintain the integrity of the type system.
+   */
+  @Test
+  @DisplayName("Value classes (Just, Nothing, Left, Right, etc.) should be final")
+  void value_classes_should_be_final_or_sealed() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Value")
+        .or()
+        .haveSimpleName("Just")
+        .or()
+        .haveSimpleName("Nothing")
+        .or()
+        .haveSimpleName("Left")
+        .or()
+        .haveSimpleName("Right")
+        .or()
+        .haveSimpleName("Success")
+        .or()
+        .haveSimpleName("Failure")
+        .should()
+        .haveModifier(JavaModifier.FINAL)
+        .orShould()
+        .beRecords() // Records are implicitly final
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/InheritanceDepthRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/InheritanceDepthRules.java
@@ -1,0 +1,216 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing inheritance depth limits.
+ *
+ * <p>Deep inheritance hierarchies make code harder to understand and maintain. These rules ensure:
+ *
+ * <ul>
+ *   <li>Class inheritance depth is limited (prefer composition)
+ *   <li>Interface hierarchies remain manageable
+ *   <li>Favor sealed hierarchies over deep inheritance
+ * </ul>
+ */
+@DisplayName("Inheritance Depth Rules")
+class InheritanceDepthRules {
+
+  private static JavaClasses classes;
+
+  /** Maximum allowed inheritance depth for classes (excluding java.lang.Object). */
+  private static final int MAX_CLASS_INHERITANCE_DEPTH = 3;
+
+  /** Maximum allowed interface implementation depth. */
+  private static final int MAX_INTERFACE_DEPTH = 5;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Classes in HKT packages should not have deep inheritance hierarchies.
+   *
+   * <p>Functional programming favors composition over inheritance. Deep hierarchies indicate
+   * potential design issues.
+   */
+  @Test
+  @DisplayName("HKT classes should have limited inheritance depth (max 3)")
+  void hkt_classes_should_have_limited_inheritance_depth() {
+    classes()
+        .that()
+        .resideInAPackage("..hkt..")
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotRecords()
+        .and()
+        .areNotEnums()
+        .should(haveInheritanceDepthAtMost(MAX_CLASS_INHERITANCE_DEPTH))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Optics classes should not have deep inheritance hierarchies. */
+  @Test
+  @DisplayName("Optics classes should have limited inheritance depth (max 3)")
+  void optics_classes_should_have_limited_inheritance_depth() {
+    classes()
+        .that()
+        .resideInAPackage("..optics..")
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotRecords()
+        .and()
+        .areNotEnums()
+        .should(haveInheritanceDepthAtMost(MAX_CLASS_INHERITANCE_DEPTH))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Type class interfaces should have reasonable hierarchy depth.
+   *
+   * <p>While Functor -> Applicative -> Monad is acceptable, overly deep hierarchies should be
+   * avoided.
+   */
+  @Test
+  @DisplayName("Type class interfaces should have manageable hierarchy depth (max 5)")
+  void type_class_interfaces_should_have_limited_depth() {
+    classes()
+        .that()
+        .areInterfaces()
+        .and()
+        .resideInAPackage("..hkt..")
+        .and()
+        .haveSimpleNameEndingWith("Functor")
+        .or()
+        .haveSimpleNameEndingWith("Applicative")
+        .or()
+        .haveSimpleNameEndingWith("Monad")
+        .should(haveInterfaceDepthAtMost(MAX_INTERFACE_DEPTH))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Custom condition checking class inheritance depth.
+   *
+   * @param maxDepth the maximum allowed inheritance depth
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveInheritanceDepthAtMost(int maxDepth) {
+    return new ArchCondition<>("have inheritance depth at most " + maxDepth) {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        int depth = calculateInheritanceDepth(javaClass);
+        if (depth > maxDepth) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Class %s has inheritance depth %d (max allowed: %d)",
+                      javaClass.getName(), depth, maxDepth)));
+        }
+      }
+    };
+  }
+
+  /**
+   * Custom condition checking interface hierarchy depth.
+   *
+   * @param maxDepth the maximum allowed interface depth
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveInterfaceDepthAtMost(int maxDepth) {
+    return new ArchCondition<>("have interface hierarchy depth at most " + maxDepth) {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        int depth = calculateInterfaceDepth(javaClass);
+        if (depth > maxDepth) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Interface %s has hierarchy depth %d (max allowed: %d)",
+                      javaClass.getName(), depth, maxDepth)));
+        }
+      }
+    };
+  }
+
+  /**
+   * Calculate the inheritance depth of a class.
+   *
+   * <p>Counts the number of superclasses excluding java.lang.Object.
+   *
+   * @param javaClass the class to check
+   * @return the inheritance depth
+   */
+  private static int calculateInheritanceDepth(JavaClass javaClass) {
+    int depth = 0;
+    JavaClass current = javaClass;
+
+    while (current.getSuperclass().isPresent()) {
+      JavaType superclassType = current.getSuperclass().get();
+      JavaClass superclass = superclassType.toErasure();
+      if (superclass.getFullName().equals("java.lang.Object")) {
+        break;
+      }
+      depth++;
+      current = superclass;
+    }
+
+    return depth;
+  }
+
+  /**
+   * Calculate the maximum interface hierarchy depth.
+   *
+   * @param javaClass the interface to check
+   * @return the maximum interface depth
+   */
+  private static int calculateInterfaceDepth(JavaClass javaClass) {
+    if (!javaClass.isInterface()) {
+      return 0;
+    }
+    return calculateMaxInterfaceDepth(javaClass, 0);
+  }
+
+  /**
+   * Recursively calculate the maximum interface depth.
+   *
+   * @param javaClass the current interface
+   * @param currentDepth the current depth
+   * @return the maximum depth found
+   */
+  private static int calculateMaxInterfaceDepth(JavaClass javaClass, int currentDepth) {
+    int maxDepth = currentDepth;
+
+    for (JavaClass superInterface : javaClass.getRawInterfaces()) {
+      // Skip java.* interfaces
+      if (superInterface.getFullName().startsWith("java.")) {
+        continue;
+      }
+      int depth = calculateMaxInterfaceDepth(superInterface, currentDepth + 1);
+      maxDepth = Math.max(maxDepth, depth);
+    }
+
+    return maxDepth;
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/MethodSignatureRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/MethodSignatureRules.java
@@ -1,0 +1,149 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing method signature conventions.
+ *
+ * <p>These rules ensure that utility classes have required methods:
+ *
+ * <ul>
+ *   <li>KindHelper classes must have widen() method
+ *   <li>KindHelper classes must have narrow() method
+ * </ul>
+ */
+@DisplayName("Method Signature Rules")
+class MethodSignatureRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * KindHelper classes must have a widen() method.
+   *
+   * <p>The widen() method converts a concrete type to its Kind representation. This is a core part
+   * of the HKT simulation pattern.
+   */
+  @Test
+  @DisplayName("KindHelper classes should have widen() method")
+  void kind_helper_should_have_widen_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("KindHelper")
+        .should(haveMethodNamed("widen"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * KindHelper classes must have a narrow() method.
+   *
+   * <p>The narrow() method converts a Kind back to its concrete type. This is a core part of the
+   * HKT simulation pattern.
+   */
+  @Test
+  @DisplayName("KindHelper classes should have narrow() method")
+  void kind_helper_should_have_narrow_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("KindHelper")
+        .should(haveMethodNamed("narrow"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Monad implementations should have flatMap method.
+   *
+   * <p>The flatMap operation is the defining operation of a Monad.
+   */
+  @Test
+  @DisplayName("Monad classes should have flatMap method")
+  void monad_should_have_flatmap_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Monad")
+        .and()
+        .areNotInterfaces()
+        .should(haveMethodNamed("flatMap"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Functor implementations should have map method.
+   *
+   * <p>The map operation is the defining operation of a Functor.
+   */
+  @Test
+  @DisplayName("Functor classes should have map method")
+  void functor_should_have_map_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Functor")
+        .and()
+        .areNotInterfaces()
+        .should(haveMethodNamed("map"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Applicative implementations should have ap method.
+   *
+   * <p>The ap (apply) operation is the defining operation of an Applicative.
+   */
+  @Test
+  @DisplayName("Applicative classes should have ap method")
+  void applicative_should_have_ap_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Applicative")
+        .and()
+        .areNotInterfaces()
+        .should(haveMethodNamed("ap"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Custom condition that checks if a class has a method with the given name.
+   *
+   * @param methodName the name of the method to check for
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveMethodNamed(String methodName) {
+    return new ArchCondition<>("have method named '" + methodName + "'") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        boolean hasMethod =
+            javaClass.getMethods().stream().anyMatch(method -> method.getName().equals(methodName));
+
+        if (!hasMethod) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Class %s does not have required method '%s'",
+                      javaClass.getName(), methodName)));
+        }
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/ModuleDependencyRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/ModuleDependencyRules.java
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing module dependency constraints.
+ *
+ * <p>These rules ensure clean separation between:
+ *
+ * <ul>
+ *   <li>API interfaces and core implementations
+ *   <li>Different type implementations (Either, Maybe, Try, etc.)
+ *   <li>Core library and annotation processing
+ * </ul>
+ */
+@DisplayName("Module Dependency Rules")
+class ModuleDependencyRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Ensures no circular dependencies exist between type implementation packages.
+   *
+   * <p>Each HKT type (either, maybe, try, list, etc.) should be independent and not create cycles
+   * with other type packages.
+   */
+  @Test
+  @DisplayName("Type implementation packages should be free of cycles")
+  void no_cycles_between_type_packages() {
+    slices()
+        .matching("org.higherkindedj.hkt.(*)..")
+        .should()
+        .beFreeOfCycles()
+        .allowEmptyShould(true) // Allow if no matching slices found
+        .check(classes);
+  }
+
+  /**
+   * Ensures monad transformer packages don't depend on each other cyclically.
+   *
+   * <p>Transformers like EitherT, MaybeT, StateT should be independent.
+   */
+  @Test
+  @DisplayName("Monad transformer packages should be free of cycles")
+  void no_cycles_between_transformer_packages() {
+    slices()
+        .matching("org.higherkindedj.hkt.(*_t)..")
+        .should()
+        .beFreeOfCycles()
+        .allowEmptyShould(true) // Allow if no matching slices found
+        .check(classes);
+  }
+
+  /**
+   * Ensures optics implementation classes don't depend on specific HKT implementations.
+   *
+   * <p>Optics should work through the generic Kind interface, not concrete types.
+   */
+  @Test
+  @DisplayName("Optics classes should not depend on specific HKT type implementations")
+  void optics_should_not_depend_on_specific_hkt_types() {
+    noClasses()
+        .that()
+        .resideInAPackage("..optics..")
+        .and()
+        .haveSimpleNameNotEndingWith("Test")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage(
+            "..hkt.either..", "..hkt.maybe..", "..hkt.trymonad..", "..hkt.list..", "..hkt.io..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Ensures example code doesn't leak into core packages.
+   *
+   * <p>Example code should only exist in example packages, not in core implementation.
+   */
+  @Test
+  @DisplayName("Core HKT classes should not depend on example code")
+  void no_example_dependencies_in_core() {
+    noClasses()
+        .that()
+        .resideInAPackage("..hkt..")
+        .and()
+        .resideOutsideOfPackage("..example..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..example..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/NamingConventionRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/NamingConventionRules.java
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Foldable;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.Traverse;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing naming conventions.
+ *
+ * <p>These rules ensure consistent naming patterns across the codebase:
+ *
+ * <ul>
+ *   <li>Type class implementations follow {@code <TypeName><TypeClass>} pattern
+ *   <li>Kind interfaces follow {@code <TypeName>Kind} pattern
+ *   <li>Helper classes follow {@code <TypeName>KindHelper} pattern
+ * </ul>
+ */
+@DisplayName("Naming Convention Rules")
+class NamingConventionRules {
+
+  private static JavaClasses productionClasses;
+
+  @BeforeAll
+  static void setup() {
+    productionClasses = getProductionClasses();
+  }
+
+  /**
+   * Functor implementations must be named with "Functor" suffix.
+   *
+   * <p>Examples: MaybeFunctor, EitherFunctor, TryFunctor
+   */
+  @Test
+  @DisplayName("Functor implementations should be named <Type>Functor")
+  void functor_implementations_should_end_with_functor() {
+    classes()
+        .that()
+        .implement(Functor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotImplement(Applicative.class) // Exclude Applicatives which also implement Functor
+        .should()
+        .haveSimpleNameEndingWith("Functor")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Monad implementations must be named with "Monad" suffix.
+   *
+   * <p>Examples: MaybeMonad, EitherMonad, ListMonad
+   */
+  @Test
+  @DisplayName("Monad implementations should be named <Type>Monad")
+  void monad_implementations_should_end_with_monad() {
+    classes()
+        .that()
+        .implement(Monad.class)
+        .and()
+        .areNotInterfaces()
+        .should()
+        .haveSimpleNameEndingWith("Monad")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Applicative implementations must be named with "Applicative" suffix.
+   *
+   * <p>Examples: MaybeApplicative, EitherApplicative
+   *
+   * <p>Note: Classes that implement Monad (which extends Applicative) are excluded as they follow
+   * the Monad naming convention.
+   */
+  @Test
+  @DisplayName("Applicative implementations should be named <Type>Applicative")
+  void applicative_implementations_should_end_with_applicative() {
+    classes()
+        .that()
+        .implement(Applicative.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotImplement(Monad.class) // Monads are named with Monad suffix
+        .should()
+        .haveSimpleNameEndingWith("Applicative")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Foldable implementations must be named with "Foldable" suffix.
+   *
+   * <p>Examples: MaybeFoldable, ListFoldable
+   *
+   * <p>Note: Classes implementing Traverse (which extends Foldable) follow Traverse naming.
+   */
+  @Test
+  @DisplayName("Foldable implementations should be named <Type>Foldable")
+  void foldable_implementations_should_end_with_foldable() {
+    classes()
+        .that()
+        .implement(Foldable.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotImplement(Traverse.class) // Traverse implementations use Traverse suffix
+        .should()
+        .haveSimpleNameEndingWith("Foldable")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Traverse implementations must be named with "Traverse" suffix.
+   *
+   * <p>Examples: MaybeTraverse, ListTraverse, EitherTraverse
+   */
+  @Test
+  @DisplayName("Traverse implementations should be named <Type>Traverse")
+  void traverse_implementations_should_end_with_traverse() {
+    classes()
+        .that()
+        .implement(Traverse.class)
+        .and()
+        .areNotInterfaces()
+        .should()
+        .haveSimpleNameEndingWith("Traverse")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * KindHelper classes must end with "KindHelper" suffix.
+   *
+   * <p>These classes provide widen() and narrow() conversion utilities.
+   */
+  @Test
+  @DisplayName("Kind helper classes should be named <Type>KindHelper")
+  void kind_helper_classes_should_end_with_kind_helper() {
+    classes()
+        .that()
+        .haveSimpleNameContaining("KindHelper")
+        .should()
+        .haveSimpleNameEndingWith("KindHelper")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Classes with "Kind" in name (but not KindHelper) should end with "Kind".
+   *
+   * <p>These are the Kind interface implementations for each type.
+   */
+  @Test
+  @DisplayName("Kind interfaces should be named <Type>Kind")
+  void kind_interfaces_should_end_with_kind() {
+    classes()
+        .that()
+        .haveSimpleNameContaining("Kind")
+        .and()
+        .areInterfaces()
+        .and()
+        .haveSimpleNameNotContaining("KindHelper")
+        .should()
+        .haveSimpleNameEndingWith("Kind")
+        .orShould()
+        .haveSimpleName("Kind") // The base Kind interface itself
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/NoSideEffectsRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/NoSideEffectsRules.java
@@ -1,0 +1,181 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.higherkindedj.hkt.Kind;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing functional purity patterns.
+ *
+ * <p>Pure functional types should not have side effects. These rules ensure:
+ *
+ * <ul>
+ *   <li>Kind implementations don't use System.out/System.err
+ *   <li>Pure types don't have mutable static fields
+ *   <li>Type class instances are side-effect free
+ * </ul>
+ */
+@DisplayName("No Side Effects Rules")
+class NoSideEffectsRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Kind implementations should not use System.out.
+   *
+   * <p>Pure functional types should not perform console I/O as a side effect.
+   */
+  @Test
+  @DisplayName("Kind implementations should not use System.out")
+  void kind_implementations_should_not_use_system_out() {
+    noClasses()
+        .that()
+        .implement(Kind.class)
+        .should()
+        .accessClassesThat()
+        .haveFullyQualifiedName("java.io.PrintStream")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Monad implementations should not use System.out.
+   *
+   * <p>Type class instances should be pure and not perform I/O.
+   */
+  @Test
+  @DisplayName("Monad classes should not use System.out")
+  void monad_classes_should_not_use_system_out() {
+    noClasses()
+        .that()
+        .haveSimpleNameEndingWith("Monad")
+        .and()
+        .areNotInterfaces()
+        .should()
+        .accessClassesThat()
+        .haveFullyQualifiedName("java.io.PrintStream")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Functor implementations should not use System.out. */
+  @Test
+  @DisplayName("Functor classes should not use System.out")
+  void functor_classes_should_not_use_system_out() {
+    noClasses()
+        .that()
+        .haveSimpleNameEndingWith("Functor")
+        .and()
+        .areNotInterfaces()
+        .should()
+        .accessClassesThat()
+        .haveFullyQualifiedName("java.io.PrintStream")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Kind implementations should not have mutable static fields.
+   *
+   * <p>Mutable static state breaks referential transparency.
+   */
+  @Test
+  @DisplayName("Kind implementations should not have mutable static fields")
+  void kind_implementations_should_not_have_mutable_static_fields() {
+    noClasses()
+        .that()
+        .implement(Kind.class)
+        .and()
+        .areNotInterfaces()
+        .should(haveMutableStaticFields())
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Type class implementations should not have mutable static fields.
+   *
+   * <p>Monad, Functor, etc. implementations should be stateless.
+   */
+  @Test
+  @DisplayName("Type class implementations should not have mutable static fields")
+  void type_class_implementations_should_not_have_mutable_static_fields() {
+    noClasses()
+        .that()
+        .haveSimpleNameEndingWith("Monad")
+        .or()
+        .haveSimpleNameEndingWith("Functor")
+        .or()
+        .haveSimpleNameEndingWith("Applicative")
+        .and()
+        .areNotInterfaces()
+        .should(haveMutableStaticFields())
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Pure algebraic data types should not throw RuntimeExceptions.
+   *
+   * <p>Instead of throwing, use Either/Try/Validated for error handling.
+   */
+  @Test
+  @DisplayName("Maybe variants should not directly throw RuntimeException")
+  void maybe_variants_should_not_throw_runtime_exception() {
+    noClasses()
+        .that()
+        .haveSimpleName("Just")
+        .or()
+        .haveSimpleName("Nothing")
+        .should()
+        .dependOnClassesThat()
+        .areAssignableTo(RuntimeException.class)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Custom condition checking for mutable static fields.
+   *
+   * <p>A field is considered mutable if it is static and not final.
+   *
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveMutableStaticFields() {
+    return new ArchCondition<>("have mutable static fields") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        javaClass.getFields().stream()
+            .filter(field -> field.getModifiers().contains(JavaModifier.STATIC))
+            .filter(field -> !field.getModifiers().contains(JavaModifier.FINAL))
+            .filter(field -> !field.getName().startsWith("$")) // Exclude synthetic fields
+            .forEach(
+                field ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            javaClass,
+                            String.format(
+                                "Class %s has mutable static field '%s' (breaks referential"
+                                    + " transparency)",
+                                javaClass.getName(), field.getName()))));
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/NullMarkedPackageRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/NullMarkedPackageRules.java
@@ -1,0 +1,175 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing @NullMarked package annotation patterns.
+ *
+ * <p>In higher-kinded-j, all packages should use @NullMarked annotation from JSpecify to enable
+ * null-safety checking at the package level. This rule verifies that:
+ *
+ * <ul>
+ *   <li>All HKT packages have a package-info.java with @NullMarked
+ *   <li>The package-info.java files contain the @NullMarked annotation
+ * </ul>
+ *
+ * <p>Note: This test uses file system checks rather than ArchUnit because ArchUnit's
+ * ClassFileImporter does not load package-info.class files by default.
+ */
+@DisplayName("NullMarked Package Annotation Rules")
+class NullMarkedPackageRules {
+
+  /** Base path for hkj-core main sources. */
+  private static final String HKJ_CORE_MAIN = "hkj-core/src/main/java/org/higherkindedj/hkt";
+
+  /** Base path for hkj-api main sources. */
+  private static final String HKJ_API_MAIN = "hkj-api/src/main/java/org/higherkindedj";
+
+  /**
+   * Core HKT packages that must have @NullMarked via package-info.java.
+   *
+   * <p>These are the primary type packages in hkj-core.
+   */
+  private static final String[] CORE_HKT_PACKAGES = {
+    "maybe",
+    "either",
+    "trymonad",
+    "validated",
+    "list",
+    "optional",
+    "id",
+    "state",
+    "reader",
+    "writer",
+    "io",
+    "lazy",
+    "future",
+    "stream",
+    "trampoline"
+  };
+
+  /**
+   * Verify that package-info.java files exist for core HKT types.
+   *
+   * <p>This test checks that package-info.java files exist for core HKT packages and contain the
+   * {@code @NullMarked} annotation.
+   */
+  @Test
+  @DisplayName("Core HKT packages should have package-info.java with @NullMarked")
+  void core_hkt_packages_should_have_nullmarked() throws IOException {
+    Path projectRoot = findProjectRoot();
+    List<String> missingPackages = new ArrayList<>();
+    List<String> missingNullMarked = new ArrayList<>();
+
+    for (String pkg : CORE_HKT_PACKAGES) {
+      Path packageInfoPath =
+          projectRoot.resolve(HKJ_CORE_MAIN).resolve(pkg).resolve("package-info.java");
+
+      if (!Files.exists(packageInfoPath)) {
+        missingPackages.add("org.higherkindedj.hkt." + pkg);
+      } else {
+        // Check if the file contains @NullMarked
+        String content = Files.readString(packageInfoPath);
+        if (!content.contains("@NullMarked")
+            && !content.contains("@org.jspecify.annotations.NullMarked")) {
+          missingNullMarked.add("org.higherkindedj.hkt." + pkg);
+        }
+      }
+    }
+
+    StringBuilder errors = new StringBuilder();
+
+    if (!missingPackages.isEmpty()) {
+      errors.append("The following core HKT packages are missing package-info.java:\n");
+      missingPackages.forEach(pkg -> errors.append("  - ").append(pkg).append("\n"));
+    }
+
+    if (!missingNullMarked.isEmpty()) {
+      if (errors.length() > 0) {
+        errors.append("\n");
+      }
+      errors.append("The following packages have package-info.java but missing @NullMarked:\n");
+      missingNullMarked.forEach(pkg -> errors.append("  - ").append(pkg).append("\n"));
+    }
+
+    assertTrue(
+        errors.length() == 0,
+        errors
+            + "\nEach package should have a package-info.java file with"
+            + " @org.jspecify.annotations.NullMarked");
+  }
+
+  /**
+   * Verify that hkj-api packages have @NullMarked annotations.
+   *
+   * <p>The API module defines core interfaces like Functor, Applicative, Monad.
+   */
+  @Test
+  @DisplayName("HKJ-API packages should have package-info.java with @NullMarked")
+  void api_packages_should_have_nullmarked() throws IOException {
+    Path projectRoot = findProjectRoot();
+    Path hktPackageInfo = projectRoot.resolve(HKJ_API_MAIN).resolve("hkt/package-info.java");
+    Path opticsPackageInfo = projectRoot.resolve(HKJ_API_MAIN).resolve("optics/package-info.java");
+
+    List<String> missingOrInvalid = new ArrayList<>();
+
+    checkPackageInfo(hktPackageInfo, "org.higherkindedj.hkt (api)", missingOrInvalid);
+    checkPackageInfo(opticsPackageInfo, "org.higherkindedj.optics (api)", missingOrInvalid);
+
+    assertTrue(
+        missingOrInvalid.isEmpty(),
+        "The following API packages are missing package-info.java or @NullMarked:\n"
+            + String.join("\n", missingOrInvalid));
+  }
+
+  /**
+   * Check if a package-info.java file exists and contains @NullMarked.
+   *
+   * @param packageInfoPath path to the package-info.java file
+   * @param packageName the package name for error reporting
+   * @param errors list to add error messages to
+   */
+  private void checkPackageInfo(Path packageInfoPath, String packageName, List<String> errors)
+      throws IOException {
+    if (!Files.exists(packageInfoPath)) {
+      errors.add("  - " + packageName + " (missing package-info.java)");
+    } else {
+      String content = Files.readString(packageInfoPath);
+      if (!content.contains("@NullMarked")
+          && !content.contains("@org.jspecify.annotations.NullMarked")) {
+        errors.add("  - " + packageName + " (missing @NullMarked annotation)");
+      }
+    }
+  }
+
+  /**
+   * Find the project root directory by looking for settings.gradle.kts.
+   *
+   * @return the project root path
+   */
+  private Path findProjectRoot() {
+    Path current = Paths.get("").toAbsolutePath();
+
+    // Walk up the directory tree to find the project root
+    while (current != null) {
+      if (Files.exists(current.resolve("settings.gradle.kts"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+
+    // Fallback to current directory
+    return Paths.get("").toAbsolutePath();
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/PackageStructureRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/PackageStructureRules.java
@@ -1,0 +1,251 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing package structure conventions.
+ *
+ * <p>These rules ensure consistent organization:
+ *
+ * <ul>
+ *   <li>Each HKT type resides in its own package
+ *   <li>Monad transformers use {@code _t} suffix in package names
+ *   <li>Related classes are co-located in their type's package
+ * </ul>
+ */
+@DisplayName("Package Structure Rules")
+class PackageStructureRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Either-related classes should be in the either package.
+   *
+   * <p>All classes with "Either" in the name (except transformers) should be in
+   * org.higherkindedj.hkt.either.
+   */
+  @Test
+  @DisplayName("Either classes should reside in the either package")
+  void either_classes_in_either_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("Either")
+        .and()
+        .haveSimpleNameNotContaining("EitherT") // Transformer is separate
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..either..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Maybe-related classes should be in the maybe package. */
+  @Test
+  @DisplayName("Maybe classes should reside in the maybe package")
+  void maybe_classes_in_maybe_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("Maybe")
+        .and()
+        .haveSimpleNameNotContaining("MaybeT") // Transformer is separate
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..maybe..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Try-related classes should be in the trymonad package.
+   *
+   * <p>Note: Package is named 'trymonad' to avoid conflict with Java's 'try' keyword.
+   */
+  @Test
+  @DisplayName("Try classes should reside in the trymonad package")
+  void try_classes_in_try_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("Try")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..trymonad..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** IO-related classes should be in the io package. */
+  @Test
+  @DisplayName("IO classes should reside in the io package")
+  void io_classes_in_io_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("IO")
+        .and()
+        .resideInAPackage("..hkt..")
+        .and()
+        .haveSimpleNameNotContaining("IOException") // Standard Java exception
+        .should()
+        .resideInAPackage("..io..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * State-related classes should be in the state package.
+   *
+   * <p>StateT transformer is in state_t package.
+   */
+  @Test
+  @DisplayName("State classes should reside in the state package")
+  void state_classes_in_state_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("State")
+        .and()
+        .haveSimpleNameNotContaining("StateT") // Transformer is separate
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..state..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** EitherT transformer classes should be in either_t package. */
+  @Test
+  @DisplayName("EitherT classes should reside in the either_t package")
+  void either_t_classes_in_either_t_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("EitherT")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..either_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** MaybeT transformer classes should be in maybe_t package. */
+  @Test
+  @DisplayName("MaybeT classes should reside in the maybe_t package")
+  void maybe_t_classes_in_maybe_t_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("MaybeT")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..maybe_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** StateT transformer classes should be in state_t package. */
+  @Test
+  @DisplayName("StateT classes should reside in the state_t package")
+  void state_t_classes_in_state_t_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("StateT")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..state_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** ReaderT transformer classes should be in reader_t package. */
+  @Test
+  @DisplayName("ReaderT classes should reside in the reader_t package")
+  void reader_t_classes_in_reader_t_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("ReaderT")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..reader_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** WriterT transformer classes should be in writer_t package. */
+  @Test
+  @DisplayName("WriterT classes should reside in the writer_t package")
+  void writer_t_classes_in_writer_t_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("WriterT")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..writer_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** OptionalT transformer classes should be in optional_t package. */
+  @Test
+  @DisplayName("OptionalT classes should reside in the optional_t package")
+  void optional_t_classes_in_optional_t_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("OptionalT")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..optional_t..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** List-related classes should be in the list package. */
+  @Test
+  @DisplayName("List HKT classes should reside in the list package")
+  void list_classes_in_list_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("List")
+        .and()
+        .resideInAPackage("..hkt..")
+        .and()
+        .haveSimpleNameNotContaining("java.util") // Exclude java.util.List
+        .should()
+        .resideInAPackage("..list..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Validated-related classes should be in the validated package. */
+  @Test
+  @DisplayName("Validated classes should reside in the validated package")
+  void validated_classes_in_validated_package() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("Validated")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..validated..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/RecordPreferenceRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/RecordPreferenceRules.java
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing record usage for data types.
+ *
+ * <p>In higher-kinded-j, immutable data types should prefer records:
+ *
+ * <ul>
+ *   <li>Algebraic data type variants should be records
+ *   <li>Value types should be records or final classes
+ *   <li>Data carriers in HKT packages should be records
+ * </ul>
+ */
+@DisplayName("Record Preference Rules")
+class RecordPreferenceRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Just variant of Maybe should be a record.
+   *
+   * <p>Records provide automatic equals/hashCode/toString and immutability.
+   */
+  @Test
+  @DisplayName("Just should be a record")
+  void just_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Just")
+        .and()
+        .resideInAPackage("..hkt.maybe..")
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Nothing variant of Maybe should be a record or final class.
+   *
+   * <p>Nothing is a singleton but should still be a value type.
+   */
+  @Test
+  @DisplayName("Nothing should be a record or final class")
+  void nothing_should_be_record_or_final() {
+    classes()
+        .that()
+        .haveSimpleName("Nothing")
+        .and()
+        .resideInAPackage("..hkt.maybe..")
+        .should()
+        .beRecords()
+        .orShould()
+        .haveModifier(JavaModifier.FINAL)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Success variant of Try should be a record. */
+  @Test
+  @DisplayName("Success should be a record")
+  void success_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Success")
+        .and()
+        .resideInAPackage("..hkt.trymonad..")
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Failure variant of Try should be a record. */
+  @Test
+  @DisplayName("Failure should be a record")
+  void failure_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Failure")
+        .and()
+        .resideInAPackage("..hkt.trymonad..")
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Valid variant of Validated should be a record. */
+  @Test
+  @DisplayName("Valid should be a record")
+  void valid_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Valid")
+        .and()
+        .resideInAPackage("..hkt.validated..")
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Invalid variant of Validated should be a record. */
+  @Test
+  @DisplayName("Invalid should be a record")
+  void invalid_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Invalid")
+        .and()
+        .resideInAPackage("..hkt.validated..")
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Tuple types should be records.
+   *
+   * <p>Tuple2, Tuple3, etc. are pure data carriers and should be records.
+   */
+  @Test
+  @DisplayName("Tuple types should be records")
+  void tuple_types_should_be_records() {
+    classes()
+        .that()
+        .haveSimpleNameStartingWith("Tuple")
+        .and()
+        .resideInAPackage("..hkt.tuple..")
+        .and()
+        .areNotInterfaces()
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Id wrapper should be a record.
+   *
+   * <p>The identity monad wrapper is a simple data carrier.
+   */
+  @Test
+  @DisplayName("Id should be a record")
+  void id_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Id")
+        .and()
+        .resideInAPackage("..hkt.id..")
+        .and()
+        .areNotInterfaces()
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Const wrapper should be a record.
+   *
+   * <p>The constant functor wrapper is a simple data carrier.
+   */
+  @Test
+  @DisplayName("Const should be a record")
+  void const_should_be_record() {
+    classes()
+        .that()
+        .haveSimpleName("Const")
+        .and()
+        .resideInAPackage("..hkt.constant..")
+        .and()
+        .areNotInterfaces()
+        .should()
+        .beRecords()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/SealedTypeRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/SealedTypeRules.java
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing sealed type hierarchy conventions.
+ *
+ * <p>In higher-kinded-j, sealed types (algebraic data types) follow specific patterns:
+ *
+ * <ul>
+ *   <li>Sealed interface variants should be in the same package as the sealed interface
+ *   <li>Or nested within the sealed interface (like Either.Left, Either.Right)
+ *   <li>Variant names should match their semantic role
+ * </ul>
+ *
+ * <p>Examples:
+ *
+ * <ul>
+ *   <li>{@code Maybe} sealed interface with {@code Just} and {@code Nothing} variants
+ *   <li>{@code Either} sealed interface with nested {@code Left} and {@code Right} records
+ *   <li>{@code Try} sealed interface with {@code Success} and {@code Failure} variants
+ * </ul>
+ */
+@DisplayName("Sealed Type Hierarchy Rules")
+class SealedTypeRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Just class should be in the maybe package.
+   *
+   * <p>The Just variant of Maybe represents a present value.
+   */
+  @Test
+  @DisplayName("Just class should be in maybe package")
+  void just_should_be_in_maybe_package() {
+    classes()
+        .that()
+        .haveSimpleName("Just")
+        .should()
+        .resideInAPackage("..maybe..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Nothing class should be in the maybe package.
+   *
+   * <p>The Nothing variant of Maybe represents an absent value.
+   */
+  @Test
+  @DisplayName("Nothing class should be in maybe package")
+  void nothing_should_be_in_maybe_package() {
+    classes()
+        .that()
+        .haveSimpleName("Nothing")
+        .should()
+        .resideInAPackage("..maybe..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Success class should be in the trymonad package.
+   *
+   * <p>The Success variant of Try represents a successful computation.
+   */
+  @Test
+  @DisplayName("Success class should be in trymonad package")
+  void success_should_be_in_try_package() {
+    classes()
+        .that()
+        .haveSimpleName("Success")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..trymonad..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Failure class should be in the trymonad package.
+   *
+   * <p>The Failure variant of Try represents a failed computation with an exception.
+   */
+  @Test
+  @DisplayName("Failure class should be in trymonad package")
+  void failure_should_be_in_try_package() {
+    classes()
+        .that()
+        .haveSimpleName("Failure")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..trymonad..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Valid class should be in the validated package.
+   *
+   * <p>The Valid variant of Validated represents valid data.
+   */
+  @Test
+  @DisplayName("Valid class should be in validated package")
+  void valid_should_be_in_validated_package() {
+    classes()
+        .that()
+        .haveSimpleName("Valid")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..validated..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Invalid class should be in the validated package.
+   *
+   * <p>The Invalid variant of Validated represents accumulated validation errors.
+   */
+  @Test
+  @DisplayName("Invalid class should be in validated package")
+  void invalid_should_be_in_validated_package() {
+    classes()
+        .that()
+        .haveSimpleName("Invalid")
+        .and()
+        .resideInAPackage("..hkt..")
+        .should()
+        .resideInAPackage("..validated..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/TestCoverageRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/TestCoverageRules.java
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getTestClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.higherkindedj.hkt.Monad;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing test coverage patterns.
+ *
+ * <p>These rules ensure that type class implementations have corresponding test classes:
+ *
+ * <ul>
+ *   <li>Monad implementations should have corresponding MonadTest classes
+ *   <li>Test classes should verify type class laws
+ * </ul>
+ */
+@DisplayName("Test Coverage Rules")
+class TestCoverageRules {
+
+  private static JavaClasses productionClasses;
+  private static JavaClasses testClasses;
+
+  @BeforeAll
+  static void setup() {
+    productionClasses = getProductionClasses();
+    testClasses = getTestClasses();
+  }
+
+  /**
+   * Monad implementations should have corresponding test classes.
+   *
+   * <p>Each Monad implementation (e.g., MaybeMonad) should have a corresponding test class (e.g.,
+   * MaybeMonadTest) to verify monad laws and behavior.
+   */
+  @Test
+  @DisplayName("Monad implementations should have corresponding test classes")
+  void monad_implementations_should_have_test_classes() {
+    classes()
+        .that()
+        .implement(Monad.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotAnonymousClasses()
+        .and()
+        .haveSimpleNameEndingWith("Monad")
+        .should(haveCorrespondingTestClass())
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Custom condition that checks if a class has a corresponding test class.
+   *
+   * <p>The test class should be named {ClassName}Test and exist in the test classes.
+   *
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveCorrespondingTestClass() {
+    return new ArchCondition<>("have a corresponding test class") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        String expectedTestClassName = javaClass.getSimpleName() + "Test";
+        String baseClassName = javaClass.getSimpleName();
+
+        boolean hasTestClass =
+            testClasses.stream()
+                .anyMatch(
+                    testClass ->
+                        testClass.getSimpleName().equals(expectedTestClassName)
+                            || testClass.getSimpleName().equals(baseClassName + "LawsTest")
+                            || testClass.getSimpleName().contains(baseClassName));
+
+        // Also check if covered by a test factory
+        boolean coveredByTestFactory =
+            testClasses.stream()
+                .anyMatch(
+                    testClass ->
+                        testClass.getSimpleName().equals("MonadLawsTestFactory")
+                            || testClass.getSimpleName().equals("FunctorLawsTestFactory"));
+
+        if (!hasTestClass && !coveredByTestFactory) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Class %s does not have a corresponding test class (expected %s or coverage"
+                          + " in a TestFactory)",
+                      javaClass.getName(), expectedTestClassName)));
+        }
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/TransformerConsistencyRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/TransformerConsistencyRules.java
@@ -1,0 +1,198 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing monad transformer consistency patterns.
+ *
+ * <p>Monad transformers (*T classes) should follow consistent patterns:
+ *
+ * <ul>
+ *   <li>Have a lift method to lift values from the base monad
+ *   <li>Have static factory methods (of, lift, etc.)
+ *   <li>Have TKind interfaces and TKindHelper classes
+ * </ul>
+ *
+ * <p>Note: Package location rules for transformers are in {@link PackageStructureRules}.
+ */
+@DisplayName("Transformer Consistency Rules")
+class TransformerConsistencyRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Transformer monad implementations should have lift method.
+   *
+   * <p>The lift method allows lifting a value from the base monad into the transformer.
+   */
+  @Test
+  @DisplayName("Transformer monad classes should have lift method")
+  void transformer_monads_should_have_lift_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("TMonad")
+        .and()
+        .areNotInterfaces()
+        .should(haveMethodNamed("lift"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * EitherT should have a static factory method.
+   *
+   * <p>Transformers should provide a convenient way to create instances.
+   */
+  @Test
+  @DisplayName("EitherT should have static factory (of or lift)")
+  void either_t_should_have_factory() {
+    classes()
+        .that()
+        .haveSimpleName("EitherT")
+        .and()
+        .areNotInterfaces()
+        .should(haveStaticMethodNamed("of"))
+        .orShould(haveStaticMethodNamed("lift"))
+        .orShould(haveStaticMethodNamed("right"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** MaybeT should have a static factory method. */
+  @Test
+  @DisplayName("MaybeT should have static factory (of or lift)")
+  void maybe_t_should_have_factory() {
+    classes()
+        .that()
+        .haveSimpleName("MaybeT")
+        .and()
+        .areNotInterfaces()
+        .should(haveStaticMethodNamed("of"))
+        .orShould(haveStaticMethodNamed("lift"))
+        .orShould(haveStaticMethodNamed("just"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** StateT should have a static factory method. */
+  @Test
+  @DisplayName("StateT should have static factory (of or lift)")
+  void state_t_should_have_factory() {
+    classes()
+        .that()
+        .haveSimpleName("StateT")
+        .and()
+        .areNotInterfaces()
+        .should(haveStaticMethodNamed("of"))
+        .orShould(haveStaticMethodNamed("lift"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Transformer Kind interfaces should follow naming convention.
+   *
+   * <p>Each transformer should have a Kind interface (e.g., EitherTKind, MaybeTKind).
+   */
+  @Test
+  @DisplayName("Transformer packages should have TKind interfaces")
+  void transformer_packages_should_have_kind_interfaces() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("TKind")
+        .should()
+        .beInterfaces()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Transformer KindHelper classes should exist.
+   *
+   * <p>Each transformer should have a KindHelper for widen/narrow operations.
+   */
+  @Test
+  @DisplayName("Transformer packages should have TKindHelper classes")
+  void transformer_packages_should_have_kind_helpers() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("TKindHelper")
+        .should()
+        .haveOnlyPrivateConstructors()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Custom condition that checks if a class has a method with the given name.
+   *
+   * @param methodName the name of the method to check for
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveMethodNamed(String methodName) {
+    return new ArchCondition<>("have method named '" + methodName + "'") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        boolean hasMethod =
+            javaClass.getMethods().stream().anyMatch(method -> method.getName().equals(methodName));
+
+        if (!hasMethod) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Class %s does not have required method '%s'",
+                      javaClass.getName(), methodName)));
+        }
+      }
+    };
+  }
+
+  /**
+   * Custom condition that checks if a class has a static method with the given name.
+   *
+   * @param methodName the name of the static method to check for
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveStaticMethodNamed(String methodName) {
+    return new ArchCondition<>("have static method named '" + methodName + "'") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        boolean hasMethod =
+            javaClass.getMethods().stream()
+                .anyMatch(
+                    method ->
+                        method.getName().equals(methodName)
+                            && method
+                                .getModifiers()
+                                .contains(com.tngtech.archunit.core.domain.JavaModifier.STATIC));
+
+        if (!hasMethod) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Class %s does not have static method '%s'",
+                      javaClass.getName(), methodName)));
+        }
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/TypeClassPatternRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/TypeClassPatternRules.java
@@ -1,0 +1,172 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Monad;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing type class instance patterns.
+ *
+ * <p>Type class instances in higher-kinded-j follow specific patterns:
+ *
+ * <ul>
+ *   <li>Singleton pattern with {@code instance()} factory method or {@code INSTANCE} constant
+ *   <li>Private constructors to enforce singleton usage
+ *   <li>Stateless implementations (no instance fields)
+ * </ul>
+ */
+@DisplayName("Type Class Pattern Rules")
+class TypeClassPatternRules {
+
+  private static JavaClasses productionClasses;
+
+  @BeforeAll
+  static void setup() {
+    productionClasses = getProductionClasses();
+  }
+
+  /**
+   * Monad implementations should provide a static factory method or constant.
+   *
+   * <p>This ensures consistent instantiation patterns across the codebase. Acceptable patterns:
+   *
+   * <ul>
+   *   <li>{@code public static <T> XxxMonad<T> instance()} method
+   *   <li>{@code public static final INSTANCE} constant
+   * </ul>
+   */
+  @Test
+  @DisplayName("Monad implementations should have instance() method or INSTANCE constant")
+  void monad_implementations_should_have_factory() {
+    classes()
+        .that()
+        .implement(Monad.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotAnonymousClasses()
+        .should(haveStaticFactoryOrInstance())
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Functor implementations should provide a static factory method or constant.
+   *
+   * <p>Excludes classes that also implement Monad (they follow Monad patterns).
+   */
+  @Test
+  @DisplayName("Functor implementations should have instance() method or INSTANCE constant")
+  void functor_implementations_should_have_factory() {
+    classes()
+        .that()
+        .implement(Functor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotAnonymousClasses()
+        .and()
+        .doNotImplement(Monad.class) // Monads tested separately
+        .should(haveStaticFactoryOrInstance())
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Type class implementations should be stateless.
+   *
+   * <p>Type class instances should not hold mutable state. They may have:
+   *
+   * <ul>
+   *   <li>Static final fields (for singleton instances)
+   *   <li>No instance fields at all
+   * </ul>
+   */
+  @Test
+  @DisplayName("Type class implementations should be stateless (no instance fields)")
+  void type_class_implementations_should_be_stateless() {
+    classes()
+        .that()
+        .implement(Functor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .areNotAnonymousClasses()
+        .should(haveNoNonStaticFields())
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Custom condition that checks for static factory method or INSTANCE constant.
+   *
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveStaticFactoryOrInstance() {
+    return new ArchCondition<>("have static instance() method or INSTANCE constant") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        boolean hasInstanceMethod =
+            javaClass.getMethods().stream()
+                .anyMatch(
+                    method ->
+                        method.getName().equals("instance")
+                            && method.getModifiers().contains(JavaModifier.STATIC));
+
+        boolean hasInstanceConstant =
+            javaClass.getFields().stream()
+                .anyMatch(
+                    field ->
+                        field.getName().equals("INSTANCE")
+                            && field.getModifiers().contains(JavaModifier.STATIC)
+                            && field.getModifiers().contains(JavaModifier.FINAL));
+
+        if (!hasInstanceMethod && !hasInstanceConstant) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Class %s does not have instance() method or INSTANCE constant",
+                      javaClass.getName())));
+        }
+      }
+    };
+  }
+
+  /**
+   * Custom condition that checks for no non-static fields (stateless).
+   *
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveNoNonStaticFields() {
+    return new ArchCondition<>("have no non-static fields") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        javaClass.getFields().stream()
+            .filter(field -> !field.getModifiers().contains(JavaModifier.STATIC))
+            .forEach(
+                field ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            javaClass,
+                            String.format(
+                                "Class %s has non-static field '%s' (type class instances should be"
+                                    + " stateless)",
+                                javaClass.getName(), field.getName()))));
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/WitnessTypeRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/WitnessTypeRules.java
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing Higher-Kinded Type witness patterns.
+ *
+ * <p>In higher-kinded-j, witness types are used to simulate higher-kinded types in Java:
+ *
+ * <ul>
+ *   <li>Each Kind implementation has a nested {@code Witness} class
+ *   <li>Witness classes are marker types that should never be instantiated
+ *   <li>Witness classes have private constructors to prevent instantiation
+ * </ul>
+ *
+ * <p>Example pattern:
+ *
+ * <pre>{@code
+ * public interface EitherKind<L, R> extends Kind<EitherKind.Witness<L>, R> {
+ *     final class Witness<TYPE_L> {
+ *         private Witness() {} // Non-instantiable marker type
+ *     }
+ * }
+ * }</pre>
+ */
+@DisplayName("Witness Type Rules")
+class WitnessTypeRules {
+
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes = getProductionClasses();
+  }
+
+  /**
+   * Witness classes must be final.
+   *
+   * <p>Witness types are marker types used for type-level programming and should not be extended.
+   */
+  @Test
+  @DisplayName("Witness classes should be final (marker types should not be extended)")
+  void witness_classes_should_be_final() {
+    classes()
+        .that()
+        .haveSimpleName("Witness")
+        .should()
+        .haveModifier(JavaModifier.FINAL)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Witness classes must have only private constructors.
+   *
+   * <p>Witness types should never be instantiated - they exist only as type markers for the
+   * higher-kinded type simulation.
+   */
+  @Test
+  @DisplayName("Witness classes should have only private constructors (non-instantiable)")
+  void witness_classes_should_have_private_constructors() {
+    classes()
+        .that()
+        .haveSimpleName("Witness")
+        .should()
+        .haveOnlyPrivateConstructors()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * KindHelper classes should be final utility classes.
+   *
+   * <p>KindHelper classes provide static widen/narrow utilities and should not be extended.
+   */
+  @Test
+  @DisplayName("KindHelper classes should be final utility classes")
+  void kind_helper_classes_should_be_final() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("KindHelper")
+        .should()
+        .haveModifier(JavaModifier.FINAL)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * KindHelper classes should have private constructors.
+   *
+   * <p>KindHelper classes contain only static methods and should not be instantiated.
+   */
+  @Test
+  @DisplayName("KindHelper classes should have only private constructors (utility classes)")
+  void kind_helper_classes_should_have_private_constructors() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("KindHelper")
+        .should()
+        .haveOnlyPrivateConstructors()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/package-info.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/package-info.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+/**
+ * Architecture tests for higher-kinded-j using ArchUnit.
+ *
+ * <p>This package contains architectural rules that enforce:
+ *
+ * <ul>
+ *   <li>Module dependency constraints (API vs implementation separation)
+ *   <li>Naming conventions (type class implementations, witness types, helpers)
+ *   <li>Higher-kinded type patterns (witness types, Kind implementations)
+ *   <li>Type class instance patterns (singleton, stateless)
+ *   <li>Immutability requirements for functional types
+ *   <li>Package structure organization
+ * </ul>
+ *
+ * <p>These rules help maintain consistency and quality as the codebase grows.
+ */
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.architecture;

--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.assertj:assertj-core:3.27.3")
-
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }
 
 tasks.test {

--- a/hkj-processor/src/test/java/org/higherkindedj/architecture/ProcessorArchitectureRules.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/architecture/ProcessorArchitectureRules.java
@@ -1,0 +1,255 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import javax.annotation.processing.AbstractProcessor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture rules enforcing annotation processor patterns.
+ *
+ * <p>These rules ensure processors follow consistent patterns:
+ *
+ * <ul>
+ *   <li>Processor classes must extend AbstractProcessor
+ *   <li>Processor classes must be annotated with @AutoService
+ *   <li>Processor naming conventions are followed
+ *   <li>SPI interfaces are properly structured
+ * </ul>
+ */
+@DisplayName("Processor Architecture Rules")
+class ProcessorArchitectureRules {
+
+  private static final String BASE_PACKAGE = "org.higherkindedj";
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes =
+        new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages(BASE_PACKAGE);
+  }
+
+  /**
+   * Processor classes must extend AbstractProcessor.
+   *
+   * <p>All annotation processors should extend the standard AbstractProcessor class.
+   */
+  @Test
+  @DisplayName("Processor classes should extend AbstractProcessor")
+  void processor_classes_should_extend_abstract_processor() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Processor")
+        .and()
+        .resideInAPackage("..processing..")
+        .and()
+        .areNotInterfaces()
+        .should()
+        .beAssignableTo(AbstractProcessor.class)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Processor classes should follow naming convention.
+   *
+   * <p>Processors should be named {Feature}Processor (e.g., LensProcessor, PrismProcessor).
+   */
+  @Test
+  @DisplayName("Classes extending AbstractProcessor should end with 'Processor'")
+  void abstract_processor_subclasses_should_end_with_processor() {
+    classes()
+        .that()
+        .areAssignableTo(AbstractProcessor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotHaveSimpleName("AbstractProcessor")
+        .should()
+        .haveSimpleNameEndingWith("Processor")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Processors should be in the processing package.
+   *
+   * <p>All annotation processors should reside in the optics.processing package.
+   */
+  @Test
+  @DisplayName("Processors should reside in processing package")
+  void processors_should_be_in_processing_package() {
+    classes()
+        .that()
+        .areAssignableTo(AbstractProcessor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotHaveSimpleName("AbstractProcessor")
+        .should()
+        .resideInAPackage("..optics.processing..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * SPI interfaces should be in the spi sub-package.
+   *
+   * <p>Service Provider Interfaces should be isolated in their own package.
+   */
+  @Test
+  @DisplayName("SPI interfaces should be in spi package")
+  void spi_interfaces_should_be_in_spi_package() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Generator")
+        .and()
+        .areInterfaces()
+        .should()
+        .resideInAPackage("..spi..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Processors should not have mutable instance fields.
+   *
+   * <p>Annotation processors should be stateless to ensure thread safety.
+   */
+  @Test
+  @DisplayName("Processors should not have mutable instance fields")
+  void processors_should_not_have_mutable_instance_fields() {
+    classes()
+        .that()
+        .areAssignableTo(AbstractProcessor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotHaveSimpleName("AbstractProcessor")
+        .should(haveOnlyFinalOrStaticFields())
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Processors should be public.
+   *
+   * <p>Annotation processors need to be public to be discovered by the service loader.
+   */
+  @Test
+  @DisplayName("Processors should be public classes")
+  void processors_should_be_public() {
+    classes()
+        .that()
+        .areAssignableTo(AbstractProcessor.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .doNotHaveSimpleName("AbstractProcessor")
+        .should()
+        .bePublic()
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Processors should not depend on runtime HKT implementations.
+   *
+   * <p>Processors should only depend on the API module, not specific implementations.
+   */
+  @Test
+  @DisplayName("Processors should not depend on HKT runtime implementations")
+  void processors_should_not_depend_on_hkt_implementations() {
+    noClasses()
+        .that()
+        .areAssignableTo(AbstractProcessor.class)
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage("..hkt.maybe..", "..hkt.either..", "..hkt.trymonad..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Generator interfaces should define required methods.
+   *
+   * <p>SPI generators should have supports() and generate*() methods.
+   */
+  @Test
+  @DisplayName("Generator interfaces should have supports method")
+  void generator_interfaces_should_have_supports_method() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Generator")
+        .and()
+        .areInterfaces()
+        .should(haveMethodNamed("supports"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Custom condition checking for final or static fields only.
+   *
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveOnlyFinalOrStaticFields() {
+    return new ArchCondition<>("have only final or static fields") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        javaClass.getFields().stream()
+            .filter(field -> !field.getModifiers().contains(JavaModifier.STATIC))
+            .filter(field -> !field.getModifiers().contains(JavaModifier.FINAL))
+            .filter(field -> !field.getName().startsWith("$")) // Exclude synthetic
+            .forEach(
+                field ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            javaClass,
+                            String.format(
+                                "Processor %s has mutable instance field '%s'",
+                                javaClass.getName(), field.getName()))));
+      }
+    };
+  }
+
+  /**
+   * Custom condition that checks if a class has a method with the given name.
+   *
+   * @param methodName the name of the method to check for
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> haveMethodNamed(String methodName) {
+    return new ArchCondition<>("have method named '" + methodName + "'") {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        boolean hasMethod =
+            javaClass.getMethods().stream().anyMatch(method -> method.getName().equals(methodName));
+
+        if (!hasMethod) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  javaClass,
+                  String.format(
+                      "Interface %s does not have required method '%s'",
+                      javaClass.getName(), methodName)));
+        }
+      }
+    };
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/architecture/package-info.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/architecture/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Architecture tests for the hkj-processor annotation processing module.
+ *
+ * <p>These tests use ArchUnit to enforce architectural constraints on the annotation processors,
+ * ensuring they follow consistent patterns and best practices.
+ */
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.architecture;

--- a/hkj-spring/autoconfigure/build.gradle.kts
+++ b/hkj-spring/autoconfigure/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
   testImplementation("org.springframework.security:spring-security-web")
   testImplementation("org.springframework.security:spring-security-config")
   testImplementation("org.springframework.security:spring-security-oauth2-jose")
+  testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }
 
 tasks.test {

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/architecture/SpringArchitectureRules.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/architecture/SpringArchitectureRules.java
@@ -1,0 +1,254 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
+
+/**
+ * Architecture rules enforcing Spring Boot integration patterns.
+ *
+ * <p>These rules ensure the Spring integration follows best practices:
+ *
+ * <ul>
+ *   <li>Auto-configuration classes in correct packages
+ *   <li>Return value handlers implement correct interfaces
+ *   <li>Proper separation between web, security, and actuator concerns
+ *   <li>No circular dependencies between Spring components
+ * </ul>
+ */
+@DisplayName("Spring Architecture Rules")
+class SpringArchitectureRules {
+
+  private static final String BASE_PACKAGE = "org.higherkindedj.spring";
+  private static JavaClasses classes;
+
+  @BeforeAll
+  static void setup() {
+    classes =
+        new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages(BASE_PACKAGE);
+  }
+
+  /**
+   * Auto-configuration classes should be in autoconfigure package.
+   *
+   * <p>Spring Boot auto-configurations should be properly organized.
+   */
+  @Test
+  @DisplayName("AutoConfiguration classes should be in autoconfigure package")
+  void autoconfiguration_classes_should_be_in_autoconfigure_package() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("AutoConfiguration")
+        .should()
+        .resideInAPackage("..autoconfigure..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Return value handlers should implement HandlerMethodReturnValueHandler.
+   *
+   * <p>Custom return value handlers must implement the Spring interface.
+   */
+  @Test
+  @DisplayName("ReturnValueHandler classes should implement HandlerMethodReturnValueHandler")
+  void return_value_handlers_should_implement_interface() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("ReturnValueHandler")
+        .and()
+        .resideInAPackage("..web.returnvalue..")
+        .should()
+        .implement(HandlerMethodReturnValueHandler.class)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Return value handlers should be in the web.returnvalue package. */
+  @Test
+  @DisplayName("ReturnValueHandler classes should be in web.returnvalue package")
+  void return_value_handlers_should_be_in_correct_package() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("ReturnValueHandler")
+        .should()
+        .resideInAPackage("..web.returnvalue..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Jackson serializers should be in the json package. */
+  @Test
+  @DisplayName("Serializer classes should be in json package")
+  void serializers_should_be_in_json_package() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Serializer")
+        .or()
+        .haveSimpleNameEndingWith("Deserializer")
+        .should()
+        .resideInAPackage("..json..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Security classes should be in the security package. */
+  @Test
+  @DisplayName("Security integration classes should be in security package")
+  void security_classes_should_be_in_security_package() {
+    classes()
+        .that()
+        .haveSimpleNameContaining("Authentication")
+        .or()
+        .haveSimpleNameContaining("Authorization")
+        .or()
+        .haveSimpleNameContaining("UserDetails")
+        .should()
+        .resideInAPackage("..security..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /** Actuator classes should be in the actuator package. */
+  @Test
+  @DisplayName("Actuator integration classes should be in actuator package")
+  void actuator_classes_should_be_in_actuator_package() {
+    classes()
+        .that()
+        .haveSimpleNameContaining("Metrics")
+        .or()
+        .haveSimpleNameContaining("HealthIndicator")
+        .or()
+        .haveSimpleNameContaining("Endpoint")
+        .and()
+        .resideInAPackage("..spring..")
+        .should()
+        .resideInAPackage("..actuator..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Configuration properties should follow naming convention.
+   *
+   * <p>Properties classes should be named *Properties and be in autoconfigure package.
+   */
+  @Test
+  @DisplayName("Properties classes should be in autoconfigure package")
+  void properties_classes_should_be_in_autoconfigure_package() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Properties")
+        .and()
+        .resideInAPackage("..spring..")
+        .should()
+        .resideInAPackage("..autoconfigure..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Web layer should not depend on security implementation details.
+   *
+   * <p>Return value handlers should not directly use security classes.
+   */
+  @Test
+  @DisplayName("Web return value handlers should not depend on security classes")
+  void web_handlers_should_not_depend_on_security() {
+    noClasses()
+        .that()
+        .resideInAPackage("..web.returnvalue..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..security..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Security should not depend on actuator.
+   *
+   * <p>Security classes should not depend on monitoring/metrics classes.
+   */
+  @Test
+  @DisplayName("Security classes should not depend on actuator")
+  void security_should_not_depend_on_actuator() {
+    noClasses()
+        .that()
+        .resideInAPackage("..security..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..actuator..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Actuator should not depend on web handlers.
+   *
+   * <p>Metrics and health indicators should not depend on HTTP handling details.
+   */
+  @Test
+  @DisplayName("Actuator classes should not depend on web handlers")
+  void actuator_should_not_depend_on_web_handlers() {
+    noClasses()
+        .that()
+        .resideInAPackage("..actuator..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..web.returnvalue..")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * Auto-configuration should use conditional annotations.
+   *
+   * <p>Auto-configuration classes should be conditionally activated.
+   */
+  @Test
+  @DisplayName("AutoConfiguration classes should be annotated with @AutoConfiguration")
+  void autoconfiguration_should_have_annotation() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("AutoConfiguration")
+        .should()
+        .beAnnotatedWith(org.springframework.boot.autoconfigure.AutoConfiguration.class)
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
+   * HKJ classes should start with Hkj prefix.
+   *
+   * <p>Spring integration classes should follow the Hkj naming convention.
+   */
+  @Test
+  @DisplayName("Spring integration classes should follow Hkj naming convention")
+  void spring_classes_should_follow_naming_convention() {
+    classes()
+        .that()
+        .resideInAPackage("..autoconfigure..")
+        .and()
+        .haveSimpleNameNotEndingWith("Test")
+        .and()
+        .areNotAnonymousClasses()
+        .and()
+        .areNotMemberClasses()
+        .should()
+        .haveSimpleNameStartingWith("Hkj")
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/architecture/package-info.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/architecture/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Architecture tests for the hkj-spring autoconfigure module.
+ *
+ * <p>These tests use ArchUnit to enforce architectural constraints on the Spring Boot integration,
+ * ensuring proper separation of concerns and adherence to Spring best practices.
+ */
+@org.jspecify.annotations.NullMarked
+package org.higherkindedj.architecture;


### PR DESCRIPTION
Adds comprehensive ArchUnit rules across hkj-core, hkj-processor, and hkj-spring modules:

hkj-core rules:
- ModuleDependencyRules: Package cycle detection, module boundaries
- NamingConventionRules: Type class naming patterns (Functor, Monad, etc.)
- WitnessTypeRules: HKT witness classes must be final with private constructors
- TypeClassPatternRules: Singleton pattern, stateless implementations
- ImmutabilityRules: Final fields for Kind implementations
- PackageStructureRules: Each HKT type in its own package
- MethodSignatureRules: KindHelper widen/narrow, Monad flatMap, etc.
- SealedTypeRules: Sealed variants in correct packages
- TestCoverageRules: Monad implementations have test classes
- NullMarkedPackageRules: @NullMarked package annotations
- DependencyLayerRules: Core types don't depend on transformers
- NoSideEffectsRules: No System.out or mutable static fields in pure types
- RecordPreferenceRules: ADT variants should be records
- InheritanceDepthRules: Limit inheritance depth
- TransformerConsistencyRules: Monad transformer patterns

hkj-processor rules:
- ProcessorArchitectureRules: Processors extend AbstractProcessor, naming conventions

hkj-spring rules:
- SpringArchitectureRules: Auto-configuration patterns, handler interfaces, package organization

Fixes #220 