### PR TITLE
Add Focus DSL to higher-kinded-j optics

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateFocus.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateFocus.java
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a Java record for which a Focus DSL utility class should be generated. The generated class
+ * will be named by appending "Focus" to the record's name.
+ *
+ * <p>The generated class provides type-safe navigation paths using the Focus DSL. Each record
+ * component becomes a static method returning a {@code FocusPath} that can be composed with other
+ * optics for deep navigation.
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * @GenerateFocus
+ * record User(String name, Address address) {}
+ *
+ * @GenerateFocus
+ * record Address(String street, String city) {}
+ *
+ * // Generated code provides:
+ * // UserFocus.name() -> FocusPath<User, String>
+ * // UserFocus.address() -> FocusPath<User, Address>
+ * // AddressFocus.street() -> FocusPath<Address, String>
+ *
+ * // Compose paths for deep navigation:
+ * FocusPath<User, String> streetPath = UserFocus.address().via(AddressFocus.street().toLens());
+ * }</pre>
+ *
+ * <h2>Fluent Navigation with Navigators</h2>
+ *
+ * <p>When {@link #generateNavigators()} is enabled, the processor generates navigator wrapper
+ * classes that enable fluent cross-type navigation without explicit {@code .via()} calls:
+ *
+ * <pre>{@code
+ * @GenerateFocus(generateNavigators = true)
+ * record Company(String name, Address headquarters) {}
+ *
+ * @GenerateFocus(generateNavigators = true)
+ * record Address(String street, String city) {}
+ *
+ * // With navigators enabled:
+ * String city = CompanyFocus.headquarters().city().get(company);
+ *
+ * // Instead of:
+ * String city = CompanyFocus.headquarters().via(AddressFocus.city().toLens()).get(company);
+ * }</pre>
+ *
+ * <p>By default, the generated class is placed in the same package as the annotated record. Use the
+ * {@link #targetPackage()} element to specify a different package for the generated class.
+ *
+ * @see org.higherkindedj.optics.focus.FocusPath
+ * @see org.higherkindedj.optics.focus.AffinePath
+ * @see org.higherkindedj.optics.focus.TraversalPath
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface GenerateFocus {
+
+  /**
+   * The package where the generated class should be placed. If empty (the default), the generated
+   * class will be placed in the same package as the annotated record.
+   *
+   * @return the target package name, or empty string to use the source package
+   */
+  String targetPackage() default "";
+
+  /**
+   * When true, generates fluent navigator wrapper classes for cross-type navigation.
+   *
+   * <p>This enables patterns like {@code PersonFocus.address().city()} without explicit {@code
+   * .via()} calls. Navigator classes are generated for fields whose types are also annotated with
+   * {@code @GenerateFocus}.
+   *
+   * <p>The navigator classes:
+   *
+   * <ul>
+   *   <li>Wrap the underlying {@code FocusPath} and delegate all standard methods
+   *   <li>Provide navigation methods for each field of the nested type
+   *   <li>Handle path type widening (e.g., {@code FocusPath} to {@code AffinePath}) automatically
+   * </ul>
+   *
+   * @return true to generate navigator classes, false otherwise (default: false)
+   */
+  boolean generateNavigators() default false;
+
+  /**
+   * Maximum depth for generated navigator chains.
+   *
+   * <p>This limits code generation for deeply nested structures. When the depth limit is reached,
+   * navigation methods return plain {@code FocusPath}/{@code AffinePath}/{@code TraversalPath}
+   * instances instead of navigators.
+   *
+   * <p>Valid range: 1-10. Default: 3.
+   *
+   * @return the maximum navigator chain depth
+   */
+  int maxNavigatorDepth() default 3;
+
+  /**
+   * Field names to include in navigator generation.
+   *
+   * <p>If empty (the default), all fields with navigable types are included. When specified, only
+   * the listed fields will have navigator methods generated.
+   *
+   * <p>This is mutually exclusive with {@link #excludeFields()}. If both are specified, {@code
+   * includeFields} takes precedence.
+   *
+   * @return array of field names to include, or empty for all fields
+   */
+  String[] includeFields() default {};
+
+  /**
+   * Field names to exclude from navigator generation.
+   *
+   * <p>When specified, the listed fields will not have navigator methods generated, even if their
+   * types are navigable.
+   *
+   * <p>This is mutually exclusive with {@link #includeFields()}. If both are specified, {@code
+   * includeFields} takes precedence.
+   *
+   * @return array of field names to exclude
+   */
+  String[] excludeFields() default {};
+}

--- a/hkj-book/puml/focus_path_hierarchy.puml
+++ b/hkj-book/puml/focus_path_hierarchy.puml
@@ -1,0 +1,81 @@
+@startuml focus_path_hierarchy
+
+!include https://raw.githubusercontent.com/ncosta-ic/catppuccin-macchiato-plantuml-theme/main/theme.puml
+
+title Focus Path Type Hierarchy
+
+package "Focus DSL - Path Types" {
+    interface "FocusPath<S, A>" as FocusPath {
+        + get(source: S) : A
+        + set(value: A, source: S) : S
+        + modify(f: Function<A,A>, source: S) : S
+        --
+        + via(lens: Lens<A,B>) : FocusPath<S,B>
+        + via(prism: Prism<A,B>) : AffinePath<S,B>
+        + via(traversal: Traversal<A,B>) : TraversalPath<S,B>
+        --
+        + each() : TraversalPath<S,E>
+        + at(index: int) : AffinePath<S,E>
+        + some() : AffinePath<S,E>
+        --
+        + toLens() : Lens<S,A>
+    }
+
+    interface "AffinePath<S, A>" as AffinePath {
+        + getOptional(source: S) : Optional<A>
+        + set(value: A, source: S) : S
+        + modify(f: Function<A,A>, source: S) : S
+        + matches(source: S) : boolean
+        --
+        + via(lens: Lens<A,B>) : AffinePath<S,B>
+        + via(prism: Prism<A,B>) : AffinePath<S,B>
+        + via(traversal: Traversal<A,B>) : TraversalPath<S,B>
+        --
+        + toAffine() : Affine<S,A>
+    }
+
+    interface "TraversalPath<S, A>" as TraversalPath {
+        + getAll(source: S) : List<A>
+        + preview(source: S) : Optional<A>
+        + setAll(value: A, source: S) : S
+        + modifyAll(f: Function<A,A>, source: S) : S
+        --
+        + filter(predicate: Predicate<A>) : TraversalPath<S,A>
+        --
+        + via(lens: Lens<A,B>) : TraversalPath<S,B>
+        + via(traversal: Traversal<A,B>) : TraversalPath<S,B>
+        --
+        + toTraversal() : Traversal<S,A>
+    }
+
+    FocusPath --> AffinePath : via(Prism)
+    FocusPath --> TraversalPath : via(Traversal)
+    AffinePath --> TraversalPath : via(Traversal)
+
+    note right of FocusPath
+        Exactly one element
+        (wraps Lens)
+    end note
+
+    note right of AffinePath
+        Zero or one element
+        (wraps Affine)
+    end note
+
+    note right of TraversalPath
+        Zero or more elements
+        (wraps Traversal)
+    end note
+}
+
+package "Core Optics (existing)" {
+    interface "Lens<S, A>" as Lens
+    interface "Affine<S, A>" as Affine
+    interface "Traversal<S, A>" as Traversal
+}
+
+FocusPath ..> Lens : wraps
+AffinePath ..> Affine : wraps
+TraversalPath ..> Traversal : wraps
+
+@enduml

--- a/hkj-book/puml/focus_processor_flow.puml
+++ b/hkj-book/puml/focus_processor_flow.puml
@@ -1,0 +1,67 @@
+@startuml focus_processor_flow
+
+!include https://raw.githubusercontent.com/ncosta-ic/catppuccin-macchiato-plantuml-theme/main/theme.puml
+
+title Focus DSL - Annotation Processing Flow
+
+actor Developer
+
+package "Source Code" {
+    class "User.java" as UserSource <<record>> {
+        @GenerateLenses
+        @GenerateFocus
+        --
+        name: String
+        age: int
+        email: Optional<String>
+        skills: List<Skill>
+    }
+}
+
+package "Annotation Processors" {
+    class "LensProcessor" as LensProc {
+        + process()
+    }
+    class "FocusProcessor" as FocusProc {
+        + process()
+        - generateFocusClass()
+        - detectFieldType()
+        - generatePathMethod()
+    }
+}
+
+package "Generated Code" {
+    class "UserLenses.java" as UserLenses <<generated>> {
+        + name() : Lens<User, String>
+        + age() : Lens<User, Integer>
+        + email() : Lens<User, Optional<String>>
+        + skills() : Lens<User, List<Skill>>
+    }
+
+    class "UserFocus.java" as UserFocus <<generated>> {
+        + name() : FocusPath<User, String>
+        + age() : FocusPath<User, Integer>
+        + email() : AffinePath<User, String>
+        + skills() : TraversalPath<User, Skill>
+        + skill(index: int) : AffinePath<User, Skill>
+    }
+}
+
+Developer --> UserSource : writes
+UserSource --> LensProc : @GenerateLenses
+UserSource --> FocusProc : @GenerateFocus
+LensProc --> UserLenses : generates
+FocusProc --> UserFocus : generates
+UserFocus ..> UserLenses : uses
+
+note bottom of FocusProc
+    FocusProcessor:
+    1. Detects field types
+    2. Generates appropriate path type:
+       - Required fields -> FocusPath
+       - Optional<T> -> AffinePath (with .some())
+       - List<T> -> TraversalPath (with .each())
+       - Map<K,V> -> TraversalPath (with .atKey())
+end note
+
+@enduml

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -98,6 +98,7 @@
 # Optics IV: Java-Friendly APIs
 - [Introduction](optics/ch4_intro.md)
   - [Fluent API](optics/fluent_api.md)
+  - [Focus DSL](optics/focus_dsl.md)
   - [Free Monad DSL](optics/free_monad_dsl.md)
   - [Interpreters](optics/interpreters.md)
 

--- a/hkj-book/src/optics/focus_dsl.md
+++ b/hkj-book/src/optics/focus_dsl.md
@@ -1,0 +1,1152 @@
+# Focus DSL: Path-Based Optic Syntax
+
+## _Type-Safe Navigation Through Nested Data_
+
+~~~admonish info title="What You'll Learn"
+- How to navigate deeply nested data structures with type-safe paths
+- Using `@GenerateFocus` to generate path builders automatically
+- **Fluent cross-type navigation** with generated navigators (no `.via()` needed)
+- The difference between `FocusPath`, `AffinePath`, and `TraversalPath`
+- Collection navigation with `.each()`, `.at()`, `.some()`, and `.traverseOver()`
+- Type class integration: effectful operations, monoid aggregation, and Traverse support
+- Working with sum types using `instanceOf()` and conditional modification with `modifyWhen()`
+- Composing Focus paths with existing optics
+- Debugging paths with `traced()`
+- When to use Focus DSL vs manual lens composition
+~~~
+
+~~~admonish title="Example Code"
+[NavigatorExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/NavigatorExample.java) | [TraverseIntegrationExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/TraverseIntegrationExample.java) | [ValidationPipelineExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/ValidationPipelineExample.java)
+~~~
+
+The Focus DSL provides a fluent, path-based syntax for working with optics. Instead of manually composing lenses, prisms, and traversals, you can navigate through your data structures using intuitive method chains that mirror the shape of your data.
+
+---
+
+## The Problem: Verbose Manual Composition
+
+When working with deeply nested data structures, manual optic composition becomes verbose:
+
+```java
+// Manual composition - verbose and repetitive
+Lens<Company, String> employeeNameLens =
+    CompanyLenses.departments()
+        .andThen(DepartmentLenses.employees())
+        .andThen(EmployeeLenses.name());
+
+// Must compose at each use site
+String name = employeeNameLens.get(company);
+```
+
+With the Focus DSL, the same operation becomes:
+
+```java
+// Focus DSL - fluent and intuitive
+String name = CompanyFocus.departments().employees().name().get(company);
+```
+
+---
+
+## Think of Focus Paths Like...
+
+- **File system paths**: `/company/departments/employees/name`
+- **JSON pointers**: `$.departments[*].employees[*].name`
+- **XPath expressions**: `//department/employee/name`
+- **IDE navigation**: Click through nested fields with autocomplete
+
+The key difference: Focus paths are fully type-safe, with compile-time checking at every step.
+
+---
+
+## A Step-by-Step Walkthrough
+
+### Step 1: Annotate Your Records
+
+Add `@GenerateFocus` alongside `@GenerateLenses` to generate path builders:
+
+```java
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.annotations.GenerateFocus;
+
+@GenerateLenses
+@GenerateFocus
+public record Company(String name, List<Department> departments) {}
+
+@GenerateLenses
+@GenerateFocus
+public record Department(String name, List<Employee> employees) {}
+
+@GenerateLenses
+@GenerateFocus
+public record Employee(String name, int age, Optional<String> email) {}
+```
+
+### Step 2: Use Generated Focus Classes
+
+The annotation processor generates companion Focus classes with path builders:
+
+```java
+// Generated: CompanyFocus.java
+// Navigate to company name
+FocusPath<Company, String> namePath = CompanyFocus.name();
+String companyName = namePath.get(company);
+
+// Navigate through collections
+TraversalPath<Company, Department> deptPath = CompanyFocus.departments();
+List<Department> allDepts = deptPath.getAll(company);
+
+// Navigate to specific index
+AffinePath<Company, Department> firstDeptPath = CompanyFocus.department(0);
+Optional<Department> firstDept = firstDeptPath.getOptional(company);
+```
+
+### Step 3: Chain Navigation Methods
+
+Focus paths support fluent chaining for deep navigation:
+
+```java
+// Deep path through collections
+TraversalPath<Company, String> allEmployeeNames =
+    CompanyFocus.departments()     // TraversalPath<Company, Department>
+        .employees()               // TraversalPath<Company, Employee>
+        .name();                   // TraversalPath<Company, String>
+
+// Get all employee names across all departments
+List<String> names = allEmployeeNames.getAll(company);
+
+// Modify all employee names
+Company updated = allEmployeeNames.modifyAll(String::toUpperCase, company);
+```
+
+---
+
+## The Three Path Types
+
+Focus DSL provides three path types, mirroring the optic hierarchy:
+
+```
+         FocusPath<S, A>
+        (exactly one focus)
+               |
+        AffinePath<S, A>
+      (zero or one focus)
+               |
+      TraversalPath<S, A>
+      (zero or more focus)
+```
+
+### FocusPath: Exactly One Element
+
+`FocusPath<S, A>` wraps a `Lens<S, A>` and guarantees exactly one focused element:
+
+```java
+// Always succeeds - the field always exists
+FocusPath<Employee, String> namePath = EmployeeFocus.name();
+
+String name = namePath.get(employee);           // Always returns a value
+Employee updated = namePath.set("Bob", employee);  // Always succeeds
+Employee modified = namePath.modify(String::toUpperCase, employee);
+```
+
+**Key Operations:**
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `get(S)` | `A` | Extract the focused value |
+| `set(A, S)` | `S` | Replace the focused value |
+| `modify(Function<A,A>, S)` | `S` | Transform the focused value |
+| `toLens()` | `Lens<S, A>` | Extract underlying optic |
+
+### AffinePath: Zero or One Element
+
+`AffinePath<S, A>` wraps an `Affine<S, A>` for optional access:
+
+```java
+// May or may not have a value
+AffinePath<Employee, String> emailPath = EmployeeFocus.email();
+
+Optional<String> email = emailPath.getOptional(employee);  // May be empty
+Employee updated = emailPath.set("new@email.com", employee);  // Always succeeds
+Employee modified = emailPath.modify(String::toLowerCase, employee);  // No-op if absent
+```
+
+**Key Operations:**
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `getOptional(S)` | `Optional<A>` | Extract if present |
+| `set(A, S)` | `S` | Replace (creates if structure allows) |
+| `modify(Function<A,A>, S)` | `S` | Transform if present |
+| `matches(S)` | `boolean` | Check if value exists |
+| `toAffine()` | `Affine<S, A>` | Extract underlying optic |
+
+### TraversalPath: Zero or More Elements
+
+`TraversalPath<S, A>` wraps a `Traversal<S, A>` for collection access:
+
+```java
+// Focuses on multiple elements
+TraversalPath<Department, Employee> employeesPath = DepartmentFocus.employees();
+
+List<Employee> all = employeesPath.getAll(department);    // All employees
+Department updated = employeesPath.setAll(defaultEmployee, department);
+Department modified = employeesPath.modifyAll(e -> promote(e), department);
+```
+
+**Key Operations:**
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `getAll(S)` | `List<A>` | Extract all focused values |
+| `setAll(A, S)` | `S` | Replace all focused values |
+| `modifyAll(Function<A,A>, S)` | `S` | Transform all focused values |
+| `filter(Predicate<A>)` | `TraversalPath<S, A>` | Filter focused elements |
+| `toTraversal()` | `Traversal<S, A>` | Extract underlying optic |
+
+---
+
+## Collection Navigation
+
+The Focus DSL provides intuitive methods for navigating collections:
+
+### `.each()` - Traverse All Elements
+
+Converts a collection field to a traversal over its elements:
+
+```java
+// List<Department> -> traversal over Department
+TraversalPath<Company, Department> allDepts = CompanyFocus.departments();
+
+// Equivalent to calling .each() on a FocusPath to List<T>
+```
+
+### `.at(index)` - Access by Index
+
+Focuses on a single element at a specific index:
+
+```java
+// Focus on first department
+AffinePath<Company, Department> firstDept = CompanyFocus.department(0);
+
+// Focus on third employee in second department
+AffinePath<Company, Employee> specificEmployee =
+    CompanyFocus.department(1).employee(2);
+
+// Returns empty if index out of bounds
+Optional<Department> maybe = firstDept.getOptional(emptyCompany);
+```
+
+### `.atKey(key)` - Access Map Values
+
+For `Map<K, V>` fields, access values by key:
+
+```java
+@GenerateLenses
+@GenerateFocus
+record Config(Map<String, Setting> settings) {}
+
+// Focus on specific setting
+AffinePath<Config, Setting> dbSetting = ConfigFocus.setting("database");
+
+Optional<Setting> setting = dbSetting.getOptional(config);
+```
+
+### `.some()` - Unwrap Optional
+
+For `Optional<T>` fields, unwrap to the inner value:
+
+```java
+// Email is Optional<String>
+AffinePath<Employee, String> emailPath = EmployeeFocus.email();
+
+// Internally uses .some() to unwrap the Optional
+Optional<String> email = emailPath.getOptional(employee);
+```
+
+---
+
+## Composition with Existing Optics
+
+Focus paths compose seamlessly with existing optics using `.via()`:
+
+### Path + Lens = Path (or Affine)
+
+```java
+// Existing lens for a computed property
+Lens<Employee, String> fullNameLens = Lens.of(
+    e -> e.firstName() + " " + e.lastName(),
+    (e, name) -> { /* setter logic */ }
+);
+
+// Compose Focus path with existing lens
+FocusPath<Department, String> employeeFullName =
+    DepartmentFocus.manager().via(fullNameLens);
+```
+
+### Path + Prism = AffinePath
+
+```java
+// Prism for sealed interface variant
+Prism<Shape, Circle> circlePrism = ShapePrisms.circle();
+
+// Compose to get AffinePath
+AffinePath<Drawing, Circle> firstCircle =
+    DrawingFocus.shape(0).via(circlePrism);
+```
+
+### Path + Traversal = TraversalPath
+
+```java
+// Custom traversal
+Traversal<String, Character> charsTraversal = StringTraversals.chars();
+
+// Compose for character-level access
+TraversalPath<Employee, Character> nameChars =
+    EmployeeFocus.name().via(charsTraversal);
+```
+
+---
+
+## Fluent Navigation with Generated Navigators
+
+~~~admonish tip title="Zero-Boilerplate Cross-Type Navigation"
+When navigating across multiple record types, the standard approach requires explicit `.via()` calls at each boundary. Generated navigators eliminate this boilerplate, enabling chains like `CompanyFocus.headquarters().city()` directly.
+~~~
+
+### The Problem: Explicit Composition
+
+Without navigators, cross-type navigation requires `.via()` at each type boundary:
+
+```java
+// Without navigators - explicit .via() at each step
+String city = CompanyFocus.headquarters()
+    .via(AddressFocus.city().toLens())
+    .get(company);
+
+// Deep navigation becomes verbose
+String managerCity = CompanyFocus.departments()
+    .each()
+    .via(DepartmentFocus.manager().toLens())
+    .via(PersonFocus.address().toLens())
+    .via(AddressFocus.city().toLens())
+    .get(company);
+```
+
+### The Solution: Generated Navigators
+
+Enable navigator generation with `generateNavigators = true`:
+
+```java
+@GenerateFocus(generateNavigators = true)
+record Company(String name, Address headquarters) {}
+
+@GenerateFocus(generateNavigators = true)
+record Address(String street, String city) {}
+
+// With navigators - fluent chaining
+String city = CompanyFocus.headquarters().city().get(company);
+
+// Navigators chain naturally
+Company updated = CompanyFocus.headquarters().city()
+    .modify(String::toUpperCase, company);
+```
+
+### How Navigators Work
+
+When `generateNavigators = true`, the processor generates navigator wrapper classes for fields whose types are also annotated with `@GenerateFocus`. The generated code looks like:
+
+```java
+// Generated in CompanyFocus.java
+public static HeadquartersNavigator<Company> headquarters() {
+    return new HeadquartersNavigator<>(
+        FocusPath.of(Lens.of(Company::headquarters, ...))
+    );
+}
+
+// Generated inner class
+public static final class HeadquartersNavigator<S> {
+    private final FocusPath<S, Address> delegate;
+
+    // Delegate methods - same as FocusPath
+    public Address get(S source) { return delegate.get(source); }
+    public S set(Address value, S source) { return delegate.set(value, source); }
+    public S modify(Function<Address, Address> f, S source) { ... }
+
+    // Navigation methods for Address fields
+    public FocusPath<S, String> street() {
+        return delegate.via(AddressFocus.street().toLens());
+    }
+
+    public FocusPath<S, String> city() {
+        return delegate.via(AddressFocus.city().toLens());
+    }
+
+    // Access underlying path
+    public FocusPath<S, Address> toPath() { return delegate; }
+}
+```
+
+### Path Type Widening
+
+Navigators automatically widen path types when navigating through optional or collection fields:
+
+| Source Field Type | Navigator Returns |
+|-------------------|-------------------|
+| Regular field (`Address address`) | `FocusPath` methods |
+| Optional field (`Optional<Address>`) | `AffinePath` methods |
+| Collection field (`List<Address>`) | `TraversalPath` methods |
+
+```java
+@GenerateFocus(generateNavigators = true)
+record User(String name, Optional<Address> homeAddress, List<Address> workAddresses) {}
+
+// homeAddress navigator methods return AffinePath
+Optional<String> homeCity = UserFocus.homeAddress().city().getOptional(user);
+
+// workAddresses navigator methods return TraversalPath
+List<String> workCities = UserFocus.workAddresses().city().getAll(user);
+```
+
+### Controlling Navigator Generation
+
+#### Depth Limiting
+
+Prevent excessive code generation for deeply nested structures:
+
+```java
+@GenerateFocus(generateNavigators = true, maxNavigatorDepth = 2)
+record Root(Level1 child) {}
+
+// Depth 1: child() returns Level1Navigator
+// Depth 2: child().nested() returns FocusPath (not a navigator)
+// Beyond depth 2: use .via() for further navigation
+
+FocusPath<Root, String> deepPath = RootFocus.child().nested()
+    .via(Level3Focus.value().toLens());
+```
+
+#### Field Filtering
+
+Include only specific fields in navigator generation:
+
+```java
+@GenerateFocus(generateNavigators = true, includeFields = {"primary"})
+record MultiAddress(Address primary, Address secondary, Address backup) {}
+
+// primary() returns navigator with navigation methods
+// secondary() and backup() return standard FocusPath<MultiAddress, Address>
+```
+
+Or exclude specific fields:
+
+```java
+@GenerateFocus(generateNavigators = true, excludeFields = {"internal"})
+record Config(Settings user, Settings internal) {}
+
+// user() returns navigator
+// internal() returns standard FocusPath (no nested navigation)
+```
+
+### When to Use Navigators
+
+**Enable navigators when:**
+- Navigating across multiple record types frequently
+- Deep navigation is common in your codebase
+- You want IDE autocomplete for nested fields
+- Teaching or onboarding developers
+
+**Keep navigators disabled when:**
+- Fields reference third-party types (not annotated with `@GenerateFocus`)
+- You need minimal generated code footprint
+- The project has shallow data structures
+
+### Combining Navigators with Other Features
+
+Navigators work seamlessly with all Focus DSL features:
+
+```java
+// With type class operations
+Company validated = CompanyFocus.headquarters().city()
+    .modifyF(this::validateCity, company, EitherMonad.INSTANCE);
+
+// With conditional modification
+Company updated = CompanyFocus.departments()
+    .each()
+    .modifyWhen(d -> d.name().equals("Engineering"), this::promote, company);
+
+// With tracing for debugging
+FocusPath<Company, String> traced = CompanyFocus.headquarters().city()
+    .traced((company, city) -> System.out.println("City: " + city));
+```
+
+---
+
+## Type Class Integration
+
+The Focus DSL integrates deeply with higher-kinded-j type classes, enabling effectful operations, monoid-based aggregation, and generic collection traversal.
+
+### Effectful Modification with `modifyF()`
+
+All path types support `modifyF()` for effectful transformations:
+
+```java
+// Validation - accumulate all errors
+Kind<ValidatedKind.Witness<List<String>>, User> result = userPath.modifyF(
+    email -> EmailValidator.validate(email),
+    user,
+    ValidatedApplicative.instance()
+);
+
+// Async updates with CompletableFuture
+Kind<CompletableFutureKind.Witness, Config> asyncResult = configPath.modifyF(
+    key -> fetchNewApiKey(key),  // Returns CompletableFuture
+    config,
+    CompletableFutureApplicative.INSTANCE
+);
+
+// IO operations
+Kind<IOKind.Witness, User> ioResult = userPath.modifyF(
+    name -> IO.of(() -> readFromDatabase(name)),
+    user,
+    IOMonad.INSTANCE
+);
+```
+
+### Monoid-Based Aggregation with `foldMap()`
+
+`TraversalPath` supports `foldMap()` for aggregating values:
+
+```java
+// Sum all salaries using integer addition monoid
+int totalSalary = employeesPath.foldMap(
+    Monoids.integerAddition(),
+    Employee::salary,
+    company
+);
+
+// Concatenate all names
+String allNames = employeesPath.foldMap(
+    Monoids.string(),
+    Employee::name,
+    company
+);
+
+// Custom monoid for set union
+Set<String> allSkills = employeesPath.foldMap(
+    Monoids.set(),
+    e -> e.skills(),
+    company
+);
+```
+
+### Generic Collection Traversal with `traverseOver()`
+
+When working with collections wrapped in `Kind<F, A>`, use `traverseOver()` with a `Traverse` instance:
+
+```java
+// Given a field with Kind<ListKind.Witness, Role> type
+FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = UserFocus.roles();
+
+// Traverse into the collection
+TraversalPath<User, Role> allRoles =
+    rolesPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+// Now operate on individual roles
+List<Role> roles = allRoles.getAll(user);
+User updated = allRoles.modifyAll(Role::promote, user);
+```
+
+**When to use `traverseOver()` vs `each()`:**
+
+| Method | Use Case |
+|--------|----------|
+| `each()` | Standard `List<T>` or `Set<T>` fields |
+| `traverseOver()` | `Kind<F, T>` fields with custom Traverse |
+
+```java
+// For List<T> - use each()
+TraversalPath<Team, User> members = TeamFocus.membersList().each();
+
+// For Kind<ListKind.Witness, T> - use traverseOver()
+TraversalPath<Team, User> members = TeamFocus.membersKind()
+    .<ListKind.Witness, User>traverseOver(ListTraverse.INSTANCE);
+```
+
+### Conditional Modification with `modifyWhen()`
+
+Modify only elements that match a predicate:
+
+```java
+// Give raises only to senior employees
+Company updated = CompanyFocus.employees()
+    .modifyWhen(
+        e -> e.yearsOfService() > 5,
+        e -> e.withSalary(e.salary().multiply(1.10)),
+        company
+    );
+
+// Enable only premium features
+Config updated = ConfigFocus.features()
+    .modifyWhen(
+        f -> f.tier() == Tier.PREMIUM,
+        Feature::enable,
+        config
+    );
+```
+
+### Working with Sum Types using `instanceOf()`
+
+Focus on specific variants of sealed interfaces:
+
+```java
+sealed interface Shape permits Circle, Rectangle, Triangle {}
+
+// Focus on circles only
+AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+
+// Compose with other paths
+TraversalPath<Drawing, Double> circleRadii =
+    DrawingFocus.shapes()
+        .via(AffinePath.instanceOf(Circle.class))
+        .via(CircleFocus.radius());
+
+// Modify only circles
+Drawing updated = DrawingFocus.shapes()
+    .via(AffinePath.instanceOf(Circle.class))
+    .modifyAll(c -> c.withRadius(c.radius() * 2), drawing);
+```
+
+### Path Debugging with `traced()`
+
+Debug complex path navigation by observing values:
+
+```java
+// Add tracing to see what values are accessed
+FocusPath<Company, String> debugPath = CompanyFocus.ceo().name()
+    .traced((company, name) ->
+        System.out.println("Accessing CEO name: " + name + " from " + company.name()));
+
+// Every get() call now logs the accessed value
+String name = debugPath.get(company);
+
+// For TraversalPath, observe all values
+TraversalPath<Company, Employee> tracedEmployees = CompanyFocus.employees()
+    .traced((company, employees) ->
+        System.out.println("Found " + employees.size() + " employees"));
+```
+
+---
+
+## Generated Class Structure
+
+For a record like:
+
+```java
+@GenerateLenses
+@GenerateFocus
+record Employee(String name, int age, Optional<String> email, List<Skill> skills) {}
+```
+
+The processor generates:
+
+```java
+@Generated
+public final class EmployeeFocus {
+    private EmployeeFocus() {}
+
+    // Required fields -> FocusPath
+    public static FocusPath<Employee, String> name() {
+        return FocusPath.of(EmployeeLenses.name());
+    }
+
+    public static FocusPath<Employee, Integer> age() {
+        return FocusPath.of(EmployeeLenses.age());
+    }
+
+    // Optional<T> field -> AffinePath (automatically unwraps)
+    public static AffinePath<Employee, String> email() {
+        return FocusPath.of(EmployeeLenses.email()).some();
+    }
+
+    // List<T> field -> TraversalPath (traverses elements)
+    public static TraversalPath<Employee, Skill> skills() {
+        return FocusPath.of(EmployeeLenses.skills()).each();
+    }
+
+    // Indexed access to List<T> -> AffinePath
+    public static AffinePath<Employee, Skill> skill(int index) {
+        return FocusPath.of(EmployeeLenses.skills()).at(index);
+    }
+}
+```
+
+---
+
+## Integration with Free Monad DSL
+
+Focus paths integrate with `OpticPrograms` for complex workflows:
+
+```java
+// Build a program using Focus paths
+Free<OpticOpKind.Witness, Company> program = OpticPrograms
+    .get(company, CompanyFocus.name().toLens())
+    .flatMap(name -> {
+        if (name.startsWith("Acme")) {
+            return OpticPrograms.modifyAll(
+                company,
+                CompanyFocus.departments().employees().age().toTraversal(),
+                age -> age + 1
+            );
+        } else {
+            return OpticPrograms.pure(company);
+        }
+    });
+
+// Execute with interpreter
+Company result = OpticInterpreters.direct().run(program);
+```
+
+---
+
+## When to Use Focus DSL vs Manual Composition
+
+### Use Focus DSL When:
+
+- **Navigating deeply nested structures** with many levels
+- **IDE autocomplete is important** for discoverability
+- **Teaching or onboarding** developers new to optics
+- **Prototyping** before optimising for performance
+
+```java
+// Focus DSL - clear intent, discoverable
+List<String> emails = CompanyFocus
+    .departments()
+    .employees()
+    .email()
+    .getAll(company);
+```
+
+### Use Manual Composition When:
+
+- **Custom optics** (computed properties, validated updates)
+- **Performance-critical code** (avoid intermediate allocations)
+- **Reusable optic libraries** (compose once, use everywhere)
+- **Complex conditional logic** in the optic itself
+
+```java
+// Manual composition - more control, reusable
+public static final Lens<Company, String> CEO_NAME =
+    CompanyLenses.ceo()
+        .andThen(ExecutiveLenses.person())
+        .andThen(PersonLenses.fullName());
+```
+
+### Hybrid Approach (Recommended)
+
+Use Focus DSL for navigation, then extract for reuse:
+
+```java
+// Use Focus for exploration
+var path = CompanyFocus.departments().employees().email();
+
+// Extract and store the composed optic
+public static final Traversal<Company, String> ALL_EMAILS =
+    path.toTraversal();
+
+// Reuse the extracted optic
+List<String> emails = Traversals.getAll(ALL_EMAILS, company);
+```
+
+---
+
+## Common Patterns
+
+### Pattern 1: Batch Updates
+
+```java
+// Give all employees in Engineering a raise
+Company updated = CompanyFocus
+    .departments()
+    .filter(d -> d.name().equals("Engineering"))
+    .employees()
+    .salary()
+    .modifyAll(s -> s.multiply(new BigDecimal("1.10")), company);
+```
+
+### Pattern 2: Safe Deep Access
+
+```java
+// Safely access deeply nested optional
+Optional<String> managerEmail = CompanyFocus
+    .department(0)
+    .manager()
+    .email()
+    .getOptional(company);
+
+// Handle absence gracefully
+String email = managerEmail.orElse("no-manager@company.com");
+```
+
+### Pattern 3: Validation with Focus
+
+```java
+// Validate all employee ages
+Validated<List<String>, Company> result = OpticOps.modifyAllValidated(
+    company,
+    CompanyFocus.departments().employees().age().toTraversal(),
+    age -> age >= 18 && age <= 100
+        ? Validated.valid(age)
+        : Validated.invalid("Invalid age: " + age)
+);
+```
+
+---
+
+## Performance Considerations
+
+Focus paths add a thin abstraction layer over raw optics:
+
+- **Path creation**: Minimal overhead (simple wrapper objects)
+- **Traversal**: Identical to underlying optic performance
+- **Memory**: One additional object per path segment
+
+**Best Practice**: For hot paths, extract the underlying optic:
+
+```java
+// Cold path - Focus DSL is fine
+var result = CompanyFocus.departments().name().getAll(company);
+
+// Hot path - extract and cache the optic
+private static final Traversal<Company, String> DEPT_NAMES =
+    CompanyFocus.departments().name().toTraversal();
+
+for (Company c : manyCompanies) {
+    var names = Traversals.getAll(DEPT_NAMES, c);  // Faster
+}
+```
+
+---
+
+## Customising Generated Code
+
+### Target Package
+
+```java
+@GenerateFocus(targetPackage = "com.myapp.optics.focus")
+record User(String name) {}
+// Generates: com.myapp.optics.focus.UserFocus
+```
+
+### Navigator Generation
+
+Enable fluent cross-type navigation with generated navigator classes:
+
+```java
+@GenerateFocus(generateNavigators = true)
+record Company(String name, Address headquarters) {}
+
+@GenerateFocus(generateNavigators = true)
+record Address(String street, String city) {}
+
+// Now navigate fluently without .via():
+String city = CompanyFocus.headquarters().city().get(company);
+```
+
+### Navigator Depth Limiting
+
+Control how deep navigator generation goes with `maxNavigatorDepth`:
+
+```java
+@GenerateFocus(generateNavigators = true, maxNavigatorDepth = 2)
+record Organisation(Division division) {}
+
+// Depth 1: Returns DivisionNavigator
+// Depth 2: Returns FocusPath (not a navigator)
+// Beyond: Use .via() for further navigation
+```
+
+### Field Filtering
+
+Control which fields get navigator generation:
+
+```java
+// Only generate navigators for specific fields
+@GenerateFocus(generateNavigators = true, includeFields = {"homeAddress"})
+record Person(String name, Address homeAddress, Address workAddress) {}
+
+// Or exclude specific fields
+@GenerateFocus(generateNavigators = true, excludeFields = {"backup"})
+record Config(Settings main, Settings backup) {}
+```
+
+---
+
+## Lens Fallback for Non-Annotated Types
+
+When navigating to a type without `@GenerateFocus`, you can continue with `.via()`:
+
+```java
+// ThirdPartyRecord doesn't have @GenerateFocus
+@GenerateLenses
+@GenerateFocus
+record MyRecord(ThirdPartyRecord external) {}
+
+// Navigate as far as Focus allows, then use .via() with existing lens
+FocusPath<MyRecord, ThirdPartyRecord> externalPath = MyRecordFocus.external();
+FocusPath<MyRecord, String> deepPath = externalPath.via(ThirdPartyLenses.someField());
+```
+
+---
+
+## Common Pitfalls
+
+### Don't: Recreate paths in loops
+
+```java
+// Bad - creates new path objects each iteration
+for (Company c : companies) {
+    var names = CompanyFocus.departments().name().getAll(c);
+}
+```
+
+### Do: Extract and reuse
+
+```java
+// Good - create path once
+var deptNames = CompanyFocus.departments().name();
+for (Company c : companies) {
+    var names = deptNames.getAll(c);
+}
+```
+
+### Don't: Ignore the path type
+
+```java
+// Confusing - what does this return?
+var result = somePath.get(source);  // Might fail if AffinePath!
+```
+
+### Do: Use the appropriate method
+
+```java
+// Clear - FocusPath always has a value
+String name = namePath.get(employee);
+
+// Clear - AffinePath might be empty
+Optional<String> email = emailPath.getOptional(employee);
+
+// Clear - TraversalPath has multiple values
+List<String> names = namesPath.getAll(department);
+```
+
+---
+
+## Troubleshooting and FAQ
+
+### Compilation Errors
+
+#### "Cannot infer type arguments for traverseOver"
+
+**Problem:**
+```java
+// This fails to compile
+TraversalPath<User, Role> allRoles = rolesPath.traverseOver(ListTraverse.INSTANCE);
+```
+
+**Solution:** Provide explicit type parameters:
+```java
+// Add explicit type witnesses
+TraversalPath<User, Role> allRoles =
+    rolesPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+```
+
+Java's type inference struggles with higher-kinded types. Explicit type parameters help the compiler.
+
+#### "Incompatible types when chaining .each().via()"
+
+**Problem:**
+```java
+// Type inference fails on long chains
+TraversalPath<Company, Integer> salaries =
+    FocusPath.of(companyDeptLens).each().via(deptEmployeesLens).each().via(salaryLens);
+```
+
+**Solution:** Break the chain into intermediate variables:
+```java
+// Use intermediate variables
+TraversalPath<Company, Department> depts = FocusPath.of(companyDeptLens).each();
+TraversalPath<Company, Employee> employees = depts.via(deptEmployeesLens).each();
+TraversalPath<Company, Integer> salaries = employees.via(salaryLens);
+```
+
+#### "Sealed or non-sealed local classes are not allowed"
+
+**Problem:** Defining sealed interfaces inside test methods fails:
+```java
+@Test void myTest() {
+    sealed interface Wrapper permits A, B {}  // Compilation error!
+    record A() implements Wrapper {}
+}
+```
+
+**Solution:** Move sealed interfaces to class level:
+```java
+class MyTest {
+    sealed interface Wrapper permits A, B {}
+    record A() implements Wrapper {}
+
+    @Test void myTest() {
+        // Use Wrapper here
+    }
+}
+```
+
+#### "Method reference ::new doesn't work with single-field records as BiFunction"
+
+**Problem:**
+```java
+// This fails for single-field records
+Lens<Outer, Inner> lens = Lens.of(Outer::inner, Outer::new);  // Error!
+```
+
+**Solution:** Use explicit lambda:
+```java
+Lens<Outer, Inner> lens = Lens.of(Outer::inner, (o, i) -> new Outer(i));
+```
+
+### Runtime Issues
+
+#### "getAll() returns empty unexpectedly"
+
+**Checklist:**
+1. Check if the AffinePath in the chain has focus (use `matches()` to verify)
+2. Verify `instanceOf()` matches the actual runtime type
+3. Ensure the source data actually contains elements
+
+```java
+// Debug with traced()
+TraversalPath<User, Role> traced = rolesPath.traced(
+    (user, roles) -> System.out.println("Found " + roles.size() + " roles")
+);
+List<Role> roles = traced.getAll(user);
+```
+
+#### "modifyAll() doesn't change anything"
+
+**Causes:**
+- The traversal has no focus (AffinePath didn't match)
+- The predicate in `modifyWhen()` never matches
+- The source collection is empty
+
+```java
+// Check focus exists
+int count = path.count(source);
+System.out.println("Path focuses on " + count + " elements");
+```
+
+### FAQ
+
+#### Q: When should I use `each()` vs `traverseOver()`?
+
+| Scenario | Use |
+|----------|-----|
+| Field is `List<T>` | `each()` |
+| Field is `Set<T>` | `each()` |
+| Field is `Kind<ListKind.Witness, T>` | `traverseOver(ListTraverse.INSTANCE)` |
+| Field is `Kind<MaybeKind.Witness, T>` | `traverseOver(MaybeTraverse.INSTANCE)` |
+| Custom traversable type | `traverseOver(YourTraverse.INSTANCE)` |
+
+#### Q: Why use `MaybeMonad.INSTANCE` for `modifyF()` instead of a dedicated Applicative?
+
+`MaybeMonad` extends `Applicative`, so it works for `modifyF()`. Higher-Kinded-J doesn't provide a separate `MaybeApplicative` because:
+- Monad already provides all Applicative operations
+- Having one instance simplifies the API
+- Most effects you'll use with `modifyF()` are monadic anyway
+
+```java
+// Use MaybeMonad for Maybe-based validation
+Kind<MaybeKind.Witness, Config> result =
+    keyPath.modifyF(validateKey, config, MaybeMonad.INSTANCE);
+```
+
+#### Q: Can I use Focus DSL with third-party types?
+
+Yes, use `.via()` to compose with manually created optics:
+
+```java
+// Create lens for third-party type
+Lens<ThirdPartyType, String> fieldLens = Lens.of(
+    ThirdPartyType::getField,
+    (obj, value) -> obj.toBuilder().field(value).build()
+);
+
+// Compose with Focus path
+FocusPath<MyRecord, String> path = MyRecordFocus.external().via(fieldLens);
+```
+
+#### Q: How do I handle nullable fields?
+
+Wrap nullable fields in `Optional` and use `some()`:
+
+```java
+// If email can be null, model as Optional<String>
+record User(String name, Optional<String> email) {}
+
+// Focus DSL handles it naturally
+AffinePath<User, String> emailPath = UserFocus.email();  // Uses .some() internally
+```
+
+If you must work with raw nullable fields:
+
+```java
+// Create a nullable-aware affine manually
+Affine<User, String> nullableEmail = Affine.of(
+    u -> Optional.ofNullable(u.email()),
+    (u, email) -> new User(u.name(), email)
+);
+
+AffinePath<User, String> emailPath = AffinePath.of(nullableEmail);
+```
+
+#### Q: What's the performance overhead of Focus DSL?
+
+- **Path creation**: Negligible (thin wrapper objects)
+- **Operations**: Same as underlying optics
+- **Hot paths**: Extract and cache the optic
+
+```java
+// For performance-critical code, cache the extracted optic
+private static final Traversal<Company, String> EMPLOYEE_NAMES =
+    CompanyFocus.departments().employees().name().toTraversal();
+
+// Use the cached optic in hot loops
+for (Company c : companies) {
+    List<String> names = Traversals.getAll(EMPLOYEE_NAMES, c);
+}
+```
+
+#### Q: Can I create Focus paths programmatically (at runtime)?
+
+Focus paths are designed for compile-time type safety. For runtime-dynamic paths, use the underlying optics directly:
+
+```java
+// Build optics dynamically
+Traversal<JsonNode, String> dynamicPath = buildTraversalFromJsonPath(jsonPathString);
+
+// Wrap in a path if needed
+TraversalPath<JsonNode, String> path = TraversalPath.of(dynamicPath);
+```
+
+---
+
+## Further Reading
+
+- [Monocle Focus](https://www.optics.dev/Monocle/docs/focus) - Scala's equivalent, inspiration for this design
+- [Lenses: Composable Getters and Setters](lenses.md) - Foundation concepts
+- [Fluent API](fluent_api.md) - Alternative fluent patterns
+- [Free Monad DSL](free_monad_dsl.md) - Composable optic programs
+
+---
+
+**Previous:** [Fluent API](fluent_api.md)
+**Next:** [Free Monad DSL](free_monad_dsl.md)

--- a/hkj-core/src/main/java/module-info.java
+++ b/hkj-core/src/main/java/module-info.java
@@ -38,4 +38,5 @@ module org.higherkindedj.core {
   exports org.higherkindedj.optics.ixed;
   exports org.higherkindedj.optics.free;
   exports org.higherkindedj.optics.fluent;
+  exports org.higherkindedj.optics.focus;
 }

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffineFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffineFocusPath.java
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Implementation of {@link AffinePath} backed by an {@link Affine}.
+ *
+ * <p>This class is package-private and should be created via {@link AffinePath#of(Affine)}.
+ *
+ * @param <S> the source type
+ * @param <A> the focused type
+ */
+@NullMarked
+record AffineFocusPath<S, A>(Affine<S, A> affine) implements AffinePath<S, A> {
+
+  AffineFocusPath {
+    Objects.requireNonNull(affine, "affine must not be null");
+  }
+
+  @Override
+  public Optional<A> getOptional(S source) {
+    return affine.getOptional(source);
+  }
+
+  @Override
+  public S set(A value, S source) {
+    return affine.set(value, source);
+  }
+
+  // ===== Composition Methods =====
+
+  @Override
+  public <B> AffinePath<S, B> via(Lens<A, B> lens) {
+    return new AffineFocusPath<>(affine.andThen(lens));
+  }
+
+  @Override
+  public <B> AffinePath<S, B> via(Prism<A, B> prism) {
+    return new AffineFocusPath<>(affine.andThen(prism));
+  }
+
+  @Override
+  public <B> AffinePath<S, B> via(Affine<A, B> other) {
+    return new AffineFocusPath<>(affine.andThen(other));
+  }
+
+  @Override
+  public <B> AffinePath<S, B> via(Iso<A, B> iso) {
+    return new AffineFocusPath<>(affine.andThen(iso));
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Traversal<A, B> traversal) {
+    return new TraversalFocusPath<>(affine.andThen(traversal));
+  }
+
+  // ===== Conversion =====
+
+  @Override
+  public Affine<S, A> toAffine() {
+    return affine;
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffinePath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffinePath.java
@@ -1,0 +1,556 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Traverse;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.TraverseTraversals;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A type-safe path through a data structure that focuses on zero or one element.
+ *
+ * <p>AffinePath wraps an {@link Affine} and provides fluent navigation and composition methods. Use
+ * this when navigating to values that may or may not exist, such as Optional fields or the result
+ * of navigating through a prism.
+ *
+ * <p>In the Focus DSL hierarchy, AffinePath sits between FocusPath and TraversalPath:
+ *
+ * <pre>
+ *      FocusPath<S, A>     (exactly one element)
+ *            │
+ *      AffinePath<S, A>    (zero or one element)
+ *            │
+ *    TraversalPath<S, A>   (zero or more elements)
+ * </pre>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * // Navigate to an optional email field
+ * AffinePath<User, String> emailPath = UserFocus.email();
+ *
+ * // Get the value (may be empty)
+ * Optional<String> email = emailPath.getOptional(user);
+ *
+ * // Set a value (always succeeds)
+ * User updated = emailPath.set("new@email.com", user);
+ *
+ * // Modify only if present
+ * User modified = emailPath.modify(String::toLowerCase, user);
+ *
+ * // Check if present
+ * if (emailPath.matches(user)) {
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * @param <S> the source type (the whole structure)
+ * @param <A> the focused value type (the part)
+ * @see FocusPath for paths focusing on exactly one element
+ * @see TraversalPath for paths focusing on zero or more elements
+ * @see FocusPaths for utility methods and optics factories
+ */
+@NullMarked
+public sealed interface AffinePath<S, A> permits AffineFocusPath {
+
+  /**
+   * Extracts the focused value if present.
+   *
+   * @param source the source structure
+   * @return Optional containing the value, or empty if not focused
+   */
+  Optional<A> getOptional(S source);
+
+  /**
+   * Creates a new source with the focused value replaced.
+   *
+   * <p>Unlike a Prism, this operation always succeeds. If the focused element was previously
+   * absent, it becomes present with the new value (if the underlying structure supports this).
+   *
+   * @param value the new value
+   * @param source the source structure
+   * @return a new structure with the updated value
+   */
+  S set(A value, S source);
+
+  /**
+   * Creates a new source with the focused value transformed, if present.
+   *
+   * <p>If the focused element is absent, the original structure is returned unchanged.
+   *
+   * @param f the transformation function
+   * @param source the source structure
+   * @return a new structure with the modified value, or the original if not focused
+   */
+  default S modify(Function<A, A> f, S source) {
+    return getOptional(source).map(a -> set(f.apply(a), source)).orElse(source);
+  }
+
+  /**
+   * Checks if this path focuses on a value in the given source.
+   *
+   * @param source the source structure to test
+   * @return true if a value is focused, false otherwise
+   */
+  default boolean matches(S source) {
+    return getOptional(source).isPresent();
+  }
+
+  /**
+   * Returns the focused value or a default if absent.
+   *
+   * @param defaultValue the value to return if not focused
+   * @param source the source structure
+   * @return the focused value or the default
+   */
+  default A getOrElse(A defaultValue, S source) {
+    return getOptional(source).orElse(defaultValue);
+  }
+
+  /**
+   * Applies a function to the focused value and returns the result in an Optional.
+   *
+   * @param f the function to apply
+   * @param source the source structure
+   * @param <B> the result type
+   * @return Optional containing the result, or empty if not focused
+   */
+  default <B> Optional<B> mapOptional(Function<? super A, ? extends B> f, S source) {
+    return getOptional(source).map(f);
+  }
+
+  /**
+   * Transforms the focused value with an effectful function.
+   *
+   * <p>This method enables effectful modifications such as validation, async operations, or
+   * computations that may fail. If this path has no focus, the original source is returned wrapped
+   * in the applicative's {@code of}.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Validation of optional field
+   * AffinePath<User, String> emailPath = UserFocus.optionalEmail();
+   *
+   * Kind<Validated.Witness, User> result = emailPath.modifyF(
+   *     email -> EmailValidator.validate(email),
+   *     user,
+   *     ValidatedApplicative.INSTANCE
+   * );
+   *
+   * // Async update of optional config value
+   * Kind<CompletableFutureKind.Witness, Config> result = configPath.modifyF(
+   *     value -> fetchUpdatedValue(value),
+   *     config,
+   *     CompletableFutureApplicative.INSTANCE
+   * );
+   * }</pre>
+   *
+   * @param f the effectful transformation function
+   * @param source the source structure
+   * @param applicative the applicative instance for the effect type F
+   * @param <F> the effect type (e.g., Optional, Validated, IO)
+   * @return the modified structure wrapped in the effect
+   */
+  default <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S source, Applicative<F> applicative) {
+    return toAffine().modifyF(f, source, applicative);
+  }
+
+  // ===== Composition Methods =====
+
+  /**
+   * Composes this path with a lens, producing an AffinePath.
+   *
+   * <p>The result is an AffinePath because this path may have no focus.
+   *
+   * @param lens the lens to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath focusing on the composed target
+   */
+  <B> AffinePath<S, B> via(Lens<A, B> lens);
+
+  /**
+   * Composes this path with a FocusPath.
+   *
+   * <p>This is a convenience method that extracts the lens from the other path. The result is an
+   * AffinePath because this path may have no focus.
+   *
+   * @param other the FocusPath to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath focusing on the composed target
+   */
+  default <B> AffinePath<S, B> via(FocusPath<A, B> other) {
+    return via(other.toLens());
+  }
+
+  /**
+   * Composes this path with another AffinePath.
+   *
+   * <p>This is a convenience method that extracts the affine from the other path. The result is an
+   * AffinePath because both paths may have no focus.
+   *
+   * @param other the AffinePath to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> via(AffinePath<A, B> other) {
+    return via(other.toAffine());
+  }
+
+  /**
+   * Composes this path with a TraversalPath.
+   *
+   * <p>This is a convenience method that extracts the traversal from the other path. The result is
+   * a TraversalPath because the other path may focus on multiple elements.
+   *
+   * @param other the TraversalPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  default <B> TraversalPath<S, B> via(TraversalPath<A, B> other) {
+    return via(other.toTraversal());
+  }
+
+  /**
+   * Composes this path with a prism, producing an AffinePath.
+   *
+   * <p>The result is an AffinePath because both this path and the prism may have no focus.
+   *
+   * @param prism the prism to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  <B> AffinePath<S, B> via(Prism<A, B> prism);
+
+  /**
+   * Composes this path with an affine, producing an AffinePath.
+   *
+   * @param affine the affine to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  <B> AffinePath<S, B> via(Affine<A, B> affine);
+
+  /**
+   * Composes this path with an iso, producing an AffinePath.
+   *
+   * @param iso the iso to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath focusing on the converted target
+   */
+  <B> AffinePath<S, B> via(Iso<A, B> iso);
+
+  /**
+   * Composes this path with a traversal, producing a TraversalPath.
+   *
+   * @param traversal the traversal to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  <B> TraversalPath<S, B> via(Traversal<A, B> traversal);
+
+  // ===== then() Aliases =====
+
+  /**
+   * Alias for {@link #via(Lens)}. Composes this path with a lens.
+   *
+   * <p>This method provides an alternative naming convention familiar to users of other optics
+   * libraries.
+   *
+   * @param lens the lens to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath focusing on the composed target
+   */
+  default <B> AffinePath<S, B> then(Lens<A, B> lens) {
+    return via(lens);
+  }
+
+  /**
+   * Alias for {@link #via(FocusPath)}. Composes this path with a FocusPath.
+   *
+   * @param other the FocusPath to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath focusing on the composed target
+   */
+  default <B> AffinePath<S, B> then(FocusPath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Prism)}. Composes this path with a prism.
+   *
+   * @param prism the prism to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> then(Prism<A, B> prism) {
+    return via(prism);
+  }
+
+  /**
+   * Alias for {@link #via(Affine)}. Composes this path with an affine.
+   *
+   * @param affine the affine to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> then(Affine<A, B> affine) {
+    return via(affine);
+  }
+
+  /**
+   * Alias for {@link #via(AffinePath)}. Composes this path with another AffinePath.
+   *
+   * @param other the AffinePath to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> then(AffinePath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Iso)}. Composes this path with an iso.
+   *
+   * @param iso the iso to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath focusing on the composed target
+   */
+  default <B> AffinePath<S, B> then(Iso<A, B> iso) {
+    return via(iso);
+  }
+
+  /**
+   * Alias for {@link #via(Traversal)}. Composes this path with a traversal.
+   *
+   * @param traversal the traversal to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  default <B> TraversalPath<S, B> then(Traversal<A, B> traversal) {
+    return via(traversal);
+  }
+
+  /**
+   * Alias for {@link #via(TraversalPath)}. Composes this path with a TraversalPath.
+   *
+   * @param other the TraversalPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  default <B> TraversalPath<S, B> then(TraversalPath<A, B> other) {
+    return via(other);
+  }
+
+  // ===== Collection Navigation =====
+
+  /**
+   * When the focused type is {@code List<E>}, traverses all elements.
+   *
+   * @param <E> the element type of the list
+   * @return a TraversalPath over list elements
+   */
+  @SuppressWarnings("unchecked")
+  default <E> TraversalPath<S, E> each() {
+    return via((Traversal<A, E>) FocusPaths.listElements());
+  }
+
+  /**
+   * When the focused type is {@code List<E>}, focuses on the element at the specified index.
+   *
+   * @param index the index to focus on
+   * @param <E> the element type of the list
+   * @return an AffinePath that may be empty if the index is out of bounds
+   */
+  @SuppressWarnings("unchecked")
+  default <E> AffinePath<S, E> at(int index) {
+    return via((Affine<A, E>) FocusPaths.listAt(index));
+  }
+
+  /**
+   * When the focused type is {@code Map<K, V>}, focuses on the value for the specified key.
+   *
+   * @param key the key to focus on
+   * @param <K> the key type of the map
+   * @param <V> the value type of the map
+   * @return an AffinePath that may be empty if the key is not present
+   */
+  @SuppressWarnings("unchecked")
+  default <K, V> AffinePath<S, V> atKey(K key) {
+    return via((Affine<A, V>) FocusPaths.mapAt(key));
+  }
+
+  /**
+   * When the focused type is {@code Optional<E>}, unwraps to the inner value.
+   *
+   * @param <E> the inner type of the Optional
+   * @return an AffinePath that may be empty
+   */
+  @SuppressWarnings("unchecked")
+  default <E> AffinePath<S, E> some() {
+    return via((Affine<A, E>) FocusPaths.optionalSome());
+  }
+
+  /**
+   * When the optionally-focused value is a traversable container {@code Kind<F, E>}, creates a
+   * TraversalPath that focuses on all elements within it.
+   *
+   * <p>This enables generic traversal over any type with a {@link org.higherkindedj.hkt.Traverse}
+   * instance, not just {@code List}. For example, {@code Set}, {@code Tree}, or custom collections.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Given: Config with optional Kind<ListKind.Witness, Feature> features field
+   * AffinePath<Config, Kind<ListKind.Witness, Feature>> featuresPath = ConfigFocus.features();
+   *
+   * // Traverse into the List elements when present
+   * TraversalPath<Config, Feature> allFeatures = featuresPath.traverseOver(
+   *     ListTraverse.INSTANCE
+   * );
+   *
+   * // Now can operate on all features (if present)
+   * List<Feature> features = allFeatures.getAll(config);
+   * Config updated = allFeatures.modifyAll(Feature::enable, config);
+   * }</pre>
+   *
+   * <p>For standard {@code List<E>} fields, prefer the {@link #each()} method which handles the
+   * conversion automatically.
+   *
+   * @param <F> the witness type of the traversable container
+   * @param <E> the element type within the container
+   * @param traverse the Traverse instance for the container type
+   * @return a TraversalPath focusing on all elements within the container
+   * @see #each() for simpler List traversal
+   * @see org.higherkindedj.optics.util.TraverseTraversals
+   */
+  @SuppressWarnings("unchecked")
+  default <F, E> TraversalPath<S, E> traverseOver(Traverse<F> traverse) {
+    Traversal<Kind<F, E>, E> traversal = TraverseTraversals.forTraverse(traverse);
+    return via((Traversal<A, E>) traversal);
+  }
+
+  // ===== Conversion Methods =====
+
+  /**
+   * Extracts the underlying affine.
+   *
+   * @return the wrapped Affine
+   */
+  Affine<S, A> toAffine();
+
+  /**
+   * Views this path as a TraversalPath.
+   *
+   * <p>This is always valid because an AffinePath (zero or one) is a special case of TraversalPath
+   * (zero or more).
+   *
+   * @return a TraversalPath view of this path
+   */
+  default TraversalPath<S, A> asTraversal() {
+    return TraversalPath.of(toAffine().asTraversal());
+  }
+
+  /**
+   * Views this path as a Fold.
+   *
+   * @return a Fold view of the underlying affine
+   */
+  default Fold<S, A> asFold() {
+    return toAffine().asFold();
+  }
+
+  // ===== Debugging =====
+
+  /**
+   * Creates a new AffinePath that invokes an observer during get operations.
+   *
+   * <p>This method is useful for debugging complex path navigations by logging or inspecting values
+   * as they are accessed. The observer receives the source and the focused value (if present).
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * AffinePath<Config, String> debugPath = ConfigFocus.apiKey()
+   *     .traced((config, key) -> log.debug("Accessing API key: {} from {}", key, config));
+   *
+   * // Every getOptional() call will now log the accessed value
+   * Optional<String> key = debugPath.getOptional(config);
+   * }</pre>
+   *
+   * @param observer a consumer that receives the source and focused value during get operations
+   * @return a new AffinePath that invokes the observer
+   */
+  default AffinePath<S, A> traced(BiConsumer<S, Optional<A>> observer) {
+    AffinePath<S, A> self = this;
+    return AffinePath.of(
+        Affine.of(
+            s -> {
+              Optional<A> result = self.getOptional(s);
+              observer.accept(s, result);
+              return result;
+            },
+            (s, a) -> self.set(a, s)));
+  }
+
+  // ===== Factory Methods =====
+
+  /**
+   * Creates an AffinePath from an affine.
+   *
+   * @param affine the affine to wrap
+   * @param <S> the source type
+   * @param <A> the focused type
+   * @return a new AffinePath
+   */
+  static <S, A> AffinePath<S, A> of(Affine<S, A> affine) {
+    return new AffineFocusPath<>(affine);
+  }
+
+  /**
+   * Creates an AffinePath that focuses on instances of a specific subclass.
+   *
+   * <p>This is useful for working with sealed interfaces or class hierarchies, allowing you to
+   * focus on a specific variant of a sum type.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * sealed interface Shape permits Circle, Rectangle {}
+   * record Circle(double radius) implements Shape {}
+   * record Rectangle(double width, double height) implements Shape {}
+   *
+   * // Focus on Circle instances only
+   * AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+   *
+   * // Get the Circle if the shape is one
+   * Optional<Circle> maybeCircle = circlePath.getOptional(someShape);
+   *
+   * // Compose with further navigation
+   * AffinePath<Shape, Double> radiusPath = circlePath.via(CircleFocus.radius());
+   * }</pre>
+   *
+   * @param subclass the class of the subtype to focus on
+   * @param <S> the source (supertype)
+   * @param <A> the focused subtype
+   * @return an AffinePath that focuses only on instances of the specified subclass
+   */
+  static <S, A extends S> AffinePath<S, A> instanceOf(Class<A> subclass) {
+    Affine<S, A> affine =
+        Affine.of(
+            s -> subclass.isInstance(s) ? Optional.of(subclass.cast(s)) : Optional.empty(),
+            (s, a) -> a);
+    return of(affine);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPath.java
@@ -1,0 +1,536 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Traverse;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.TraverseTraversals;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A type-safe path through a data structure that focuses on exactly one element.
+ *
+ * <p>FocusPath wraps a {@link Lens} and provides fluent navigation and composition methods. Use
+ * this when navigating to fields that are guaranteed to exist.
+ *
+ * <p>In the Focus DSL hierarchy, FocusPath is the most specific type:
+ *
+ * <pre>
+ *      FocusPath<S, A>     (exactly one element)
+ *            │
+ *      AffinePath<S, A>    (zero or one element)
+ *            │
+ *    TraversalPath<S, A>   (zero or more elements)
+ * </pre>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * // Create from a lens
+ * FocusPath<User, String> namePath = FocusPath.of(UserLenses.name());
+ *
+ * // Get a value
+ * String name = namePath.get(user);
+ *
+ * // Set a value
+ * User updated = namePath.set("Bob", user);
+ *
+ * // Modify a value
+ * User modified = namePath.modify(String::toUpperCase, user);
+ *
+ * // Compose with another lens
+ * FocusPath<User, String> cityPath = namePath.via(AddressLenses.city());
+ * }</pre>
+ *
+ * @param <S> the source type (the whole structure)
+ * @param <A> the focused value type (the part)
+ * @see AffinePath for paths focusing on zero or one element
+ * @see TraversalPath for paths focusing on zero or more elements
+ * @see FocusPaths for utility methods and optics factories
+ */
+@NullMarked
+public sealed interface FocusPath<S, A> permits LensFocusPath {
+
+  /**
+   * Extracts the focused value from the source.
+   *
+   * <p>This operation always succeeds because a FocusPath guarantees exactly one focused element.
+   *
+   * @param source the source structure
+   * @return the focused value
+   */
+  A get(S source);
+
+  /**
+   * Creates a new source with the focused value replaced.
+   *
+   * <p>This operation is immutable; the original source is not modified.
+   *
+   * @param value the new value
+   * @param source the source structure
+   * @return a new structure with the updated value
+   */
+  S set(A value, S source);
+
+  /**
+   * Creates a new source with the focused value transformed.
+   *
+   * <p>This is equivalent to {@code set(f.apply(get(source)), source)}.
+   *
+   * @param f the transformation function
+   * @param source the source structure
+   * @return a new structure with the modified value
+   */
+  default S modify(Function<A, A> f, S source) {
+    return set(f.apply(get(source)), source);
+  }
+
+  /**
+   * Transforms the focused value with an effectful function.
+   *
+   * <p>This method enables effectful modifications such as validation, async operations, or
+   * computations that may fail. The effect is captured in the functor F.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Validation example
+   * FocusPath<User, String> emailPath = UserFocus.email();
+   *
+   * Kind<Validated.Witness, User> result = emailPath.modifyF(
+   *     email -> EmailValidator.validate(email),
+   *     user,
+   *     ValidatedFunctor.INSTANCE
+   * );
+   *
+   * // Optional example (transformation that may fail)
+   * Kind<OptionalKind.Witness, Config> result = configPath.modifyF(
+   *     value -> parseConfig(value),  // Returns Optional
+   *     config,
+   *     OptionalFunctor.INSTANCE
+   * );
+   * }</pre>
+   *
+   * @param f the effectful transformation function
+   * @param source the source structure
+   * @param functor the functor instance for the effect type F
+   * @param <F> the effect type (e.g., Optional, Validated, IO)
+   * @return the modified structure wrapped in the effect
+   */
+  default <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S source, Functor<F> functor) {
+    return toLens().modifyF(f, source, functor);
+  }
+
+  // ===== Composition Methods =====
+
+  /**
+   * Composes this path with a lens to focus deeper into the structure.
+   *
+   * <p>The result is a FocusPath because both this path and the lens focus on exactly one element.
+   *
+   * @param lens the lens to compose with
+   * @param <B> the new focused type
+   * @return a new FocusPath focusing on the composed target
+   */
+  <B> FocusPath<S, B> via(Lens<A, B> lens);
+
+  /**
+   * Composes this path with another FocusPath.
+   *
+   * <p>This is a convenience method that extracts the lens from the other path. The result is a
+   * FocusPath because both paths focus on exactly one element.
+   *
+   * @param other the FocusPath to compose with
+   * @param <B> the new focused type
+   * @return a new FocusPath focusing on the composed target
+   */
+  default <B> FocusPath<S, B> via(FocusPath<A, B> other) {
+    return via(other.toLens());
+  }
+
+  /**
+   * Composes this path with an AffinePath.
+   *
+   * <p>This is a convenience method that extracts the affine from the other path. The result is an
+   * AffinePath because the other path may have no focus.
+   *
+   * @param other the AffinePath to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> via(AffinePath<A, B> other) {
+    return via(other.toAffine());
+  }
+
+  /**
+   * Composes this path with a TraversalPath.
+   *
+   * <p>This is a convenience method that extracts the traversal from the other path. The result is
+   * a TraversalPath because the other path may focus on multiple elements.
+   *
+   * @param other the TraversalPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  default <B> TraversalPath<S, B> via(TraversalPath<A, B> other) {
+    return via(other.toTraversal());
+  }
+
+  /**
+   * Composes this path with an iso to focus through a type conversion.
+   *
+   * <p>The result is a FocusPath because an iso is a lossless, reversible transformation.
+   *
+   * @param iso the iso to compose with
+   * @param <B> the new focused type
+   * @return a new FocusPath focusing on the composed target
+   */
+  <B> FocusPath<S, B> via(Iso<A, B> iso);
+
+  /**
+   * Composes this path with a prism, producing an AffinePath.
+   *
+   * <p>The result is an AffinePath because the prism may not match (zero or one focus).
+   *
+   * @param prism the prism to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  <B> AffinePath<S, B> via(Prism<A, B> prism);
+
+  /**
+   * Composes this path with an affine, producing an AffinePath.
+   *
+   * <p>The result is an AffinePath because the affine may have no focus.
+   *
+   * @param affine the affine to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  <B> AffinePath<S, B> via(Affine<A, B> affine);
+
+  /**
+   * Composes this path with a traversal, producing a TraversalPath.
+   *
+   * <p>The result is a TraversalPath because the traversal may focus on multiple elements.
+   *
+   * @param traversal the traversal to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  <B> TraversalPath<S, B> via(Traversal<A, B> traversal);
+
+  // ===== then() Aliases =====
+
+  /**
+   * Alias for {@link #via(Lens)}. Composes this path with a lens.
+   *
+   * <p>This method provides an alternative naming convention familiar to users of other optics
+   * libraries.
+   *
+   * @param lens the lens to compose with
+   * @param <B> the new focused type
+   * @return a new FocusPath focusing on the composed target
+   */
+  default <B> FocusPath<S, B> then(Lens<A, B> lens) {
+    return via(lens);
+  }
+
+  /**
+   * Alias for {@link #via(FocusPath)}. Composes this path with another FocusPath.
+   *
+   * @param other the FocusPath to compose with
+   * @param <B> the new focused type
+   * @return a new FocusPath focusing on the composed target
+   */
+  default <B> FocusPath<S, B> then(FocusPath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Iso)}. Composes this path with an iso.
+   *
+   * @param iso the iso to compose with
+   * @param <B> the new focused type
+   * @return a new FocusPath focusing on the composed target
+   */
+  default <B> FocusPath<S, B> then(Iso<A, B> iso) {
+    return via(iso);
+  }
+
+  /**
+   * Alias for {@link #via(Prism)}. Composes this path with a prism.
+   *
+   * @param prism the prism to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> then(Prism<A, B> prism) {
+    return via(prism);
+  }
+
+  /**
+   * Alias for {@link #via(Affine)}. Composes this path with an affine.
+   *
+   * @param affine the affine to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> then(Affine<A, B> affine) {
+    return via(affine);
+  }
+
+  /**
+   * Alias for {@link #via(AffinePath)}. Composes this path with an AffinePath.
+   *
+   * @param other the AffinePath to compose with
+   * @param <B> the new focused type
+   * @return an AffinePath that may or may not focus on a value
+   */
+  default <B> AffinePath<S, B> then(AffinePath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Traversal)}. Composes this path with a traversal.
+   *
+   * @param traversal the traversal to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  default <B> TraversalPath<S, B> then(Traversal<A, B> traversal) {
+    return via(traversal);
+  }
+
+  /**
+   * Alias for {@link #via(TraversalPath)}. Composes this path with a TraversalPath.
+   *
+   * @param other the TraversalPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on multiple elements
+   */
+  default <B> TraversalPath<S, B> then(TraversalPath<A, B> other) {
+    return via(other);
+  }
+
+  // ===== Collection Navigation =====
+
+  /**
+   * When the focused type is {@code List<E>}, traverses all elements.
+   *
+   * <p>This method requires that the focused type {@code A} is a {@code List<E>}. It returns a
+   * TraversalPath that focuses on each element in the list.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * // departments() returns FocusPath<Company, List<Department>>
+   * TraversalPath<Company, Department> allDepts = CompanyFocus.departmentList().each();
+   * }</pre>
+   *
+   * @param <E> the element type of the list
+   * @return a TraversalPath over list elements
+   * @throws ClassCastException if the focused type {@code A} is not a {@code List}
+   */
+  @SuppressWarnings("unchecked")
+  default <E> TraversalPath<S, E> each() {
+    // This cast is safe when A is List<E>
+    return via((Traversal<A, E>) FocusPaths.listElements());
+  }
+
+  /**
+   * When the focused type is {@code List<E>}, focuses on the element at the specified index.
+   *
+   * <p>This method returns an AffinePath because the index may be out of bounds.
+   *
+   * @param index the index to focus on
+   * @param <E> the element type of the list
+   * @return an AffinePath that may be empty if the index is out of bounds
+   * @throws ClassCastException if the focused type {@code A} is not a {@code List}
+   */
+  @SuppressWarnings("unchecked")
+  default <E> AffinePath<S, E> at(int index) {
+    return via((Affine<A, E>) FocusPaths.listAt(index));
+  }
+
+  /**
+   * When the focused type is {@code Map<K, V>}, focuses on the value for the specified key.
+   *
+   * <p>This method returns an AffinePath because the key may not exist in the map.
+   *
+   * @param key the key to focus on
+   * @param <K> the key type of the map
+   * @param <V> the value type of the map
+   * @return an AffinePath that may be empty if the key is not present
+   * @throws ClassCastException if the focused type {@code A} is not a {@code Map}
+   */
+  @SuppressWarnings("unchecked")
+  default <K, V> AffinePath<S, V> atKey(K key) {
+    return via((Affine<A, V>) FocusPaths.mapAt(key));
+  }
+
+  /**
+   * When the focused type is {@code Optional<E>}, unwraps to the inner value.
+   *
+   * <p>This method returns an AffinePath because the Optional may be empty.
+   *
+   * @param <E> the inner type of the Optional
+   * @return an AffinePath that may be empty if the Optional is empty
+   * @throws ClassCastException if the focused type {@code A} is not an {@code Optional}
+   */
+  @SuppressWarnings("unchecked")
+  default <E> AffinePath<S, E> some() {
+    return via((Affine<A, E>) FocusPaths.optionalSome());
+  }
+
+  /**
+   * When the focused value is a traversable container {@code Kind<F, E>}, creates a TraversalPath
+   * that focuses on all elements within it.
+   *
+   * <p>This enables generic traversal over any type with a {@link org.higherkindedj.hkt.Traverse}
+   * instance, not just {@code List}. For example, {@code Set}, {@code Tree}, or custom collections.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Given: User with Kind<ListKind.Witness, Role> roles field
+   * FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = UserFocus.roles();
+   *
+   * // Traverse into the List elements using Traverse type class
+   * TraversalPath<User, Role> allRoles = rolesPath.traverseOver(
+   *     ListTraverse.INSTANCE
+   * );
+   *
+   * // Now can operate on all roles
+   * List<Role> roles = allRoles.getAll(user);
+   * User updated = allRoles.modifyAll(Role::promote, user);
+   * }</pre>
+   *
+   * <p>For standard {@code List<E>} fields, prefer the {@link #each()} method which handles the
+   * conversion automatically.
+   *
+   * @param <F> the witness type of the traversable container
+   * @param <E> the element type within the container
+   * @param traverse the Traverse instance for the container type
+   * @return a TraversalPath focusing on all elements within the container
+   * @see #each() for simpler List traversal
+   * @see org.higherkindedj.optics.util.TraverseTraversals
+   */
+  @SuppressWarnings("unchecked")
+  default <F, E> TraversalPath<S, E> traverseOver(Traverse<F> traverse) {
+    Traversal<Kind<F, E>, E> traversal = TraverseTraversals.forTraverse(traverse);
+    return via((Traversal<A, E>) traversal);
+  }
+
+  // ===== Conversion Methods =====
+
+  /**
+   * Extracts the underlying lens.
+   *
+   * @return the wrapped Lens
+   */
+  Lens<S, A> toLens();
+
+  /**
+   * Views this path as an AffinePath.
+   *
+   * <p>This is always valid because a FocusPath (exactly one) is a special case of AffinePath (zero
+   * or one).
+   *
+   * @return an AffinePath view of this path
+   */
+  default AffinePath<S, A> asAffine() {
+    Lens<S, A> lens = toLens();
+    return AffinePath.of(Affine.of(s -> Optional.of(lens.get(s)), (s, a) -> lens.set(a, s)));
+  }
+
+  /**
+   * Views this path as a TraversalPath.
+   *
+   * <p>This is always valid because a FocusPath (exactly one) is a special case of TraversalPath
+   * (zero or more).
+   *
+   * @return a TraversalPath view of this path
+   */
+  default TraversalPath<S, A> asTraversal() {
+    return TraversalPath.of(toLens().asTraversal());
+  }
+
+  /**
+   * Views this path as a Fold.
+   *
+   * @return a Fold view of the underlying lens
+   */
+  default Fold<S, A> asFold() {
+    return toLens().asFold();
+  }
+
+  // ===== Debugging =====
+
+  /**
+   * Creates a new FocusPath that invokes an observer during get operations.
+   *
+   * <p>This method is useful for debugging complex path navigations by logging or inspecting values
+   * as they are accessed.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * FocusPath<Company, String> debugPath = CompanyFocus.ceo().name()
+   *     .traced((company, name) -> log.debug("Accessing CEO name: {} from {}", name, company));
+   *
+   * // Every get() call will now log the accessed value
+   * String name = debugPath.get(company);
+   * }</pre>
+   *
+   * @param observer a consumer that receives the source and focused value during get operations
+   * @return a new FocusPath that invokes the observer
+   */
+  default FocusPath<S, A> traced(BiConsumer<S, A> observer) {
+    FocusPath<S, A> self = this;
+    return FocusPath.of(
+        Lens.of(
+            s -> {
+              A a = self.get(s);
+              observer.accept(s, a);
+              return a;
+            },
+            (s, a) -> self.set(a, s)));
+  }
+
+  // ===== Factory Methods =====
+
+  /**
+   * Creates a FocusPath from a lens.
+   *
+   * @param lens the lens to wrap
+   * @param <S> the source type
+   * @param <A> the focused type
+   * @return a new FocusPath
+   */
+  static <S, A> FocusPath<S, A> of(Lens<S, A> lens) {
+    return new LensFocusPath<>(lens);
+  }
+
+  /**
+   * Creates an identity FocusPath that focuses on the source itself.
+   *
+   * <p>This is useful as a starting point for path composition.
+   *
+   * @param <S> the source/target type
+   * @return an identity FocusPath
+   */
+  static <S> FocusPath<S, S> identity() {
+    return of(Lens.of(Function.identity(), (s, a) -> a));
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPaths.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPaths.java
@@ -1,0 +1,290 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Static utilities for creating optics used in Focus path navigation.
+ *
+ * <p>This class provides pre-built optics for common collection types that are used internally by
+ * the Focus DSL for methods like {@code each()}, {@code at()}, {@code some()}, and {@code atKey()}.
+ *
+ * <h2>Supported Types</h2>
+ *
+ * <ul>
+ *   <li>{@link List} - via {@link #listElements()} and {@link #listAt(int)}
+ *   <li>{@link Map} - via {@link #mapValues()} and {@link #mapAt(Object)}
+ *   <li>{@link Optional} - via {@link #optionalSome()}
+ * </ul>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * // Get a traversal over list elements
+ * Traversal<List<String>, String> strings = FocusPaths.listElements();
+ *
+ * // Get an affine for a specific index
+ * Affine<List<String>, String> second = FocusPaths.listAt(1);
+ *
+ * // Get an affine for Optional unwrapping
+ * Affine<Optional<String>, String> some = FocusPaths.optionalSome();
+ * }</pre>
+ */
+@NullMarked
+public final class FocusPaths {
+
+  private FocusPaths() {
+    // Utility class
+  }
+
+  // ===== List Optics =====
+
+  /**
+   * Creates a traversal over all elements in a list.
+   *
+   * @param <E> the element type
+   * @return a traversal focusing on all list elements
+   */
+  public static <E> Traversal<List<E>, E> listElements() {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, List<E>> modifyF(
+          Function<E, Kind<F, E>> f, List<E> source, Applicative<F> app) {
+        if (source.isEmpty()) {
+          return app.of(source);
+        }
+
+        // Start with the first element
+        Kind<F, List<E>> result = app.map(List::of, f.apply(source.get(0)));
+
+        // Combine with remaining elements
+        for (int i = 1; i < source.size(); i++) {
+          Kind<F, E> modifiedElement = f.apply(source.get(i));
+          result = app.map2(result, modifiedElement, FocusPaths::appendToList);
+        }
+
+        return result;
+      }
+    };
+  }
+
+  /**
+   * Creates an affine focusing on a specific index in a list.
+   *
+   * <p>The affine will return empty if the index is out of bounds. Setting a value at an index
+   * requires the index to be within the current list size.
+   *
+   * @param index the index to focus on
+   * @param <E> the element type
+   * @return an affine focusing on the element at the given index
+   */
+  public static <E> Affine<List<E>, E> listAt(int index) {
+    return Affine.of(
+        list ->
+            (index >= 0 && index < list.size()) ? Optional.of(list.get(index)) : Optional.empty(),
+        (list, element) -> {
+          if (index >= 0 && index < list.size()) {
+            List<E> result = new ArrayList<>(list);
+            result.set(index, element);
+            return result;
+          }
+          return list;
+        });
+  }
+
+  /**
+   * Creates an affine focusing on the first element of a list.
+   *
+   * @param <E> the element type
+   * @return an affine focusing on the first element
+   */
+  public static <E> Affine<List<E>, E> listHead() {
+    return listAt(0);
+  }
+
+  /**
+   * Creates an affine focusing on the last element of a list.
+   *
+   * @param <E> the element type
+   * @return an affine focusing on the last element
+   */
+  public static <E> Affine<List<E>, E> listLast() {
+    return Affine.of(
+        list -> list.isEmpty() ? Optional.empty() : Optional.of(list.get(list.size() - 1)),
+        (list, element) -> {
+          if (!list.isEmpty()) {
+            List<E> result = new ArrayList<>(list);
+            result.set(result.size() - 1, element);
+            return result;
+          }
+          return list;
+        });
+  }
+
+  // ===== Map Optics =====
+
+  /**
+   * Creates a traversal over all values in a map.
+   *
+   * <p>Note: The traversal order depends on the map implementation. For predictable ordering, use a
+   * {@code LinkedHashMap} or {@code TreeMap}.
+   *
+   * @param <K> the key type
+   * @param <V> the value type
+   * @return a traversal focusing on all map values
+   */
+  public static <K, V> Traversal<Map<K, V>, V> mapValues() {
+    return new Traversal<>() {
+      @Override
+      public <F> Kind<F, Map<K, V>> modifyF(
+          Function<V, Kind<F, V>> f, Map<K, V> source, Applicative<F> app) {
+        if (source.isEmpty()) {
+          return app.of(source);
+        }
+
+        // Convert to list for ordered processing
+        List<Map.Entry<K, V>> entries = new ArrayList<>(source.entrySet());
+
+        // Start with the first entry
+        Map.Entry<K, V> first = entries.get(0);
+        Kind<F, Map<K, V>> result =
+            app.map(v -> Map.of(first.getKey(), v), f.apply(first.getValue()));
+
+        // Combine with remaining entries
+        for (int i = 1; i < entries.size(); i++) {
+          Map.Entry<K, V> entry = entries.get(i);
+          Kind<F, V> modifiedValue = f.apply(entry.getValue());
+          K key = entry.getKey();
+          result = app.map2(result, modifiedValue, (map, v) -> putInMap(map, key, v));
+        }
+
+        return result;
+      }
+    };
+  }
+
+  /**
+   * Creates an affine focusing on a specific key in a map.
+   *
+   * <p>The affine will return empty if the key is not present. Setting a value will add or update
+   * the key.
+   *
+   * @param key the key to focus on
+   * @param <K> the key type
+   * @param <V> the value type
+   * @return an affine focusing on the value at the given key
+   */
+  public static <K, V> Affine<Map<K, V>, V> mapAt(K key) {
+    return Affine.of(
+        map -> Optional.ofNullable(map.get(key)),
+        (map, value) -> {
+          Map<K, V> result = new HashMap<>(map);
+          result.put(key, value);
+          return result;
+        },
+        map -> {
+          Map<K, V> result = new HashMap<>(map);
+          result.remove(key);
+          return result;
+        });
+  }
+
+  // ===== Optional Optics =====
+
+  /**
+   * Creates an affine that unwraps an Optional.
+   *
+   * <p>The affine returns empty if the Optional is empty. Setting always creates a present
+   * Optional.
+   *
+   * @param <E> the inner type
+   * @return an affine for unwrapping Optional
+   */
+  public static <E> Affine<Optional<E>, E> optionalSome() {
+    return Affine.of(
+        Function.identity(), (opt, value) -> Optional.of(value), opt -> Optional.empty());
+  }
+
+  // ===== Array Optics =====
+
+  /**
+   * Creates a traversal over all elements in an array.
+   *
+   * @param <E> the element type
+   * @return a traversal focusing on all array elements
+   */
+  public static <E> Traversal<E[], E> arrayElements() {
+    return new Traversal<>() {
+      @Override
+      @SuppressWarnings("unchecked")
+      public <F> Kind<F, E[]> modifyF(Function<E, Kind<F, E>> f, E[] source, Applicative<F> app) {
+        if (source.length == 0) {
+          return app.of(source);
+        }
+
+        // Start with the first element wrapped in a list
+        Kind<F, List<E>> result = app.map(List::of, f.apply(source[0]));
+
+        // Combine with remaining elements
+        for (int i = 1; i < source.length; i++) {
+          Kind<F, E> modifiedElement = f.apply(source[i]);
+          result = app.map2(result, modifiedElement, FocusPaths::appendToList);
+        }
+
+        // Convert back to array
+        return app.map(
+            list ->
+                list.toArray(
+                    (E[])
+                        java.lang.reflect.Array.newInstance(
+                            source.getClass().getComponentType(), list.size())),
+            result);
+      }
+    };
+  }
+
+  /**
+   * Creates an affine focusing on a specific index in an array.
+   *
+   * @param index the index to focus on
+   * @param <E> the element type
+   * @return an affine focusing on the element at the given index
+   */
+  public static <E> Affine<E[], E> arrayAt(int index) {
+    return Affine.of(
+        arr -> (index >= 0 && index < arr.length) ? Optional.of(arr[index]) : Optional.empty(),
+        (arr, element) -> {
+          if (index >= 0 && index < arr.length) {
+            E[] result = arr.clone();
+            result[index] = element;
+            return result;
+          }
+          return arr;
+        });
+  }
+
+  // ===== Helper Methods =====
+
+  private static <E> List<E> appendToList(List<E> list, E element) {
+    List<E> result = new ArrayList<>(list);
+    result.add(element);
+    return result;
+  }
+
+  private static <K, V> Map<K, V> putInMap(Map<K, V> map, K key, V value) {
+    Map<K, V> result = new HashMap<>(map);
+    result.put(key, value);
+    return result;
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/LensFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/LensFocusPath.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.Objects;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Implementation of {@link FocusPath} backed by a {@link Lens}.
+ *
+ * <p>This class is package-private and should be created via {@link FocusPath#of(Lens)}.
+ *
+ * @param <S> the source type
+ * @param <A> the focused type
+ */
+@NullMarked
+record LensFocusPath<S, A>(Lens<S, A> lens) implements FocusPath<S, A> {
+
+  LensFocusPath {
+    Objects.requireNonNull(lens, "lens must not be null");
+  }
+
+  @Override
+  public A get(S source) {
+    return lens.get(source);
+  }
+
+  @Override
+  public S set(A value, S source) {
+    return lens.set(value, source);
+  }
+
+  // ===== Composition Methods =====
+
+  @Override
+  public <B> FocusPath<S, B> via(Lens<A, B> other) {
+    return new LensFocusPath<>(lens.andThen(other));
+  }
+
+  @Override
+  public <B> FocusPath<S, B> via(Iso<A, B> iso) {
+    return new LensFocusPath<>(lens.andThen(iso));
+  }
+
+  @Override
+  public <B> AffinePath<S, B> via(Prism<A, B> prism) {
+    return new AffineFocusPath<>(lens.andThen(prism));
+  }
+
+  @Override
+  public <B> AffinePath<S, B> via(Affine<A, B> affine) {
+    return new AffineFocusPath<>(lens.andThen(affine));
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Traversal<A, B> traversal) {
+    return new TraversalFocusPath<>(lens.andThen(traversal));
+  }
+
+  // ===== Conversion =====
+
+  @Override
+  public Lens<S, A> toLens() {
+    return lens;
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TracedTraversalFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TracedTraversalFocusPath.java
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A traced implementation of {@link TraversalPath} that invokes an observer during get operations.
+ *
+ * <p>This class wraps an underlying TraversalPath and adds tracing behavior to the {@link
+ * #getAll(Object)} method. The observer is only invoked during get operations, not during modify
+ * operations.
+ *
+ * @param <S> the source type
+ * @param <A> the focused type
+ */
+@NullMarked
+record TracedTraversalFocusPath<S, A>(
+    TraversalPath<S, A> underlying, BiConsumer<S, List<A>> observer)
+    implements TraversalPath<S, A> {
+
+  TracedTraversalFocusPath {
+    Objects.requireNonNull(underlying, "underlying must not be null");
+    Objects.requireNonNull(observer, "observer must not be null");
+  }
+
+  @Override
+  public List<A> getAll(S source) {
+    List<A> result = underlying.getAll(source);
+    observer.accept(source, result);
+    return result;
+  }
+
+  @Override
+  public S setAll(A value, S source) {
+    return underlying.setAll(value, source);
+  }
+
+  @Override
+  public S modifyAll(Function<A, A> f, S source) {
+    return underlying.modifyAll(f, source);
+  }
+
+  @Override
+  public TraversalPath<S, A> filter(Predicate<A> predicate) {
+    return underlying.filter(predicate);
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Lens<A, B> lens) {
+    return underlying.via(lens);
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Prism<A, B> prism) {
+    return underlying.via(prism);
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Affine<A, B> affine) {
+    return underlying.via(affine);
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Traversal<A, B> traversal) {
+    return underlying.via(traversal);
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Iso<A, B> iso) {
+    return underlying.via(iso);
+  }
+
+  @Override
+  public Traversal<S, A> toTraversal() {
+    return underlying.toTraversal();
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalFocusPath.java
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Implementation of {@link TraversalPath} backed by a {@link Traversal}.
+ *
+ * <p>This class is package-private and should be created via {@link TraversalPath#of(Traversal)}.
+ *
+ * @param <S> the source type
+ * @param <A> the focused type
+ */
+@NullMarked
+record TraversalFocusPath<S, A>(Traversal<S, A> traversal) implements TraversalPath<S, A> {
+
+  TraversalFocusPath {
+    Objects.requireNonNull(traversal, "traversal must not be null");
+  }
+
+  @Override
+  public List<A> getAll(S source) {
+    return Traversals.getAll(traversal, source);
+  }
+
+  @Override
+  public S setAll(A value, S source) {
+    return Traversals.modify(traversal, _ -> value, source);
+  }
+
+  @Override
+  public S modifyAll(Function<A, A> f, S source) {
+    return Traversals.modify(traversal, f, source);
+  }
+
+  @Override
+  public TraversalPath<S, A> filter(Predicate<A> predicate) {
+    return new TraversalFocusPath<>(traversal.filtered(predicate));
+  }
+
+  // ===== Composition Methods =====
+
+  @Override
+  public <B> TraversalPath<S, B> via(Lens<A, B> lens) {
+    return new TraversalFocusPath<>(traversal.andThen(lens));
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Prism<A, B> prism) {
+    return new TraversalFocusPath<>(traversal.andThen(prism));
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Affine<A, B> affine) {
+    // Traversal >>> Affine requires going through traversal composition
+    return new TraversalFocusPath<>(traversal.andThen(affine.asTraversal()));
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Traversal<A, B> other) {
+    return new TraversalFocusPath<>(traversal.andThen(other));
+  }
+
+  @Override
+  public <B> TraversalPath<S, B> via(Iso<A, B> iso) {
+    // Compose via lens view of the iso
+    Lens<A, B> lensView = Lens.of(iso::get, (a, b) -> iso.reverseGet(b));
+    return new TraversalFocusPath<>(traversal.andThen(lensView));
+  }
+
+  // ===== Conversion =====
+
+  @Override
+  public Traversal<S, A> toTraversal() {
+    return traversal;
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalPath.java
@@ -1,0 +1,651 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Traverse;
+import org.higherkindedj.hkt.constant.Const;
+import org.higherkindedj.hkt.constant.ConstApplicative;
+import org.higherkindedj.hkt.constant.ConstKind;
+import org.higherkindedj.hkt.constant.ConstKindHelper;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.TraverseTraversals;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A type-safe path through a data structure that focuses on zero or more elements.
+ *
+ * <p>TraversalPath wraps a {@link Traversal} and provides fluent navigation and composition
+ * methods. Use this when navigating to collections or when the path may focus on multiple values.
+ *
+ * <p>In the Focus DSL hierarchy, TraversalPath is the most general type:
+ *
+ * <pre>
+ *      FocusPath<S, A>     (exactly one element)
+ *            │
+ *      AffinePath<S, A>    (zero or one element)
+ *            │
+ *    TraversalPath<S, A>   (zero or more elements)
+ * </pre>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * // Navigate to all employees in a company
+ * TraversalPath<Company, Employee> employeesPath = CompanyFocus.departments().employees();
+ *
+ * // Get all values
+ * List<Employee> employees = employeesPath.getAll(company);
+ *
+ * // Get the first value
+ * Optional<Employee> first = employeesPath.preview(company);
+ *
+ * // Set all values to the same value
+ * Company updated = employeesPath.setAll(defaultEmployee, company);
+ *
+ * // Modify all values
+ * Company modified = employeesPath.modifyAll(Employee::promote, company);
+ *
+ * // Filter to specific elements
+ * TraversalPath<Company, Employee> seniors = employeesPath.filter(e -> e.age() > 50);
+ * }</pre>
+ *
+ * @param <S> the source type (the whole structure)
+ * @param <A> the focused value type (the parts)
+ * @see FocusPath for paths focusing on exactly one element
+ * @see AffinePath for paths focusing on zero or one element
+ * @see FocusPaths for utility methods and optics factories
+ */
+@NullMarked
+public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTraversalFocusPath {
+
+  /**
+   * Extracts all focused values from the source.
+   *
+   * @param source the source structure
+   * @return list of all focused values (may be empty)
+   */
+  List<A> getAll(S source);
+
+  /**
+   * Extracts the first focused value if any.
+   *
+   * @param source the source structure
+   * @return Optional containing the first value, or empty if no elements are focused
+   */
+  default Optional<A> preview(S source) {
+    List<A> all = getAll(source);
+    return all.isEmpty() ? Optional.empty() : Optional.of(all.get(0));
+  }
+
+  /**
+   * Creates a new source with all focused values replaced by the given value.
+   *
+   * @param value the new value for all focused elements
+   * @param source the source structure
+   * @return a new structure with all focused values updated
+   */
+  S setAll(A value, S source);
+
+  /**
+   * Creates a new source with all focused values transformed.
+   *
+   * @param f the transformation function
+   * @param source the source structure
+   * @return a new structure with all focused values modified
+   */
+  S modifyAll(Function<A, A> f, S source);
+
+  /**
+   * Counts the number of focused elements.
+   *
+   * @param source the source structure
+   * @return the number of focused elements
+   */
+  default int count(S source) {
+    return getAll(source).size();
+  }
+
+  /**
+   * Checks if the traversal focuses on no elements.
+   *
+   * @param source the source structure
+   * @return true if no elements are focused
+   */
+  default boolean isEmpty(S source) {
+    return getAll(source).isEmpty();
+  }
+
+  /**
+   * Checks if any focused element matches the predicate.
+   *
+   * @param predicate the condition to test
+   * @param source the source structure
+   * @return true if any element matches
+   */
+  default boolean exists(Predicate<A> predicate, S source) {
+    return getAll(source).stream().anyMatch(predicate);
+  }
+
+  /**
+   * Checks if all focused elements match the predicate.
+   *
+   * <p>Returns true if there are no focused elements (vacuously true).
+   *
+   * @param predicate the condition to test
+   * @param source the source structure
+   * @return true if all elements match (or there are no elements)
+   */
+  default boolean all(Predicate<A> predicate, S source) {
+    return getAll(source).stream().allMatch(predicate);
+  }
+
+  /**
+   * Finds the first focused element matching the predicate.
+   *
+   * @param predicate the condition to test
+   * @param source the source structure
+   * @return Optional containing the first matching element, or empty
+   */
+  default Optional<A> find(Predicate<A> predicate, S source) {
+    return getAll(source).stream().filter(predicate).findFirst();
+  }
+
+  // ===== Filtering =====
+
+  /**
+   * Creates a new TraversalPath that only focuses on elements matching the predicate.
+   *
+   * <p>Elements that don't match are preserved unchanged during modifications but excluded from
+   * queries like {@code getAll}.
+   *
+   * @param predicate the filter condition
+   * @return a new TraversalPath focusing only on matching elements
+   */
+  TraversalPath<S, A> filter(Predicate<A> predicate);
+
+  // ===== Composition Methods =====
+
+  /**
+   * Composes this path with a lens, producing a TraversalPath.
+   *
+   * <p>For each element this traversal focuses on, the lens focuses on a field of that element.
+   *
+   * @param lens the lens to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  <B> TraversalPath<S, B> via(Lens<A, B> lens);
+
+  /**
+   * Composes this path with a FocusPath.
+   *
+   * <p>This is a convenience method that extracts the lens from the other path. For each element
+   * this traversal focuses on, the FocusPath focuses on a field of that element.
+   *
+   * @param other the FocusPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  default <B> TraversalPath<S, B> via(FocusPath<A, B> other) {
+    return via(other.toLens());
+  }
+
+  /**
+   * Composes this path with an AffinePath.
+   *
+   * <p>This is a convenience method that extracts the affine from the other path. For each element
+   * this traversal focuses on, the AffinePath optionally focuses on a nested value.
+   *
+   * @param other the AffinePath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  default <B> TraversalPath<S, B> via(AffinePath<A, B> other) {
+    return via(other.toAffine().asTraversal());
+  }
+
+  /**
+   * Composes this path with another TraversalPath.
+   *
+   * <p>This is a convenience method that extracts the traversal from the other path. For each
+   * element this traversal focuses on, the other TraversalPath may focus on multiple nested
+   * elements.
+   *
+   * @param other the TraversalPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on all nested targets
+   */
+  default <B> TraversalPath<S, B> via(TraversalPath<A, B> other) {
+    return via(other.toTraversal());
+  }
+
+  /**
+   * Composes this path with a prism, producing a TraversalPath.
+   *
+   * <p>For each element this traversal focuses on, the prism optionally matches.
+   *
+   * @param prism the prism to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on matching elements
+   */
+  <B> TraversalPath<S, B> via(Prism<A, B> prism);
+
+  /**
+   * Composes this path with an affine, producing a TraversalPath.
+   *
+   * @param affine the affine to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  <B> TraversalPath<S, B> via(Affine<A, B> affine);
+
+  /**
+   * Composes this path with another traversal, producing a TraversalPath.
+   *
+   * @param traversal the traversal to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on all nested targets
+   */
+  <B> TraversalPath<S, B> via(Traversal<A, B> traversal);
+
+  /**
+   * Composes this path with an iso, producing a TraversalPath.
+   *
+   * @param iso the iso to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath with converted values
+   */
+  <B> TraversalPath<S, B> via(Iso<A, B> iso);
+
+  // ===== then() Aliases =====
+
+  /**
+   * Alias for {@link #via(Lens)}. Composes this path with a lens.
+   *
+   * <p>This method provides an alternative naming convention familiar to users of other optics
+   * libraries.
+   *
+   * @param lens the lens to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  default <B> TraversalPath<S, B> then(Lens<A, B> lens) {
+    return via(lens);
+  }
+
+  /**
+   * Alias for {@link #via(FocusPath)}. Composes this path with a FocusPath.
+   *
+   * @param other the FocusPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  default <B> TraversalPath<S, B> then(FocusPath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Prism)}. Composes this path with a prism.
+   *
+   * @param prism the prism to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on matching elements
+   */
+  default <B> TraversalPath<S, B> then(Prism<A, B> prism) {
+    return via(prism);
+  }
+
+  /**
+   * Alias for {@link #via(Affine)}. Composes this path with an affine.
+   *
+   * @param affine the affine to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  default <B> TraversalPath<S, B> then(Affine<A, B> affine) {
+    return via(affine);
+  }
+
+  /**
+   * Alias for {@link #via(AffinePath)}. Composes this path with an AffinePath.
+   *
+   * @param other the AffinePath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on the composed targets
+   */
+  default <B> TraversalPath<S, B> then(AffinePath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Traversal)}. Composes this path with a traversal.
+   *
+   * @param traversal the traversal to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on all nested targets
+   */
+  default <B> TraversalPath<S, B> then(Traversal<A, B> traversal) {
+    return via(traversal);
+  }
+
+  /**
+   * Alias for {@link #via(TraversalPath)}. Composes this path with another TraversalPath.
+   *
+   * @param other the TraversalPath to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath focusing on all nested targets
+   */
+  default <B> TraversalPath<S, B> then(TraversalPath<A, B> other) {
+    return via(other);
+  }
+
+  /**
+   * Alias for {@link #via(Iso)}. Composes this path with an iso.
+   *
+   * @param iso the iso to compose with
+   * @param <B> the new focused type
+   * @return a TraversalPath with converted values
+   */
+  default <B> TraversalPath<S, B> then(Iso<A, B> iso) {
+    return via(iso);
+  }
+
+  // ===== Conditional Modification =====
+
+  /**
+   * Modifies only elements that satisfy the given predicate.
+   *
+   * <p>Elements that don't match the predicate are left unchanged. This is a convenience method
+   * combining {@link #filter(Predicate)} with {@link #modifyAll(Function, Object)}.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Give raises only to senior employees
+   * Company updated = CompanyFocus.employees()
+   *     .modifyWhen(
+   *         e -> e.yearsOfService() > 5,
+   *         e -> e.withSalary(e.salary() * 1.1),
+   *         company);
+   * }</pre>
+   *
+   * @param condition the predicate that elements must satisfy to be modified
+   * @param f the transformation function to apply to matching elements
+   * @param source the source structure
+   * @return a new structure with matching elements modified
+   */
+  default S modifyWhen(Predicate<A> condition, Function<A, A> f, S source) {
+    return modifyAll(a -> condition.test(a) ? f.apply(a) : a, source);
+  }
+
+  // ===== Effectful Operations =====
+
+  /**
+   * Transforms all focused values with an effectful function.
+   *
+   * <p>This method enables effectful modifications such as validation, async operations, or
+   * computations that may fail. The effects from all focused elements are combined using the
+   * applicative's sequencing.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Validate all employee emails
+   * TraversalPath<Company, String> emailsPath = CompanyFocus.employees().email();
+   *
+   * Kind<Validated.Witness, Company> result = emailsPath.modifyF(
+   *     email -> EmailValidator.validate(email),
+   *     company,
+   *     ValidatedApplicative.INSTANCE
+   * );
+   *
+   * // Async fetch for all items
+   * Kind<CompletableFutureKind.Witness, Order> result = orderItemsPath.modifyF(
+   *     item -> fetchUpdatedPrice(item),
+   *     order,
+   *     CompletableFutureApplicative.INSTANCE
+   * );
+   * }</pre>
+   *
+   * @param f the effectful transformation function
+   * @param source the source structure
+   * @param applicative the applicative instance for the effect type F
+   * @param <F> the effect type (e.g., Optional, Validated, IO)
+   * @return the modified structure wrapped in the effect
+   */
+  default <F> Kind<F, S> modifyF(Function<A, Kind<F, A>> f, S source, Applicative<F> applicative) {
+    return toTraversal().modifyF(f, source, applicative);
+  }
+
+  // ===== Monoid-based Aggregation =====
+
+  /**
+   * Maps each focused element to a monoidal value and combines them.
+   *
+   * <p>This is the fundamental operation for aggregating values from a traversal. Many common
+   * operations can be expressed in terms of foldMap with an appropriate monoid.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Sum all salaries
+   * TraversalPath<Company, Integer> salariesPath = CompanyFocus.employees().salary();
+   * int total = salariesPath.foldMap(Monoids.intSum(), s -> s, company);
+   *
+   * // Concatenate all names with separator
+   * String names = namesPath.foldMap(
+   *     Monoid.of("", (a, b) -> a.isEmpty() ? b : a + ", " + b),
+   *     Function.identity(),
+   *     source
+   * );
+   *
+   * // Check if any element matches
+   * boolean hasAdmin = rolesPath.foldMap(
+   *     Monoids.booleanOr(),
+   *     role -> role.equals("admin"),
+   *     user
+   * );
+   * }</pre>
+   *
+   * @param monoid the monoid for combining mapped values
+   * @param f the function to map each element to a monoidal value
+   * @param source the source structure
+   * @param <M> the monoidal result type
+   * @return the combined result of mapping all focused elements
+   */
+  default <M> M foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f, S source) {
+    return asFold().foldMap(monoid, f, source);
+  }
+
+  /**
+   * Reduces all focused elements using a monoid.
+   *
+   * <p>This is equivalent to {@code foldMap(monoid, Function.identity(), source)}.
+   *
+   * @param monoid the monoid for combining elements
+   * @param source the source structure
+   * @return the combined result of all focused elements
+   */
+  default A fold(Monoid<A> monoid, S source) {
+    return foldMap(monoid, Function.identity(), source);
+  }
+
+  // ===== Collection Navigation =====
+
+  /**
+   * When each focused element is a {@code List<E>}, flattens to traverse all nested elements.
+   *
+   * @param <E> the element type of the nested lists
+   * @return a TraversalPath over all nested list elements
+   */
+  @SuppressWarnings("unchecked")
+  default <E> TraversalPath<S, E> each() {
+    return via((Traversal<A, E>) FocusPaths.listElements());
+  }
+
+  /**
+   * When each focused element is a {@code List<E>}, focuses on elements at the specified index.
+   *
+   * @param index the index to focus on in each list
+   * @param <E> the element type of the lists
+   * @return a TraversalPath focusing on elements at the index (skipping lists that are too short)
+   */
+  @SuppressWarnings("unchecked")
+  default <E> TraversalPath<S, E> at(int index) {
+    // Compose with affine, which gives us a Traversal (Traversal >>> Affine = Traversal)
+    Affine<A, E> indexAffine = (Affine<A, E>) FocusPaths.listAt(index);
+    return via(indexAffine.asTraversal());
+  }
+
+  /**
+   * When each focused element is a {@code Map<K, V>}, focuses on values at the specified key.
+   *
+   * @param key the key to look up in each map
+   * @param <K> the key type
+   * @param <V> the value type
+   * @return a TraversalPath focusing on values at the key (skipping maps without the key)
+   */
+  @SuppressWarnings("unchecked")
+  default <K, V> TraversalPath<S, V> atKey(K key) {
+    Affine<A, V> keyAffine = (Affine<A, V>) FocusPaths.mapAt(key);
+    return via(keyAffine.asTraversal());
+  }
+
+  /**
+   * When each focused element is {@code Optional<E>}, flattens to focus on present values.
+   *
+   * @param <E> the inner type of the Optionals
+   * @return a TraversalPath over present Optional values
+   */
+  @SuppressWarnings("unchecked")
+  default <E> TraversalPath<S, E> some() {
+    Affine<A, E> someAffine = (Affine<A, E>) FocusPaths.optionalSome();
+    return via(someAffine.asTraversal());
+  }
+
+  /**
+   * For each element this traversal focuses on, if that element is a traversable container {@code
+   * Kind<F, E>}, flattens to traverse all nested elements.
+   *
+   * <p>This enables generic traversal over any type with a {@link org.higherkindedj.hkt.Traverse}
+   * instance, not just {@code List}. For example, {@code Set}, {@code Tree}, or custom collections.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * // Given: Company with List<Department>, where each Department has Kind<ListKind.Witness, Employee>
+   * TraversalPath<Company, Kind<ListKind.Witness, Employee>> deptEmployeesPath =
+   *     CompanyFocus.departments().via(DepartmentFocus.employees());
+   *
+   * // Traverse into the nested Lists
+   * TraversalPath<Company, Employee> allEmployees = deptEmployeesPath.traverseOver(
+   *     ListTraverse.INSTANCE
+   * );
+   *
+   * // Now can operate on all employees across all departments
+   * List<Employee> employees = allEmployees.getAll(company);
+   * Company updated = allEmployees.modifyAll(Employee::giveRaise, company);
+   * }</pre>
+   *
+   * <p>For standard {@code List<E>} fields, prefer the {@link #each()} method which handles the
+   * conversion automatically.
+   *
+   * @param <F> the witness type of the traversable container
+   * @param <E> the element type within the container
+   * @param traverse the Traverse instance for the container type
+   * @return a TraversalPath focusing on all nested elements within each container
+   * @see #each() for simpler List traversal
+   * @see org.higherkindedj.optics.util.TraverseTraversals
+   */
+  @SuppressWarnings("unchecked")
+  default <F, E> TraversalPath<S, E> traverseOver(Traverse<F> traverse) {
+    Traversal<Kind<F, E>, E> traversal = TraverseTraversals.forTraverse(traverse);
+    return via((Traversal<A, E>) traversal);
+  }
+
+  // ===== Conversion Methods =====
+
+  /**
+   * Extracts the underlying traversal.
+   *
+   * @return the wrapped Traversal
+   */
+  Traversal<S, A> toTraversal();
+
+  /**
+   * Views this path as a Fold.
+   *
+   * <p>This method converts the underlying Traversal to a Fold using the Const applicative, which
+   * is the standard functional programming approach for this conversion.
+   *
+   * @return a Fold view of the underlying traversal
+   */
+  default Fold<S, A> asFold() {
+    Traversal<S, A> traversal = toTraversal();
+    return new Fold<>() {
+      @Override
+      public <M> M foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f, S source) {
+        ConstApplicative<M> constApp = new ConstApplicative<>(monoid);
+        Kind<ConstKind.Witness<M>, S> result =
+            traversal.modifyF(
+                a -> ConstKindHelper.CONST.widen(new Const<>(f.apply(a))), source, constApp);
+        Const<M, S> finalConst = ConstKindHelper.CONST.narrow(result);
+        return finalConst.value();
+      }
+    };
+  }
+
+  // ===== Debugging =====
+
+  /**
+   * Creates a new TraversalPath that invokes an observer during get operations.
+   *
+   * <p>This method is useful for debugging complex path navigations by logging or inspecting values
+   * as they are accessed. The observer receives the source and the list of all focused values.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * TraversalPath<Company, Employee> debugPath = CompanyFocus.employees()
+   *     .traced((company, employees) ->
+   *         log.debug("Found {} employees in {}", employees.size(), company.name()));
+   *
+   * // Every getAll() call will now log the accessed values
+   * List<Employee> employees = debugPath.getAll(company);
+   * }</pre>
+   *
+   * @param observer a consumer that receives the source and all focused values during get
+   *     operations
+   * @return a new TraversalPath that invokes the observer
+   */
+  default TraversalPath<S, A> traced(BiConsumer<S, List<A>> observer) {
+    return new TracedTraversalFocusPath<>(this, observer);
+  }
+
+  // ===== Factory Methods =====
+
+  /**
+   * Creates a TraversalPath from a traversal.
+   *
+   * @param traversal the traversal to wrap
+   * @param <S> the source type
+   * @param <A> the focused type
+   * @return a new TraversalPath
+   */
+  static <S, A> TraversalPath<S, A> of(Traversal<S, A> traversal) {
+    return new TraversalFocusPath<>(traversal);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/package-info.java
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+/**
+ * Focus DSL for path-based optic navigation.
+ *
+ * <p>This package provides a fluent, type-safe DSL for navigating through nested data structures
+ * using optics. Instead of manually composing lenses, prisms, and traversals, you can use Focus
+ * paths to navigate with intuitive method chains that mirror the shape of your data.
+ *
+ * <h2>Core Types</h2>
+ *
+ * <p>The Focus DSL provides three path types, corresponding to the optic hierarchy:
+ *
+ * <ul>
+ *   <li>{@link org.higherkindedj.optics.focus.FocusPath} - wraps a {@link
+ *       org.higherkindedj.optics.Lens}, focusing on exactly one element
+ *   <li>{@link org.higherkindedj.optics.focus.AffinePath} - wraps an {@link
+ *       org.higherkindedj.optics.Affine}, focusing on zero or one element
+ *   <li>{@link org.higherkindedj.optics.focus.TraversalPath} - wraps a {@link
+ *       org.higherkindedj.optics.Traversal}, focusing on zero or more elements
+ * </ul>
+ *
+ * <h2>Quick Start</h2>
+ *
+ * <pre>{@code
+ * // Given generated Focus classes
+ * @GenerateLenses
+ * @GenerateFocus
+ * record Company(String name, List<Department> departments) {}
+ *
+ * // Navigate through the structure
+ * List<String> employeeNames = CompanyFocus
+ *     .departments()           // TraversalPath<Company, Department>
+ *     .employees()             // TraversalPath<Company, Employee>
+ *     .name()                  // TraversalPath<Company, String>
+ *     .getAll(company);
+ *
+ * // Modify all values
+ * Company updated = CompanyFocus.departments().employees().name()
+ *     .modifyAll(String::toUpperCase, company);
+ * }</pre>
+ *
+ * <h2>Collection Navigation</h2>
+ *
+ * <p>Focus paths provide methods for navigating collections:
+ *
+ * <ul>
+ *   <li>{@code each()} - traverse all elements in a List, Set, or array
+ *   <li>{@code at(int)} - focus on a single element by index
+ *   <li>{@code atKey(K)} - focus on a map value by key
+ *   <li>{@code some()} - unwrap an Optional value
+ *   <li>{@code traverseOver(Traverse)} - traverse Kind-wrapped collections using Traverse type
+ *       class
+ * </ul>
+ *
+ * <h2>Type Class Integration</h2>
+ *
+ * <p>The Focus DSL integrates with higher-kinded-j type classes:
+ *
+ * <ul>
+ *   <li><b>Effectful Operations</b> - Use {@code modifyF()} with any Applicative for validation,
+ *       async operations, or other effects
+ *   <li><b>Monoid Aggregation</b> - Use {@code foldMap()} on TraversalPath to aggregate values
+ *       using a Monoid
+ *   <li><b>Traverse Support</b> - Use {@code traverseOver()} to navigate into Kind-wrapped
+ *       collections
+ * </ul>
+ *
+ * <pre>{@code
+ * // Effectful modification with Maybe (MaybeMonad extends Applicative)
+ * Kind<MaybeKind.Witness, Config> result = configPath.modifyF(
+ *     key -> validateApiKey(key),  // Returns Maybe
+ *     config,
+ *     MaybeMonad.INSTANCE
+ * );
+ *
+ * // Aggregate with Monoid
+ * int totalSalary = employeesPath.via(salaryLens).foldMap(
+ *     Monoids.intSum(),
+ *     salary -> salary,
+ *     company
+ * );
+ *
+ * // Traverse Kind-wrapped collection
+ * TraversalPath<User, Role> allRoles = rolesPath
+ *     .<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+ * }</pre>
+ *
+ * <h2>Conditional and Sum Type Support</h2>
+ *
+ * <ul>
+ *   <li><b>Conditional Modification</b> - Use {@code modifyWhen()} to update only elements matching
+ *       a predicate
+ *   <li><b>Sum Types</b> - Use {@code AffinePath.instanceOf()} to focus on specific variants of
+ *       sealed interfaces
+ * </ul>
+ *
+ * <pre>{@code
+ * // Conditional modification
+ * Company updated = employeesPath.modifyWhen(
+ *     e -> e.yearsOfService() > 5,
+ *     Employee::promote,
+ *     company
+ * );
+ *
+ * // Sum type navigation
+ * TraversalPath<Drawing, Circle> circles = shapesPath
+ *     .via(AffinePath.instanceOf(Circle.class));
+ * }</pre>
+ *
+ * <h2>Debugging</h2>
+ *
+ * <p>Use {@code traced()} to observe path navigation:
+ *
+ * <pre>{@code
+ * TraversalPath<Company, Employee> traced = employeesPath.traced(
+ *     (company, employees) -> System.out.println("Found " + employees.size() + " employees")
+ * );
+ * }</pre>
+ *
+ * <h2>Composition</h2>
+ *
+ * <p>Focus paths compose with existing optics via the {@code via()} method:
+ *
+ * <pre>{@code
+ * // Compose with an existing lens
+ * FocusPath<User, String> fullName = UserFocus.name().via(fullNameLens);
+ *
+ * // Compose with a prism (produces AffinePath)
+ * AffinePath<Shape, Circle> circle = ShapeFocus.value().via(circlePrism);
+ * }</pre>
+ *
+ * @see org.higherkindedj.optics.focus.FocusPath
+ * @see org.higherkindedj.optics.focus.AffinePath
+ * @see org.higherkindedj.optics.focus.TraversalPath
+ * @see org.higherkindedj.optics.focus.FocusPaths
+ * @see org.higherkindedj.optics.util.TraverseTraversals
+ */
+@NullMarked
+package org.higherkindedj.optics.focus;
+
+import org.jspecify.annotations.NullMarked;

--- a/hkj-core/src/main/java/org/higherkindedj/optics/util/TraverseTraversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/util/TraverseTraversals.java
@@ -1,0 +1,279 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Traverse;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.stream.StreamKind;
+import org.higherkindedj.hkt.stream.StreamTraverse;
+import org.higherkindedj.optics.Traversal;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Utility class providing {@link Traversal} instances derived from {@link Traverse} type class
+ * instances.
+ *
+ * <p>This class bridges the Traverse type class with the optics Traversal, enabling generic
+ * collection manipulation through optics for any type with a Traverse instance.
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>{@code
+ * // Create a Traversal for List elements
+ * Traversal<Kind<ListKind.Witness, String>, String> listTraversal =
+ *     TraverseTraversals.forTraverse(ListTraverse.INSTANCE);
+ *
+ * // Use convenience methods for common types
+ * Traversal<Maybe<String>, String> maybeTraversal = TraverseTraversals.forMaybe();
+ *
+ * // Compose with other optics
+ * FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = UserFocus.roles();
+ * TraversalPath<User, Role> allRoles = rolesPath.traverseOver(
+ *     ListTraverse.INSTANCE,
+ *     ListKindHelper.LIST
+ * );
+ * }</pre>
+ *
+ * @see Traverse
+ * @see Traversal
+ */
+@NullMarked
+public final class TraverseTraversals {
+
+  /** Private constructor to prevent instantiation. */
+  private TraverseTraversals() {}
+
+  /**
+   * Creates a {@link Traversal} for any type with a {@link Traverse} instance.
+   *
+   * <p>This is the fundamental bridge between the Traverse type class and optics Traversal. It
+   * allows any traversable container to be used with the optics composition API.
+   *
+   * <h2>Example</h2>
+   *
+   * <pre>{@code
+   * // For a custom Tree type with TreeTraverse instance
+   * Traverse<TreeKind.Witness> treeTraverse = TreeTraverse.INSTANCE;
+   *
+   * Traversal<Kind<TreeKind.Witness, String>, String> treeTraversal =
+   *     TraverseTraversals.forTraverse(treeTraverse);
+   *
+   * // Now use with optics
+   * Kind<TreeKind.Witness, String> tree = createTree();
+   * List<String> allValues = Traversals.getAll(treeTraversal, tree);
+   * }</pre>
+   *
+   * @param <F> the witness type of the traversable container
+   * @param <A> the element type within the container
+   * @param traverse the Traverse instance for the container type; must not be null
+   * @return a Traversal over the container's elements; never null
+   * @throws NullPointerException if traverse is null
+   */
+  public static <F, A> Traversal<Kind<F, A>, A> forTraverse(Traverse<F> traverse) {
+    Objects.requireNonNull(traverse, "traverse must not be null");
+
+    return new Traversal<>() {
+      @Override
+      public <G> Kind<G, Kind<F, A>> modifyF(
+          Function<A, Kind<G, A>> f, Kind<F, A> source, Applicative<G> applicative) {
+        // Use Traverse.traverse to map over elements with the effectful function
+        return traverse.traverse(applicative, f, source);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@link Traversal} for {@link List} elements using the standard List encoding.
+   *
+   * <p>This traversal focuses on all elements within a {@code Kind<ListKind.Witness, A>}. For
+   * working with raw {@code java.util.List}, use {@link ListTraversals#forList()} instead.
+   *
+   * <h2>Example</h2>
+   *
+   * <pre>{@code
+   * Kind<ListKind.Witness, String> names = ListKindHelper.LIST.widen(List.of("Alice", "Bob"));
+   *
+   * Traversal<Kind<ListKind.Witness, String>, String> traversal =
+   *     TraverseTraversals.forListKind();
+   *
+   * Kind<ListKind.Witness, String> upper = Traversals.modify(
+   *     traversal,
+   *     String::toUpperCase,
+   *     names
+   * );
+   * // ["ALICE", "BOB"]
+   * }</pre>
+   *
+   * @param <A> the element type within the list
+   * @return a Traversal over list elements; never null
+   */
+  public static <A> Traversal<Kind<ListKind.Witness, A>, A> forListKind() {
+    return forTraverse(ListTraverse.INSTANCE);
+  }
+
+  /**
+   * Creates a {@link Traversal} for {@link Maybe} values.
+   *
+   * <p>This traversal focuses on the value inside a {@code Maybe} when present (the {@code Just}
+   * case). When the {@code Maybe} is {@code Nothing}, the traversal has zero targets.
+   *
+   * <h2>Example</h2>
+   *
+   * <pre>{@code
+   * Maybe<String> present = Maybe.just("hello");
+   * Maybe<String> absent = Maybe.nothing();
+   *
+   * Traversal<Maybe<String>, String> traversal = TraverseTraversals.forMaybe();
+   *
+   * Maybe<String> modified = Traversals.modify(traversal, String::toUpperCase, present);
+   * // Maybe.just("HELLO")
+   *
+   * Maybe<String> unchanged = Traversals.modify(traversal, String::toUpperCase, absent);
+   * // Maybe.nothing()
+   * }</pre>
+   *
+   * @param <A> the element type within the Maybe
+   * @return a Traversal over Maybe's value when present; never null
+   */
+  public static <A> Traversal<Maybe<A>, A> forMaybe() {
+    return new Traversal<>() {
+      @Override
+      public <G> Kind<G, Maybe<A>> modifyF(
+          Function<A, Kind<G, A>> f, Maybe<A> source, Applicative<G> applicative) {
+        if (source.isJust()) {
+          return applicative.map(Maybe::just, f.apply(source.get()));
+        }
+        return applicative.of(source);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@link Traversal} for {@link Maybe} values using the Kind encoding.
+   *
+   * <p>This is the Kind-encoded version of {@link #forMaybe()}, useful when working with the
+   * higher-kinded type representation.
+   *
+   * @param <A> the element type within the Maybe
+   * @return a Traversal over Maybe's value when present; never null
+   */
+  public static <A> Traversal<Kind<MaybeKind.Witness, A>, A> forMaybeKind() {
+    return new Traversal<>() {
+      @Override
+      public <G> Kind<G, Kind<MaybeKind.Witness, A>> modifyF(
+          Function<A, Kind<G, A>> f,
+          Kind<MaybeKind.Witness, A> source,
+          Applicative<G> applicative) {
+        Maybe<A> maybe = MaybeKindHelper.MAYBE.narrow(source);
+        if (maybe.isJust()) {
+          return applicative.map(
+              a -> MaybeKindHelper.MAYBE.widen(Maybe.just(a)), f.apply(maybe.get()));
+        }
+        return applicative.of(source);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@link Traversal} for {@link Stream} elements using the Kind encoding.
+   *
+   * <p>This traversal focuses on all elements within a {@code Kind<StreamKind.Witness, A>}.
+   *
+   * <p><b>Note:</b> Streams are consumed during traversal, so the resulting stream can only be used
+   * once.
+   *
+   * @param <A> the element type within the stream
+   * @return a Traversal over stream elements; never null
+   */
+  public static <A> Traversal<Kind<StreamKind.Witness, A>, A> forStreamKind() {
+    return forTraverse(StreamTraverse.INSTANCE);
+  }
+
+  /**
+   * Creates a {@link Traversal} for {@link java.util.Set} elements.
+   *
+   * <p>This traversal focuses on all elements within a {@code Set<A>}. Since sets have no defined
+   * order, the traversal order may vary between invocations.
+   *
+   * <h2>Example</h2>
+   *
+   * <pre>{@code
+   * Set<String> names = Set.of("Alice", "Bob", "Charlie");
+   *
+   * Traversal<Set<String>, String> traversal = TraverseTraversals.forSet();
+   *
+   * Set<String> upper = Traversals.modify(traversal, String::toUpperCase, names);
+   * // Set.of("ALICE", "BOB", "CHARLIE")
+   * }</pre>
+   *
+   * @param <A> the element type within the set
+   * @return a Traversal over set elements; never null
+   */
+  public static <A> Traversal<Set<A>, A> forSet() {
+    return new Traversal<>() {
+      @Override
+      public <G> Kind<G, Set<A>> modifyF(
+          Function<A, Kind<G, A>> f, Set<A> source, Applicative<G> applicative) {
+        // Convert Set to List for traversal, then collect back to Set
+        List<A> asList = List.copyOf(source);
+        Kind<ListKind.Witness, A> listKind = ListKindHelper.LIST.widen(asList);
+
+        Kind<G, Kind<ListKind.Witness, A>> traversed =
+            ListTraverse.INSTANCE.traverse(applicative, f, listKind);
+
+        return applicative.map(
+            kindResult -> {
+              List<A> resultList = ListKindHelper.LIST.narrow(kindResult);
+              return Set.copyOf(resultList);
+            },
+            traversed);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@link Traversal} for {@link java.util.stream.Stream} elements.
+   *
+   * <p>This traversal focuses on all elements within a {@code Stream<A>}.
+   *
+   * <p><b>Warning:</b> Streams can only be consumed once. After using this traversal, the original
+   * stream will be exhausted. The result will be a new stream.
+   *
+   * @param <A> the element type within the stream
+   * @return a Traversal over stream elements; never null
+   */
+  public static <A> Traversal<Stream<A>, A> forStream() {
+    return new Traversal<>() {
+      @Override
+      public <G> Kind<G, Stream<A>> modifyF(
+          Function<A, Kind<G, A>> f, Stream<A> source, Applicative<G> applicative) {
+        // Collect stream to list (consuming it), traverse, then convert back to stream
+        List<A> asList = source.collect(Collectors.toList());
+        Kind<ListKind.Witness, A> listKind = ListKindHelper.LIST.widen(asList);
+
+        Kind<G, Kind<ListKind.Witness, A>> traversed =
+            ListTraverse.INSTANCE.traverse(applicative, f, listKind);
+
+        return applicative.map(
+            kindResult -> {
+              List<A> resultList = ListKindHelper.LIST.narrow(kindResult);
+              return resultList.stream();
+            },
+            traversed);
+      }
+    };
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/AffinePathTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/AffinePathTest.java
@@ -1,0 +1,367 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AffinePath<S, A> Tests")
+class AffinePathTest {
+
+  // Test Data Structures
+  record Config(Optional<Database> database) {}
+
+  record Database(String host, int port, Optional<String> username) {}
+
+  sealed interface Result permits Success, Failure {}
+
+  record Success(String value) implements Result {}
+
+  record Failure(String error) implements Result {}
+
+  @Nested
+  @DisplayName("Core Functionality")
+  class CoreFunctionality {
+
+    @Test
+    @DisplayName("of should create an AffinePath from an Affine")
+    void ofShouldCreateAffinePath() {
+      Affine<Optional<String>, String> someAffine = FocusPaths.optionalSome();
+      AffinePath<Optional<String>, String> path = AffinePath.of(someAffine);
+
+      assertThat(path).isNotNull();
+      assertThat(path.toAffine()).isSameAs(someAffine);
+    }
+
+    @Test
+    @DisplayName("getOptional should return value when present")
+    void getOptionalShouldReturnValueWhenPresent() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      assertThat(path.getOptional(Optional.of("hello"))).contains("hello");
+    }
+
+    @Test
+    @DisplayName("getOptional should return empty when absent")
+    void getOptionalShouldReturnEmptyWhenAbsent() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      assertThat(path.getOptional(Optional.empty())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("set should update value")
+    void setShouldUpdateValue() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      Optional<String> result = path.set("world", Optional.of("hello"));
+      assertThat(result).contains("world");
+
+      // Set on empty also works
+      Optional<String> fromEmpty = path.set("new", Optional.empty());
+      assertThat(fromEmpty).contains("new");
+    }
+
+    @Test
+    @DisplayName("modify should transform value when present")
+    void modifyShouldTransformWhenPresent() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      Optional<String> result = path.modify(String::toUpperCase, Optional.of("hello"));
+      assertThat(result).contains("HELLO");
+    }
+
+    @Test
+    @DisplayName("modify should return original when absent")
+    void modifyShouldReturnOriginalWhenAbsent() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      Optional<String> result = path.modify(String::toUpperCase, Optional.empty());
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("matches should return true when value present")
+    void matchesShouldReturnTrueWhenPresent() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      assertThat(path.matches(Optional.of("hello"))).isTrue();
+      assertThat(path.matches(Optional.empty())).isFalse();
+    }
+
+    @Test
+    @DisplayName("getOrElse should return value or default")
+    void getOrElseShouldReturnValueOrDefault() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      assertThat(path.getOrElse("default", Optional.of("hello"))).isEqualTo("hello");
+      assertThat(path.getOrElse("default", Optional.empty())).isEqualTo("default");
+    }
+
+    @Test
+    @DisplayName("mapOptional should transform and wrap in Optional")
+    void mapOptionalShouldTransformAndWrap() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+
+      assertThat(path.mapOptional(String::length, Optional.of("hello"))).contains(5);
+      assertThat(path.mapOptional(String::length, Optional.empty())).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Lens")
+  class CompositionWithLens {
+
+    @Test
+    @DisplayName("via(Lens) should produce an AffinePath")
+    void viaLensShouldProduceAffinePath() {
+      Lens<Config, Optional<Database>> dbLens = Lens.of(Config::database, (c, d) -> new Config(d));
+      Prism<Optional<Database>, Database> somePrism = Prism.of(opt -> opt, db -> Optional.of(db));
+
+      Lens<Database, String> hostLens =
+          Lens.of(Database::host, (db, h) -> new Database(h, db.port(), db.username()));
+
+      // Config -> Optional<Database> -> Database -> String
+      AffinePath<Config, Database> dbPath = FocusPath.of(dbLens).via(somePrism);
+      AffinePath<Config, String> hostPath = dbPath.via(hostLens);
+
+      Config withDb = new Config(Optional.of(new Database("localhost", 5432, Optional.empty())));
+      Config withoutDb = new Config(Optional.empty());
+
+      assertThat(hostPath.getOptional(withDb)).contains("localhost");
+      assertThat(hostPath.getOptional(withoutDb)).isEmpty();
+
+      Config updated = hostPath.set("127.0.0.1", withDb);
+      assertThat(updated.database().get().host()).isEqualTo("127.0.0.1");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Prism")
+  class CompositionWithPrism {
+
+    @Test
+    @DisplayName("via(Prism) should produce an AffinePath")
+    void viaPrismShouldProduceAffinePath() {
+      Prism<Result, String> successPrism =
+          Prism.of(
+              r -> r instanceof Success s ? Optional.of(s.value()) : Optional.empty(),
+              Success::new);
+      Prism<Optional<Result>, Result> somePrism = Prism.of(opt -> opt, r -> Optional.of(r));
+
+      AffinePath<Optional<Result>, Result> resultPath =
+          AffinePath.of(Affine.of(opt -> opt, (opt, r) -> Optional.of(r)));
+      AffinePath<Optional<Result>, String> valuePath = resultPath.via(successPrism);
+
+      Optional<Result> success = Optional.of(new Success("data"));
+      Optional<Result> failure = Optional.of(new Failure("error"));
+      Optional<Result> empty = Optional.empty();
+
+      assertThat(valuePath.getOptional(success)).contains("data");
+      assertThat(valuePath.getOptional(failure)).isEmpty();
+      assertThat(valuePath.getOptional(empty)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Affine")
+  class CompositionWithAffine {
+
+    @Test
+    @DisplayName("via(Affine) should compose two affines")
+    void viaAffineShouldComposeTwoAffines() {
+      Lens<Config, Optional<Database>> dbLens = Lens.of(Config::database, (c, d) -> new Config(d));
+      Affine<Optional<Database>, Database> dbAffine = FocusPaths.optionalSome();
+
+      Lens<Database, Optional<String>> usernameLens =
+          Lens.of(Database::username, (db, u) -> new Database(db.host(), db.port(), u));
+      Affine<Optional<String>, String> usernameAffine = FocusPaths.optionalSome();
+
+      // Config -> Optional<Database> -> Database -> Optional<String> -> String
+      AffinePath<Config, Database> dbPath = FocusPath.of(dbLens).via(dbAffine);
+      AffinePath<Config, Optional<String>> userOptPath = dbPath.via(usernameLens);
+      AffinePath<Config, String> usernamePath = userOptPath.via(usernameAffine);
+
+      Config withUser =
+          new Config(Optional.of(new Database("localhost", 5432, Optional.of("admin"))));
+      Config withoutUser =
+          new Config(Optional.of(new Database("localhost", 5432, Optional.empty())));
+      Config withoutDb = new Config(Optional.empty());
+
+      assertThat(usernamePath.getOptional(withUser)).contains("admin");
+      assertThat(usernamePath.getOptional(withoutUser)).isEmpty();
+      assertThat(usernamePath.getOptional(withoutDb)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Traversal")
+  class CompositionWithTraversal {
+
+    @Test
+    @DisplayName("via(Traversal) should produce a TraversalPath")
+    void viaTraversalShouldProduceTraversalPath() {
+      record Container(Optional<List<String>> items) {}
+
+      Lens<Container, Optional<List<String>>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+      Affine<Optional<List<String>>, List<String>> someAffine = FocusPaths.optionalSome();
+      Traversal<List<String>, String> listTraversal = Traversals.forList();
+
+      AffinePath<Container, List<String>> listPath = FocusPath.of(itemsLens).via(someAffine);
+      TraversalPath<Container, String> elementsPath = listPath.via(listTraversal);
+
+      Container withItems = new Container(Optional.of(List.of("a", "b", "c")));
+      Container withoutItems = new Container(Optional.empty());
+
+      assertThat(elementsPath.getAll(withItems)).containsExactly("a", "b", "c");
+      assertThat(elementsPath.getAll(withoutItems)).isEmpty();
+
+      Container modified = elementsPath.modifyAll(String::toUpperCase, withItems);
+      assertThat(modified.items().get()).containsExactly("A", "B", "C");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Iso")
+  class CompositionWithIso {
+
+    @Test
+    @DisplayName("via(Iso) should produce an AffinePath")
+    void viaIsoShouldProduceAffinePath() {
+      record Wrapper(String value) {}
+
+      Iso<String, Wrapper> wrapperIso = Iso.of(Wrapper::new, Wrapper::value);
+      AffinePath<Optional<String>, String> somePath = AffinePath.of(FocusPaths.optionalSome());
+      AffinePath<Optional<String>, Wrapper> wrappedPath = somePath.via(wrapperIso);
+
+      assertThat(wrappedPath.getOptional(Optional.of("hello")).map(Wrapper::value))
+          .contains("hello");
+      assertThat(wrappedPath.getOptional(Optional.empty())).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Collection Navigation")
+  class CollectionNavigation {
+
+    @Test
+    @DisplayName("each() should traverse optional list elements")
+    void eachShouldTraverseOptionalListElements() {
+      AffinePath<Optional<List<String>>, List<String>> listPath =
+          AffinePath.of(FocusPaths.optionalSome());
+      TraversalPath<Optional<List<String>>, String> elementsPath = listPath.each();
+
+      Optional<List<String>> present = Optional.of(List.of("a", "b"));
+      Optional<List<String>> empty = Optional.empty();
+
+      assertThat(elementsPath.getAll(present)).containsExactly("a", "b");
+      assertThat(elementsPath.getAll(empty)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("at(index) should focus on element in optional list")
+    void atShouldFocusOnElementInOptionalList() {
+      AffinePath<Optional<List<String>>, List<String>> listPath =
+          AffinePath.of(FocusPaths.optionalSome());
+      AffinePath<Optional<List<String>>, String> firstPath = listPath.at(0);
+
+      Optional<List<String>> present = Optional.of(List.of("a", "b"));
+      Optional<List<String>> emptyList = Optional.of(List.of());
+      Optional<List<String>> absent = Optional.empty();
+
+      assertThat(firstPath.getOptional(present)).contains("a");
+      assertThat(firstPath.getOptional(emptyList)).isEmpty();
+      assertThat(firstPath.getOptional(absent)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("some() should unwrap nested Optional")
+    void someShouldUnwrapNestedOptional() {
+      AffinePath<Optional<Optional<String>>, Optional<String>> outerPath =
+          AffinePath.of(FocusPaths.optionalSome());
+      AffinePath<Optional<Optional<String>>, String> innerPath = outerPath.some();
+
+      Optional<Optional<String>> full = Optional.of(Optional.of("value"));
+      Optional<Optional<String>> innerEmpty = Optional.of(Optional.empty());
+      Optional<Optional<String>> outerEmpty = Optional.empty();
+
+      assertThat(innerPath.getOptional(full)).contains("value");
+      assertThat(innerPath.getOptional(innerEmpty)).isEmpty();
+      assertThat(innerPath.getOptional(outerEmpty)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("atKey() should focus on map value by key")
+    void atKeyShouldFocusOnMapValue() {
+      AffinePath<Optional<Map<String, String>>, Map<String, String>> mapPath =
+          AffinePath.of(FocusPaths.optionalSome());
+      AffinePath<Optional<Map<String, String>>, String> themePath = mapPath.atKey("theme");
+
+      Optional<Map<String, String>> present =
+          Optional.of(Map.of("theme", "dark", "language", "en"));
+      Optional<Map<String, String>> missingKey = Optional.of(Map.of("language", "en"));
+      Optional<Map<String, String>> absent = Optional.empty();
+
+      assertThat(themePath.getOptional(present)).contains("dark");
+      assertThat(themePath.getOptional(missingKey)).isEmpty();
+      assertThat(themePath.getOptional(absent)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Conversion Methods")
+  class ConversionMethods {
+
+    @Test
+    @DisplayName("asTraversal should return a TraversalPath view")
+    void asTraversalShouldReturnTraversalPathView() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+      TraversalPath<Optional<String>, String> traversalPath = path.asTraversal();
+
+      assertThat(traversalPath.getAll(Optional.of("hello"))).containsExactly("hello");
+      assertThat(traversalPath.getAll(Optional.empty())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toAffine should return the underlying Affine")
+    void toAffineShouldReturnUnderlyingAffine() {
+      Affine<Optional<String>, String> affine = FocusPaths.optionalSome();
+      AffinePath<Optional<String>, String> path = AffinePath.of(affine);
+
+      assertThat(path.toAffine()).isSameAs(affine);
+    }
+
+    @Test
+    @DisplayName("asFold should return a Fold view")
+    void asFoldShouldReturnFoldView() {
+      AffinePath<Optional<String>, String> path = AffinePath.of(FocusPaths.optionalSome());
+      Fold<Optional<String>, String> fold = path.asFold();
+
+      // Use foldMap to verify the fold works
+      String result = fold.foldMap(Monoids.string(), s -> s, Optional.of("hello"));
+      assertThat(result).isEqualTo("hello");
+
+      String emptyResult = fold.foldMap(Monoids.string(), s -> s, Optional.empty());
+      assertThat(emptyResult).isEmpty();
+
+      // Preview should also work
+      assertThat(fold.preview(Optional.of("hello"))).contains("hello");
+      assertThat(fold.preview(Optional.empty())).isEmpty();
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathEnhancementsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathEnhancementsTest.java
@@ -1,0 +1,1479 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Focus DSL enhancements including:
+ *
+ * <ul>
+ *   <li>Simplified via() overloads accepting path types
+ *   <li>then() aliases for via()
+ *   <li>instanceOf() for sum type support
+ *   <li>modifyF() effectful operations
+ *   <li>modifyWhen() conditional modification
+ *   <li>foldMap() Monoid integration
+ * </ul>
+ */
+@DisplayName("Focus DSL Enhancements")
+class FocusPathEnhancementsTest {
+
+  // Test domain types
+  record Person(String name, int age, Address address) {}
+
+  record Address(String street, String city) {}
+
+  record Team(String name, List<Person> members) {}
+
+  record Config(Optional<String> apiKey) {}
+
+  sealed interface Shape permits Circle, Rectangle {}
+
+  record Circle(double radius) implements Shape {}
+
+  record Rectangle(double width, double height) implements Shape {}
+
+  record Drawing(List<Shape> shapes) {}
+
+  // Lenses for test domain
+  static final Lens<Person, String> personNameLens =
+      Lens.of(Person::name, (p, n) -> new Person(n, p.age(), p.address()));
+
+  static final Lens<Person, Address> personAddressLens =
+      Lens.of(Person::address, (p, a) -> new Person(p.name(), p.age(), a));
+
+  static final Lens<Address, String> addressCityLens =
+      Lens.of(Address::city, (a, c) -> new Address(a.street(), c));
+
+  static final Lens<Address, String> addressStreetLens =
+      Lens.of(Address::street, (a, s) -> new Address(s, a.city()));
+
+  static final Lens<Team, List<Person>> teamMembersLens =
+      Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+  static final Lens<Person, Integer> personAgeLens =
+      Lens.of(Person::age, (p, a) -> new Person(p.name(), a, p.address()));
+
+  @Nested
+  @DisplayName("Simplified via() Overloads")
+  class ViaOverloadsTests {
+
+    @Test
+    @DisplayName("FocusPath.via(FocusPath) should compose paths without toLens()")
+    void focusPathViaFocusPath() {
+      FocusPath<Person, Address> addressPath = FocusPath.of(personAddressLens);
+      FocusPath<Address, String> cityPath = FocusPath.of(addressCityLens);
+
+      // Using via(FocusPath) directly instead of via(path.toLens())
+      FocusPath<Person, String> personCityPath = addressPath.via(cityPath);
+
+      Person person = new Person("Alice", 30, new Address("123 Main St", "London"));
+      assertThat(personCityPath.get(person)).isEqualTo("London");
+
+      Person updated = personCityPath.set("Paris", person);
+      assertThat(updated.address().city()).isEqualTo("Paris");
+    }
+
+    @Test
+    @DisplayName("FocusPath.via(AffinePath) should produce AffinePath")
+    void focusPathViaAffinePath() {
+      FocusPath<Config, Optional<String>> apiKeyOptPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k)));
+      AffinePath<Optional<String>, String> somePath = AffinePath.of(FocusPaths.optionalSome());
+
+      // Using via(AffinePath) directly
+      AffinePath<Config, String> apiKeyPath = apiKeyOptPath.via(somePath);
+
+      Config withKey = new Config(Optional.of("secret-123"));
+      Config withoutKey = new Config(Optional.empty());
+
+      assertThat(apiKeyPath.getOptional(withKey)).contains("secret-123");
+      assertThat(apiKeyPath.getOptional(withoutKey)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FocusPath.via(TraversalPath) should produce TraversalPath")
+    void focusPathViaTraversalPath() {
+      FocusPath<Team, List<Person>> membersPath = FocusPath.of(teamMembersLens);
+      TraversalPath<List<Person>, Person> allPath = TraversalPath.of(FocusPaths.listElements());
+
+      // Using via(TraversalPath) directly
+      TraversalPath<Team, Person> teamMembersPath = membersPath.via(allPath);
+
+      Team team =
+          new Team(
+              "Engineering",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      assertThat(teamMembersPath.getAll(team)).hasSize(2);
+      assertThat(teamMembersPath.getAll(team).stream().map(Person::name))
+          .containsExactly("Alice", "Bob");
+    }
+
+    @Test
+    @DisplayName("AffinePath.via(FocusPath) should compose correctly")
+    void affinePathViaFocusPath() {
+      Lens<Config, Optional<String>> apiKeyOptLens =
+          Lens.of(Config::apiKey, (c, k) -> new Config(k));
+      AffinePath<Config, String> apiKeyPath = FocusPath.of(apiKeyOptLens).some();
+
+      // Create a trivial FocusPath for String manipulation
+      FocusPath<String, String> identityPath = FocusPath.identity();
+
+      AffinePath<Config, String> composedPath = apiKeyPath.via(identityPath);
+
+      Config withKey = new Config(Optional.of("secret"));
+      assertThat(composedPath.getOptional(withKey)).contains("secret");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.via(FocusPath) should compose correctly")
+    void traversalPathViaFocusPath() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+
+      // Using via(FocusPath) directly
+      TraversalPath<Team, String> namesPath = membersPath.via(namePath);
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      assertThat(namesPath.getAll(team)).containsExactly("Alice", "Bob");
+    }
+  }
+
+  @Nested
+  @DisplayName("then() Aliases")
+  class ThenAliasesTests {
+
+    @Test
+    @DisplayName("FocusPath.then(Lens) should work like via(Lens)")
+    void focusPathThenLens() {
+      FocusPath<Person, Address> addressPath = FocusPath.of(personAddressLens);
+
+      FocusPath<Person, String> viaResult = addressPath.via(addressCityLens);
+      FocusPath<Person, String> thenResult = addressPath.then(addressCityLens);
+
+      Person person = new Person("Alice", 30, new Address("Main", "London"));
+
+      assertThat(viaResult.get(person)).isEqualTo(thenResult.get(person));
+      assertThat(viaResult.set("Paris", person)).isEqualTo(thenResult.set("Paris", person));
+    }
+
+    @Test
+    @DisplayName("FocusPath.then(FocusPath) should work like via(FocusPath)")
+    void focusPathThenFocusPath() {
+      FocusPath<Person, Address> addressPath = FocusPath.of(personAddressLens);
+      FocusPath<Address, String> cityPath = FocusPath.of(addressCityLens);
+
+      FocusPath<Person, String> viaResult = addressPath.via(cityPath);
+      FocusPath<Person, String> thenResult = addressPath.then(cityPath);
+
+      Person person = new Person("Bob", 25, new Address("Oak", "Berlin"));
+
+      assertThat(viaResult.get(person)).isEqualTo(thenResult.get(person));
+    }
+
+    @Test
+    @DisplayName("AffinePath.then() should work as alias for via()")
+    void affinePathThen() {
+      AffinePath<Config, String> apiKeyPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k))).some();
+
+      FocusPath<String, String> identityPath = FocusPath.identity();
+
+      AffinePath<Config, String> viaResult = apiKeyPath.via(identityPath);
+      AffinePath<Config, String> thenResult = apiKeyPath.then(identityPath);
+
+      Config config = new Config(Optional.of("key123"));
+
+      assertThat(viaResult.getOptional(config)).isEqualTo(thenResult.getOptional(config));
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then() should work as alias for via()")
+    void traversalPathThen() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      TraversalPath<Team, String> viaResult = membersPath.via(personNameLens);
+      TraversalPath<Team, String> thenResult = membersPath.then(personNameLens);
+
+      Team team =
+          new Team(
+              "QA",
+              List.of(
+                  new Person("Carol", 35, new Address("C", "Z")),
+                  new Person("Dave", 40, new Address("D", "W"))));
+
+      assertThat(viaResult.getAll(team)).isEqualTo(thenResult.getAll(team));
+    }
+  }
+
+  @Nested
+  @DisplayName("instanceOf() for Sum Types")
+  class InstanceOfTests {
+
+    @Test
+    @DisplayName("instanceOf should focus on matching subclass")
+    void instanceOfMatchingSubclass() {
+      AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+
+      Shape circle = new Circle(5.0);
+      Shape rectangle = new Rectangle(3.0, 4.0);
+
+      assertThat(circlePath.getOptional(circle)).contains(new Circle(5.0));
+      assertThat(circlePath.getOptional(rectangle)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("instanceOf should allow setting (replacing) the value")
+    void instanceOfSetting() {
+      AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+
+      Shape circle = new Circle(5.0);
+      Shape updated = circlePath.set(new Circle(10.0), circle);
+
+      assertThat(updated).isEqualTo(new Circle(10.0));
+    }
+
+    @Test
+    @DisplayName("instanceOf should work with matches()")
+    void instanceOfMatches() {
+      AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+      AffinePath<Shape, Rectangle> rectanglePath = AffinePath.instanceOf(Rectangle.class);
+
+      Shape circle = new Circle(5.0);
+
+      assertThat(circlePath.matches(circle)).isTrue();
+      assertThat(rectanglePath.matches(circle)).isFalse();
+    }
+
+    @Test
+    @DisplayName("instanceOf should compose with further paths")
+    void instanceOfComposition() {
+      Lens<Circle, Double> radiusLens = Lens.of(Circle::radius, (c, r) -> new Circle(r));
+
+      AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+      AffinePath<Shape, Double> radiusPath = circlePath.via(radiusLens);
+
+      Shape circle = new Circle(5.0);
+      Shape rectangle = new Rectangle(3.0, 4.0);
+
+      assertThat(radiusPath.getOptional(circle)).contains(5.0);
+      assertThat(radiusPath.getOptional(rectangle)).isEmpty();
+
+      Shape updatedCircle = radiusPath.set(7.5, circle);
+      assertThat(((Circle) updatedCircle).radius()).isEqualTo(7.5);
+    }
+
+    @Test
+    @DisplayName("instanceOf should work with TraversalPath over sealed types")
+    void instanceOfWithTraversal() {
+      Lens<Drawing, List<Shape>> shapesLens = Lens.of(Drawing::shapes, (d, s) -> new Drawing(s));
+
+      TraversalPath<Drawing, Shape> allShapes = FocusPath.of(shapesLens).each();
+      AffinePath<Shape, Circle> circlePath = AffinePath.instanceOf(Circle.class);
+
+      // Compose traversal with instanceOf
+      TraversalPath<Drawing, Circle> allCircles =
+          allShapes.via(circlePath.toAffine().asTraversal());
+
+      Drawing drawing =
+          new Drawing(
+              List.of(new Circle(1.0), new Rectangle(2.0, 3.0), new Circle(4.0), new Circle(5.0)));
+
+      List<Circle> circles = allCircles.getAll(drawing);
+      assertThat(circles).hasSize(3);
+      assertThat(circles.stream().map(Circle::radius)).containsExactly(1.0, 4.0, 5.0);
+    }
+  }
+
+  @Nested
+  @DisplayName("modifyF() Effectful Operations")
+  class ModifyFTests {
+
+    @Test
+    @DisplayName("FocusPath.modifyF should work with Maybe functor")
+    void focusPathModifyFWithMaybe() {
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+      Person person = new Person("Alice", 30, new Address("Main", "London"));
+
+      // Effectful modification: uppercase if not empty
+      Function<String, Kind<MaybeKind.Witness, String>> upperIfNotEmpty =
+          s ->
+              s.isEmpty()
+                  ? MaybeKindHelper.MAYBE.widen(Maybe.nothing())
+                  : MaybeKindHelper.MAYBE.widen(Maybe.just(s.toUpperCase()));
+
+      Kind<MaybeKind.Witness, Person> result =
+          namePath.modifyF(upperIfNotEmpty, person, MaybeMonad.INSTANCE);
+
+      Maybe<Person> maybePerson = MaybeKindHelper.MAYBE.narrow(result);
+      assertThat(maybePerson.isJust()).isTrue();
+      assertThat(maybePerson.orElse(null).name()).isEqualTo("ALICE");
+    }
+
+    @Test
+    @DisplayName("AffinePath.modifyF should return source unchanged when no focus")
+    void affinePathModifyFNoFocus() {
+      AffinePath<Config, String> apiKeyPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k))).some();
+
+      Config withoutKey = new Config(Optional.empty());
+
+      Function<String, Kind<MaybeKind.Witness, String>> transform =
+          s -> MaybeKindHelper.MAYBE.widen(Maybe.just(s.toUpperCase()));
+
+      Kind<MaybeKind.Witness, Config> result =
+          apiKeyPath.modifyF(transform, withoutKey, MaybeMonad.INSTANCE);
+
+      Maybe<Config> maybeConfig = MaybeKindHelper.MAYBE.narrow(result);
+      assertThat(maybeConfig.isJust()).isTrue();
+      assertThat(maybeConfig.orElse(null).apiKey()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TraversalPath.modifyF should sequence effects across elements")
+    void traversalPathModifyFSequencesEffects() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      // Increment age wrapped in Maybe
+      Function<Person, Kind<MaybeKind.Witness, Person>> incrementAge =
+          p ->
+              MaybeKindHelper.MAYBE.widen(
+                  Maybe.just(new Person(p.name(), p.age() + 1, p.address())));
+
+      Kind<MaybeKind.Witness, Team> result =
+          membersPath.modifyF(incrementAge, team, MaybeMonad.INSTANCE);
+
+      Maybe<Team> maybeTeam = MaybeKindHelper.MAYBE.narrow(result);
+      assertThat(maybeTeam.isJust()).isTrue();
+
+      Team updatedTeam = maybeTeam.orElse(null);
+      assertThat(updatedTeam.members().stream().map(Person::age)).containsExactly(31, 26);
+    }
+  }
+
+  @Nested
+  @DisplayName("modifyWhen() Conditional Modification")
+  class ModifyWhenTests {
+
+    @Test
+    @DisplayName("modifyWhen should only modify elements matching predicate")
+    void modifyWhenOnlyModifiesMatchingElements() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y")),
+                  new Person("Carol", 35, new Address("C", "Z"))));
+
+      // Only modify people over 28
+      Team updated =
+          membersPath.modifyWhen(
+              p -> p.age() > 28,
+              p -> new Person(p.name().toUpperCase(), p.age(), p.address()),
+              team);
+
+      List<String> names = updated.members().stream().map(Person::name).toList();
+      assertThat(names).containsExactly("ALICE", "Bob", "CAROL");
+    }
+
+    @Test
+    @DisplayName("modifyWhen should leave non-matching elements unchanged")
+    void modifyWhenLeavesNonMatchingUnchanged() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Team",
+              List.of(
+                  new Person("Young", 20, new Address("A", "X")),
+                  new Person("Old", 50, new Address("B", "Y"))));
+
+      // Give raise only to seniors (age >= 30)
+      Team updated =
+          membersPath.modifyWhen(
+              p -> p.age() >= 30, p -> new Person(p.name(), p.age(), p.address()), team);
+
+      // Young person should be completely unchanged
+      assertThat(updated.members().get(0)).isEqualTo(team.members().get(0));
+    }
+
+    @Test
+    @DisplayName("modifyWhen with no matches should return original")
+    void modifyWhenNoMatchesReturnsOriginal() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Young Team",
+              List.of(
+                  new Person("A", 20, new Address("A", "X")),
+                  new Person("B", 22, new Address("B", "Y"))));
+
+      // No one is over 100
+      Team updated =
+          membersPath.modifyWhen(
+              p -> p.age() > 100, p -> new Person("MODIFIED", p.age(), p.address()), team);
+
+      assertThat(updated.members()).isEqualTo(team.members());
+    }
+  }
+
+  @Nested
+  @DisplayName("foldMap() Monoid Integration")
+  class FoldMapTests {
+
+    @Test
+    @DisplayName("foldMap should aggregate values with string monoid")
+    void foldMapWithStringMonoid() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y")),
+                  new Person("Carol", 35, new Address("C", "Z"))));
+
+      String concatenatedNames = membersPath.foldMap(Monoids.string(), Person::name, team);
+
+      assertThat(concatenatedNames).isEqualTo("AliceBobCarol");
+    }
+
+    @Test
+    @DisplayName("foldMap should work with integer sum")
+    void foldMapWithIntegerSum() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y")),
+                  new Person("Carol", 35, new Address("C", "Z"))));
+
+      Integer totalAge = membersPath.foldMap(Monoids.integerAddition(), Person::age, team);
+
+      assertThat(totalAge).isEqualTo(90);
+    }
+
+    @Test
+    @DisplayName("foldMap should return empty for empty traversal")
+    void foldMapEmptyTraversal() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team emptyTeam = new Team("Empty", List.of());
+
+      String result = membersPath.foldMap(Monoids.string(), Person::name, emptyTeam);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("fold should combine elements directly")
+    void foldCombinesElements() {
+      Lens<Team, List<String>> tagsLens =
+          Lens.of(t -> t.members().stream().map(Person::name).toList(), (t, tags) -> t);
+      TraversalPath<Team, String> tagsPath = FocusPath.of(tagsLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("A", 30, new Address("A", "X")),
+                  new Person("B", 25, new Address("B", "Y"))));
+
+      String folded = tagsPath.fold(Monoids.string(), team);
+
+      assertThat(folded).isEqualTo("AB");
+    }
+
+    @Test
+    @DisplayName("foldMap with custom monoid")
+    void foldMapWithCustomMonoid() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      // Custom monoid for finding max age
+      Monoid<Integer> maxMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return Integer.MIN_VALUE;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return Math.max(a, b);
+            }
+          };
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y")),
+                  new Person("Carol", 45, new Address("C", "Z"))));
+
+      Integer maxAge = membersPath.foldMap(maxMonoid, Person::age, team);
+
+      assertThat(maxAge).isEqualTo(45);
+    }
+  }
+
+  @Nested
+  @DisplayName("Additional FocusPath then() Aliases Coverage")
+  class FocusPathThenAliasesTests {
+
+    // Iso: String <-> String (uppercase/lowercase)
+    static final Iso<String, String> uppercaseIso =
+        Iso.of(String::toUpperCase, String::toLowerCase);
+
+    // Prism: String -> Integer (parse)
+    static final Prism<String, Integer> parseIntPrism =
+        Prism.of(
+            s -> {
+              try {
+                return Optional.of(Integer.parseInt(s));
+              } catch (NumberFormatException e) {
+                return Optional.empty();
+              }
+            },
+            Object::toString);
+
+    // Affine: accessing Optional content
+    static final Affine<Optional<String>, String> optionalAffine =
+        Affine.of(opt -> opt, (opt, s) -> Optional.of(s));
+
+    // Traversal over list
+    static final Traversal<List<String>, String> listTraversal = FocusPaths.listElements();
+
+    @Test
+    @DisplayName("FocusPath.then(Iso) should work like via(Iso)")
+    void focusPathThenIso() {
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+
+      FocusPath<Person, String> thenResult = namePath.then(uppercaseIso);
+
+      Person person = new Person("alice", 30, new Address("Main", "London"));
+      assertThat(thenResult.get(person)).isEqualTo("ALICE");
+
+      Person updated = thenResult.set("bob", person);
+      assertThat(updated.name()).isEqualTo("bob");
+    }
+
+    @Test
+    @DisplayName("FocusPath.then(Prism) should produce AffinePath")
+    void focusPathThenPrism() {
+      // Person with a numeric name for testing
+      record NumericName(String value) {}
+      record PersonWithNumeric(NumericName numericName) {}
+
+      Lens<PersonWithNumeric, String> numericLens =
+          Lens.of(
+              p -> p.numericName().value(), (p, v) -> new PersonWithNumeric(new NumericName(v)));
+      FocusPath<PersonWithNumeric, String> numPath = FocusPath.of(numericLens);
+
+      AffinePath<PersonWithNumeric, Integer> parsedPath = numPath.then(parseIntPrism);
+
+      PersonWithNumeric validNum = new PersonWithNumeric(new NumericName("123"));
+      PersonWithNumeric invalidNum = new PersonWithNumeric(new NumericName("abc"));
+
+      assertThat(parsedPath.getOptional(validNum)).contains(123);
+      assertThat(parsedPath.getOptional(invalidNum)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FocusPath.then(Affine) should produce AffinePath")
+    void focusPathThenAffine() {
+      FocusPath<Config, Optional<String>> configPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k)));
+
+      AffinePath<Config, String> keyPath = configPath.then(optionalAffine);
+
+      Config withKey = new Config(Optional.of("secret"));
+      Config withoutKey = new Config(Optional.empty());
+
+      assertThat(keyPath.getOptional(withKey)).contains("secret");
+      assertThat(keyPath.getOptional(withoutKey)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FocusPath.then(AffinePath) should produce AffinePath")
+    void focusPathThenAffinePath() {
+      FocusPath<Config, Optional<String>> configPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k)));
+      AffinePath<Optional<String>, String> somePath = AffinePath.of(optionalAffine);
+
+      AffinePath<Config, String> keyPath = configPath.then(somePath);
+
+      Config withKey = new Config(Optional.of("api-key"));
+      assertThat(keyPath.getOptional(withKey)).contains("api-key");
+    }
+
+    @Test
+    @DisplayName("FocusPath.then(Traversal) should produce TraversalPath")
+    void focusPathThenTraversal() {
+      record Container(List<String> items) {}
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+      FocusPath<Container, List<String>> containerPath = FocusPath.of(itemsLens);
+
+      TraversalPath<Container, String> allItems = containerPath.then(listTraversal);
+
+      Container container = new Container(List.of("a", "b", "c"));
+      assertThat(allItems.getAll(container)).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("FocusPath.then(TraversalPath) should produce TraversalPath")
+    void focusPathThenTraversalPath() {
+      record Container(List<String> items) {}
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+      FocusPath<Container, List<String>> containerPath = FocusPath.of(itemsLens);
+      TraversalPath<List<String>, String> allPath = TraversalPath.of(listTraversal);
+
+      TraversalPath<Container, String> allItems = containerPath.then(allPath);
+
+      Container container = new Container(List.of("x", "y", "z"));
+      assertThat(allItems.getAll(container)).containsExactly("x", "y", "z");
+    }
+  }
+
+  @Nested
+  @DisplayName("Additional AffinePath via() and then() Coverage")
+  class AffinePathViaAndThenTests {
+
+    static final Prism<String, Integer> parseIntPrism =
+        Prism.of(
+            s -> {
+              try {
+                return Optional.of(Integer.parseInt(s));
+              } catch (NumberFormatException e) {
+                return Optional.empty();
+              }
+            },
+            Object::toString);
+
+    static final Affine<Optional<String>, String> optionalAffine =
+        Affine.of(opt -> opt, (opt, s) -> Optional.of(s));
+
+    static final Iso<String, String> uppercaseIso =
+        Iso.of(String::toUpperCase, String::toLowerCase);
+
+    static final Traversal<List<String>, String> listTraversal = FocusPaths.listElements();
+
+    @Test
+    @DisplayName("AffinePath.via(AffinePath) should compose affine paths")
+    void affinePathViaAffinePath() {
+      // Nested optionals: Optional<Optional<String>>
+      record DoubleOptional(Optional<Optional<String>> value) {}
+
+      Lens<DoubleOptional, Optional<Optional<String>>> valueLens =
+          Lens.of(DoubleOptional::value, (d, v) -> new DoubleOptional(v));
+
+      AffinePath<DoubleOptional, Optional<String>> firstOpt = FocusPath.of(valueLens).some();
+      AffinePath<Optional<String>, String> secondOpt = AffinePath.of(optionalAffine);
+
+      AffinePath<DoubleOptional, String> nestedPath = firstOpt.via(secondOpt);
+
+      DoubleOptional present = new DoubleOptional(Optional.of(Optional.of("hello")));
+      DoubleOptional partiallyPresent = new DoubleOptional(Optional.of(Optional.empty()));
+      DoubleOptional absent = new DoubleOptional(Optional.empty());
+
+      assertThat(nestedPath.getOptional(present)).contains("hello");
+      assertThat(nestedPath.getOptional(partiallyPresent)).isEmpty();
+      assertThat(nestedPath.getOptional(absent)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("AffinePath.via(TraversalPath) should produce TraversalPath")
+    void affinePathViaTraversalPath() {
+      record OptionalList(Optional<List<String>> items) {}
+
+      Lens<OptionalList, Optional<List<String>>> itemsLens =
+          Lens.of(OptionalList::items, (o, i) -> new OptionalList(i));
+
+      AffinePath<OptionalList, List<String>> optListPath = FocusPath.of(itemsLens).some();
+      TraversalPath<List<String>, String> allItems = TraversalPath.of(listTraversal);
+
+      TraversalPath<OptionalList, String> allOptItems = optListPath.via(allItems);
+
+      OptionalList present = new OptionalList(Optional.of(List.of("a", "b")));
+      OptionalList absent = new OptionalList(Optional.empty());
+
+      assertThat(allOptItems.getAll(present)).containsExactly("a", "b");
+      assertThat(allOptItems.getAll(absent)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(Lens) should work like via(Lens)")
+    void affinePathThenLens() {
+      AffinePath<Config, String> apiKeyPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k))).some();
+
+      // Create a simple lens that gets the length of a string
+      Lens<String, Integer> lengthLens =
+          Lens.of(String::length, (s, len) -> s.substring(0, Math.min(len, s.length())));
+
+      AffinePath<Config, Integer> keyLengthPath = apiKeyPath.then(lengthLens);
+
+      Config withKey = new Config(Optional.of("hello"));
+      assertThat(keyLengthPath.getOptional(withKey)).contains(5);
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(Prism) should produce AffinePath")
+    void affinePathThenPrism() {
+      record NumericConfig(Optional<String> numericValue) {}
+
+      Lens<NumericConfig, Optional<String>> valueLens =
+          Lens.of(NumericConfig::numericValue, (c, v) -> new NumericConfig(v));
+
+      AffinePath<NumericConfig, String> valuePath = FocusPath.of(valueLens).some();
+      AffinePath<NumericConfig, Integer> intPath = valuePath.then(parseIntPrism);
+
+      NumericConfig validNum = new NumericConfig(Optional.of("42"));
+      NumericConfig invalidNum = new NumericConfig(Optional.of("abc"));
+      NumericConfig empty = new NumericConfig(Optional.empty());
+
+      assertThat(intPath.getOptional(validNum)).contains(42);
+      assertThat(intPath.getOptional(invalidNum)).isEmpty();
+      assertThat(intPath.getOptional(empty)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(Affine) should produce AffinePath")
+    void affinePathThenAffine() {
+      record NestedOpt(Optional<Optional<String>> nested) {}
+
+      Lens<NestedOpt, Optional<Optional<String>>> nestedLens =
+          Lens.of(NestedOpt::nested, (n, v) -> new NestedOpt(v));
+
+      AffinePath<NestedOpt, Optional<String>> firstLevel = FocusPath.of(nestedLens).some();
+      AffinePath<NestedOpt, String> deepPath = firstLevel.then(optionalAffine);
+
+      NestedOpt present = new NestedOpt(Optional.of(Optional.of("deep")));
+      assertThat(deepPath.getOptional(present)).contains("deep");
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(AffinePath) should produce AffinePath")
+    void affinePathThenAffinePath() {
+      record NestedOpt(Optional<Optional<String>> nested) {}
+
+      Lens<NestedOpt, Optional<Optional<String>>> nestedLens =
+          Lens.of(NestedOpt::nested, (n, v) -> new NestedOpt(v));
+
+      AffinePath<NestedOpt, Optional<String>> firstLevel = FocusPath.of(nestedLens).some();
+      AffinePath<Optional<String>, String> secondLevel = AffinePath.of(optionalAffine);
+
+      AffinePath<NestedOpt, String> deepPath = firstLevel.then(secondLevel);
+
+      NestedOpt present = new NestedOpt(Optional.of(Optional.of("nested")));
+      assertThat(deepPath.getOptional(present)).contains("nested");
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(Iso) should produce AffinePath")
+    void affinePathThenIso() {
+      AffinePath<Config, String> apiKeyPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k))).some();
+
+      AffinePath<Config, String> uppercasePath = apiKeyPath.then(uppercaseIso);
+
+      Config withKey = new Config(Optional.of("secret"));
+      assertThat(uppercasePath.getOptional(withKey)).contains("SECRET");
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(Traversal) should produce TraversalPath")
+    void affinePathThenTraversal() {
+      record OptionalList(Optional<List<String>> items) {}
+
+      Lens<OptionalList, Optional<List<String>>> itemsLens =
+          Lens.of(OptionalList::items, (o, i) -> new OptionalList(i));
+
+      AffinePath<OptionalList, List<String>> optListPath = FocusPath.of(itemsLens).some();
+
+      TraversalPath<OptionalList, String> allItems = optListPath.then(listTraversal);
+
+      OptionalList present = new OptionalList(Optional.of(List.of("1", "2", "3")));
+      assertThat(allItems.getAll(present)).containsExactly("1", "2", "3");
+    }
+
+    @Test
+    @DisplayName("AffinePath.then(TraversalPath) should produce TraversalPath")
+    void affinePathThenTraversalPath() {
+      record OptionalList(Optional<List<String>> items) {}
+
+      Lens<OptionalList, Optional<List<String>>> itemsLens =
+          Lens.of(OptionalList::items, (o, i) -> new OptionalList(i));
+
+      AffinePath<OptionalList, List<String>> optListPath = FocusPath.of(itemsLens).some();
+      TraversalPath<List<String>, String> allPath = TraversalPath.of(listTraversal);
+
+      TraversalPath<OptionalList, String> allItems = optListPath.then(allPath);
+
+      OptionalList present = new OptionalList(Optional.of(List.of("x", "y")));
+      assertThat(allItems.getAll(present)).containsExactly("x", "y");
+    }
+  }
+
+  @Nested
+  @DisplayName("Additional TraversalPath via() and then() Coverage")
+  class TraversalPathViaAndThenTests {
+
+    static final Prism<String, Integer> parseIntPrism =
+        Prism.of(
+            s -> {
+              try {
+                return Optional.of(Integer.parseInt(s));
+              } catch (NumberFormatException e) {
+                return Optional.empty();
+              }
+            },
+            Object::toString);
+
+    static final Affine<Optional<String>, String> optionalAffine =
+        Affine.of(opt -> opt, (opt, s) -> Optional.of(s));
+
+    static final Iso<String, String> uppercaseIso =
+        Iso.of(String::toUpperCase, String::toLowerCase);
+
+    static final Traversal<List<String>, String> listTraversal = FocusPaths.listElements();
+
+    @Test
+    @DisplayName("TraversalPath.via(AffinePath) should compose with affine path")
+    void traversalPathViaAffinePath() {
+      record Container(List<Optional<String>> items) {}
+
+      Lens<Container, List<Optional<String>>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+
+      TraversalPath<Container, Optional<String>> allOptionals = FocusPath.of(itemsLens).each();
+      AffinePath<Optional<String>, String> somePath = AffinePath.of(optionalAffine);
+
+      TraversalPath<Container, String> allPresent = allOptionals.via(somePath);
+
+      Container container =
+          new Container(List.of(Optional.of("a"), Optional.empty(), Optional.of("b")));
+
+      assertThat(allPresent.getAll(container)).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.via(TraversalPath) should compose traversal paths")
+    void traversalPathViaTraversalPath() {
+      record NestedLists(List<List<String>> items) {}
+
+      Lens<NestedLists, List<List<String>>> itemsLens =
+          Lens.of(NestedLists::items, (n, i) -> new NestedLists(i));
+
+      TraversalPath<NestedLists, List<String>> allLists = FocusPath.of(itemsLens).each();
+      TraversalPath<List<String>, String> allStrings = TraversalPath.of(listTraversal);
+
+      TraversalPath<NestedLists, String> allDeep = allLists.via(allStrings);
+
+      NestedLists nested = new NestedLists(List.of(List.of("a", "b"), List.of("c")));
+
+      assertThat(allDeep.getAll(nested)).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(FocusPath) should work like via(FocusPath)")
+    void traversalPathThenFocusPath() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+
+      TraversalPath<Team, String> namesPath = membersPath.then(namePath);
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      assertThat(namesPath.getAll(team)).containsExactly("Alice", "Bob");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(Prism) should produce TraversalPath")
+    void traversalPathThenPrism() {
+      record NumericList(List<String> numbers) {}
+
+      Lens<NumericList, List<String>> numbersLens =
+          Lens.of(NumericList::numbers, (n, l) -> new NumericList(l));
+
+      TraversalPath<NumericList, String> allStrings = FocusPath.of(numbersLens).each();
+      TraversalPath<NumericList, Integer> allInts = allStrings.then(parseIntPrism);
+
+      NumericList mixed = new NumericList(List.of("1", "abc", "2", "def", "3"));
+
+      assertThat(allInts.getAll(mixed)).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(Affine) should produce TraversalPath")
+    void traversalPathThenAffine() {
+      record OptionalContainer(List<Optional<String>> items) {}
+
+      Lens<OptionalContainer, List<Optional<String>>> itemsLens =
+          Lens.of(OptionalContainer::items, (c, i) -> new OptionalContainer(i));
+
+      TraversalPath<OptionalContainer, Optional<String>> allOptionals =
+          FocusPath.of(itemsLens).each();
+
+      TraversalPath<OptionalContainer, String> allPresent = allOptionals.then(optionalAffine);
+
+      OptionalContainer container =
+          new OptionalContainer(List.of(Optional.of("x"), Optional.empty(), Optional.of("y")));
+
+      assertThat(allPresent.getAll(container)).containsExactly("x", "y");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(AffinePath) should produce TraversalPath")
+    void traversalPathThenAffinePath() {
+      record OptionalContainer(List<Optional<String>> items) {}
+
+      Lens<OptionalContainer, List<Optional<String>>> itemsLens =
+          Lens.of(OptionalContainer::items, (c, i) -> new OptionalContainer(i));
+
+      TraversalPath<OptionalContainer, Optional<String>> allOptionals =
+          FocusPath.of(itemsLens).each();
+      AffinePath<Optional<String>, String> somePath = AffinePath.of(optionalAffine);
+
+      TraversalPath<OptionalContainer, String> allPresent = allOptionals.then(somePath);
+
+      OptionalContainer container =
+          new OptionalContainer(List.of(Optional.of("a"), Optional.empty(), Optional.of("b")));
+
+      assertThat(allPresent.getAll(container)).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(Traversal) should produce TraversalPath")
+    void traversalPathThenTraversal() {
+      record NestedLists(List<List<String>> items) {}
+
+      Lens<NestedLists, List<List<String>>> itemsLens =
+          Lens.of(NestedLists::items, (n, i) -> new NestedLists(i));
+
+      TraversalPath<NestedLists, List<String>> allLists = FocusPath.of(itemsLens).each();
+
+      TraversalPath<NestedLists, String> allStrings = allLists.then(listTraversal);
+
+      NestedLists nested = new NestedLists(List.of(List.of("a", "b"), List.of("c", "d")));
+
+      assertThat(allStrings.getAll(nested)).containsExactly("a", "b", "c", "d");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(TraversalPath) should produce TraversalPath")
+    void traversalPathThenTraversalPath() {
+      record NestedLists(List<List<String>> items) {}
+
+      Lens<NestedLists, List<List<String>>> itemsLens =
+          Lens.of(NestedLists::items, (n, i) -> new NestedLists(i));
+
+      TraversalPath<NestedLists, List<String>> allLists = FocusPath.of(itemsLens).each();
+      TraversalPath<List<String>, String> allPath = TraversalPath.of(listTraversal);
+
+      TraversalPath<NestedLists, String> allStrings = allLists.then(allPath);
+
+      NestedLists nested = new NestedLists(List.of(List.of("x"), List.of("y", "z")));
+
+      assertThat(allStrings.getAll(nested)).containsExactly("x", "y", "z");
+    }
+
+    @Test
+    @DisplayName("TraversalPath.then(Iso) should produce TraversalPath")
+    void traversalPathThenIso() {
+      record Container(List<String> items) {}
+
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+
+      TraversalPath<Container, String> allStrings = FocusPath.of(itemsLens).each();
+      TraversalPath<Container, String> allUppercase = allStrings.then(uppercaseIso);
+
+      Container container = new Container(List.of("hello", "world"));
+
+      assertThat(allUppercase.getAll(container)).containsExactly("HELLO", "WORLD");
+    }
+  }
+
+  @Nested
+  @DisplayName("traced() Path Debugging")
+  class TracedPathDebuggingTests {
+
+    @Test
+    @DisplayName("FocusPath.traced() should invoke observer on get")
+    void focusPathTracedInvokesObserver() {
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+      Person person = new Person("Alice", 30, new Address("Main", "London"));
+
+      // Track what was observed
+      List<String> observedValues = new ArrayList<>();
+      List<Person> observedSources = new ArrayList<>();
+
+      FocusPath<Person, String> tracedPath =
+          namePath.traced(
+              (source, value) -> {
+                observedSources.add(source);
+                observedValues.add(value);
+              });
+
+      // Get should invoke the observer
+      String result = tracedPath.get(person);
+
+      assertThat(result).isEqualTo("Alice");
+      assertThat(observedSources).containsExactly(person);
+      assertThat(observedValues).containsExactly("Alice");
+    }
+
+    @Test
+    @DisplayName("FocusPath.traced() should still allow set operations")
+    void focusPathTracedAllowsSet() {
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+      Person person = new Person("Alice", 30, new Address("Main", "London"));
+
+      List<String> observedValues = new ArrayList<>();
+
+      FocusPath<Person, String> tracedPath =
+          namePath.traced((source, value) -> observedValues.add(value));
+
+      // Set should work without invoking observer
+      Person updated = tracedPath.set("Bob", person);
+
+      assertThat(updated.name()).isEqualTo("Bob");
+      // Observer not called on set
+      assertThat(observedValues).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FocusPath.traced() can be chained multiple times")
+    void focusPathTracedCanBeChained() {
+      FocusPath<Person, String> namePath = FocusPath.of(personNameLens);
+      Person person = new Person("Alice", 30, new Address("Main", "London"));
+
+      List<String> trace1 = new ArrayList<>();
+      List<String> trace2 = new ArrayList<>();
+
+      FocusPath<Person, String> doubleTracedPath =
+          namePath
+              .traced((s, v) -> trace1.add("first: " + v))
+              .traced((s, v) -> trace2.add("second: " + v));
+
+      String result = doubleTracedPath.get(person);
+
+      assertThat(result).isEqualTo("Alice");
+      assertThat(trace1).containsExactly("first: Alice");
+      assertThat(trace2).containsExactly("second: Alice");
+    }
+
+    @Test
+    @DisplayName("AffinePath.traced() should invoke observer with Optional")
+    void affinePathTracedInvokesObserver() {
+      AffinePath<Config, String> apiKeyPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k))).some();
+
+      Config withKey = new Config(Optional.of("secret-123"));
+      Config withoutKey = new Config(Optional.empty());
+
+      List<Optional<String>> observedValues = new ArrayList<>();
+
+      AffinePath<Config, String> tracedPath =
+          apiKeyPath.traced((source, value) -> observedValues.add(value));
+
+      // Get with present value
+      Optional<String> result1 = tracedPath.getOptional(withKey);
+      // Get with absent value
+      Optional<String> result2 = tracedPath.getOptional(withoutKey);
+
+      assertThat(result1).contains("secret-123");
+      assertThat(result2).isEmpty();
+      assertThat(observedValues).containsExactly(Optional.of("secret-123"), Optional.empty());
+    }
+
+    @Test
+    @DisplayName("AffinePath.traced() should still allow set operations")
+    void affinePathTracedAllowsSet() {
+      AffinePath<Config, String> apiKeyPath =
+          FocusPath.of(Lens.of(Config::apiKey, (c, k) -> new Config(k))).some();
+
+      Config config = new Config(Optional.of("old-key"));
+
+      List<Optional<String>> observedValues = new ArrayList<>();
+
+      AffinePath<Config, String> tracedPath =
+          apiKeyPath.traced((source, value) -> observedValues.add(value));
+
+      Config updated = tracedPath.set("new-key", config);
+
+      assertThat(updated.apiKey()).contains("new-key");
+      // Observer not called on set
+      assertThat(observedValues).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TraversalPath.traced() should invoke observer with list")
+    void traversalPathTracedInvokesObserver() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+      List<Team> observedSources = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced(
+              (source, values) -> {
+                observedSources.add(source);
+                observedCounts.add(values.size());
+              });
+
+      List<Person> result = tracedPath.getAll(team);
+
+      assertThat(result).hasSize(2);
+      assertThat(observedSources).containsExactly(team);
+      assertThat(observedCounts).containsExactly(2);
+    }
+
+    @Test
+    @DisplayName("TraversalPath.traced() should still allow modify operations")
+    void traversalPathTracedAllowsModify() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      Team updated =
+          tracedPath.modifyAll(p -> new Person(p.name().toUpperCase(), p.age(), p.address()), team);
+
+      assertThat(updated.members().stream().map(Person::name)).containsExactly("ALICE", "BOB");
+      // Observer not called on modify
+      assertThat(observedCounts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TraversalPath.traced() with empty traversal")
+    void traversalPathTracedWithEmpty() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team emptyTeam = new Team("Empty", List.of());
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      List<Person> result = tracedPath.getAll(emptyTeam);
+
+      assertThat(result).isEmpty();
+      assertThat(observedCounts).containsExactly(0);
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.setAll() should delegate to underlying without tracing")
+    void tracedTraversalPathSetAll() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      Person defaultPerson = new Person("Default", 0, new Address("D", "D"));
+      Team updated = tracedPath.setAll(defaultPerson, team);
+
+      assertThat(updated.members()).hasSize(2);
+      assertThat(updated.members().stream().map(Person::name))
+          .containsExactly("Default", "Default");
+      // Observer not called on setAll
+      assertThat(observedCounts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.filter() should delegate to underlying")
+    void tracedTraversalPathFilter() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y")),
+                  new Person("Charlie", 35, new Address("C", "Z"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      TraversalPath<Team, Person> filteredPath = tracedPath.filter(p -> p.age() > 28);
+      List<Person> result = filteredPath.getAll(team);
+
+      assertThat(result).hasSize(2);
+      assertThat(result.stream().map(Person::name)).containsExactly("Alice", "Charlie");
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.via(Lens) should delegate to underlying")
+    void tracedTraversalPathViaLens() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      TraversalPath<Team, String> namesPath = tracedPath.via(personNameLens);
+      List<String> names = namesPath.getAll(team);
+
+      assertThat(names).containsExactly("Alice", "Bob");
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.via(Prism) should delegate to underlying")
+    void tracedTraversalPathViaPrism() {
+      // Create a prism for strings that parses to integers
+      Prism<String, Integer> parseIntPrism =
+          Prism.of(
+              s -> {
+                try {
+                  return Optional.of(Integer.parseInt(s));
+                } catch (NumberFormatException e) {
+                  return Optional.empty();
+                }
+              },
+              Object::toString);
+
+      Lens<Team, List<Person>> membersLensLocal =
+          Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+      Lens<Person, String> nameAsStringLens =
+          Lens.of(Person::name, (p, n) -> new Person(n, p.age(), p.address()));
+
+      TraversalPath<Team, Person> membersPath = FocusPath.of(membersLensLocal).each();
+      TraversalPath<Team, String> namesPath = membersPath.via(nameAsStringLens);
+
+      Team team =
+          new Team(
+              "Numbers",
+              List.of(
+                  new Person("123", 30, new Address("A", "X")),
+                  new Person("notAnumber", 25, new Address("B", "Y")),
+                  new Person("456", 35, new Address("C", "Z"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, String> tracedPath =
+          namesPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      TraversalPath<Team, Integer> numbersPath = tracedPath.via(parseIntPrism);
+      List<Integer> numbers = numbersPath.getAll(team);
+
+      assertThat(numbers).containsExactly(123, 456);
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.via(Affine) should delegate to underlying")
+    void tracedTraversalPathViaAffine() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      // Create an affine that gets the first character of a name if non-empty
+      Affine<String, Character> firstCharAffine =
+          Affine.of(
+              s -> s.isEmpty() ? Optional.empty() : Optional.of(s.charAt(0)),
+              (s, c) -> s.isEmpty() ? s : c + s.substring(1));
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedMembersPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      TraversalPath<Team, String> namesPath = tracedMembersPath.via(personNameLens);
+
+      // Now we need to create a traced TraversalPath for names to test via(Affine)
+      TraversalPath<Team, String> tracedNamesPath =
+          namesPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      TraversalPath<Team, Character> firstCharsPath = tracedNamesPath.via(firstCharAffine);
+      List<Character> firstChars = firstCharsPath.getAll(team);
+
+      assertThat(firstChars).containsExactly('A', 'B');
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.via(Traversal) should delegate to underlying")
+    void tracedTraversalPathViaTraversal() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      // Use a traversal that returns nothing (empty traversal as identity)
+      Traversal<Person, Person> identityTraversal =
+          new Traversal<>() {
+            @Override
+            public <F> Kind<F, Person> modifyF(
+                Function<Person, Kind<F, Person>> f, Person source, Applicative<F> applicative) {
+              return f.apply(source);
+            }
+          };
+
+      TraversalPath<Team, Person> composedPath = tracedPath.via(identityTraversal);
+      List<Person> result = composedPath.getAll(team);
+
+      assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.via(Iso) should delegate to underlying")
+    void tracedTraversalPathViaIso() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedMembersPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      TraversalPath<Team, String> namesPath = tracedMembersPath.via(personNameLens);
+
+      TraversalPath<Team, String> tracedNamesPath =
+          namesPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      // Create an ISO that converts between String and its uppercase version
+      Iso<String, String> upperIso = Iso.of(String::toUpperCase, String::toLowerCase);
+
+      TraversalPath<Team, String> upperNamesPath = tracedNamesPath.via(upperIso);
+      List<String> upperNames = upperNamesPath.getAll(team);
+
+      assertThat(upperNames).containsExactly("ALICE", "BOB");
+    }
+
+    @Test
+    @DisplayName("TracedTraversalFocusPath.toTraversal() should return underlying traversal")
+    void tracedTraversalPathToTraversal() {
+      TraversalPath<Team, Person> membersPath = FocusPath.of(teamMembersLens).each();
+
+      Team team =
+          new Team(
+              "Dev",
+              List.of(
+                  new Person("Alice", 30, new Address("A", "X")),
+                  new Person("Bob", 25, new Address("B", "Y"))));
+
+      List<Integer> observedCounts = new ArrayList<>();
+
+      TraversalPath<Team, Person> tracedPath =
+          membersPath.traced((source, values) -> observedCounts.add(values.size()));
+
+      Traversal<Team, Person> traversal = tracedPath.toTraversal();
+
+      // The traversal should work correctly
+      List<Person> result = Traversals.getAll(traversal, team);
+      assertThat(result).hasSize(2);
+      assertThat(result.stream().map(Person::name)).containsExactly("Alice", "Bob");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathTest.java
@@ -1,0 +1,382 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FocusPath<S, A> Tests")
+class FocusPathTest {
+
+  // Test Data Structures
+  record Street(String name) {}
+
+  record Address(Street street, String city) {}
+
+  record Person(String name, Address address) {}
+
+  record NameWrapper(String value) {}
+
+  sealed interface Json permits JsonString, JsonNumber {}
+
+  record JsonString(String value) implements Json {}
+
+  record JsonNumber(int value) implements Json {}
+
+  // Lenses
+  private Lens<Street, String> streetNameLens;
+  private Lens<Address, Street> addressStreetLens;
+  private Lens<Address, String> addressCityLens;
+  private Lens<Person, Address> personAddressLens;
+
+  @BeforeEach
+  void setUp() {
+    streetNameLens = Lens.of(Street::name, (s, n) -> new Street(n));
+    addressStreetLens = Lens.of(Address::street, (a, s) -> new Address(s, a.city()));
+    addressCityLens = Lens.of(Address::city, (a, c) -> new Address(a.street(), c));
+    personAddressLens = Lens.of(Person::address, (p, a) -> new Person(p.name(), a));
+  }
+
+  @Nested
+  @DisplayName("Core Functionality")
+  class CoreFunctionality {
+
+    @Test
+    @DisplayName("of should create a FocusPath from a Lens")
+    void ofShouldCreateFocusPath() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      assertThat(path).isNotNull();
+      assertThat(path.toLens()).isSameAs(streetNameLens);
+    }
+
+    @Test
+    @DisplayName("get should extract the focused value")
+    void getShouldExtractValue() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      Street street = new Street("Main St");
+
+      assertThat(path.get(street)).isEqualTo("Main St");
+    }
+
+    @Test
+    @DisplayName("set should create a new structure with updated value")
+    void setShouldCreateNewStructure() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      Street street = new Street("Main St");
+
+      Street updated = path.set("Broadway", street);
+
+      assertThat(updated.name()).isEqualTo("Broadway");
+      assertThat(street.name()).isEqualTo("Main St"); // Original unchanged
+    }
+
+    @Test
+    @DisplayName("modify should transform the focused value")
+    void modifyShouldTransformValue() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      Street street = new Street("main st");
+
+      Street modified = path.modify(String::toUpperCase, street);
+
+      assertThat(modified.name()).isEqualTo("MAIN ST");
+    }
+
+    @Test
+    @DisplayName("identity should focus on the source itself")
+    void identityShouldFocusOnSource() {
+      FocusPath<String, String> path = FocusPath.identity();
+
+      assertThat(path.get("hello")).isEqualTo("hello");
+      assertThat(path.set("world", "hello")).isEqualTo("world");
+      assertThat(path.modify(String::toUpperCase, "hello")).isEqualTo("HELLO");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Lens")
+  class CompositionWithLens {
+
+    @Test
+    @DisplayName("via(Lens) should compose two paths")
+    void viaShouldComposePaths() {
+      FocusPath<Address, Street> addressPath = FocusPath.of(addressStreetLens);
+      FocusPath<Address, String> composedPath = addressPath.via(streetNameLens);
+
+      Address address = new Address(new Street("Oak Ave"), "London");
+
+      assertThat(composedPath.get(address)).isEqualTo("Oak Ave");
+      Address updated = composedPath.set("Elm St", address);
+      assertThat(updated.street().name()).isEqualTo("Elm St");
+      assertThat(updated.city()).isEqualTo("London");
+    }
+
+    @Test
+    @DisplayName("deep composition should work through multiple levels")
+    void deepCompositionShouldWork() {
+      FocusPath<Person, String> streetNamePath =
+          FocusPath.of(personAddressLens).via(addressStreetLens).via(streetNameLens);
+
+      Person person = new Person("Alice", new Address(new Street("High St"), "Oxford"));
+
+      assertThat(streetNamePath.get(person)).isEqualTo("High St");
+
+      Person updated = streetNamePath.set("Low St", person);
+      assertThat(updated.address().street().name()).isEqualTo("Low St");
+      assertThat(updated.name()).isEqualTo("Alice");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Prism")
+  class CompositionWithPrism {
+
+    @Test
+    @DisplayName("via(Prism) should produce an AffinePath")
+    void viaPrismShouldProduceAffinePath() {
+      record Profile(Json data) {}
+
+      Lens<Profile, Json> profileDataLens = Lens.of(Profile::data, (p, d) -> new Profile(d));
+      Prism<Json, String> jsonStringPrism =
+          Prism.of(
+              json -> json instanceof JsonString s ? Optional.of(s.value()) : Optional.empty(),
+              JsonString::new);
+
+      FocusPath<Profile, Json> dataPath = FocusPath.of(profileDataLens);
+      AffinePath<Profile, String> stringPath = dataPath.via(jsonStringPrism);
+
+      Profile stringProfile = new Profile(new JsonString("hello"));
+      Profile numberProfile = new Profile(new JsonNumber(42));
+
+      assertThat(stringPath.getOptional(stringProfile)).contains("hello");
+      assertThat(stringPath.getOptional(numberProfile)).isEmpty();
+
+      Profile updated = stringPath.set("world", stringProfile);
+      assertThat(((JsonString) updated.data()).value()).isEqualTo("world");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Affine")
+  class CompositionWithAffine {
+
+    @Test
+    @DisplayName("via(Affine) should produce an AffinePath")
+    void viaAffineShouldProduceAffinePath() {
+      record Config(Optional<String> setting) {}
+
+      Lens<Config, Optional<String>> settingLens =
+          Lens.of(Config::setting, (c, s) -> new Config(s));
+      Affine<Optional<String>, String> someAffine = FocusPaths.optionalSome();
+
+      FocusPath<Config, Optional<String>> configPath = FocusPath.of(settingLens);
+      AffinePath<Config, String> valuePath = configPath.via(someAffine);
+
+      Config present = new Config(Optional.of("value"));
+      Config absent = new Config(Optional.empty());
+
+      assertThat(valuePath.getOptional(present)).contains("value");
+      assertThat(valuePath.getOptional(absent)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Traversal")
+  class CompositionWithTraversal {
+
+    @Test
+    @DisplayName("via(Traversal) should produce a TraversalPath")
+    void viaTraversalShouldProduceTraversalPath() {
+      record Team(List<String> members) {}
+
+      Lens<Team, List<String>> membersLens = Lens.of(Team::members, (t, m) -> new Team(m));
+      Traversal<List<String>, String> listTraversal = Traversals.forList();
+
+      FocusPath<Team, List<String>> teamPath = FocusPath.of(membersLens);
+      TraversalPath<Team, String> membersPath = teamPath.via(listTraversal);
+
+      Team team = new Team(List.of("Alice", "Bob", "Charlie"));
+
+      assertThat(membersPath.getAll(team)).containsExactly("Alice", "Bob", "Charlie");
+
+      Team updated = membersPath.modifyAll(String::toUpperCase, team);
+      assertThat(updated.members()).containsExactly("ALICE", "BOB", "CHARLIE");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Iso")
+  class CompositionWithIso {
+
+    @Test
+    @DisplayName("via(Iso) should produce a FocusPath")
+    void viaIsoShouldProduceFocusPath() {
+      Iso<String, NameWrapper> wrapperIso = Iso.of(NameWrapper::new, NameWrapper::value);
+
+      FocusPath<Street, String> namePath = FocusPath.of(streetNameLens);
+      FocusPath<Street, NameWrapper> wrappedPath = namePath.via(wrapperIso);
+
+      Street street = new Street("Main St");
+
+      assertThat(wrappedPath.get(street).value()).isEqualTo("Main St");
+
+      Street updated = wrappedPath.set(new NameWrapper("Broadway"), street);
+      assertThat(updated.name()).isEqualTo("Broadway");
+    }
+  }
+
+  @Nested
+  @DisplayName("Collection Navigation")
+  class CollectionNavigation {
+
+    @Test
+    @DisplayName("each() should traverse list elements")
+    void eachShouldTraverseListElements() {
+      record Container(List<String> items) {}
+
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+      FocusPath<Container, List<String>> containerPath = FocusPath.of(itemsLens);
+
+      TraversalPath<Container, String> itemsPath = containerPath.each();
+
+      Container container = new Container(List.of("a", "b", "c"));
+
+      assertThat(itemsPath.getAll(container)).containsExactly("a", "b", "c");
+      Container modified = itemsPath.modifyAll(String::toUpperCase, container);
+      assertThat(modified.items()).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("at(index) should focus on specific element")
+    void atShouldFocusOnSpecificElement() {
+      record Container(List<String> items) {}
+
+      Lens<Container, List<String>> itemsLens =
+          Lens.of(Container::items, (c, i) -> new Container(i));
+      FocusPath<Container, List<String>> containerPath = FocusPath.of(itemsLens);
+
+      AffinePath<Container, String> secondItem = containerPath.at(1);
+
+      Container container = new Container(List.of("a", "b", "c"));
+
+      assertThat(secondItem.getOptional(container)).contains("b");
+      Container updated = secondItem.set("X", container);
+      assertThat(updated.items()).containsExactly("a", "X", "c");
+
+      // Out of bounds
+      Container small = new Container(List.of("only"));
+      assertThat(secondItem.getOptional(small)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("some() should unwrap Optional")
+    void someShouldUnwrapOptional() {
+      record Box(Optional<String> content) {}
+
+      Lens<Box, Optional<String>> contentLens = Lens.of(Box::content, (b, c) -> new Box(c));
+      FocusPath<Box, Optional<String>> boxPath = FocusPath.of(contentLens);
+
+      AffinePath<Box, String> valuePath = boxPath.some();
+
+      Box full = new Box(Optional.of("treasure"));
+      Box empty = new Box(Optional.empty());
+
+      assertThat(valuePath.getOptional(full)).contains("treasure");
+      assertThat(valuePath.getOptional(empty)).isEmpty();
+
+      Box updated = valuePath.set("gold", full);
+      assertThat(updated.content()).contains("gold");
+    }
+
+    @Test
+    @DisplayName("atKey() should focus on map value by key")
+    void atKeyShouldFocusOnMapValue() {
+      record Settings(Map<String, String> values) {}
+
+      Lens<Settings, Map<String, String>> valuesLens =
+          Lens.of(Settings::values, (s, v) -> new Settings(v));
+      FocusPath<Settings, Map<String, String>> settingsPath = FocusPath.of(valuesLens);
+
+      AffinePath<Settings, String> themePath = settingsPath.atKey("theme");
+
+      Settings settings = new Settings(Map.of("theme", "dark", "language", "en"));
+
+      assertThat(themePath.getOptional(settings)).contains("dark");
+
+      // Missing key
+      assertThat(settingsPath.atKey("missing").getOptional(settings)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Conversion Methods")
+  class ConversionMethods {
+
+    @Test
+    @DisplayName("asAffine should return an AffinePath view")
+    void asAffineShouldReturnAffinePathView() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      AffinePath<Street, String> affinePath = path.asAffine();
+
+      Street street = new Street("Main St");
+
+      assertThat(affinePath.getOptional(street)).contains("Main St");
+      assertThat(affinePath.matches(street)).isTrue();
+
+      // Test setter functionality
+      Street updated = affinePath.set("Oak Ave", street);
+      assertThat(updated.name()).isEqualTo("Oak Ave");
+    }
+
+    @Test
+    @DisplayName("asTraversal should return a TraversalPath view")
+    void asTraversalShouldReturnTraversalPathView() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      TraversalPath<Street, String> traversalPath = path.asTraversal();
+
+      Street street = new Street("Main St");
+
+      assertThat(traversalPath.getAll(street)).containsExactly("Main St");
+      assertThat(traversalPath.count(street)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("toLens should return the underlying Lens")
+    void toLensShouldReturnUnderlyingLens() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+
+      assertThat(path.toLens()).isSameAs(streetNameLens);
+    }
+
+    @Test
+    @DisplayName("asFold should return a Fold view")
+    void asFoldShouldReturnFoldView() {
+      FocusPath<Street, String> path = FocusPath.of(streetNameLens);
+      Fold<Street, String> fold = path.asFold();
+
+      Street street = new Street("Main St");
+
+      // Use foldMap to verify the fold works
+      String result = fold.foldMap(Monoids.string(), s -> s, street);
+      assertThat(result).isEqualTo("Main St");
+
+      // Preview should also work
+      assertThat(fold.preview(street)).contains("Main St");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathsTest.java
@@ -1,0 +1,342 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FocusPaths Utility Tests")
+class FocusPathsTest {
+
+  @Nested
+  @DisplayName("List Optics")
+  class ListOptics {
+
+    @Test
+    @DisplayName("listElements should traverse all elements")
+    void listElementsShouldTraverseAllElements() {
+      Traversal<List<String>, String> traversal = FocusPaths.listElements();
+
+      List<String> list = List.of("a", "b", "c");
+
+      assertThat(Traversals.getAll(traversal, list)).containsExactly("a", "b", "c");
+      assertThat(Traversals.modify(traversal, String::toUpperCase, list))
+          .containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("listElements should handle empty list")
+    void listElementsShouldHandleEmptyList() {
+      Traversal<List<String>, String> traversal = FocusPaths.listElements();
+
+      List<String> emptyList = List.of();
+
+      assertThat(Traversals.getAll(traversal, emptyList)).isEmpty();
+      assertThat(Traversals.modify(traversal, String::toUpperCase, emptyList)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listAt should focus on element at index")
+    void listAtShouldFocusOnElementAtIndex() {
+      Affine<List<String>, String> affine = FocusPaths.listAt(1);
+
+      List<String> list = List.of("a", "b", "c");
+
+      assertThat(affine.getOptional(list)).contains("b");
+      assertThat(affine.set("X", list)).containsExactly("a", "X", "c");
+    }
+
+    @Test
+    @DisplayName("listAt should return empty for out of bounds index")
+    void listAtShouldReturnEmptyForOutOfBounds() {
+      Affine<List<String>, String> affine = FocusPaths.listAt(5);
+
+      List<String> list = List.of("a", "b", "c");
+
+      assertThat(affine.getOptional(list)).isEmpty();
+      // Set on out of bounds returns original
+      assertThat(affine.set("X", list)).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("listAt should handle negative index")
+    void listAtShouldHandleNegativeIndex() {
+      Affine<List<String>, String> affine = FocusPaths.listAt(-1);
+
+      List<String> list = List.of("a", "b", "c");
+
+      assertThat(affine.getOptional(list)).isEmpty();
+      // Setter with negative index should return original list unchanged
+      assertThat(affine.set("X", list)).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("listHead should focus on first element")
+    void listHeadShouldFocusOnFirstElement() {
+      Affine<List<String>, String> affine = FocusPaths.listHead();
+
+      assertThat(affine.getOptional(List.of("a", "b", "c"))).contains("a");
+      assertThat(affine.getOptional(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listLast should focus on last element")
+    void listLastShouldFocusOnLastElement() {
+      Affine<List<String>, String> affine = FocusPaths.listLast();
+
+      assertThat(affine.getOptional(List.of("a", "b", "c"))).contains("c");
+      assertThat(affine.getOptional(List.of())).isEmpty();
+
+      assertThat(affine.set("X", List.of("a", "b", "c"))).containsExactly("a", "b", "X");
+    }
+
+    @Test
+    @DisplayName("listLast setter should return empty list unchanged")
+    void listLastSetterShouldReturnEmptyListUnchanged() {
+      Affine<List<String>, String> affine = FocusPaths.listLast();
+
+      List<String> emptyList = List.of();
+
+      // Setter on empty list should return the empty list unchanged
+      assertThat(affine.set("X", emptyList)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Map Optics")
+  class MapOptics {
+
+    @Test
+    @DisplayName("mapValues should traverse all values")
+    void mapValuesShouldTraverseAllValues() {
+      Traversal<Map<String, Integer>, Integer> traversal = FocusPaths.mapValues();
+
+      Map<String, Integer> map = new HashMap<>();
+      map.put("a", 1);
+      map.put("b", 2);
+      map.put("c", 3);
+
+      assertThat(Traversals.getAll(traversal, map)).containsExactlyInAnyOrder(1, 2, 3);
+
+      Map<String, Integer> modified = Traversals.modify(traversal, n -> n * 10, map);
+      assertThat(modified.values()).containsExactlyInAnyOrder(10, 20, 30);
+    }
+
+    @Test
+    @DisplayName("mapValues should handle empty map")
+    void mapValuesShouldHandleEmptyMap() {
+      Traversal<Map<String, Integer>, Integer> traversal = FocusPaths.mapValues();
+
+      Map<String, Integer> emptyMap = Map.of();
+
+      assertThat(Traversals.getAll(traversal, emptyMap)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapAt should focus on value at key")
+    void mapAtShouldFocusOnValueAtKey() {
+      Affine<Map<String, Integer>, Integer> affine = FocusPaths.mapAt("b");
+
+      Map<String, Integer> map = new HashMap<>();
+      map.put("a", 1);
+      map.put("b", 2);
+      map.put("c", 3);
+
+      assertThat(affine.getOptional(map)).contains(2);
+
+      Map<String, Integer> updated = affine.set(20, map);
+      assertThat(updated.get("b")).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("mapAt should return empty for missing key")
+    void mapAtShouldReturnEmptyForMissingKey() {
+      Affine<Map<String, Integer>, Integer> affine = FocusPaths.mapAt("missing");
+
+      Map<String, Integer> map = Map.of("a", 1);
+
+      assertThat(affine.getOptional(map)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapAt should add key when setting on missing key")
+    void mapAtShouldAddKeyWhenSettingOnMissingKey() {
+      Affine<Map<String, Integer>, Integer> affine = FocusPaths.mapAt("new");
+
+      Map<String, Integer> map = new HashMap<>();
+      map.put("a", 1);
+
+      Map<String, Integer> updated = affine.set(99, map);
+      assertThat(updated.get("new")).isEqualTo(99);
+      assertThat(updated.get("a")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("mapAt should support remove operation")
+    void mapAtShouldSupportRemove() {
+      Affine<Map<String, Integer>, Integer> affine = FocusPaths.mapAt("b");
+
+      Map<String, Integer> map = new HashMap<>();
+      map.put("a", 1);
+      map.put("b", 2);
+      map.put("c", 3);
+
+      Map<String, Integer> removed = affine.remove(map);
+      assertThat(removed).containsOnlyKeys("a", "c");
+    }
+  }
+
+  @Nested
+  @DisplayName("Optional Optics")
+  class OptionalOptics {
+
+    @Test
+    @DisplayName("optionalSome should unwrap present Optional")
+    void optionalSomeShouldUnwrapPresent() {
+      Affine<Optional<String>, String> affine = FocusPaths.optionalSome();
+
+      assertThat(affine.getOptional(Optional.of("hello"))).contains("hello");
+    }
+
+    @Test
+    @DisplayName("optionalSome should return empty for empty Optional")
+    void optionalSomeShouldReturnEmptyForEmpty() {
+      Affine<Optional<String>, String> affine = FocusPaths.optionalSome();
+
+      assertThat(affine.getOptional(Optional.empty())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("optionalSome should wrap value when setting")
+    void optionalSomeShouldWrapWhenSetting() {
+      Affine<Optional<String>, String> affine = FocusPaths.optionalSome();
+
+      assertThat(affine.set("world", Optional.of("hello"))).contains("world");
+      assertThat(affine.set("new", Optional.empty())).contains("new");
+    }
+
+    @Test
+    @DisplayName("optionalSome should support remove operation")
+    void optionalSomeShouldSupportRemove() {
+      Affine<Optional<String>, String> affine = FocusPaths.optionalSome();
+
+      assertThat(affine.remove(Optional.of("hello"))).isEmpty();
+      assertThat(affine.remove(Optional.empty())).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Array Optics")
+  class ArrayOptics {
+
+    @Test
+    @DisplayName("arrayElements should traverse all elements")
+    void arrayElementsShouldTraverseAllElements() {
+      Traversal<String[], String> traversal = FocusPaths.arrayElements();
+
+      String[] array = {"a", "b", "c"};
+
+      assertThat(Traversals.getAll(traversal, array)).containsExactly("a", "b", "c");
+
+      String[] modified = Traversals.modify(traversal, String::toUpperCase, array);
+      assertThat(modified).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("arrayElements should handle empty array")
+    void arrayElementsShouldHandleEmptyArray() {
+      Traversal<String[], String> traversal = FocusPaths.arrayElements();
+
+      String[] emptyArray = {};
+
+      assertThat(Traversals.getAll(traversal, emptyArray)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("arrayAt should focus on element at index")
+    void arrayAtShouldFocusOnElementAtIndex() {
+      Affine<String[], String> affine = FocusPaths.arrayAt(1);
+
+      String[] array = {"a", "b", "c"};
+
+      assertThat(affine.getOptional(array)).contains("b");
+
+      String[] updated = affine.set("X", array);
+      assertThat(updated).containsExactly("a", "X", "c");
+      // Original unchanged
+      assertThat(array).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("arrayAt should return empty for out of bounds")
+    void arrayAtShouldReturnEmptyForOutOfBounds() {
+      Affine<String[], String> affine = FocusPaths.arrayAt(10);
+
+      String[] array = {"a", "b", "c"};
+
+      assertThat(affine.getOptional(array)).isEmpty();
+      // Setter with out of bounds index should return original array unchanged
+      assertThat(affine.set("X", array)).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("arrayAt should handle negative index")
+    void arrayAtShouldHandleNegativeIndex() {
+      Affine<String[], String> affine = FocusPaths.arrayAt(-1);
+
+      String[] array = {"a", "b", "c"};
+
+      assertThat(affine.getOptional(array)).isEmpty();
+      // Setter with negative index should return original array unchanged
+      assertThat(affine.set("X", array)).containsExactly("a", "b", "c");
+    }
+  }
+
+  @Nested
+  @DisplayName("Integration Tests")
+  class IntegrationTests {
+
+    @Test
+    @DisplayName("should support complex nested navigation")
+    void shouldSupportComplexNestedNavigation() {
+      record User(String name, List<Map<String, Optional<String>>> settings) {}
+
+      // Lens to settings
+      var settingsLens =
+          Lens.<User, List<Map<String, Optional<String>>>>of(
+              User::settings, (u, s) -> new User(u.name(), s));
+
+      // Navigate: User -> List<Map> -> Map -> Optional -> String
+      var path =
+          FocusPath.of(settingsLens)
+              .<Map<String, Optional<String>>>each()
+              .<String, Optional<String>>atKey("theme")
+              .<String>some();
+
+      Map<String, Optional<String>> map1 = new HashMap<>();
+      map1.put("theme", Optional.of("dark"));
+
+      Map<String, Optional<String>> map2 = new HashMap<>();
+      map2.put("theme", Optional.empty());
+
+      Map<String, Optional<String>> map3 = new HashMap<>();
+      map3.put("language", Optional.of("en"));
+
+      User user = new User("Alice", List.of(map1, map2, map3));
+
+      // Should find only the present theme value
+      assertThat(path.getAll(user)).containsExactly("dark");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/TraversalPathTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/TraversalPathTest.java
@@ -1,0 +1,373 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TraversalPath<S, A> Tests")
+class TraversalPathTest {
+
+  // Test Data Structures
+  record Team(String name, List<Player> players) {}
+
+  record Player(String name, int score, List<String> achievements) {}
+
+  sealed interface Shape permits Circle, Rectangle {}
+
+  record Circle(double radius) implements Shape {}
+
+  record Rectangle(double width, double height) implements Shape {}
+
+  @Nested
+  @DisplayName("Core Functionality")
+  class CoreFunctionality {
+
+    @Test
+    @DisplayName("of should create a TraversalPath from a Traversal")
+    void ofShouldCreateTraversalPath() {
+      Traversal<List<String>, String> traversal = Traversals.forList();
+      TraversalPath<List<String>, String> path = TraversalPath.of(traversal);
+
+      assertThat(path).isNotNull();
+      assertThat(path.toTraversal()).isSameAs(traversal);
+    }
+
+    @Test
+    @DisplayName("getAll should return all focused values")
+    void getAllShouldReturnAllValues() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.getAll(List.of("a", "b", "c"))).containsExactly("a", "b", "c");
+      assertThat(path.getAll(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("preview should return first value if present")
+    void previewShouldReturnFirstValue() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.preview(List.of("a", "b", "c"))).contains("a");
+      assertThat(path.preview(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("setAll should replace all values")
+    void setAllShouldReplaceAllValues() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+
+      List<String> result = path.setAll("X", List.of("a", "b", "c"));
+      assertThat(result).containsExactly("X", "X", "X");
+    }
+
+    @Test
+    @DisplayName("modifyAll should transform all values")
+    void modifyAllShouldTransformAllValues() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+
+      List<String> result = path.modifyAll(String::toUpperCase, List.of("a", "b", "c"));
+      assertThat(result).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("count should return number of focused elements")
+    void countShouldReturnNumberOfElements() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.count(List.of("a", "b", "c"))).isEqualTo(3);
+      assertThat(path.count(List.of())).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("isEmpty should check if no elements focused")
+    void isEmptyShouldCheckIfNoElements() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.isEmpty(List.of("a"))).isFalse();
+      assertThat(path.isEmpty(List.of())).isTrue();
+    }
+
+    @Test
+    @DisplayName("exists should check if any element matches predicate")
+    void existsShouldCheckIfAnyMatches() {
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.exists(n -> n > 5, List.of(1, 2, 10))).isTrue();
+      assertThat(path.exists(n -> n > 5, List.of(1, 2, 3))).isFalse();
+      assertThat(path.exists(n -> n > 5, List.of())).isFalse();
+    }
+
+    @Test
+    @DisplayName("all should check if all elements match predicate")
+    void allShouldCheckIfAllMatch() {
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.all(n -> n > 0, List.of(1, 2, 3))).isTrue();
+      assertThat(path.all(n -> n > 0, List.of(1, -1, 3))).isFalse();
+      assertThat(path.all(n -> n > 0, List.of())).isTrue(); // Vacuously true
+    }
+
+    @Test
+    @DisplayName("find should return first matching element")
+    void findShouldReturnFirstMatching() {
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(Traversals.forList());
+
+      assertThat(path.find(n -> n > 5, List.of(1, 7, 10))).contains(7);
+      assertThat(path.find(n -> n > 100, List.of(1, 7, 10))).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Filtering")
+  class Filtering {
+
+    @Test
+    @DisplayName("filter should only affect matching elements")
+    void filterShouldOnlyAffectMatchingElements() {
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(Traversals.forList());
+      TraversalPath<List<Integer>, Integer> evenPath = path.filter(n -> n % 2 == 0);
+
+      List<Integer> numbers = List.of(1, 2, 3, 4, 5, 6);
+
+      assertThat(evenPath.getAll(numbers)).containsExactly(2, 4, 6);
+
+      List<Integer> doubled = evenPath.modifyAll(n -> n * 2, numbers);
+      assertThat(doubled).containsExactly(1, 4, 3, 8, 5, 12);
+    }
+
+    @Test
+    @DisplayName("filter can be chained")
+    void filterCanBeChained() {
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(Traversals.forList());
+      TraversalPath<List<Integer>, Integer> filteredPath =
+          path.filter(n -> n > 0).filter(n -> n < 10);
+
+      assertThat(filteredPath.getAll(List.of(-5, 1, 5, 15, 8))).containsExactly(1, 5, 8);
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Lens")
+  class CompositionWithLens {
+
+    @Test
+    @DisplayName("via(Lens) should compose with all traversed elements")
+    void viaLensShouldComposeWithAllElements() {
+      Lens<Team, List<Player>> playersLens =
+          Lens.of(Team::players, (t, p) -> new Team(t.name(), p));
+      Traversal<List<Player>, Player> playerTraversal = Traversals.forList();
+      Lens<Player, String> nameLens =
+          Lens.of(Player::name, (p, n) -> new Player(n, p.score(), p.achievements()));
+
+      TraversalPath<Team, Player> playersPath = FocusPath.of(playersLens).via(playerTraversal);
+      TraversalPath<Team, String> namesPath = playersPath.via(nameLens);
+
+      Team team =
+          new Team(
+              "Red",
+              List.of(new Player("Alice", 100, List.of()), new Player("Bob", 85, List.of())));
+
+      assertThat(namesPath.getAll(team)).containsExactly("Alice", "Bob");
+
+      Team modified = namesPath.modifyAll(String::toUpperCase, team);
+      assertThat(modified.players().get(0).name()).isEqualTo("ALICE");
+      assertThat(modified.players().get(1).name()).isEqualTo("BOB");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Prism")
+  class CompositionWithPrism {
+
+    @Test
+    @DisplayName("via(Prism) should filter to matching elements")
+    void viaPrismShouldFilterToMatchingElements() {
+      Prism<Shape, Circle> circlePrism =
+          Prism.of(s -> s instanceof Circle c ? Optional.of(c) : Optional.empty(), c -> c);
+
+      TraversalPath<List<Shape>, Shape> shapesPath = TraversalPath.of(Traversals.forList());
+      TraversalPath<List<Shape>, Circle> circlesPath = shapesPath.via(circlePrism);
+
+      List<Shape> shapes = List.of(new Circle(5), new Rectangle(3, 4), new Circle(10));
+
+      assertThat(circlesPath.getAll(shapes)).hasSize(2);
+      assertThat(circlesPath.getAll(shapes).get(0).radius()).isEqualTo(5);
+      assertThat(circlesPath.getAll(shapes).get(1).radius()).isEqualTo(10);
+
+      // Modify only circles
+      List<Shape> modified = circlesPath.modifyAll(c -> new Circle(c.radius() * 2), shapes);
+      assertThat(((Circle) modified.get(0)).radius()).isEqualTo(10);
+      assertThat(((Rectangle) modified.get(1)).width()).isEqualTo(3); // Unchanged
+      assertThat(((Circle) modified.get(2)).radius()).isEqualTo(20);
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Affine")
+  class CompositionWithAffine {
+
+    @Test
+    @DisplayName("via(Affine) should compose and filter to present elements")
+    void viaAffineShouldComposeAndFilterToPresent() {
+      record Item(String name, Optional<String> description) {}
+
+      Lens<Item, Optional<String>> descLens =
+          Lens.of(Item::description, (item, desc) -> new Item(item.name(), desc));
+      Affine<Optional<String>, String> someAffine = FocusPaths.optionalSome();
+
+      TraversalPath<List<Item>, Item> itemsPath = TraversalPath.of(Traversals.forList());
+      TraversalPath<List<Item>, Optional<String>> descPath = itemsPath.via(descLens);
+      TraversalPath<List<Item>, String> presentDescPath = descPath.via(someAffine);
+
+      List<Item> items =
+          List.of(
+              new Item("Widget", Optional.of("A useful widget")),
+              new Item("Gadget", Optional.empty()),
+              new Item("Gizmo", Optional.of("A cool gizmo")));
+
+      // Only items with descriptions are focused
+      assertThat(presentDescPath.getAll(items)).containsExactly("A useful widget", "A cool gizmo");
+
+      // Modify only present descriptions
+      List<Item> modified = presentDescPath.modifyAll(String::toUpperCase, items);
+      assertThat(modified.get(0).description()).contains("A USEFUL WIDGET");
+      assertThat(modified.get(1).description()).isEmpty(); // Unchanged
+      assertThat(modified.get(2).description()).contains("A COOL GIZMO");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Traversal")
+  class CompositionWithTraversal {
+
+    @Test
+    @DisplayName("via(Traversal) should compose for nested collections")
+    void viaTraversalShouldComposeForNestedCollections() {
+      Lens<Team, List<Player>> playersLens =
+          Lens.of(Team::players, (t, p) -> new Team(t.name(), p));
+      Traversal<List<Player>, Player> playerTraversal = Traversals.forList();
+      Lens<Player, List<String>> achievementsLens =
+          Lens.of(Player::achievements, (p, a) -> new Player(p.name(), p.score(), a));
+      Traversal<List<String>, String> achievementTraversal = Traversals.forList();
+
+      TraversalPath<Team, String> allAchievementsPath =
+          FocusPath.of(playersLens)
+              .via(playerTraversal)
+              .via(achievementsLens)
+              .via(achievementTraversal);
+
+      Team team =
+          new Team(
+              "Champions",
+              List.of(
+                  new Player("Alice", 100, List.of("MVP", "First Blood")),
+                  new Player("Bob", 85, List.of("Ace"))));
+
+      assertThat(allAchievementsPath.getAll(team)).containsExactly("MVP", "First Blood", "Ace");
+
+      Team modified = allAchievementsPath.modifyAll(String::toUpperCase, team);
+      assertThat(modified.players().get(0).achievements()).containsExactly("MVP", "FIRST BLOOD");
+      assertThat(modified.players().get(1).achievements()).containsExactly("ACE");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition with Iso")
+  class CompositionWithIso {
+
+    @Test
+    @DisplayName("via(Iso) should transform all elements")
+    void viaIsoShouldTransformAllElements() {
+      record Wrapper(String value) {}
+
+      Iso<String, Wrapper> wrapperIso = Iso.of(Wrapper::new, Wrapper::value);
+
+      TraversalPath<List<String>, String> stringsPath = TraversalPath.of(Traversals.forList());
+      TraversalPath<List<String>, Wrapper> wrappersPath = stringsPath.via(wrapperIso);
+
+      List<String> strings = List.of("a", "b");
+
+      assertThat(wrappersPath.getAll(strings)).extracting(Wrapper::value).containsExactly("a", "b");
+    }
+  }
+
+  @Nested
+  @DisplayName("Collection Navigation")
+  class CollectionNavigation {
+
+    @Test
+    @DisplayName("each() should flatten nested lists")
+    void eachShouldFlattenNestedLists() {
+      TraversalPath<List<List<String>>, List<String>> outerPath =
+          TraversalPath.of(Traversals.forList());
+      TraversalPath<List<List<String>>, String> innerPath = outerPath.each();
+
+      List<List<String>> nested = List.of(List.of("a", "b"), List.of("c"), List.of("d", "e"));
+
+      assertThat(innerPath.getAll(nested)).containsExactly("a", "b", "c", "d", "e");
+    }
+
+    @Test
+    @DisplayName("at(index) should access element at index in all sublists")
+    void atShouldAccessElementInAllSublists() {
+      TraversalPath<List<List<String>>, List<String>> outerPath =
+          TraversalPath.of(Traversals.forList());
+      TraversalPath<List<List<String>>, String> firstPath = outerPath.at(0);
+
+      List<List<String>> nested = List.of(List.of("a", "b"), List.of("c"), List.of("d", "e"));
+
+      // Gets first element from each sublist that has one
+      assertThat(firstPath.getAll(nested)).containsExactly("a", "c", "d");
+    }
+
+    @Test
+    @DisplayName("some() should unwrap Optional values in list")
+    void someShouldUnwrapOptionalValuesInList() {
+      TraversalPath<List<Optional<String>>, Optional<String>> optPath =
+          TraversalPath.of(Traversals.forList());
+      TraversalPath<List<Optional<String>>, String> valuesPath = optPath.some();
+
+      List<Optional<String>> opts = List.of(Optional.of("a"), Optional.empty(), Optional.of("c"));
+
+      assertThat(valuesPath.getAll(opts)).containsExactly("a", "c");
+    }
+  }
+
+  @Nested
+  @DisplayName("Conversion Methods")
+  class ConversionMethods {
+
+    @Test
+    @DisplayName("toTraversal should return the underlying Traversal")
+    void toTraversalShouldReturnUnderlyingTraversal() {
+      Traversal<List<String>, String> traversal = Traversals.forList();
+      TraversalPath<List<String>, String> path = TraversalPath.of(traversal);
+
+      assertThat(path.toTraversal()).isSameAs(traversal);
+    }
+
+    @Test
+    @DisplayName("asFold should return a Fold view")
+    void asFoldShouldReturnFoldView() {
+      TraversalPath<List<String>, String> path = TraversalPath.of(Traversals.forList());
+      var fold = path.asFold();
+
+      List<String> list = List.of("hello", "world");
+
+      // Fold can query but not modify
+      assertThat(fold.exists(s -> s.length() > 4, list)).isTrue();
+      assertThat(fold.all(s -> s.length() > 3, list)).isTrue();
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/TraverseIntegrationTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/TraverseIntegrationTest.java
@@ -1,0 +1,628 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeTraverse;
+import org.higherkindedj.optics.Lens;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for Traverse type class support in Focus DSL.
+ *
+ * <p>Tests the {@code traverseOver()} method across FocusPath, AffinePath, and TraversalPath.
+ */
+@DisplayName("Traverse Integration with Focus DSL")
+class TraverseIntegrationTest {
+
+  // Test domain types
+  record User(String name, Kind<ListKind.Witness, Role> roles) {}
+
+  record Role(String name, int level) {}
+
+  record Config(String name, Kind<MaybeKind.Witness, Kind<ListKind.Witness, Feature>> features) {}
+
+  record Feature(String name, boolean enabled) {}
+
+  record Team(String name, List<User> members) {}
+
+  // Nested structure test types
+  record Outer(Kind<ListKind.Witness, Middle> middles) {}
+
+  record Middle(Kind<ListKind.Witness, Inner> inners) {}
+
+  record Inner(String value) {}
+
+  // Lenses for test domain
+  static final Lens<User, String> userNameLens =
+      Lens.of(User::name, (u, n) -> new User(n, u.roles()));
+
+  static final Lens<User, Kind<ListKind.Witness, Role>> userRolesLens =
+      Lens.of(User::roles, (u, r) -> new User(u.name(), r));
+
+  static final Lens<Role, String> roleNameLens =
+      Lens.of(Role::name, (r, n) -> new Role(n, r.level()));
+
+  static final Lens<Role, Integer> roleLevelLens =
+      Lens.of(Role::level, (r, l) -> new Role(r.name(), l));
+
+  static final Lens<Config, Kind<MaybeKind.Witness, Kind<ListKind.Witness, Feature>>>
+      configFeaturesLens = Lens.of(Config::features, (c, f) -> new Config(c.name(), f));
+
+  static final Lens<Feature, Boolean> featureEnabledLens =
+      Lens.of(Feature::enabled, (f, e) -> new Feature(f.name(), e));
+
+  static final Lens<Team, List<User>> teamMembersLens =
+      Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+  static final Lens<Outer, Kind<ListKind.Witness, Middle>> outerMiddlesLens =
+      Lens.of(Outer::middles, (o, m) -> new Outer(m));
+
+  static final Lens<Middle, Kind<ListKind.Witness, Inner>> middleInnersLens =
+      Lens.of(Middle::inners, (m, i) -> new Middle(i));
+
+  static final Lens<Inner, String> innerValueLens = Lens.of(Inner::value, (i, v) -> new Inner(v));
+
+  @Nested
+  @DisplayName("FocusPath.traverseOver()")
+  class FocusPathTraverseOverTests {
+
+    @Test
+    @DisplayName("should traverse into Kind<ListKind.Witness, _> field")
+    void shouldTraverseIntoListKindField() {
+      User user =
+          new User(
+              "Alice",
+              ListKindHelper.LIST.widen(
+                  List.of(new Role("Admin", 10), new Role("User", 1), new Role("Guest", 0))));
+
+      FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = FocusPath.of(userRolesLens);
+
+      TraversalPath<User, Role> allRoles =
+          rolesPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+      List<Role> roles = allRoles.getAll(user);
+
+      assertThat(roles).hasSize(3);
+      assertThat(roles.stream().map(Role::name)).containsExactly("Admin", "User", "Guest");
+    }
+
+    @Test
+    @DisplayName("should modify all elements via traverseOver")
+    void shouldModifyAllViaTraverseOver() {
+      User user =
+          new User(
+              "Bob",
+              ListKindHelper.LIST.widen(List.of(new Role("Admin", 10), new Role("User", 1))));
+
+      FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = FocusPath.of(userRolesLens);
+
+      TraversalPath<User, Role> allRoles =
+          rolesPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+      User updated = allRoles.modifyAll(r -> new Role(r.name().toUpperCase(), r.level()), user);
+
+      List<Role> updatedRoles = ListKindHelper.LIST.narrow(updated.roles());
+      assertThat(updatedRoles.stream().map(Role::name)).containsExactly("ADMIN", "USER");
+    }
+
+    @Test
+    @DisplayName("should compose traverseOver with via for nested access")
+    void shouldComposeTraverseOverWithVia() {
+      User user =
+          new User(
+              "Charlie",
+              ListKindHelper.LIST.widen(List.of(new Role("Admin", 10), new Role("User", 5))));
+
+      FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = FocusPath.of(userRolesLens);
+
+      // First get TraversalPath<User, Role>, then compose with roleLevelLens
+      TraversalPath<User, Role> allRoles =
+          rolesPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+      TraversalPath<User, Integer> allLevels = allRoles.via(roleLevelLens);
+
+      List<Integer> levels = allLevels.getAll(user);
+
+      assertThat(levels).containsExactly(10, 5);
+    }
+
+    @Test
+    @DisplayName("should handle empty container via traverseOver")
+    void shouldHandleEmptyContainer() {
+      User user = new User("Empty", ListKindHelper.LIST.widen(List.of()));
+
+      FocusPath<User, Kind<ListKind.Witness, Role>> rolesPath = FocusPath.of(userRolesLens);
+
+      TraversalPath<User, Role> allRoles =
+          rolesPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+      List<Role> roles = allRoles.getAll(user);
+
+      assertThat(roles).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("AffinePath.traverseOver()")
+  class AffinePathTraverseOverTests {
+
+    // Test domain for AffinePath-specific tests
+    record Container(Kind<MaybeKind.Witness, Kind<ListKind.Witness, String>> data) {}
+
+    static final Lens<Container, Kind<MaybeKind.Witness, Kind<ListKind.Witness, String>>>
+        containerDataLens = Lens.of(Container::data, (c, d) -> new Container(d));
+
+    // Sealed interface for instanceOf tests (must be at class level, not local)
+    sealed interface Wrapper permits ListWrapper, SingleWrapper {}
+
+    record ListWrapper(Kind<ListKind.Witness, String> items) implements Wrapper {}
+
+    record SingleWrapper(String item) implements Wrapper {}
+
+    @Test
+    @DisplayName("should traverse into optional container field")
+    void shouldTraverseIntoOptionalContainerField() {
+      Config config =
+          new Config(
+              "MyApp",
+              MaybeKindHelper.MAYBE.widen(
+                  Maybe.just(
+                      ListKindHelper.LIST.widen(
+                          List.of(
+                              new Feature("DarkMode", true), new Feature("Analytics", false))))));
+
+      // Create a FocusPath to the optional features
+      FocusPath<Config, Kind<MaybeKind.Witness, Kind<ListKind.Witness, Feature>>> focusPath =
+          FocusPath.of(configFeaturesLens);
+
+      // First traverse the Maybe, then traverse the List
+      TraversalPath<Config, Kind<ListKind.Witness, Feature>> maybeTraversed =
+          focusPath.<MaybeKind.Witness, Kind<ListKind.Witness, Feature>>traverseOver(
+              MaybeTraverse.INSTANCE);
+
+      TraversalPath<Config, Feature> allFeatures =
+          maybeTraversed.<ListKind.Witness, Feature>traverseOver(ListTraverse.INSTANCE);
+
+      List<Feature> features = allFeatures.getAll(config);
+
+      assertThat(features).hasSize(2);
+      assertThat(features.stream().map(Feature::name)).containsExactly("DarkMode", "Analytics");
+    }
+
+    @Test
+    @DisplayName("should handle Nothing in optional container")
+    void shouldHandleNothingInOptionalContainer() {
+      Config config = new Config("EmptyApp", MaybeKindHelper.MAYBE.widen(Maybe.nothing()));
+
+      FocusPath<Config, Kind<MaybeKind.Witness, Kind<ListKind.Witness, Feature>>> focusPath =
+          FocusPath.of(configFeaturesLens);
+
+      TraversalPath<Config, Kind<ListKind.Witness, Feature>> maybeTraversed =
+          focusPath.<MaybeKind.Witness, Kind<ListKind.Witness, Feature>>traverseOver(
+              MaybeTraverse.INSTANCE);
+
+      List<Kind<ListKind.Witness, Feature>> results = maybeTraversed.getAll(config);
+
+      assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should traverse directly from AffinePath with instanceOf")
+    void shouldTraverseDirectlyFromAffinePath() {
+      // Use Wrapper sealed interface defined at class level
+      ListWrapper wrapper = new ListWrapper(ListKindHelper.LIST.widen(List.of("a", "b", "c")));
+
+      // Create an AffinePath using instanceOf
+      AffinePath<Wrapper, ListWrapper> listWrapperPath = AffinePath.instanceOf(ListWrapper.class);
+
+      // Get the list wrapper via the affine
+      assertThat(listWrapperPath.getOptional(wrapper)).isPresent();
+      assertThat(listWrapperPath.getOptional(wrapper).get().items()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should modify all elements via AffinePath.traverseOver when focused")
+    void shouldModifyAllViaAffinePathTraverseOver() {
+      Container container =
+          new Container(
+              MaybeKindHelper.MAYBE.widen(
+                  Maybe.just(ListKindHelper.LIST.widen(List.of("hello", "world")))));
+
+      // Start with AffinePath via at(0) pattern (simulate optional access)
+      FocusPath<Container, Kind<MaybeKind.Witness, Kind<ListKind.Witness, String>>> dataPath =
+          FocusPath.of(containerDataLens);
+
+      // Traverse Maybe first
+      TraversalPath<Container, Kind<ListKind.Witness, String>> maybeTraversed =
+          dataPath.<MaybeKind.Witness, Kind<ListKind.Witness, String>>traverseOver(
+              MaybeTraverse.INSTANCE);
+
+      // Then traverse the List
+      TraversalPath<Container, String> allStrings =
+          maybeTraversed.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      // Modify all strings
+      Container updated = allStrings.modifyAll(String::toUpperCase, container);
+
+      // Verify modification
+      Maybe<Kind<ListKind.Witness, String>> maybeList =
+          MaybeKindHelper.MAYBE.narrow(updated.data());
+      assertThat(maybeList.isJust()).isTrue();
+      List<String> resultList = ListKindHelper.LIST.narrow(maybeList.get());
+      assertThat(resultList).containsExactly("HELLO", "WORLD");
+    }
+
+    @Test
+    @DisplayName("should return empty when AffinePath has no focus")
+    void shouldReturnEmptyWhenNoFocus() {
+      Container container =
+          new Container(
+              MaybeKindHelper.MAYBE.widen(Maybe.<Kind<ListKind.Witness, String>>nothing()));
+
+      FocusPath<Container, Kind<MaybeKind.Witness, Kind<ListKind.Witness, String>>> dataPath =
+          FocusPath.of(containerDataLens);
+
+      TraversalPath<Container, Kind<ListKind.Witness, String>> maybeTraversed =
+          dataPath.<MaybeKind.Witness, Kind<ListKind.Witness, String>>traverseOver(
+              MaybeTraverse.INSTANCE);
+
+      List<Kind<ListKind.Witness, String>> results = maybeTraversed.getAll(container);
+
+      assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should count elements correctly via AffinePath.traverseOver")
+    void shouldCountElementsCorrectly() {
+      Container container =
+          new Container(
+              MaybeKindHelper.MAYBE.widen(
+                  Maybe.just(ListKindHelper.LIST.widen(List.of("a", "b", "c", "d")))));
+
+      FocusPath<Container, Kind<MaybeKind.Witness, Kind<ListKind.Witness, String>>> dataPath =
+          FocusPath.of(containerDataLens);
+
+      TraversalPath<Container, Kind<ListKind.Witness, String>> maybeTraversed =
+          dataPath.<MaybeKind.Witness, Kind<ListKind.Witness, String>>traverseOver(
+              MaybeTraverse.INSTANCE);
+
+      TraversalPath<Container, String> allStrings =
+          maybeTraversed.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      assertThat(allStrings.count(container)).isEqualTo(4);
+    }
+
+    // ===== Direct AffinePath.traverseOver() tests =====
+
+    // Domain type where AffinePath directly holds a Kind<F, E>
+    record OptionalItems(Kind<MaybeKind.Witness, Kind<ListKind.Witness, Integer>> maybeItems) {}
+
+    static final Lens<OptionalItems, Kind<MaybeKind.Witness, Kind<ListKind.Witness, Integer>>>
+        optionalItemsLens = Lens.of(OptionalItems::maybeItems, (o, m) -> new OptionalItems(m));
+
+    // Sealed interface where one variant holds a Kind<ListKind.Witness, E>
+    sealed interface ItemHolder permits ItemList, SingleItem {}
+
+    record ItemList(Kind<ListKind.Witness, String> items) implements ItemHolder {}
+
+    record SingleItem(String item) implements ItemHolder {}
+
+    static final Lens<ItemList, Kind<ListKind.Witness, String>> itemListItemsLens =
+        Lens.of(ItemList::items, (il, i) -> new ItemList(i));
+
+    @Test
+    @DisplayName("should call traverseOver directly on AffinePath created via instanceOf")
+    void shouldCallTraverseOverDirectlyOnAffinePath() {
+      // Create an ItemHolder that is an ItemList
+      ItemHolder holder = new ItemList(ListKindHelper.LIST.widen(List.of("x", "y", "z")));
+
+      // Create an AffinePath using instanceOf
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+
+      // Compose with lens to get the Kind<ListKind.Witness, String>
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      // Call traverseOver DIRECTLY on the AffinePath
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      // Verify getAll works
+      List<String> items = allItemsPath.getAll(holder);
+      assertThat(items).containsExactly("x", "y", "z");
+    }
+
+    @Test
+    @DisplayName("should return empty when AffinePath.traverseOver has no focus (instanceOf fails)")
+    void shouldReturnEmptyWhenAffinePathHasNoFocusOnTraverseOver() {
+      // Create an ItemHolder that is a SingleItem (not an ItemList)
+      ItemHolder holder = new SingleItem("solo");
+
+      // Create an AffinePath using instanceOf for ItemList
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+
+      // Compose with lens to get the Kind<ListKind.Witness, String>
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      // Call traverseOver on AffinePath - should handle no focus gracefully
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      // Should return empty since instanceOf didn't match
+      List<String> items = allItemsPath.getAll(holder);
+      assertThat(items).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should modifyAll via AffinePath.traverseOver when focus exists")
+    void shouldModifyAllViaDirectAffinePathTraverseOver() {
+      ItemHolder holder = new ItemList(ListKindHelper.LIST.widen(List.of("alpha", "beta")));
+
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      // Call traverseOver directly on AffinePath
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      // Modify all items
+      ItemHolder updated = allItemsPath.modifyAll(String::toUpperCase, holder);
+
+      // Verify modification
+      assertThat(updated).isInstanceOf(ItemList.class);
+      ItemList updatedList = (ItemList) updated;
+      List<String> resultItems = ListKindHelper.LIST.narrow(updatedList.items());
+      assertThat(resultItems).containsExactly("ALPHA", "BETA");
+    }
+
+    @Test
+    @DisplayName(
+        "should leave source unchanged when modifyAll via AffinePath.traverseOver has no focus")
+    void shouldLeaveUnchangedWhenModifyAllHasNoFocus() {
+      ItemHolder holder = new SingleItem("untouched");
+
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      // Modify should have no effect since AffinePath has no focus
+      ItemHolder updated = allItemsPath.modifyAll(String::toUpperCase, holder);
+
+      // Source should be unchanged
+      assertThat(updated).isInstanceOf(SingleItem.class);
+      assertThat(((SingleItem) updated).item()).isEqualTo("untouched");
+    }
+
+    @Test
+    @DisplayName("should handle empty container when AffinePath.traverseOver has focus")
+    void shouldHandleEmptyContainerWhenAffinePathHasFocus() {
+      ItemHolder holder = new ItemList(ListKindHelper.LIST.widen(List.of()));
+
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      // Focus exists but container is empty
+      List<String> items = allItemsPath.getAll(holder);
+      assertThat(items).isEmpty();
+
+      // Count should be 0
+      assertThat(allItemsPath.count(holder)).isEqualTo(0);
+    }
+
+    // Types for chaining test (must be at class level, not local)
+    record ChainItem(String name, int length) {}
+
+    record ChainItemsHolder(Kind<ListKind.Witness, ChainItem> items) {}
+
+    sealed interface ChainWrapper permits ChainItemsWrapper, ChainEmptyWrapper {}
+
+    record ChainItemsWrapper(ChainItemsHolder holder) implements ChainWrapper {}
+
+    record ChainEmptyWrapper() implements ChainWrapper {}
+
+    static final Lens<ChainItemsHolder, Kind<ListKind.Witness, ChainItem>> chainItemsHolderLens =
+        Lens.of(ChainItemsHolder::items, (h, i) -> new ChainItemsHolder(i));
+
+    static final Lens<ChainItem, String> chainItemNameLens =
+        Lens.of(ChainItem::name, (i, n) -> new ChainItem(n, i.length()));
+
+    static final Lens<ChainItemsWrapper, ChainItemsHolder> chainItemsWrapperHolderLens =
+        Lens.of(ChainItemsWrapper::holder, (w, h) -> new ChainItemsWrapper(h));
+
+    @Test
+    @DisplayName("should chain via() after AffinePath.traverseOver")
+    void shouldChainViaAfterAffinePathTraverseOver() {
+      ChainItemsHolder holder =
+          new ChainItemsHolder(
+              ListKindHelper.LIST.widen(
+                  List.of(new ChainItem("first", 5), new ChainItem("second", 6))));
+      ChainWrapper wrapper = new ChainItemsWrapper(holder);
+
+      // Create AffinePath via instanceOf
+      AffinePath<ChainWrapper, ChainItemsWrapper> wrapperPath =
+          AffinePath.instanceOf(ChainItemsWrapper.class);
+
+      // Chain: AffinePath -> via(lens) -> via(lens) -> traverseOver -> via(lens)
+      AffinePath<ChainWrapper, ChainItemsHolder> holderPath =
+          wrapperPath.via(chainItemsWrapperHolderLens);
+      AffinePath<ChainWrapper, Kind<ListKind.Witness, ChainItem>> itemsPath =
+          holderPath.via(chainItemsHolderLens);
+      TraversalPath<ChainWrapper, ChainItem> allItems =
+          itemsPath.<ListKind.Witness, ChainItem>traverseOver(ListTraverse.INSTANCE);
+      TraversalPath<ChainWrapper, String> allNames = allItems.via(chainItemNameLens);
+
+      // Verify chain works
+      List<String> names = allNames.getAll(wrapper);
+      assertThat(names).containsExactly("first", "second");
+
+      // Modify through the chain
+      ChainWrapper updated = allNames.modifyAll(String::toUpperCase, wrapper);
+      List<String> updatedNames = allNames.getAll(updated);
+      assertThat(updatedNames).containsExactly("FIRST", "SECOND");
+    }
+
+    @Test
+    @DisplayName("should count correctly through AffinePath.traverseOver")
+    void shouldCountCorrectlyThroughAffinePathTraverseOver() {
+      ItemHolder holder = new ItemList(ListKindHelper.LIST.widen(List.of("a", "b", "c", "d", "e")));
+
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      assertThat(allItemsPath.count(holder)).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("should return 0 count when AffinePath.traverseOver has no focus")
+    void shouldReturnZeroCountWhenNoFocus() {
+      ItemHolder holder = new SingleItem("alone");
+
+      AffinePath<ItemHolder, ItemList> itemListPath = AffinePath.instanceOf(ItemList.class);
+      AffinePath<ItemHolder, Kind<ListKind.Witness, String>> itemsKindPath =
+          itemListPath.via(itemListItemsLens);
+
+      TraversalPath<ItemHolder, String> allItemsPath =
+          itemsKindPath.<ListKind.Witness, String>traverseOver(ListTraverse.INSTANCE);
+
+      assertThat(allItemsPath.count(holder)).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  @DisplayName("TraversalPath.traverseOver()")
+  class TraversalPathTraverseOverTests {
+
+    @Test
+    @DisplayName("should flatten nested traversals")
+    void shouldFlattenNestedTraversals() {
+      Team team =
+          new Team(
+              "DevTeam",
+              List.of(
+                  new User(
+                      "Alice",
+                      ListKindHelper.LIST.widen(
+                          List.of(new Role("Admin", 10), new Role("Dev", 5)))),
+                  new User("Bob", ListKindHelper.LIST.widen(List.of(new Role("User", 1))))));
+
+      // Start with TraversalPath over team members
+      TraversalPath<Team, User> membersPath = FocusPath.of(teamMembersLens).each();
+
+      // Navigate to each member's roles (which is a Kind<ListKind.Witness, Role>)
+      TraversalPath<Team, Kind<ListKind.Witness, Role>> rolesKindPath =
+          membersPath.via(userRolesLens);
+
+      // Traverse into the list to get all roles
+      TraversalPath<Team, Role> allRoles =
+          rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+      List<Role> roles = allRoles.getAll(team);
+
+      assertThat(roles).hasSize(3);
+      assertThat(roles.stream().map(Role::name)).containsExactly("Admin", "Dev", "User");
+    }
+
+    @Test
+    @DisplayName("should modify all nested elements")
+    void shouldModifyAllNestedElements() {
+      Team team =
+          new Team(
+              "DevTeam",
+              List.of(
+                  new User("Alice", ListKindHelper.LIST.widen(List.of(new Role("Admin", 10)))),
+                  new User("Bob", ListKindHelper.LIST.widen(List.of(new Role("User", 1))))));
+
+      TraversalPath<Team, User> membersPath = FocusPath.of(teamMembersLens).each();
+      TraversalPath<Team, Kind<ListKind.Witness, Role>> rolesKindPath =
+          membersPath.via(userRolesLens);
+      TraversalPath<Team, Role> allRoles =
+          rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+      // Give everyone a promotion
+      Team updated = allRoles.modifyAll(r -> new Role(r.name(), r.level() + 1), team);
+
+      // Verify all levels were increased - build path step by step
+      FocusPath<Team, List<User>> step1 = FocusPath.of(teamMembersLens);
+      TraversalPath<Team, User> step2 = step1.each();
+      TraversalPath<Team, Kind<ListKind.Witness, Role>> step3 = step2.via(userRolesLens);
+      TraversalPath<Team, Role> verifyPath =
+          step3.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+      List<Role> updatedRoles = verifyPath.getAll(updated);
+
+      assertThat(updatedRoles.stream().map(Role::level)).containsExactly(11, 2);
+    }
+
+    @Test
+    @DisplayName("should handle mixed empty and non-empty containers")
+    void shouldHandleMixedEmptyAndNonEmpty() {
+      Team team =
+          new Team(
+              "MixedTeam",
+              List.of(
+                  new User("Alice", ListKindHelper.LIST.widen(List.of(new Role("Admin", 10)))),
+                  new User("Bob", ListKindHelper.LIST.widen(List.of())), // Empty roles
+                  new User("Charlie", ListKindHelper.LIST.widen(List.of(new Role("User", 1))))));
+
+      // Build path step by step to avoid type inference issues
+      FocusPath<Team, List<User>> pathStep1 = FocusPath.of(teamMembersLens);
+      TraversalPath<Team, User> pathStep2 = pathStep1.each();
+      TraversalPath<Team, Kind<ListKind.Witness, Role>> pathStep3 = pathStep2.via(userRolesLens);
+      TraversalPath<Team, Role> allRoles =
+          pathStep3.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+      List<Role> roles = allRoles.getAll(team);
+
+      assertThat(roles).hasSize(2);
+      assertThat(roles.stream().map(Role::name)).containsExactly("Admin", "User");
+    }
+
+    @Test
+    @DisplayName("should compose multiple traverseOver calls")
+    void shouldComposeMultipleTraverseOverCalls() {
+      Outer data =
+          new Outer(
+              ListKindHelper.LIST.widen(
+                  List.of(
+                      new Middle(
+                          ListKindHelper.LIST.widen(List.of(new Inner("a1"), new Inner("a2")))),
+                      new Middle(ListKindHelper.LIST.widen(List.of(new Inner("b1")))))));
+
+      // Build the path step by step with explicit types
+      FocusPath<Outer, Kind<ListKind.Witness, Middle>> step1 = FocusPath.of(outerMiddlesLens);
+      TraversalPath<Outer, Middle> step2 =
+          step1.<ListKind.Witness, Middle>traverseOver(ListTraverse.INSTANCE);
+      TraversalPath<Outer, Kind<ListKind.Witness, Inner>> step3 = step2.via(middleInnersLens);
+      TraversalPath<Outer, Inner> step4 =
+          step3.<ListKind.Witness, Inner>traverseOver(ListTraverse.INSTANCE);
+      TraversalPath<Outer, String> allValues = step4.via(innerValueLens);
+
+      List<String> values = allValues.getAll(data);
+
+      assertThat(values).containsExactly("a1", "a2", "b1");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/TraverseTraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/TraverseTraversalsTest.java
@@ -1,0 +1,300 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.stream.StreamKind;
+import org.higherkindedj.hkt.stream.StreamKindHelper;
+import org.higherkindedj.optics.Traversal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link TraverseTraversals} utility class. */
+@DisplayName("TraverseTraversals")
+class TraverseTraversalsTest {
+
+  @Nested
+  @DisplayName("forListKind()")
+  class ForListKindTests {
+
+    @Test
+    @DisplayName("should get all elements from a list")
+    void shouldGetAllElements() {
+      Kind<ListKind.Witness, String> list =
+          ListKindHelper.LIST.widen(List.of("Alice", "Bob", "Charlie"));
+
+      Traversal<Kind<ListKind.Witness, String>, String> traversal =
+          TraverseTraversals.forListKind();
+
+      List<String> result = Traversals.getAll(traversal, list);
+
+      assertThat(result).containsExactly("Alice", "Bob", "Charlie");
+    }
+
+    @Test
+    @DisplayName("should modify all elements in a list")
+    void shouldModifyAllElements() {
+      Kind<ListKind.Witness, String> list = ListKindHelper.LIST.widen(List.of("Alice", "Bob"));
+
+      Traversal<Kind<ListKind.Witness, String>, String> traversal =
+          TraverseTraversals.forListKind();
+
+      Kind<ListKind.Witness, String> result =
+          Traversals.modify(traversal, String::toUpperCase, list);
+
+      assertThat(ListKindHelper.LIST.narrow(result)).containsExactly("ALICE", "BOB");
+    }
+
+    @Test
+    @DisplayName("should handle empty list")
+    void shouldHandleEmptyList() {
+      Kind<ListKind.Witness, String> list = ListKindHelper.LIST.widen(List.of());
+
+      Traversal<Kind<ListKind.Witness, String>, String> traversal =
+          TraverseTraversals.forListKind();
+
+      List<String> result = Traversals.getAll(traversal, list);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("forMaybe()")
+  class ForMaybeTests {
+
+    @Test
+    @DisplayName("should get value from Just")
+    void shouldGetValueFromJust() {
+      Maybe<String> maybe = Maybe.just("hello");
+
+      Traversal<Maybe<String>, String> traversal = TraverseTraversals.forMaybe();
+
+      List<String> result = Traversals.getAll(traversal, maybe);
+
+      assertThat(result).containsExactly("hello");
+    }
+
+    @Test
+    @DisplayName("should return empty for Nothing")
+    void shouldReturnEmptyForNothing() {
+      Maybe<String> maybe = Maybe.nothing();
+
+      Traversal<Maybe<String>, String> traversal = TraverseTraversals.forMaybe();
+
+      List<String> result = Traversals.getAll(traversal, maybe);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should modify value in Just")
+    void shouldModifyValueInJust() {
+      Maybe<String> maybe = Maybe.just("hello");
+
+      Traversal<Maybe<String>, String> traversal = TraverseTraversals.forMaybe();
+
+      Maybe<String> result = Traversals.modify(traversal, String::toUpperCase, maybe);
+
+      assertThat(result.isJust()).isTrue();
+      assertThat(result.get()).isEqualTo("HELLO");
+    }
+
+    @Test
+    @DisplayName("should preserve Nothing on modify")
+    void shouldPreserveNothingOnModify() {
+      Maybe<String> maybe = Maybe.nothing();
+
+      Traversal<Maybe<String>, String> traversal = TraverseTraversals.forMaybe();
+
+      Maybe<String> result = Traversals.modify(traversal, String::toUpperCase, maybe);
+
+      assertThat(result.isNothing()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("forMaybeKind()")
+  class ForMaybeKindTests {
+
+    @Test
+    @DisplayName("should get value from Just Kind")
+    void shouldGetValueFromJustKind() {
+      Kind<MaybeKind.Witness, String> maybe = MaybeKindHelper.MAYBE.widen(Maybe.just("hello"));
+
+      Traversal<Kind<MaybeKind.Witness, String>, String> traversal =
+          TraverseTraversals.forMaybeKind();
+
+      List<String> result = Traversals.getAll(traversal, maybe);
+
+      assertThat(result).containsExactly("hello");
+    }
+
+    @Test
+    @DisplayName("should return empty for Nothing Kind")
+    void shouldReturnEmptyForNothingKind() {
+      Kind<MaybeKind.Witness, String> maybe = MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+
+      Traversal<Kind<MaybeKind.Witness, String>, String> traversal =
+          TraverseTraversals.forMaybeKind();
+
+      List<String> result = Traversals.getAll(traversal, maybe);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("forSet()")
+  class ForSetTests {
+
+    @Test
+    @DisplayName("should get all elements from a set")
+    void shouldGetAllElements() {
+      Set<String> set = Set.of("Alice", "Bob", "Charlie");
+
+      Traversal<Set<String>, String> traversal = TraverseTraversals.forSet();
+
+      List<String> result = Traversals.getAll(traversal, set);
+
+      assertThat(result).containsExactlyInAnyOrder("Alice", "Bob", "Charlie");
+    }
+
+    @Test
+    @DisplayName("should modify all elements in a set")
+    void shouldModifyAllElements() {
+      Set<String> set = Set.of("Alice", "Bob");
+
+      Traversal<Set<String>, String> traversal = TraverseTraversals.forSet();
+
+      Set<String> result = Traversals.modify(traversal, String::toUpperCase, set);
+
+      assertThat(result).containsExactlyInAnyOrder("ALICE", "BOB");
+    }
+
+    @Test
+    @DisplayName("should handle empty set")
+    void shouldHandleEmptySet() {
+      Set<String> set = Set.of();
+
+      Traversal<Set<String>, String> traversal = TraverseTraversals.forSet();
+
+      List<String> result = Traversals.getAll(traversal, set);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("forStream()")
+  class ForStreamTests {
+
+    @Test
+    @DisplayName("should get all elements from a stream")
+    void shouldGetAllElements() {
+      Stream<String> stream = Stream.of("Alice", "Bob", "Charlie");
+
+      Traversal<Stream<String>, String> traversal = TraverseTraversals.forStream();
+
+      List<String> result = Traversals.getAll(traversal, stream);
+
+      assertThat(result).containsExactly("Alice", "Bob", "Charlie");
+    }
+
+    @Test
+    @DisplayName("should modify all elements in a stream")
+    void shouldModifyAllElements() {
+      Stream<String> stream = Stream.of("Alice", "Bob");
+
+      Traversal<Stream<String>, String> traversal = TraverseTraversals.forStream();
+
+      Stream<String> result = Traversals.modify(traversal, String::toUpperCase, stream);
+
+      assertThat(result.toList()).containsExactly("ALICE", "BOB");
+    }
+
+    @Test
+    @DisplayName("should handle empty stream")
+    void shouldHandleEmptyStream() {
+      Stream<String> stream = Stream.empty();
+
+      Traversal<Stream<String>, String> traversal = TraverseTraversals.forStream();
+
+      List<String> result = Traversals.getAll(traversal, stream);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("forStreamKind()")
+  class ForStreamKindTests {
+
+    @Test
+    @DisplayName("should get all elements from a StreamKind")
+    void shouldGetAllElements() {
+      Kind<StreamKind.Witness, String> stream =
+          StreamKindHelper.STREAM.widen(Stream.of("Alice", "Bob", "Charlie"));
+
+      Traversal<Kind<StreamKind.Witness, String>, String> traversal =
+          TraverseTraversals.forStreamKind();
+
+      List<String> result = Traversals.getAll(traversal, stream);
+
+      assertThat(result).containsExactly("Alice", "Bob", "Charlie");
+    }
+
+    @Test
+    @DisplayName("should modify all elements in a StreamKind")
+    void shouldModifyAllElements() {
+      Kind<StreamKind.Witness, String> stream =
+          StreamKindHelper.STREAM.widen(Stream.of("Alice", "Bob"));
+
+      Traversal<Kind<StreamKind.Witness, String>, String> traversal =
+          TraverseTraversals.forStreamKind();
+
+      Kind<StreamKind.Witness, String> result =
+          Traversals.modify(traversal, String::toUpperCase, stream);
+
+      assertThat(StreamKindHelper.STREAM.narrow(result).toList()).containsExactly("ALICE", "BOB");
+    }
+
+    @Test
+    @DisplayName("should handle empty StreamKind")
+    void shouldHandleEmptyStreamKind() {
+      Kind<StreamKind.Witness, String> stream = StreamKindHelper.STREAM.widen(Stream.empty());
+
+      Traversal<Kind<StreamKind.Witness, String>, String> traversal =
+          TraverseTraversals.forStreamKind();
+
+      List<String> result = Traversals.getAll(traversal, stream);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should compose with other traversals")
+    void shouldComposeWithOtherTraversals() {
+      Kind<StreamKind.Witness, Integer> stream =
+          StreamKindHelper.STREAM.widen(Stream.of(1, 2, 3, 4, 5));
+
+      Traversal<Kind<StreamKind.Witness, Integer>, Integer> traversal =
+          TraverseTraversals.forStreamKind();
+
+      // Get all elements and verify
+      List<Integer> result = Traversals.getAll(traversal, stream);
+      assertThat(result).containsExactly(1, 2, 3, 4, 5);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/AsyncFetchExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/AsyncFetchExample.java
@@ -1,0 +1,354 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.focus;
+
+import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+
+/**
+ * Demonstrates async data fetching using the Focus DSL with CompletableFuture.
+ *
+ * <p>This example shows how to use {@code modifyF()} with {@link CompletableFutureMonad} for
+ * asynchronous operations, including:
+ *
+ * <ul>
+ *   <li>Async data enrichment through Focus paths
+ *   <li>Error handling with MonadError
+ *   <li>Parallel async transformations on collections
+ *   <li>Combining async operations with optic composition
+ * </ul>
+ *
+ * <h2>Key Concepts</h2>
+ *
+ * <p>The Focus DSL's {@code modifyF()} method accepts any Applicative instance, including {@link
+ * CompletableFutureMonad}. This enables async transformations that:
+ *
+ * <ul>
+ *   <li>Run asynchronously without blocking
+ *   <li>Propagate errors through the Future chain
+ *   <li>Compose naturally with other Focus operations
+ * </ul>
+ */
+public class AsyncFetchExample {
+
+  // ============= Domain Model =============
+
+  /** User profile with enrichable fields. */
+  record UserProfile(String userId, String displayName, String avatarUrl, ProfileStats stats) {}
+
+  /** Profile statistics that can be fetched asynchronously. */
+  record ProfileStats(int followers, int following, int posts) {
+    static ProfileStats empty() {
+      return new ProfileStats(0, 0, 0);
+    }
+  }
+
+  /** Product with pricing that can be updated from external service. */
+  record Product(String productId, String name, PricingInfo pricing) {}
+
+  /** Pricing information fetched from external service. */
+  record PricingInfo(double basePrice, double discountPercent, String currency) {
+    double effectivePrice() {
+      return basePrice * (1 - discountPercent / 100);
+    }
+
+    static PricingInfo unknown() {
+      return new PricingInfo(0.0, 0.0, "USD");
+    }
+  }
+
+  /** Shopping cart with products to be enriched. */
+  record ShoppingCart(String cartId, List<Product> products) {}
+
+  // ============= Lenses =============
+
+  static final Lens<UserProfile, String> displayNameLens =
+      Lens.of(
+          UserProfile::displayName,
+          (u, name) -> new UserProfile(u.userId(), name, u.avatarUrl(), u.stats()));
+
+  static final Lens<UserProfile, String> avatarUrlLens =
+      Lens.of(
+          UserProfile::avatarUrl,
+          (u, url) -> new UserProfile(u.userId(), u.displayName(), url, u.stats()));
+
+  static final Lens<UserProfile, ProfileStats> statsLens =
+      Lens.of(
+          UserProfile::stats,
+          (u, stats) -> new UserProfile(u.userId(), u.displayName(), u.avatarUrl(), stats));
+
+  static final Lens<Product, PricingInfo> pricingLens =
+      Lens.of(Product::pricing, (p, pricing) -> new Product(p.productId(), p.name(), pricing));
+
+  static final Lens<ShoppingCart, List<Product>> productsLens =
+      Lens.of(ShoppingCart::products, (c, products) -> new ShoppingCart(c.cartId(), products));
+
+  // ============= Simulated Async Services =============
+
+  /** Simulates fetching display name from a remote service. */
+  static CompletableFuture<String> fetchDisplayName(String userId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          simulateLatency(50);
+          return "User " + userId.toUpperCase();
+        });
+  }
+
+  /** Simulates fetching avatar URL from a CDN. */
+  static CompletableFuture<String> fetchAvatarUrl(String userId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          simulateLatency(30);
+          return "https://cdn.example.com/avatars/" + userId + ".png";
+        });
+  }
+
+  /** Simulates fetching profile stats from analytics service. */
+  static CompletableFuture<ProfileStats> fetchStats(String userId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          simulateLatency(100);
+          // Simulate fetched stats
+          int hash = userId.hashCode();
+          return new ProfileStats(
+              Math.abs(hash % 10000), Math.abs((hash >> 8) % 1000), Math.abs((hash >> 16) % 500));
+        });
+  }
+
+  /** Simulates fetching pricing from external pricing service. */
+  static CompletableFuture<PricingInfo> fetchPricing(String productId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          simulateLatency(40);
+          // Simulate different pricing based on product
+          double basePrice =
+              switch (productId) {
+                case "PROD-A" -> 29.99;
+                case "PROD-B" -> 149.99;
+                case "PROD-C" -> 9.99;
+                default -> 19.99;
+              };
+          double discount = productId.hashCode() % 20;
+          return new PricingInfo(basePrice, discount, "USD");
+        });
+  }
+
+  /** Simulates a service that may fail. */
+  static CompletableFuture<String> fetchUnreliableData(String id) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          simulateLatency(20);
+          if (id.startsWith("BAD")) {
+            throw new RuntimeException("Service unavailable for ID: " + id);
+          }
+          return "Data for " + id;
+        });
+  }
+
+  private static void simulateLatency(long millis) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  // ============= Examples =============
+
+  public static void main(String[] args) {
+    System.out.println("=== Async Fetch Example with Focus DSL ===\n");
+
+    basicAsyncEnrichment();
+    multiFieldAsyncEnrichment();
+    collectionAsyncEnrichment();
+    errorHandlingExample();
+  }
+
+  /** Demonstrates basic async enrichment of a single field. */
+  static void basicAsyncEnrichment() {
+    System.out.println("--- Basic Async Enrichment ---");
+
+    CompletableFutureMonad futureMonad = CompletableFutureMonad.INSTANCE;
+
+    // Initial profile with placeholder values
+    UserProfile profile = new UserProfile("user123", "", "", ProfileStats.empty());
+    System.out.println("Initial profile: " + profile);
+
+    // Create path to display name
+    FocusPath<UserProfile, String> displayNamePath = FocusPath.of(displayNameLens);
+
+    // Async function to fetch and update display name
+    Function<String, Kind<CompletableFutureKind.Witness, String>> fetchName =
+        currentName -> FUTURE.widen(fetchDisplayName(profile.userId()));
+
+    // Use modifyF to asynchronously update the display name
+    Kind<CompletableFutureKind.Witness, UserProfile> enrichedKind =
+        displayNamePath.modifyF(fetchName, profile, futureMonad);
+
+    // Wait for result and print
+    UserProfile enrichedProfile = FUTURE.join(enrichedKind);
+    System.out.println("Enriched profile: " + enrichedProfile);
+
+    System.out.println();
+  }
+
+  /** Demonstrates enriching multiple fields asynchronously in sequence. */
+  static void multiFieldAsyncEnrichment() {
+    System.out.println("--- Multi-Field Async Enrichment ---");
+
+    CompletableFutureMonad futureMonad = CompletableFutureMonad.INSTANCE;
+
+    // Initial profile
+    UserProfile profile = new UserProfile("alice42", "", "", ProfileStats.empty());
+    System.out.println("Initial: " + profile);
+
+    // Create paths
+    FocusPath<UserProfile, String> namePath = FocusPath.of(displayNameLens);
+    FocusPath<UserProfile, String> avatarPath = FocusPath.of(avatarUrlLens);
+    FocusPath<UserProfile, ProfileStats> statsPath = FocusPath.of(statsLens);
+
+    // Capture userId for closures
+    String userId = profile.userId();
+
+    // Chain async enrichments using flatMap
+    Kind<CompletableFutureKind.Witness, UserProfile> result =
+        futureMonad.flatMap(
+            p1 -> avatarPath.modifyF(_ -> FUTURE.widen(fetchAvatarUrl(userId)), p1, futureMonad),
+            namePath.modifyF(_ -> FUTURE.widen(fetchDisplayName(userId)), profile, futureMonad));
+
+    // Continue the chain for stats
+    Kind<CompletableFutureKind.Witness, UserProfile> finalResult =
+        futureMonad.flatMap(
+            p2 -> statsPath.modifyF(_ -> FUTURE.widen(fetchStats(userId)), p2, futureMonad),
+            result);
+
+    // Wait and print
+    UserProfile enrichedProfile = FUTURE.join(finalResult);
+    System.out.println("Fully enriched: " + enrichedProfile);
+
+    System.out.println();
+  }
+
+  /** Demonstrates async enrichment of all items in a collection. */
+  static void collectionAsyncEnrichment() {
+    System.out.println("--- Collection Async Enrichment ---");
+
+    CompletableFutureMonad futureMonad = CompletableFutureMonad.INSTANCE;
+
+    // Shopping cart with products needing price updates
+    ShoppingCart cart =
+        new ShoppingCart(
+            "CART-001",
+            List.of(
+                new Product("PROD-A", "Widget", PricingInfo.unknown()),
+                new Product("PROD-B", "Gadget", PricingInfo.unknown()),
+                new Product("PROD-C", "Gizmo", PricingInfo.unknown())));
+
+    System.out.println("Initial cart products:");
+    printCartProducts(cart);
+
+    // Path to all products - we update products directly to get pricing
+    TraversalPath<ShoppingCart, Product> allProductsPath =
+        FocusPath.of(productsLens).<Product>each();
+
+    // Async function to enrich each product with its pricing
+    Function<Product, Kind<CompletableFutureKind.Witness, Product>> enrichProduct =
+        product ->
+            FUTURE.widen(
+                fetchPricing(product.productId())
+                    .thenApply(
+                        pricing -> new Product(product.productId(), product.name(), pricing)));
+
+    // Use modifyF on the traversal to update all products
+    Kind<CompletableFutureKind.Witness, ShoppingCart> enrichedCartKind =
+        allProductsPath.modifyF(enrichProduct, cart, futureMonad);
+
+    // Wait and print
+    ShoppingCart enrichedCart = FUTURE.join(enrichedCartKind);
+    System.out.println("\nEnriched cart products:");
+    printCartProducts(enrichedCart);
+
+    // Calculate total
+    double total =
+        enrichedCart.products().stream().mapToDouble(p -> p.pricing().effectivePrice()).sum();
+    System.out.printf("Cart total: $%.2f%n", total);
+
+    System.out.println();
+  }
+
+  /** Demonstrates error handling with async operations. */
+  static void errorHandlingExample() {
+    System.out.println("--- Error Handling with Async Operations ---");
+
+    CompletableFutureMonad futureMonad = CompletableFutureMonad.INSTANCE;
+
+    // Test with good and bad IDs
+    UserProfile goodProfile = new UserProfile("user999", "", "", ProfileStats.empty());
+    UserProfile badProfile = new UserProfile("BAD_USER", "", "", ProfileStats.empty());
+
+    FocusPath<UserProfile, String> namePath = FocusPath.of(displayNameLens);
+
+    // Function that may fail
+    Function<String, Kind<CompletableFutureKind.Witness, String>> unreliableFetch =
+        _ -> FUTURE.widen(fetchUnreliableData(goodProfile.userId()));
+
+    // Successful case
+    Kind<CompletableFutureKind.Witness, UserProfile> successResult =
+        namePath.modifyF(unreliableFetch, goodProfile, futureMonad);
+
+    UserProfile successProfile = FUTURE.join(successResult);
+    System.out.println("Success case: " + successProfile.displayName());
+
+    // Error case with recovery
+    Function<String, Kind<CompletableFutureKind.Witness, String>> unreliableFetchBad =
+        _ -> FUTURE.widen(fetchUnreliableData(badProfile.userId()));
+
+    Kind<CompletableFutureKind.Witness, UserProfile> errorResult =
+        namePath.modifyF(unreliableFetchBad, badProfile, futureMonad);
+
+    // Use handleErrorWith for recovery
+    Kind<CompletableFutureKind.Witness, UserProfile> recoveredResult =
+        futureMonad.handleErrorWith(
+            errorResult,
+            error -> {
+              System.out.println("Caught error: " + error.getMessage());
+              // Return a fallback profile
+              UserProfile fallback =
+                  new UserProfile(
+                      badProfile.userId(),
+                      "[Unavailable]",
+                      badProfile.avatarUrl(),
+                      badProfile.stats());
+              return futureMonad.of(fallback);
+            });
+
+    UserProfile recoveredProfile = FUTURE.join(recoveredResult);
+    System.out.println("Recovered profile: " + recoveredProfile.displayName());
+
+    System.out.println();
+  }
+
+  private static void printCartProducts(ShoppingCart cart) {
+    for (Product product : cart.products()) {
+      PricingInfo p = product.pricing();
+      System.out.printf(
+          "  %s (%s): base=$%.2f, discount=%.0f%%, effective=$%.2f %s%n",
+          product.productId(),
+          product.name(),
+          p.basePrice(),
+          p.discountPercent(),
+          p.effectivePrice(),
+          p.currency());
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/NavigatorExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/NavigatorExample.java
@@ -1,0 +1,271 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.focus;
+
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.annotations.GenerateFocus;
+import org.higherkindedj.optics.focus.FocusPath;
+
+/**
+ * Demonstrates fluent navigation using generated navigator classes.
+ *
+ * <p>This example shows how to use {@code @GenerateFocus(generateNavigators = true)} to enable
+ * fluent cross-type navigation without explicit {@code .via()} calls.
+ *
+ * <h2>Key Concepts</h2>
+ *
+ * <ul>
+ *   <li>Enabling navigator generation with {@code generateNavigators = true}
+ *   <li>Fluent cross-type navigation: {@code CompanyFocus.headquarters().city()}
+ *   <li>Navigator delegate methods: {@code get()}, {@code set()}, {@code modify()}
+ *   <li>Controlling navigator generation with {@code maxNavigatorDepth}, {@code includeFields}, and
+ *       {@code excludeFields}
+ *   <li>Falling back to {@code .via()} for deeper navigation beyond the depth limit
+ * </ul>
+ *
+ * <h2>Comparison: With vs Without Navigators</h2>
+ *
+ * <p><strong>Without navigators</strong> (explicit composition):
+ *
+ * <pre>{@code
+ * String city = CompanyFocus.headquarters()
+ *     .via(AddressFocus.city().toLens())
+ *     .get(company);
+ * }</pre>
+ *
+ * <p><strong>With navigators</strong> (fluent navigation):
+ *
+ * <pre>{@code
+ * String city = CompanyFocus.headquarters().city().get(company);
+ * }</pre>
+ *
+ * <p>Navigators are generated for fields whose types are also annotated with
+ * {@code @GenerateFocus(generateNavigators = true)}.
+ */
+public class NavigatorExample {
+
+  // ============= Domain Model with Navigators Enabled =============
+
+  /**
+   * A company with a headquarters address.
+   *
+   * <p>With {@code generateNavigators = true}, the processor generates a {@code
+   * HeadquartersNavigator} inner class in {@code CompanyFocus} that enables fluent navigation to
+   * {@code Address} fields.
+   */
+  @GenerateFocus(generateNavigators = true)
+  public record Company(String name, Address headquarters, int employeeCount) {}
+
+  /**
+   * An address with street and city fields.
+   *
+   * <p>Both fields are navigable from parent types when navigators are enabled.
+   */
+  @GenerateFocus(generateNavigators = true)
+  public record Address(String street, String city, String postcode) {}
+
+  // ============= Domain Model with Depth Limiting =============
+
+  /**
+   * An organisation with nested department structure.
+   *
+   * <p>The {@code maxNavigatorDepth = 2} limits how deep navigator generation goes. At depth 2, the
+   * navigation returns plain {@code FocusPath} instances instead of further navigators.
+   */
+  @GenerateFocus(generateNavigators = true, maxNavigatorDepth = 2)
+  public record Organisation(String name, Division mainDivision) {}
+
+  /** A division containing a department. */
+  @GenerateFocus(generateNavigators = true)
+  public record Division(String name, Department department) {}
+
+  /** A department with a manager name. */
+  @GenerateFocus(generateNavigators = true)
+  public record Department(String name, String managerName) {}
+
+  // ============= Domain Model with Field Filtering =============
+
+  /**
+   * A person with multiple addresses, demonstrating field filtering.
+   *
+   * <p>The {@code includeFields} attribute restricts navigator generation to only the specified
+   * fields. Here, only {@code homeAddress} gets a navigator; {@code workAddress} uses standard
+   * {@code FocusPath}.
+   */
+  @GenerateFocus(
+      generateNavigators = true,
+      includeFields = {"homeAddress"})
+  public record Person(String name, Address homeAddress, Address workAddress) {}
+
+  // ============= Manual Lenses for Demonstration =============
+
+  // These lenses simulate what the processor generates
+  static final Lens<Company, Address> companyHeadquartersLens =
+      Lens.of(Company::headquarters, (c, a) -> new Company(c.name(), a, c.employeeCount()));
+
+  static final Lens<Address, String> addressCityLens =
+      Lens.of(Address::city, (a, city) -> new Address(a.street(), city, a.postcode()));
+
+  static final Lens<Address, String> addressStreetLens =
+      Lens.of(Address::street, (a, street) -> new Address(street, a.city(), a.postcode()));
+
+  // ============= Examples =============
+
+  public static void main(String[] args) {
+    System.out.println("=== Navigator Example ===\n");
+
+    basicNavigatorUsage();
+    navigatorDelegateMethods();
+    depthLimitingExample();
+    fieldFilteringExample();
+  }
+
+  /**
+   * Demonstrates basic fluent navigation using generated navigators.
+   *
+   * <p>When the annotation processor runs on {@code Company} and {@code Address}, it generates
+   * navigator classes that enable:
+   *
+   * <pre>{@code
+   * CompanyFocus.headquarters().city()  // Returns FocusPath<Company, String>
+   * }</pre>
+   *
+   * <p>Instead of:
+   *
+   * <pre>{@code
+   * CompanyFocus.headquarters().via(AddressFocus.city().toLens())
+   * }</pre>
+   */
+  static void basicNavigatorUsage() {
+    System.out.println("--- Basic Navigator Usage ---");
+
+    Company company =
+        new Company("Acme Corp", new Address("123 Main St", "London", "SW1A 1AA"), 100);
+
+    // Without navigators - explicit composition required
+    FocusPath<Company, Address> headquartersPath = FocusPath.of(companyHeadquartersLens);
+    FocusPath<Company, String> cityPathManual = headquartersPath.via(addressCityLens);
+    String cityManual = cityPathManual.get(company);
+    System.out.println("City (manual composition): " + cityManual);
+
+    // With navigators - the generated CompanyFocus.headquarters() returns a
+    // HeadquartersNavigator that has a city() method, enabling:
+    //
+    //   String city = CompanyFocus.headquarters().city().get(company);
+    //
+    // This example shows what the generated code enables.
+    // The navigator wraps the underlying FocusPath and delegates operations.
+    System.out.println("With navigators: CompanyFocus.headquarters().city().get(company)");
+    System.out.println("  -> Returns the city without explicit .via() call\n");
+  }
+
+  /**
+   * Demonstrates navigator delegate methods.
+   *
+   * <p>Navigator classes delegate all {@code FocusPath} operations to the underlying path:
+   *
+   * <ul>
+   *   <li>{@code get(source)} - Extract the focused value
+   *   <li>{@code set(value, source)} - Replace the focused value
+   *   <li>{@code modify(f, source)} - Transform the focused value
+   *   <li>{@code toPath()} - Access the underlying {@code FocusPath}
+   *   <li>{@code toLens()} - Extract the underlying {@code Lens}
+   * </ul>
+   */
+  static void navigatorDelegateMethods() {
+    System.out.println("--- Navigator Delegate Methods ---");
+
+    Company company = new Company("TechCo", new Address("456 Oak Ave", "Manchester", "M1 1AA"), 50);
+
+    // Demonstrate the operations that navigators support
+    FocusPath<Company, Address> hqPath = FocusPath.of(companyHeadquartersLens);
+
+    // get() - extract value
+    Address hq = hqPath.get(company);
+    System.out.println("get(): " + hq.city());
+
+    // set() - replace value
+    Company movedCompany = hqPath.set(new Address("789 New St", "Birmingham", "B1 1AA"), company);
+    System.out.println("set(): Moved to " + hqPath.get(movedCompany).city());
+
+    // modify() - transform value
+    Company updatedCompany =
+        hqPath.modify(
+            addr -> new Address(addr.street().toUpperCase(), addr.city(), addr.postcode()),
+            company);
+    System.out.println("modify(): Street is now " + hqPath.get(updatedCompany).street());
+
+    // With navigators, these same operations work on the nested path:
+    //   CompanyFocus.headquarters().city().get(company)
+    //   CompanyFocus.headquarters().city().set("Edinburgh", company)
+    //   CompanyFocus.headquarters().city().modify(String::toUpperCase, company)
+    System.out.println("\nNavigators enable the same operations on nested paths.\n");
+  }
+
+  /**
+   * Demonstrates depth limiting with {@code maxNavigatorDepth}.
+   *
+   * <p>Navigator generation stops at the specified depth. Beyond this, navigation returns plain
+   * {@code FocusPath} instances. For deeper access, use {@code .via()} composition.
+   *
+   * <pre>{@code
+   * @GenerateFocus(generateNavigators = true, maxNavigatorDepth = 2)
+   * record Organisation(Division mainDivision) {}
+   *
+   * // Depth 1: Returns DivisionNavigator
+   * OrganisationFocus.mainDivision()
+   *
+   * // Depth 2: Returns FocusPath (not a navigator)
+   * OrganisationFocus.mainDivision().department()
+   *
+   * // Beyond depth: Use .via() for further navigation
+   * OrganisationFocus.mainDivision().department().via(DepartmentFocus.managerName().toLens())
+   * }</pre>
+   */
+  static void depthLimitingExample() {
+    System.out.println("--- Depth Limiting ---");
+
+    System.out.println("With maxNavigatorDepth = 2:");
+    System.out.println("  Depth 1: OrganisationFocus.mainDivision() -> DivisionNavigator");
+    System.out.println("  Depth 2: .department() -> FocusPath<Organisation, Department>");
+    System.out.println("  Beyond: Use .via(DepartmentFocus.managerName().toLens())\n");
+
+    // This prevents excessive code generation for deeply nested structures
+    // while still allowing navigation via explicit composition.
+  }
+
+  /**
+   * Demonstrates field filtering with {@code includeFields} and {@code excludeFields}.
+   *
+   * <p>Control which fields get navigator generation:
+   *
+   * <ul>
+   *   <li>{@code includeFields = {"field1", "field2"}} - Only these fields get navigators
+   *   <li>{@code excludeFields = {"field3"}} - These fields use standard {@code FocusPath}
+   * </ul>
+   *
+   * <p>If both are specified, {@code includeFields} takes precedence.
+   *
+   * <pre>{@code
+   * @GenerateFocus(generateNavigators = true, includeFields = {"homeAddress"})
+   * record Person(String name, Address homeAddress, Address workAddress) {}
+   *
+   * // homeAddress gets a navigator
+   * PersonFocus.homeAddress().city()  // Returns FocusPath<Person, String>
+   *
+   * // workAddress uses standard FocusPath (no navigator)
+   * PersonFocus.workAddress()  // Returns FocusPath<Person, Address>
+   * PersonFocus.workAddress().via(AddressFocus.city().toLens())  // Explicit composition
+   * }</pre>
+   */
+  static void fieldFilteringExample() {
+    System.out.println("--- Field Filtering ---");
+
+    System.out.println("With includeFields = {\"homeAddress\"}:");
+    System.out.println(
+        "  PersonFocus.homeAddress() -> HomeAddressNavigator (has city(), street())");
+    System.out.println("  PersonFocus.workAddress() -> FocusPath<Person, Address> (no navigator)");
+    System.out.println(
+        "\nExcludeFields works similarly - excluded fields get standard FocusPath.\n");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/TraverseIntegrationExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/TraverseIntegrationExample.java
@@ -1,0 +1,328 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.focus;
+
+import java.util.List;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeTraverse;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+
+/**
+ * Demonstrates the integration of the Focus DSL with the Traverse type class.
+ *
+ * <p>This example shows how to use {@code traverseOver()} to navigate into Kind-wrapped
+ * collections, enabling generic traversal over any type with a Traverse instance.
+ *
+ * <h2>Key Concepts</h2>
+ *
+ * <ul>
+ *   <li>Using {@code traverseOver()} with ListTraverse for Kind-wrapped lists
+ *   <li>Using {@code traverseOver()} with MaybeTraverse for optional values
+ *   <li>Composing traversals across multiple levels
+ *   <li>Working with sum types and Kind-wrapped collections together
+ * </ul>
+ */
+public class TraverseIntegrationExample {
+
+  // ============= Domain Model =============
+
+  /** A role with a name and permission level. */
+  record Role(String name, int level) {
+    Role promote() {
+      return new Role(name, level + 1);
+    }
+  }
+
+  /** A team member with Kind-wrapped roles. */
+  record Member(String name, Kind<ListKind.Witness, Role> roles) {}
+
+  /** A team with Kind-wrapped members. */
+  record Team(String name, Kind<ListKind.Witness, Member> members) {}
+
+  /** A project with an optional lead team. */
+  record Project(
+      String name, Kind<MaybeKind.Witness, Team> leadTeam, Kind<ListKind.Witness, Team> allTeams) {}
+
+  // ============= Lenses =============
+
+  static final Lens<Team, Kind<ListKind.Witness, Member>> teamMembersLens =
+      Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+  static final Lens<Member, Kind<ListKind.Witness, Role>> memberRolesLens =
+      Lens.of(Member::roles, (m, r) -> new Member(m.name(), r));
+
+  static final Lens<Role, Integer> roleLevelLens =
+      Lens.of(Role::level, (r, l) -> new Role(r.name(), l));
+
+  static final Lens<Project, Kind<MaybeKind.Witness, Team>> projectLeadTeamLens =
+      Lens.of(Project::leadTeam, (p, t) -> new Project(p.name(), t, p.allTeams()));
+
+  static final Lens<Project, Kind<ListKind.Witness, Team>> projectAllTeamsLens =
+      Lens.of(Project::allTeams, (p, t) -> new Project(p.name(), p.leadTeam(), t));
+
+  // ============= Sum Types for Combined Pattern =============
+
+  /** Sealed interface for project variants. */
+  sealed interface ProjectVariant permits ActiveProject, ArchivedProject {}
+
+  /** An active project with full details. */
+  record ActiveProject(Project project) implements ProjectVariant {}
+
+  /** An archived project with limited information. */
+  record ArchivedProject(String name, String archiveDate) implements ProjectVariant {}
+
+  // ============= Examples =============
+
+  public static void main(String[] args) {
+    System.out.println("=== Traverse Integration Example ===\n");
+
+    basicTraverseOverExample();
+    nestedTraverseOverExample();
+    optionalTraverseExample();
+    combinedPatternExample();
+  }
+
+  /** Demonstrates basic traverseOver usage with a single Kind-wrapped collection. */
+  static void basicTraverseOverExample() {
+    System.out.println("--- Basic traverseOver() ---");
+
+    // Create a team with Kind-wrapped members
+    Team team =
+        new Team(
+            "Platform",
+            ListKindHelper.LIST.widen(
+                List.of(
+                    new Member(
+                        "Alice",
+                        ListKindHelper.LIST.widen(
+                            List.of(new Role("Admin", 10), new Role("Developer", 5)))),
+                    new Member(
+                        "Bob", ListKindHelper.LIST.widen(List.of(new Role("Developer", 3)))))));
+
+    // Create a path to the Kind<ListKind.Witness, Member> field
+    FocusPath<Team, Kind<ListKind.Witness, Member>> membersKindPath = FocusPath.of(teamMembersLens);
+
+    // Use traverseOver to traverse into the Kind-wrapped list
+    // Note: Explicit type parameters are required for Java's type inference
+    TraversalPath<Team, Member> allMembersPath =
+        membersKindPath.<ListKind.Witness, Member>traverseOver(ListTraverse.INSTANCE);
+
+    // Get all members
+    List<Member> members = allMembersPath.getAll(team);
+    System.out.println("Members: " + members.stream().map(Member::name).toList());
+
+    // Count members
+    System.out.println("Member count: " + allMembersPath.count(team));
+
+    System.out.println();
+  }
+
+  /** Demonstrates nested traverseOver for deep navigation. */
+  static void nestedTraverseOverExample() {
+    System.out.println("--- Nested traverseOver() ---");
+
+    Team team =
+        new Team(
+            "Engineering",
+            ListKindHelper.LIST.widen(
+                List.of(
+                    new Member(
+                        "Alice",
+                        ListKindHelper.LIST.widen(
+                            List.of(new Role("Lead", 10), new Role("Architect", 8)))),
+                    new Member(
+                        "Bob",
+                        ListKindHelper.LIST.widen(
+                            List.of(new Role("Senior", 6), new Role("Mentor", 4)))),
+                    new Member(
+                        "Charlie", ListKindHelper.LIST.widen(List.of(new Role("Junior", 2)))))));
+
+    // Build path step by step (helps with type inference)
+    FocusPath<Team, Kind<ListKind.Witness, Member>> step1 = FocusPath.of(teamMembersLens);
+    TraversalPath<Team, Member> step2 =
+        step1.<ListKind.Witness, Member>traverseOver(ListTraverse.INSTANCE);
+    TraversalPath<Team, Kind<ListKind.Witness, Role>> step3 = step2.via(memberRolesLens);
+    TraversalPath<Team, Role> allRolesPath =
+        step3.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // Get all roles across all members
+    List<Role> allRoles = allRolesPath.getAll(team);
+    System.out.println("All roles: " + allRoles.stream().map(Role::name).toList());
+    System.out.println("Total roles: " + allRolesPath.count(team));
+
+    // Navigate to role levels
+    TraversalPath<Team, Integer> allLevelsPath = allRolesPath.via(roleLevelLens);
+    List<Integer> levels = allLevelsPath.getAll(team);
+    System.out.println("All levels: " + levels);
+
+    // Promote all roles (increase level by 1)
+    Team promoted = allRolesPath.modifyAll(Role::promote, team);
+    List<Integer> newLevels = allLevelsPath.getAll(promoted);
+    System.out.println("After promotion: " + newLevels);
+
+    // Conditional promotion - only promote roles with level >= 5
+    Team conditionalPromoted = allRolesPath.modifyWhen(r -> r.level() >= 5, Role::promote, team);
+    List<Integer> conditionalLevels = allLevelsPath.getAll(conditionalPromoted);
+    System.out.println("After conditional promotion (level >= 5): " + conditionalLevels);
+
+    System.out.println();
+  }
+
+  /** Demonstrates traverseOver with Maybe for optional values. */
+  static void optionalTraverseExample() {
+    System.out.println("--- Optional traverseOver() with Maybe ---");
+
+    // Project with a lead team
+    Project projectWithLead =
+        new Project(
+            "Alpha",
+            MaybeKindHelper.MAYBE.widen(
+                Maybe.just(
+                    new Team(
+                        "Core",
+                        ListKindHelper.LIST.widen(
+                            List.of(
+                                new Member(
+                                    "Alice",
+                                    ListKindHelper.LIST.widen(List.of(new Role("Lead", 10))))))))),
+            ListKindHelper.LIST.widen(List.of()));
+
+    // Project without a lead team
+    Project projectWithoutLead =
+        new Project(
+            "Beta",
+            MaybeKindHelper.MAYBE.widen(Maybe.nothing()),
+            ListKindHelper.LIST.widen(List.of()));
+
+    // Path through the optional lead team
+    FocusPath<Project, Kind<MaybeKind.Witness, Team>> leadTeamKindPath =
+        FocusPath.of(projectLeadTeamLens);
+
+    // Traverse the Maybe to get the Team (if present)
+    TraversalPath<Project, Team> leadTeamPath =
+        leadTeamKindPath.<MaybeKind.Witness, Team>traverseOver(MaybeTraverse.INSTANCE);
+
+    // Get lead team from each project
+    List<Team> leadsFromWithLead = leadTeamPath.getAll(projectWithLead);
+    List<Team> leadsFromWithoutLead = leadTeamPath.getAll(projectWithoutLead);
+
+    System.out.println("Lead teams (project with lead): " + leadsFromWithLead.size());
+    System.out.println("Lead teams (project without lead): " + leadsFromWithoutLead.size());
+
+    // Continue traversing through the lead team to members and roles
+    TraversalPath<Project, Kind<ListKind.Witness, Member>> membersKindPath =
+        leadTeamPath.via(teamMembersLens);
+    TraversalPath<Project, Member> membersPath =
+        membersKindPath.<ListKind.Witness, Member>traverseOver(ListTraverse.INSTANCE);
+    TraversalPath<Project, Kind<ListKind.Witness, Role>> rolesKindPath =
+        membersPath.via(memberRolesLens);
+    TraversalPath<Project, Role> rolesPath =
+        rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // Get all roles from lead team (if exists)
+    List<Role> rolesWithLead = rolesPath.getAll(projectWithLead);
+    List<Role> rolesWithoutLead = rolesPath.getAll(projectWithoutLead);
+
+    System.out.println("Roles from lead (with lead): " + rolesWithLead);
+    System.out.println("Roles from lead (without lead): " + rolesWithoutLead);
+
+    System.out.println();
+  }
+
+  /** Demonstrates combining sum types with traverseOver. */
+  static void combinedPatternExample() {
+    System.out.println("--- Combined Pattern: Sum Types + traverseOver ---");
+
+    // Create project variants
+    List<ProjectVariant> variants =
+        List.of(
+            new ActiveProject(
+                new Project(
+                    "Alpha",
+                    MaybeKindHelper.MAYBE.widen(Maybe.nothing()),
+                    ListKindHelper.LIST.widen(
+                        List.of(
+                            new Team(
+                                "Team1",
+                                ListKindHelper.LIST.widen(
+                                    List.of(
+                                        new Member(
+                                            "Alice",
+                                            ListKindHelper.LIST.widen(
+                                                List.of(new Role("Dev", 5))))))))))),
+            new ArchivedProject("Legacy", "2024-01-01"),
+            new ActiveProject(
+                new Project(
+                    "Beta",
+                    MaybeKindHelper.MAYBE.widen(Maybe.nothing()),
+                    ListKindHelper.LIST.widen(
+                        List.of(
+                            new Team(
+                                "Team2",
+                                ListKindHelper.LIST.widen(
+                                    List.of(
+                                        new Member(
+                                            "Bob",
+                                            ListKindHelper.LIST.widen(
+                                                List.of(
+                                                    new Role("Lead", 8),
+                                                    new Role("Arch", 7))))))))))));
+
+    // Use instanceOf to focus on ActiveProject only
+    AffinePath<ProjectVariant, ActiveProject> activeProjectPath =
+        AffinePath.instanceOf(ActiveProject.class);
+
+    // Count active projects
+    int activeCount = 0;
+    for (ProjectVariant v : variants) {
+      if (activeProjectPath.matches(v)) {
+        activeCount++;
+      }
+    }
+    System.out.println("Active projects: " + activeCount);
+
+    // For each active project, count roles
+    for (ProjectVariant v : variants) {
+      activeProjectPath
+          .getOptional(v)
+          .ifPresent(
+              active -> {
+                // Build path to all roles in the project
+                Lens<ActiveProject, Kind<ListKind.Witness, Team>> allTeamsLens =
+                    Lens.of(
+                        ap -> ap.project().allTeams(),
+                        (ap, teams) ->
+                            new ActiveProject(
+                                new Project(ap.project().name(), ap.project().leadTeam(), teams)));
+
+                FocusPath<ActiveProject, Kind<ListKind.Witness, Team>> teamsKindPath =
+                    FocusPath.of(allTeamsLens);
+                TraversalPath<ActiveProject, Team> teamsPath =
+                    teamsKindPath.<ListKind.Witness, Team>traverseOver(ListTraverse.INSTANCE);
+                TraversalPath<ActiveProject, Kind<ListKind.Witness, Member>> membersKindPath =
+                    teamsPath.via(teamMembersLens);
+                TraversalPath<ActiveProject, Member> membersPath =
+                    membersKindPath.<ListKind.Witness, Member>traverseOver(ListTraverse.INSTANCE);
+                TraversalPath<ActiveProject, Kind<ListKind.Witness, Role>> rolesKindPath =
+                    membersPath.via(memberRolesLens);
+                TraversalPath<ActiveProject, Role> rolesPath =
+                    rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+                int roleCount = rolesPath.count(active);
+                System.out.println(
+                    "Project '" + active.project().name() + "' has " + roleCount + " roles");
+              });
+    }
+
+    System.out.println();
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/ValidationPipelineExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/ValidationPipelineExample.java
@@ -1,0 +1,387 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.focus;
+
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+
+/**
+ * Demonstrates validation pipelines using the Focus DSL with effectful operations.
+ *
+ * <p>This example shows how to use {@code modifyF()} for validation that can fail, and {@code
+ * foldMap()} for aggregating values with monoids.
+ *
+ * <h2>Key Concepts</h2>
+ *
+ * <ul>
+ *   <li>Using {@code modifyF()} with Maybe for validation that may fail
+ *   <li>Short-circuit validation (fail-fast)
+ *   <li>Using {@code foldMap()} with custom Monoids for aggregation
+ *   <li>Combining validation with transformation
+ * </ul>
+ */
+public class ValidationPipelineExample {
+
+  // ============= Domain Model =============
+
+  /** Configuration with various fields that need validation. */
+  record Config(String apiKey, String databaseUrl, int timeout, int maxConnections) {}
+
+  /** User profile with fields requiring validation. */
+  record UserProfile(String username, String email, int age) {}
+
+  /** Order with line items for aggregation example. */
+  record Order(String orderId, List<LineItem> items) {}
+
+  /** Line item in an order. */
+  record LineItem(String productId, int quantity, double unitPrice) {
+    double total() {
+      return quantity * unitPrice;
+    }
+  }
+
+  // ============= Lenses =============
+
+  static final Lens<Config, String> configApiKeyLens =
+      Lens.of(
+          Config::apiKey,
+          (c, k) -> new Config(k, c.databaseUrl(), c.timeout(), c.maxConnections()));
+
+  static final Lens<Config, String> configDbUrlLens =
+      Lens.of(
+          Config::databaseUrl,
+          (c, url) -> new Config(c.apiKey(), url, c.timeout(), c.maxConnections()));
+
+  static final Lens<Config, Integer> configTimeoutLens =
+      Lens.of(
+          Config::timeout,
+          (c, t) -> new Config(c.apiKey(), c.databaseUrl(), t, c.maxConnections()));
+
+  static final Lens<UserProfile, String> usernameLens =
+      Lens.of(UserProfile::username, (u, name) -> new UserProfile(name, u.email(), u.age()));
+
+  static final Lens<UserProfile, String> emailLens =
+      Lens.of(UserProfile::email, (u, email) -> new UserProfile(u.username(), email, u.age()));
+
+  static final Lens<UserProfile, Integer> ageLens =
+      Lens.of(UserProfile::age, (u, age) -> new UserProfile(u.username(), u.email(), age));
+
+  static final Lens<Order, List<LineItem>> orderItemsLens =
+      Lens.of(Order::items, (o, items) -> new Order(o.orderId(), items));
+
+  static final Lens<LineItem, Integer> lineItemQuantityLens =
+      Lens.of(LineItem::quantity, (li, q) -> new LineItem(li.productId(), q, li.unitPrice()));
+
+  static final Lens<LineItem, Double> lineItemPriceLens =
+      Lens.of(LineItem::unitPrice, (li, p) -> new LineItem(li.productId(), li.quantity(), p));
+
+  // ============= Examples =============
+
+  public static void main(String[] args) {
+    System.out.println("=== Validation Pipeline Example ===\n");
+
+    basicValidationExample();
+    chainedValidationExample();
+    aggregationWithFoldMapExample();
+    conditionalModificationExample();
+  }
+
+  /** Demonstrates basic validation using modifyF with Maybe. */
+  static void basicValidationExample() {
+    System.out.println("--- Basic Validation with modifyF() ---");
+
+    Config validConfig = new Config("abc123xyz", "jdbc:postgresql://localhost/db", 30, 10);
+    Config invalidConfig = new Config("short", "jdbc:postgresql://localhost/db", 30, 10);
+
+    // Validation function: API key must be at least 8 characters
+    Function<String, Kind<MaybeKind.Witness, String>> validateApiKey =
+        key -> {
+          if (key != null && key.length() >= 8) {
+            // Valid: transform to uppercase
+            return MaybeKindHelper.MAYBE.widen(Maybe.just(key.toUpperCase()));
+          } else {
+            // Invalid: return Nothing
+            return MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+          }
+        };
+
+    // Create path to API key
+    FocusPath<Config, String> apiKeyPath = FocusPath.of(configApiKeyLens);
+
+    // Validate and transform valid config
+    Kind<MaybeKind.Witness, Config> validResult =
+        apiKeyPath.modifyF(validateApiKey, validConfig, MaybeMonad.INSTANCE);
+
+    Maybe<Config> validMaybe = MaybeKindHelper.MAYBE.narrow(validResult);
+    System.out.println("Valid config result: " + (validMaybe.isJust() ? "Success" : "Failure"));
+    if (validMaybe.isJust()) {
+      System.out.println("  Transformed API key: " + validMaybe.get().apiKey());
+    }
+
+    // Validate invalid config
+    Kind<MaybeKind.Witness, Config> invalidResult =
+        apiKeyPath.modifyF(validateApiKey, invalidConfig, MaybeMonad.INSTANCE);
+
+    Maybe<Config> invalidMaybe = MaybeKindHelper.MAYBE.narrow(invalidResult);
+    System.out.println("Invalid config result: " + (invalidMaybe.isJust() ? "Success" : "Failure"));
+
+    System.out.println();
+  }
+
+  /** Demonstrates chaining multiple validations. */
+  static void chainedValidationExample() {
+    System.out.println("--- Chained Validation ---");
+
+    UserProfile validProfile = new UserProfile("alice_smith", "alice@example.com", 25);
+    UserProfile invalidEmail = new UserProfile("bob_jones", "not-an-email", 30);
+    UserProfile invalidAge = new UserProfile("charlie", "charlie@test.com", -5);
+
+    // Username validation: alphanumeric and underscores, 3-20 chars
+    Function<String, Kind<MaybeKind.Witness, String>> validateUsername =
+        username -> {
+          if (username != null
+              && username.length() >= 3
+              && username.length() <= 20
+              && username.matches("^[a-zA-Z0-9_]+$")) {
+            return MaybeKindHelper.MAYBE.widen(Maybe.just(username.toLowerCase()));
+          }
+          return MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+        };
+
+    // Email validation: simple check for @ symbol
+    Function<String, Kind<MaybeKind.Witness, String>> validateEmail =
+        email -> {
+          if (email != null && email.contains("@") && email.contains(".")) {
+            return MaybeKindHelper.MAYBE.widen(Maybe.just(email.toLowerCase()));
+          }
+          return MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+        };
+
+    // Age validation: must be positive and reasonable
+    Function<Integer, Kind<MaybeKind.Witness, Integer>> validateAge =
+        age -> {
+          if (age >= 0 && age <= 150) {
+            return MaybeKindHelper.MAYBE.widen(Maybe.just(age));
+          }
+          return MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+        };
+
+    // Create paths
+    FocusPath<UserProfile, String> usernamePath = FocusPath.of(usernameLens);
+    FocusPath<UserProfile, String> emailPath = FocusPath.of(emailLens);
+    FocusPath<UserProfile, Integer> agePath = FocusPath.of(ageLens);
+
+    // Chain validations manually (fail-fast)
+    System.out.println("Validating valid profile:");
+    validateProfile(
+        validProfile,
+        usernamePath,
+        emailPath,
+        agePath,
+        validateUsername,
+        validateEmail,
+        validateAge);
+
+    System.out.println("\nValidating profile with invalid email:");
+    validateProfile(
+        invalidEmail,
+        usernamePath,
+        emailPath,
+        agePath,
+        validateUsername,
+        validateEmail,
+        validateAge);
+
+    System.out.println("\nValidating profile with invalid age:");
+    validateProfile(
+        invalidAge, usernamePath, emailPath, agePath, validateUsername, validateEmail, validateAge);
+
+    System.out.println();
+  }
+
+  private static void validateProfile(
+      UserProfile profile,
+      FocusPath<UserProfile, String> usernamePath,
+      FocusPath<UserProfile, String> emailPath,
+      FocusPath<UserProfile, Integer> agePath,
+      Function<String, Kind<MaybeKind.Witness, String>> validateUsername,
+      Function<String, Kind<MaybeKind.Witness, String>> validateEmail,
+      Function<Integer, Kind<MaybeKind.Witness, Integer>> validateAge) {
+
+    // Chain validations: username -> email -> age
+    Kind<MaybeKind.Witness, UserProfile> step1 =
+        usernamePath.modifyF(validateUsername, profile, MaybeMonad.INSTANCE);
+
+    Maybe<UserProfile> afterUsername = MaybeKindHelper.MAYBE.narrow(step1);
+    if (afterUsername.isNothing()) {
+      System.out.println("  Failed at: username validation");
+      return;
+    }
+
+    Kind<MaybeKind.Witness, UserProfile> step2 =
+        emailPath.modifyF(validateEmail, afterUsername.get(), MaybeMonad.INSTANCE);
+
+    Maybe<UserProfile> afterEmail = MaybeKindHelper.MAYBE.narrow(step2);
+    if (afterEmail.isNothing()) {
+      System.out.println("  Failed at: email validation");
+      return;
+    }
+
+    Kind<MaybeKind.Witness, UserProfile> step3 =
+        agePath.modifyF(validateAge, afterEmail.get(), MaybeMonad.INSTANCE);
+
+    Maybe<UserProfile> result = MaybeKindHelper.MAYBE.narrow(step3);
+    if (result.isJust()) {
+      System.out.println("  All validations passed!");
+      System.out.println("  Final profile: " + result.get());
+    } else {
+      System.out.println("  Failed at: age validation");
+    }
+  }
+
+  /** Demonstrates aggregation using foldMap with various Monoids. */
+  static void aggregationWithFoldMapExample() {
+    System.out.println("--- Aggregation with foldMap() ---");
+
+    Order order =
+        new Order(
+            "ORD-001",
+            List.of(
+                new LineItem("PROD-A", 2, 29.99),
+                new LineItem("PROD-B", 1, 149.99),
+                new LineItem("PROD-C", 5, 9.99)));
+
+    // Path to all line items
+    TraversalPath<Order, LineItem> allItemsPath = FocusPath.of(orderItemsLens).each();
+
+    // Path to quantities
+    TraversalPath<Order, Integer> quantitiesPath = allItemsPath.via(lineItemQuantityLens);
+
+    // Path to prices
+    TraversalPath<Order, Double> pricesPath = allItemsPath.via(lineItemPriceLens);
+
+    // Integer sum monoid
+    Monoid<Integer> intSum =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    // Double sum monoid
+    Monoid<Double> doubleSum =
+        new Monoid<>() {
+          @Override
+          public Double empty() {
+            return 0.0;
+          }
+
+          @Override
+          public Double combine(Double a, Double b) {
+            return a + b;
+          }
+        };
+
+    // Integer max monoid
+    Monoid<Integer> intMax =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return Integer.MIN_VALUE;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return Math.max(a, b);
+          }
+        };
+
+    // Sum all quantities
+    int totalQuantity = quantitiesPath.foldMap(intSum, q -> q, order);
+    System.out.println("Total quantity: " + totalQuantity);
+
+    // Calculate total using line item totals
+    double orderTotal = allItemsPath.foldMap(doubleSum, LineItem::total, order);
+    System.out.println("Order total: $" + String.format("%.2f", orderTotal));
+
+    // Find max quantity
+    int maxQuantity = quantitiesPath.foldMap(intMax, q -> q, order);
+    System.out.println("Max quantity in single item: " + maxQuantity);
+
+    // Count items
+    int itemCount = allItemsPath.count(order);
+    System.out.println("Number of line items: " + itemCount);
+
+    // Calculate average price
+    double sumPrices = pricesPath.foldMap(doubleSum, p -> p, order);
+    double avgPrice = sumPrices / itemCount;
+    System.out.println("Average unit price: $" + String.format("%.2f", avgPrice));
+
+    System.out.println();
+  }
+
+  /** Demonstrates conditional modification with modifyWhen. */
+  static void conditionalModificationExample() {
+    System.out.println("--- Conditional Modification with modifyWhen() ---");
+
+    Order order =
+        new Order(
+            "ORD-002",
+            List.of(
+                new LineItem("BULK-A", 100, 5.00), // Bulk item
+                new LineItem("SMALL-B", 2, 25.00), // Small order
+                new LineItem("BULK-C", 50, 8.00), // Another bulk item
+                new LineItem("TINY-D", 1, 100.00) // Single item
+                ));
+
+    TraversalPath<Order, LineItem> allItemsPath = FocusPath.of(orderItemsLens).each();
+
+    System.out.println("Original items:");
+    printOrderItems(order);
+
+    // Apply 10% discount to bulk orders (quantity >= 50)
+    Order discountedOrder =
+        allItemsPath.modifyWhen(
+            item -> item.quantity() >= 50,
+            item -> new LineItem(item.productId(), item.quantity(), item.unitPrice() * 0.90),
+            order);
+
+    System.out.println("\nAfter bulk discount (10% off for qty >= 50):");
+    printOrderItems(discountedOrder);
+
+    // Double the quantity for small orders (quantity < 5)
+    Order doubledSmallOrder =
+        allItemsPath.modifyWhen(
+            item -> item.quantity() < 5,
+            item -> new LineItem(item.productId(), item.quantity() * 2, item.unitPrice()),
+            order);
+
+    System.out.println("\nAfter doubling small orders (qty < 5):");
+    printOrderItems(doubledSmallOrder);
+
+    System.out.println();
+  }
+
+  private static void printOrderItems(Order order) {
+    for (LineItem item : order.items()) {
+      System.out.printf(
+          "  %s: qty=%d, price=$%.2f, total=$%.2f%n",
+          item.productId(), item.quantity(), item.unitPrice(), item.total());
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/package-info.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/focus/package-info.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+/**
+ * Example applications demonstrating the Focus DSL for optics.
+ *
+ * <p>This package contains runnable examples showcasing Focus DSL features:
+ *
+ * <ul>
+ *   <li>{@link org.higherkindedj.example.optics.focus.NavigatorExample} - Fluent cross-type
+ *       navigation using generated navigator classes
+ *   <li>{@link org.higherkindedj.example.optics.focus.TraverseIntegrationExample} - Using
+ *       traverseOver() with Traverse type class
+ *   <li>{@link org.higherkindedj.example.optics.focus.ValidationPipelineExample} - Validation
+ *       pipelines using modifyF() and foldMap()
+ *   <li>{@link org.higherkindedj.example.optics.focus.AsyncFetchExample} - Async data loading with
+ *       CompletableFuture and modifyF()
+ * </ul>
+ *
+ * @see org.higherkindedj.optics.focus.FocusPath
+ * @see org.higherkindedj.optics.focus.AffinePath
+ * @see org.higherkindedj.optics.focus.TraversalPath
+ */
+@NullMarked
+package org.higherkindedj.example.optics.focus;
+
+import org.jspecify.annotations.NullMarked;

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial12_FocusDSL.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial12_FocusDSL.java
@@ -1,0 +1,482 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.FocusPaths;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 12: Focus DSL - Type-Safe Path Navigation
+ *
+ * <p>The Focus DSL provides an ergonomic, type-safe way to navigate through nested data structures.
+ * Instead of manually composing optics, you build navigation paths that automatically track type
+ * changes as you traverse deeper.
+ *
+ * <p>Key concepts:
+ *
+ * <ul>
+ *   <li><b>FocusPath</b>: Wraps a Lens - focuses on exactly one element (always present)
+ *   <li><b>AffinePath</b>: Wraps an Affine - focuses on zero or one element (may be absent)
+ *   <li><b>TraversalPath</b>: Wraps a Traversal - focuses on zero or more elements
+ * </ul>
+ *
+ * <p>Path type transitions:
+ *
+ * <pre>
+ *   FocusPath --via(Prism)--> AffinePath --via(Traversal)--> TraversalPath
+ *             --via(Affine)-->            --via(Lens)     -->
+ *             --via(Traversal)-->
+ * </pre>
+ *
+ * <p>Prerequisites: Complete Tutorials 1-6 (core optics) before this one.
+ */
+public class Tutorial12_FocusDSL {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
+
+  /**
+   * Exercise 1: Creating a FocusPath from a Lens
+   *
+   * <p>FocusPath wraps a Lens, providing a fluent API for navigation. You create one using
+   * FocusPath.of(lens).
+   *
+   * <p>Task: Create a FocusPath and use it to get and set values
+   */
+  @Test
+  void exercise1_basicFocusPath() {
+    record Person(String name, int age) {}
+
+    // Create a lens for the name field
+    Lens<Person, String> nameLens = Lens.of(Person::name, (p, n) -> new Person(n, p.age()));
+
+    Person alice = new Person("Alice", 30);
+
+    // TODO: Replace null with FocusPath.of(nameLens)
+    FocusPath<Person, String> namePath = answerRequired();
+
+    // Use the path to get the name
+    // TODO: Replace null with namePath.get(alice)
+    String name = answerRequired();
+    assertThat(name).isEqualTo("Alice");
+
+    // Use the path to set a new name
+    // TODO: Replace null with namePath.set("Alicia", alice)
+    Person renamed = answerRequired();
+    assertThat(renamed.name()).isEqualTo("Alicia");
+    assertThat(renamed.age()).isEqualTo(30); // Age unchanged
+  }
+
+  /**
+   * Exercise 2: Composing paths with via()
+   *
+   * <p>Paths can be composed using the via() method. When you compose a FocusPath with another
+   * Lens, you get a FocusPath that navigates deeper.
+   *
+   * <p>Task: Compose paths to navigate through nested structures
+   */
+  @Test
+  void exercise2_composingPaths() {
+    record Street(String name) {}
+
+    record Address(Street street, String city) {}
+
+    record Person(String name, Address address) {}
+
+    // Create lenses for each level
+    Lens<Person, Address> addressLens = Lens.of(Person::address, (p, a) -> new Person(p.name(), a));
+    Lens<Address, Street> streetLens = Lens.of(Address::street, (a, s) -> new Address(s, a.city()));
+    Lens<Street, String> streetNameLens = Lens.of(Street::name, (s, n) -> new Street(n));
+
+    Person person = new Person("Alice", new Address(new Street("High Street"), "London"));
+
+    // Build a path from Person to street name
+    // TODO: Replace null with FocusPath.of(addressLens).via(streetLens).via(streetNameLens)
+    FocusPath<Person, String> streetNamePath = answerRequired();
+
+    // Get the street name
+    // TODO: Replace null with streetNamePath.get(person)
+    String streetName = answerRequired();
+    assertThat(streetName).isEqualTo("High Street");
+
+    // Modify the street name
+    // TODO: Replace null with streetNamePath.modify(String::toUpperCase, person)
+    Person updated = answerRequired();
+    assertThat(updated.address().street().name()).isEqualTo("HIGH STREET");
+  }
+
+  /**
+   * Exercise 3: AffinePath for optional values
+   *
+   * <p>When navigating through Optional fields or using Prisms, the path becomes an AffinePath
+   * because the target may not exist.
+   *
+   * <p>Task: Use AffinePath to navigate through optional data
+   */
+  @Test
+  void exercise3_affinePathBasics() {
+    record Config(Optional<String> apiKey) {}
+
+    Lens<Config, Optional<String>> apiKeyLens = Lens.of(Config::apiKey, (c, k) -> new Config(k));
+
+    Config withKey = new Config(Optional.of("secret-123"));
+    Config withoutKey = new Config(Optional.empty());
+
+    // Create a path that unwraps the Optional
+    // FocusPath + some() -> AffinePath
+    // TODO: Replace null with FocusPath.of(apiKeyLens).some()
+    AffinePath<Config, String> keyPath = answerRequired();
+
+    // getOptional returns Optional<A>
+    // TODO: Replace null with keyPath.getOptional(withKey)
+    Optional<String> foundKey = answerRequired();
+    assertThat(foundKey).contains("secret-123");
+
+    // TODO: Replace null with keyPath.getOptional(withoutKey)
+    Optional<String> missingKey = answerRequired();
+    assertThat(missingKey).isEmpty();
+
+    // matches() checks if the target exists
+    // TODO: Replace null with keyPath.matches(withKey)
+    boolean hasKey = answerRequired();
+    assertThat(hasKey).isTrue();
+
+    // TODO: Replace null with keyPath.matches(withoutKey)
+    boolean noKey = answerRequired();
+    assertThat(noKey).isFalse();
+  }
+
+  /**
+   * Exercise 4: TraversalPath for collections
+   *
+   * <p>When navigating into collections, the path becomes a TraversalPath that can focus on
+   * multiple elements.
+   *
+   * <p>Task: Use TraversalPath to work with list elements
+   */
+  @Test
+  void exercise4_traversalPathBasics() {
+    record Team(String name, List<String> members) {}
+
+    Lens<Team, List<String>> membersLens = Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+    Team team = new Team("Engineering", List.of("Alice", "Bob", "Charlie"));
+
+    // Create a path that traverses all members
+    // FocusPath + each() -> TraversalPath
+    // TODO: Replace null with FocusPath.of(membersLens).each()
+    TraversalPath<Team, String> membersPath = answerRequired();
+
+    // getAll returns all focused elements
+    // TODO: Replace null with membersPath.getAll(team)
+    List<String> allMembers = answerRequired();
+    assertThat(allMembers).containsExactly("Alice", "Bob", "Charlie");
+
+    // modifyAll transforms all elements
+    // TODO: Replace null with membersPath.modifyAll(String::toUpperCase, team)
+    Team shouting = answerRequired();
+    assertThat(shouting.members()).containsExactly("ALICE", "BOB", "CHARLIE");
+
+    // count returns the number of focused elements
+    // TODO: Replace null with membersPath.count(team)
+    int memberCount = answerRequired();
+    assertThat(memberCount).isEqualTo(3);
+  }
+
+  /**
+   * Exercise 5: Accessing specific list elements
+   *
+   * <p>The at(index) method creates an AffinePath for a specific list index. It returns empty if
+   * the index is out of bounds.
+   *
+   * <p>Task: Focus on specific elements by index
+   */
+  @Test
+  void exercise5_listIndexAccess() {
+    record Playlist(String name, List<String> songs) {}
+
+    Lens<Playlist, List<String>> songsLens =
+        Lens.of(Playlist::songs, (p, s) -> new Playlist(p.name(), s));
+
+    Playlist playlist = new Playlist("Favourites", List.of("Song A", "Song B", "Song C"));
+
+    // Create a path to the first song
+    // FocusPath + at(0) -> AffinePath
+    // TODO: Replace null with FocusPath.of(songsLens).at(0)
+    AffinePath<Playlist, String> firstSongPath = answerRequired();
+
+    // Get the first song
+    // TODO: Replace null with firstSongPath.getOptional(playlist)
+    Optional<String> firstSong = answerRequired();
+    assertThat(firstSong).contains("Song A");
+
+    // Create a path to an out-of-bounds index
+    AffinePath<Playlist, String> tenthSongPath = FocusPath.of(songsLens).at(10);
+
+    // TODO: Replace null with tenthSongPath.getOptional(playlist)
+    Optional<String> noSong = answerRequired();
+    assertThat(noSong).isEmpty();
+
+    // Set a specific song
+    // TODO: Replace null with firstSongPath.set("New First Song", playlist)
+    Playlist updated = answerRequired();
+    assertThat(updated.songs()).containsExactly("New First Song", "Song B", "Song C");
+  }
+
+  /**
+   * Exercise 6: Map navigation
+   *
+   * <p>Maps can be navigated using atKey(key) for a specific key.
+   *
+   * <p>Task: Navigate through map structures
+   */
+  @Test
+  void exercise6_mapNavigation() {
+    record Settings(Map<String, String> values) {}
+
+    Lens<Settings, Map<String, String>> valuesLens =
+        Lens.of(Settings::values, (s, v) -> new Settings(v));
+
+    Settings settings =
+        new Settings(
+            Map.of(
+                "theme", "dark",
+                "language", "en",
+                "timezone", "UTC"));
+
+    // Create a path to a specific map key
+    // FocusPath + atKey("theme") -> AffinePath
+    // TODO: Replace null with FocusPath.of(valuesLens).atKey("theme")
+    AffinePath<Settings, String> themePath = answerRequired();
+
+    // Get the theme value
+    // TODO: Replace null with themePath.getOptional(settings)
+    Optional<String> theme = answerRequired();
+    assertThat(theme).contains("dark");
+
+    // Check a missing key
+    AffinePath<Settings, String> missingPath = FocusPath.of(valuesLens).atKey("missing");
+    assertThat(missingPath.getOptional(settings)).isEmpty();
+  }
+
+  /**
+   * Exercise 7: Deep nested navigation
+   *
+   * <p>The real power of Focus DSL shows when navigating deeply nested structures with mixed
+   * optionality.
+   *
+   * <p>Task: Navigate through a complex nested structure
+   */
+  @Test
+  void exercise7_deepNavigation() {
+    record Department(String name, Optional<String> manager) {}
+
+    record Company(String name, List<Department> departments) {}
+
+    Lens<Company, List<Department>> deptLens =
+        Lens.of(Company::departments, (c, d) -> new Company(c.name(), d));
+    Lens<Department, Optional<String>> managerLens =
+        Lens.of(Department::manager, (d, m) -> new Department(d.name(), m));
+
+    Company company =
+        new Company(
+            "TechCorp",
+            List.of(
+                new Department("Engineering", Optional.of("Alice")),
+                new Department("Sales", Optional.empty()),
+                new Department("Marketing", Optional.of("Charlie"))));
+
+    // Path to all department managers (only those that exist)
+    // Company -> List<Department> -> Department -> Optional<String> -> String
+    // This chains: each() (list), via(managerLens) (lens), some() (optional)
+    TraversalPath<Company, String> managersPath =
+        FocusPath.of(deptLens).<Department>each().via(managerLens).<String>some();
+
+    // TODO: Replace null with managersPath.getAll(company)
+    List<String> managers = answerRequired();
+    // Should only get managers that exist (Alice and Charlie, not Sales which is empty)
+    assertThat(managers).containsExactly("Alice", "Charlie");
+
+    // Modify all existing managers
+    // TODO: Replace null with managersPath.modifyAll(String::toUpperCase, company)
+    Company updated = answerRequired();
+
+    // Verify modifications
+    List<String> updatedManagers =
+        FocusPath.of(deptLens).<Department>each().via(managerLens).<String>some().getAll(updated);
+    assertThat(updatedManagers).containsExactly("ALICE", "CHARLIE");
+  }
+
+  /**
+   * Exercise 8: Filtering traversals
+   *
+   * <p>TraversalPath provides a filter() method to focus only on elements matching a predicate.
+   *
+   * <p>Task: Filter elements during traversal
+   */
+  @Test
+  void exercise8_filteringTraversals() {
+    record Product(String name, double price) {}
+
+    record Inventory(List<Product> products) {}
+
+    Lens<Inventory, List<Product>> productsLens =
+        Lens.of(Inventory::products, (i, p) -> new Inventory(p));
+    Lens<Product, Double> priceLens = Lens.of(Product::price, (p, pr) -> new Product(p.name(), pr));
+
+    Inventory inventory =
+        new Inventory(
+            List.of(
+                new Product("Widget", 10.0),
+                new Product("Gadget", 150.0),
+                new Product("Gizmo", 75.0),
+                new Product("Thingamajig", 200.0)));
+
+    // Path to all products
+    TraversalPath<Inventory, Product> allProducts = FocusPath.of(productsLens).each();
+
+    // Filter to only expensive products (price > 100)
+    // TODO: Replace null with allProducts.filter(p -> p.price() > 100)
+    TraversalPath<Inventory, Product> expensiveProducts = answerRequired();
+
+    // Get expensive product names
+    List<String> expensiveNames =
+        expensiveProducts.getAll(inventory).stream().map(Product::name).toList();
+    assertThat(expensiveNames).containsExactly("Gadget", "Thingamajig");
+
+    // Apply a 10% discount to all expensive products
+    Inventory discounted =
+        expensiveProducts.modifyAll(p -> new Product(p.name(), p.price() * 0.9), inventory);
+
+    // Verify discounts applied only to expensive items
+    Product gadget =
+        discounted.products().stream().filter(p -> p.name().equals("Gadget")).findFirst().get();
+    assertThat(gadget.price()).isEqualTo(135.0); // Was 150, now 135
+
+    Product widget =
+        discounted.products().stream().filter(p -> p.name().equals("Widget")).findFirst().get();
+    assertThat(widget.price()).isEqualTo(10.0); // Unchanged (was not expensive)
+  }
+
+  /**
+   * Exercise 9: Conversion between path types
+   *
+   * <p>Paths can be converted to their underlying optics using toLens(), toAffine(), and
+   * toTraversal(). They can also be viewed as less-specific path types using asAffine() and
+   * asTraversal().
+   *
+   * <p>Task: Convert paths for use with other optics APIs
+   */
+  @Test
+  void exercise9_pathConversion() {
+    record Box(String content) {}
+
+    Lens<Box, String> contentLens = Lens.of(Box::content, (b, c) -> new Box(c));
+
+    FocusPath<Box, String> contentPath = FocusPath.of(contentLens);
+
+    // Convert FocusPath to the underlying Lens
+    // TODO: Replace null with contentPath.toLens()
+    Lens<Box, String> extractedLens = answerRequired();
+    assertThat(extractedLens.get(new Box("hello"))).isEqualTo("hello");
+
+    // View FocusPath as AffinePath (always successful, so Optional is always present)
+    AffinePath<Box, String> asAffine = contentPath.asAffine();
+    assertThat(asAffine.getOptional(new Box("world"))).contains("world");
+
+    // View FocusPath as TraversalPath (focuses on exactly one element)
+    TraversalPath<Box, String> asTraversal = contentPath.asTraversal();
+    assertThat(asTraversal.getAll(new Box("test"))).containsExactly("test");
+  }
+
+  /**
+   * Exercise 10: Using FocusPaths utility class
+   *
+   * <p>FocusPaths provides pre-built optics for common collection operations.
+   *
+   * <p>Task: Use FocusPaths utilities directly
+   */
+  @Test
+  void exercise10_focusPathsUtility() {
+    // FocusPaths provides optics for lists
+    var listTraversal = FocusPaths.<String>listElements();
+    var firstElement = FocusPaths.<String>listAt(0);
+    var lastElement = FocusPaths.<String>listLast();
+
+    List<String> fruits = List.of("apple", "banana", "cherry");
+
+    // Use listElements traversal
+    // TODO: Replace null with appropriate call using listTraversal
+    // Hint: Use org.higherkindedj.optics.util.Traversals.getAll(traversal, source)
+    List<String> allFruits = Traversals.getAll(listTraversal, fruits);
+    assertThat(allFruits).containsExactly("apple", "banana", "cherry");
+
+    // Use listAt affine for first element
+    // TODO: Replace null with firstElement.getOptional(fruits)
+    Optional<String> first = answerRequired();
+    assertThat(first).contains("apple");
+
+    // Use listLast affine
+    // TODO: Replace null with lastElement.getOptional(fruits)
+    Optional<String> last = answerRequired();
+    assertThat(last).contains("cherry");
+
+    // FocusPaths also provides optionalSome for unwrapping Optional
+    var someAffine = FocusPaths.<String>optionalSome();
+
+    Optional<String> maybeValue = Optional.of("present");
+    // TODO: Replace null with someAffine.getOptional(maybeValue)
+    Optional<String> unwrapped = answerRequired();
+    assertThat(unwrapped).contains("present");
+
+    Optional<String> emptyValue = Optional.empty();
+    assertThat(someAffine.getOptional(emptyValue)).isEmpty();
+  }
+
+  /**
+   * Congratulations! You have completed Tutorial 12: Focus DSL
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>Creating FocusPath from Lens using FocusPath.of()
+   *   <li>Composing paths with via() for deep navigation
+   *   <li>AffinePath for optional/nullable values using some()
+   *   <li>TraversalPath for collections using each()
+   *   <li>Accessing specific elements with at(index) and atKey(key)
+   *   <li>Filtering traversals with filter()
+   *   <li>Converting paths with toLens(), asAffine(), asTraversal()
+   *   <li>Using FocusPaths utility for common operations
+   * </ul>
+   *
+   * <p>Key Takeaways:
+   *
+   * <ul>
+   *   <li>FocusPath wraps Lens - always focuses on exactly one element
+   *   <li>AffinePath wraps Affine - may focus on zero or one element
+   *   <li>TraversalPath wraps Traversal - may focus on zero or more elements
+   *   <li>Path types automatically widen as you navigate through optional/collection types
+   *   <li>Use the generated *Focus classes (via @GenerateFocus) for record types
+   * </ul>
+   *
+   * <p>Next Steps:
+   *
+   * <ul>
+   *   <li>Use @GenerateFocus annotation to generate Focus classes for your records
+   *   <li>Combine Focus DSL with Free Monad DSL (Tutorial 11) for complex workflows
+   *   <li>Build type-safe navigation for your domain models
+   * </ul>
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial13_AdvancedFocusDSL.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial13_AdvancedFocusDSL.java
@@ -1,0 +1,551 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 13: Advanced Focus DSL - Type Class Integration
+ *
+ * <p>This tutorial covers advanced features of the Focus DSL that integrate with higher-kinded-j
+ * type classes for effectful operations, monoid aggregation, and generic collection traversal.
+ *
+ * <p>Key concepts:
+ *
+ * <ul>
+ *   <li><b>modifyF()</b>: Effectful modification using Applicative/Monad
+ *   <li><b>foldMap()</b>: Aggregate values using a Monoid
+ *   <li><b>traverseOver()</b>: Generic collection traversal via Traverse type class
+ *   <li><b>modifyWhen()</b>: Conditional modification with predicates
+ *   <li><b>instanceOf()</b>: Focus on specific variants of sealed interfaces
+ *   <li><b>traced()</b>: Debug path navigation with observers
+ * </ul>
+ *
+ * <p>Prerequisites: Complete Tutorial 12 (Focus DSL basics) before this one.
+ */
+public class Tutorial13_AdvancedFocusDSL {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
+
+  // ========== Test Domain Types ==========
+
+  /** A role with name and privilege level. */
+  record Role(String name, int level) {
+    Role promote() {
+      return new Role(name, level + 1);
+    }
+  }
+
+  /** A user with roles stored as Kind<ListKind.Witness, Role>. */
+  record User(String name, Kind<ListKind.Witness, Role> roles) {}
+
+  /** A team with members. */
+  record Team(String name, List<User> members) {}
+
+  /** An employee with salary. */
+  record Employee(String name, int yearsOfService, int salary) {
+    Employee withSalary(int newSalary) {
+      return new Employee(name, yearsOfService, newSalary);
+    }
+  }
+
+  /** A department with employees. */
+  record Department(List<Employee> employees) {}
+
+  // Sealed interface for sum type exercises
+  sealed interface Shape permits Circle, Rectangle {}
+
+  record Circle(double radius) implements Shape {}
+
+  record Rectangle(double width, double height) implements Shape {}
+
+  record Drawing(List<Shape> shapes) {}
+
+  // ========== Lenses ==========
+
+  static final Lens<User, String> userNameLens =
+      Lens.of(User::name, (u, n) -> new User(n, u.roles()));
+
+  static final Lens<User, Kind<ListKind.Witness, Role>> userRolesLens =
+      Lens.of(User::roles, (u, r) -> new User(u.name(), r));
+
+  static final Lens<Role, Integer> roleLevelLens =
+      Lens.of(Role::level, (r, l) -> new Role(r.name(), l));
+
+  static final Lens<Team, List<User>> teamMembersLens =
+      Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+  static final Lens<Department, List<Employee>> deptEmployeesLens =
+      Lens.of(Department::employees, (d, e) -> new Department(e));
+
+  static final Lens<Employee, Integer> employeeSalaryLens =
+      Lens.of(Employee::salary, (e, s) -> new Employee(e.name(), e.yearsOfService(), s));
+
+  static final Lens<Employee, Integer> employeeYearsLens =
+      Lens.of(Employee::yearsOfService, (e, y) -> new Employee(e.name(), y, e.salary()));
+
+  static final Lens<Drawing, List<Shape>> drawingShapesLens =
+      Lens.of(Drawing::shapes, (d, s) -> new Drawing(s));
+
+  static final Lens<Circle, Double> circleRadiusLens =
+      Lens.of(Circle::radius, (c, r) -> new Circle(r));
+
+  /**
+   * Exercise 1: Effectful Modification with modifyF()
+   *
+   * <p>The modifyF() method allows you to perform effectful modifications where the transformation
+   * function returns a value wrapped in an effect type (like Maybe, Either, or IO).
+   *
+   * <p>This is useful for:
+   *
+   * <ul>
+   *   <li>Validation that may fail
+   *   <li>Async operations
+   *   <li>Operations that may produce no result
+   * </ul>
+   *
+   * <p>Task: Use modifyF to validate and transform a value
+   */
+  @Test
+  void exercise1_effectfulModification() {
+    record Config(String apiKey) {}
+
+    Lens<Config, String> apiKeyLens = Lens.of(Config::apiKey, (c, k) -> new Config(k));
+
+    Config config = new Config("abc123");
+
+    FocusPath<Config, String> keyPath = FocusPath.of(apiKeyLens);
+
+    // A validation function that returns Maybe.just if key is valid, Maybe.nothing if not
+    // Valid keys must be at least 6 characters
+    Function<String, Kind<MaybeKind.Witness, String>> validateAndTransform =
+        key -> {
+          if (key.length() >= 6) {
+            return MaybeKindHelper.MAYBE.widen(Maybe.just(key.toUpperCase()));
+          } else {
+            return MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+          }
+        };
+
+    // Use modifyF with MaybeMonad to perform the effectful modification
+    // TODO: Replace null with keyPath.modifyF(validateAndTransform, config, MaybeMonad.INSTANCE)
+    Kind<MaybeKind.Witness, Config> result = answerRequired();
+
+    // The result should be Just(Config("ABC123")) because the key is valid
+    Maybe<Config> maybeConfig = MaybeKindHelper.MAYBE.narrow(result);
+    assertThat(maybeConfig.isJust()).isTrue();
+    assertThat(maybeConfig.get().apiKey()).isEqualTo("ABC123");
+
+    // Now test with an invalid key
+    Config shortKeyConfig = new Config("abc");
+    // TODO: Replace null with keyPath.modifyF(validateAndTransform, shortKeyConfig,
+    // MaybeMonad.INSTANCE)
+    Kind<MaybeKind.Witness, Config> invalidResult = answerRequired();
+
+    Maybe<Config> invalidMaybe = MaybeKindHelper.MAYBE.narrow(invalidResult);
+    assertThat(invalidMaybe.isNothing()).isTrue();
+  }
+
+  /**
+   * Exercise 2: Monoid Aggregation with foldMap()
+   *
+   * <p>TraversalPath supports foldMap() to aggregate values using a Monoid. This is powerful for
+   * computing summaries across multiple focused elements.
+   *
+   * <p>Task: Use foldMap to compute aggregate values
+   */
+  @Test
+  void exercise2_monoidAggregation() {
+    Department dept =
+        new Department(
+            List.of(
+                new Employee("Alice", 5, 60000),
+                new Employee("Bob", 3, 50000),
+                new Employee("Charlie", 8, 75000)));
+
+    // Path to all employee salaries - using intermediate step for type inference
+    TraversalPath<Department, Employee> employeesPath = FocusPath.of(deptEmployeesLens).each();
+    TraversalPath<Department, Integer> salariesPath = employeesPath.via(employeeSalaryLens);
+
+    // Define a Monoid for integer addition
+    Monoid<Integer> intAddition =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    // Use foldMap to sum all salaries
+    // foldMap takes a Monoid and a mapper function
+    // TODO: Replace 0 with salariesPath.foldMap(intAddition, salary -> salary, dept)
+    int totalSalary = answerRequired();
+    assertThat(totalSalary).isEqualTo(185000);
+
+    // Path to all years of service - reusing employeesPath from above
+    TraversalPath<Department, Integer> yearsPath = employeesPath.via(employeeYearsLens);
+
+    // Sum all years of service
+    // TODO: Replace 0 with yearsPath.foldMap(intAddition, years -> years, dept)
+    int totalYears = answerRequired();
+    assertThat(totalYears).isEqualTo(16);
+
+    // Use foldMap to find maximum salary (using max monoid pattern)
+    // We'll map salaries to a wrapper that tracks the max
+    Monoid<Integer> intMax =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return Integer.MIN_VALUE;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return Math.max(a, b);
+          }
+        };
+
+    // TODO: Replace 0 with salariesPath.foldMap(intMax, salary -> salary, dept)
+    int maxSalary = answerRequired();
+    assertThat(maxSalary).isEqualTo(75000);
+  }
+
+  /**
+   * Exercise 3: Generic Collection Traversal with traverseOver()
+   *
+   * <p>When your data contains collections wrapped in Kind<F, A> (rather than raw List<A>), use
+   * traverseOver() with a Traverse instance to navigate into the collection elements.
+   *
+   * <p>Task: Use traverseOver to access elements in Kind-wrapped collections
+   */
+  @Test
+  void exercise3_traverseTypeClassIntegration() {
+    User user =
+        new User(
+            "Alice",
+            ListKindHelper.LIST.widen(
+                List.of(new Role("Admin", 10), new Role("Developer", 5), new Role("Viewer", 1))));
+
+    // The roles field is Kind<ListKind.Witness, Role>, not List<Role>
+    // We need to use traverseOver() with ListTraverse to navigate into it
+    FocusPath<User, Kind<ListKind.Witness, Role>> rolesKindPath = FocusPath.of(userRolesLens);
+
+    // TODO: Replace null with rolesKindPath.<ListKind.Witness,
+    // Role>traverseOver(ListTraverse.INSTANCE)
+    TraversalPath<User, Role> allRolesPath = answerRequired();
+
+    // Get all roles
+    // TODO: Replace null with allRolesPath.getAll(user)
+    List<Role> roles = answerRequired();
+    assertThat(roles).hasSize(3);
+    assertThat(roles.stream().map(Role::name).toList())
+        .containsExactly("Admin", "Developer", "Viewer");
+
+    // Modify all roles - promote everyone
+    // TODO: Replace null with allRolesPath.modifyAll(Role::promote, user)
+    User promoted = answerRequired();
+
+    List<Role> promotedRoles =
+        rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE).getAll(promoted);
+    assertThat(promotedRoles.stream().map(Role::level).toList()).containsExactly(11, 6, 2);
+  }
+
+  /**
+   * Exercise 4: Chaining traverseOver with other operations
+   *
+   * <p>traverseOver() returns a TraversalPath, which can be further composed with via() to navigate
+   * deeper into each element.
+   *
+   * <p>Task: Compose traverseOver with via to access nested properties
+   */
+  @Test
+  void exercise4_traverseOverComposition() {
+    User user =
+        new User(
+            "Bob",
+            ListKindHelper.LIST.widen(
+                List.of(new Role("Admin", 10), new Role("User", 3), new Role("Guest", 1))));
+
+    // Build path step by step for clarity
+    FocusPath<User, Kind<ListKind.Witness, Role>> step1 = FocusPath.of(userRolesLens);
+    TraversalPath<User, Role> step2 =
+        step1.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // Compose with roleLevelLens to get all levels
+    // TODO: Replace null with step2.via(roleLevelLens)
+    TraversalPath<User, Integer> allLevelsPath = answerRequired();
+
+    // Get all levels
+    // TODO: Replace null with allLevelsPath.getAll(user)
+    List<Integer> levels = answerRequired();
+    assertThat(levels).containsExactly(10, 3, 1);
+
+    // Modify all levels - double them
+    // TODO: Replace null with allLevelsPath.modifyAll(level -> level * 2, user)
+    User doubled = answerRequired();
+
+    List<Integer> doubledLevels =
+        FocusPath.of(userRolesLens)
+            .<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE)
+            .via(roleLevelLens)
+            .getAll(doubled);
+    assertThat(doubledLevels).containsExactly(20, 6, 2);
+  }
+
+  /**
+   * Exercise 5: Conditional Modification with modifyWhen()
+   *
+   * <p>modifyWhen() allows you to modify only elements that match a predicate, leaving others
+   * unchanged.
+   *
+   * <p>Task: Use modifyWhen to selectively update elements
+   */
+  @Test
+  void exercise5_conditionalModification() {
+    Department dept =
+        new Department(
+            List.of(
+                new Employee("Alice", 8, 60000),
+                new Employee("Bob", 2, 45000),
+                new Employee("Charlie", 6, 55000),
+                new Employee("Diana", 1, 40000)));
+
+    TraversalPath<Department, Employee> employeesPath = FocusPath.of(deptEmployeesLens).each();
+
+    // Give a 10% raise only to employees with 5+ years of service
+    // TODO: Replace null with:
+    // employeesPath.modifyWhen(
+    //     e -> e.yearsOfService() >= 5,
+    //     e -> e.withSalary((int) (e.salary() * 1.10)),
+    //     dept)
+    Department afterRaises = answerRequired();
+
+    List<Integer> updatedSalaries = employeesPath.via(employeeSalaryLens).getAll(afterRaises);
+
+    // Alice (8 years): 60000 * 1.10 = 66000
+    // Bob (2 years): unchanged at 45000
+    // Charlie (6 years): 55000 * 1.10 = 60500
+    // Diana (1 year): unchanged at 40000
+    assertThat(updatedSalaries).containsExactly(66000, 45000, 60500, 40000);
+  }
+
+  /**
+   * Exercise 6: Working with Sum Types using instanceOf()
+   *
+   * <p>AffinePath.instanceOf() creates a path that focuses on values of a specific subtype. This is
+   * useful for working with sealed interfaces and other sum types.
+   *
+   * <p>Task: Use instanceOf to focus on specific variants
+   */
+  @Test
+  void exercise6_sumTypeNavigation() {
+    Drawing drawing =
+        new Drawing(
+            List.of(
+                new Circle(5.0),
+                new Rectangle(10.0, 20.0),
+                new Circle(3.0),
+                new Rectangle(5.0, 5.0),
+                new Circle(7.0)));
+
+    // Path to all shapes
+    TraversalPath<Drawing, Shape> allShapes = FocusPath.of(drawingShapesLens).each();
+
+    // Create a path that only focuses on Circles
+    // TODO: Replace null with AffinePath.instanceOf(Circle.class)
+    AffinePath<Shape, Circle> circlePrism = answerRequired();
+
+    // Compose to get a path to all circles in the drawing
+    // TODO: Replace null with allShapes.via(circlePrism)
+    TraversalPath<Drawing, Circle> circlesPath = answerRequired();
+
+    // Get all circles
+    // TODO: Replace null with circlesPath.getAll(drawing)
+    List<Circle> circles = answerRequired();
+    assertThat(circles).hasSize(3);
+    assertThat(circles.stream().map(Circle::radius).toList()).containsExactly(5.0, 3.0, 7.0);
+
+    // Double all circle radii
+    // TODO: Replace null with circlesPath.via(circleRadiusLens).modifyAll(r -> r * 2, drawing)
+    Drawing enlarged = answerRequired();
+
+    List<Circle> enlargedCircles =
+        FocusPath.of(drawingShapesLens)
+            .each()
+            .via(AffinePath.instanceOf(Circle.class))
+            .getAll(enlarged);
+    assertThat(enlargedCircles.stream().map(Circle::radius).toList())
+        .containsExactly(10.0, 6.0, 14.0);
+  }
+
+  /**
+   * Exercise 7: Path Debugging with traced()
+   *
+   * <p>The traced() method adds an observer that is called during getAll() operations, allowing you
+   * to debug complex path navigation.
+   *
+   * <p>Task: Use traced to observe path navigation
+   */
+  @Test
+  void exercise7_pathDebugging() {
+    Department dept =
+        new Department(List.of(new Employee("Alice", 5, 60000), new Employee("Bob", 3, 50000)));
+
+    // Create a list to capture observed values
+    List<String> observations = new ArrayList<>();
+
+    // Path to all employee names
+    TraversalPath<Department, Employee> employeesPath = FocusPath.of(deptEmployeesLens).each();
+
+    // Create an observer that logs each employee accessed
+    BiConsumer<Department, List<Employee>> observer =
+        (source, employees) -> {
+          for (Employee e : employees) {
+            observations.add("Observed: " + e.name());
+          }
+        };
+
+    // Create a traced path
+    // TODO: Replace null with employeesPath.traced(observer)
+    TraversalPath<Department, Employee> tracedPath = answerRequired();
+
+    // Get all employees - this should trigger the observer
+    // TODO: Replace null with tracedPath.getAll(dept)
+    List<Employee> employees = answerRequired();
+
+    assertThat(employees).hasSize(2);
+    assertThat(observations).containsExactly("Observed: Alice", "Observed: Bob");
+
+    // Note: traced() only observes during getAll(), not during modifyAll()
+    observations.clear();
+    tracedPath.modifyAll(e -> e.withSalary(e.salary() + 1000), dept);
+    assertThat(observations).isEmpty(); // No observations during modify
+  }
+
+  /**
+   * Exercise 8: Combining Multiple Advanced Features
+   *
+   * <p>This exercise combines traverseOver, modifyWhen, and foldMap to solve a real-world scenario.
+   *
+   * <p>Task: Process a team structure using multiple Focus DSL features
+   */
+  @Test
+  void exercise8_combiningFeatures() {
+    Team team =
+        new Team(
+            "Platform",
+            List.of(
+                new User(
+                    "Alice",
+                    ListKindHelper.LIST.widen(List.of(new Role("Admin", 10), new Role("Dev", 5)))),
+                new User("Bob", ListKindHelper.LIST.widen(List.of(new Role("User", 2)))),
+                new User(
+                    "Charlie",
+                    ListKindHelper.LIST.widen(
+                        List.of(new Role("Admin", 8), new Role("Dev", 6), new Role("User", 3))))));
+
+    // Build a path to all roles across all team members
+    FocusPath<Team, List<User>> step1 = FocusPath.of(teamMembersLens);
+    TraversalPath<Team, User> step2 = step1.each();
+    TraversalPath<Team, Kind<ListKind.Witness, Role>> step3 = step2.via(userRolesLens);
+    TraversalPath<Team, Role> allRoles =
+        step3.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // Count total number of roles
+    // TODO: Replace 0 with allRoles.count(team)
+    int totalRoles = answerRequired();
+    assertThat(totalRoles).isEqualTo(6);
+
+    // Sum all role levels using foldMap
+    Monoid<Integer> intSum =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    // Get path to all role levels
+    TraversalPath<Team, Integer> allLevels = allRoles.via(roleLevelLens);
+
+    // TODO: Replace 0 with allLevels.foldMap(intSum, level -> level, team)
+    int totalLevels = answerRequired();
+    assertThat(totalLevels).isEqualTo(34); // 10+5+2+8+6+3
+
+    // Promote all Admin roles (those with level >= 8)
+    // TODO: Replace null with allRoles.modifyWhen(r -> r.level() >= 8, Role::promote, team)
+    Team promotedTeam = answerRequired();
+
+    // Verify only high-level admins were promoted - reuse allLevels path
+    List<Integer> updatedLevels = allLevels.getAll(promotedTeam);
+
+    // Alice's Admin (10->11), Dev (5 unchanged)
+    // Bob's User (2 unchanged)
+    // Charlie's Admin (8->9), Dev (6 unchanged), User (3 unchanged)
+    assertThat(updatedLevels).containsExactly(11, 5, 2, 9, 6, 3);
+  }
+
+  /**
+   * Congratulations! You have completed Tutorial 13: Advanced Focus DSL
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>modifyF() for effectful modifications with Applicative/Monad
+   *   <li>foldMap() for aggregating values using Monoid
+   *   <li>traverseOver() for generic collection traversal via Traverse
+   *   <li>modifyWhen() for conditional modifications
+   *   <li>instanceOf() for sum type navigation
+   *   <li>traced() for debugging path navigation
+   * </ul>
+   *
+   * <p>Key Takeaways:
+   *
+   * <ul>
+   *   <li>Type class integration enables powerful abstractions over effects and aggregation
+   *   <li>traverseOver() bridges the Traverse type class with optics traversal
+   *   <li>modifyWhen() provides clean syntax for conditional updates
+   *   <li>instanceOf() makes sum type handling type-safe and ergonomic
+   *   <li>traced() helps debug complex optic compositions
+   * </ul>
+   *
+   * <p>Next Steps:
+   *
+   * <ul>
+   *   <li>Explore the TraverseTraversals utility class for more Traverse-based optics
+   *   <li>Combine Focus DSL with Free Monad patterns for complex workflows
+   *   <li>Create custom Traverse instances for your collection types
+   * </ul>
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial12_FocusDSL_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial12_FocusDSL_Solution.java
@@ -1,0 +1,299 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.FocusPaths;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 12: Focus DSL - Type-Safe Path Navigation
+ *
+ * <p>These are the completed solutions for all exercises in Tutorial12_FocusDSL.java
+ */
+public class Tutorial12_FocusDSL_Solution {
+
+  @Test
+  void exercise1_basicFocusPath() {
+    record Person(String name, int age) {}
+
+    Lens<Person, String> nameLens = Lens.of(Person::name, (p, n) -> new Person(n, p.age()));
+
+    Person alice = new Person("Alice", 30);
+
+    // SOLUTION: Create a FocusPath from the lens
+    FocusPath<Person, String> namePath = FocusPath.of(nameLens);
+
+    // SOLUTION: Use the path to get the name
+    String name = namePath.get(alice);
+    assertThat(name).isEqualTo("Alice");
+
+    // SOLUTION: Use the path to set a new name
+    Person renamed = namePath.set("Alicia", alice);
+    assertThat(renamed.name()).isEqualTo("Alicia");
+    assertThat(renamed.age()).isEqualTo(30);
+  }
+
+  @Test
+  void exercise2_composingPaths() {
+    record Street(String name) {}
+
+    record Address(Street street, String city) {}
+
+    record Person(String name, Address address) {}
+
+    Lens<Person, Address> addressLens = Lens.of(Person::address, (p, a) -> new Person(p.name(), a));
+    Lens<Address, Street> streetLens = Lens.of(Address::street, (a, s) -> new Address(s, a.city()));
+    Lens<Street, String> streetNameLens = Lens.of(Street::name, (s, n) -> new Street(n));
+
+    Person person = new Person("Alice", new Address(new Street("High Street"), "London"));
+
+    // SOLUTION: Compose paths using via()
+    FocusPath<Person, String> streetNamePath =
+        FocusPath.of(addressLens).via(streetLens).via(streetNameLens);
+
+    // SOLUTION: Get the street name
+    String streetName = streetNamePath.get(person);
+    assertThat(streetName).isEqualTo("High Street");
+
+    // SOLUTION: Modify the street name
+    Person updated = streetNamePath.modify(String::toUpperCase, person);
+    assertThat(updated.address().street().name()).isEqualTo("HIGH STREET");
+  }
+
+  @Test
+  void exercise3_affinePathBasics() {
+    record Config(Optional<String> apiKey) {}
+
+    Lens<Config, Optional<String>> apiKeyLens = Lens.of(Config::apiKey, (c, k) -> new Config(k));
+
+    Config withKey = new Config(Optional.of("secret-123"));
+    Config withoutKey = new Config(Optional.empty());
+
+    // SOLUTION: Create path that unwraps Optional using some()
+    AffinePath<Config, String> keyPath = FocusPath.of(apiKeyLens).some();
+
+    // SOLUTION: getOptional returns Optional<A>
+    Optional<String> foundKey = keyPath.getOptional(withKey);
+    assertThat(foundKey).contains("secret-123");
+
+    // SOLUTION: Empty when Optional is empty
+    Optional<String> missingKey = keyPath.getOptional(withoutKey);
+    assertThat(missingKey).isEmpty();
+
+    // SOLUTION: matches() checks if target exists
+    boolean hasKey = keyPath.matches(withKey);
+    assertThat(hasKey).isTrue();
+
+    // SOLUTION: False when target doesn't exist
+    boolean noKey = keyPath.matches(withoutKey);
+    assertThat(noKey).isFalse();
+  }
+
+  @Test
+  void exercise4_traversalPathBasics() {
+    record Team(String name, List<String> members) {}
+
+    Lens<Team, List<String>> membersLens = Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+    Team team = new Team("Engineering", List.of("Alice", "Bob", "Charlie"));
+
+    // SOLUTION: Create traversal path using each()
+    TraversalPath<Team, String> membersPath = FocusPath.of(membersLens).each();
+
+    // SOLUTION: getAll returns all focused elements
+    List<String> allMembers = membersPath.getAll(team);
+    assertThat(allMembers).containsExactly("Alice", "Bob", "Charlie");
+
+    // SOLUTION: modifyAll transforms all elements
+    Team shouting = membersPath.modifyAll(String::toUpperCase, team);
+    assertThat(shouting.members()).containsExactly("ALICE", "BOB", "CHARLIE");
+
+    // SOLUTION: count returns element count
+    int memberCount = membersPath.count(team);
+    assertThat(memberCount).isEqualTo(3);
+  }
+
+  @Test
+  void exercise5_listIndexAccess() {
+    record Playlist(String name, List<String> songs) {}
+
+    Lens<Playlist, List<String>> songsLens =
+        Lens.of(Playlist::songs, (p, s) -> new Playlist(p.name(), s));
+
+    Playlist playlist = new Playlist("Favourites", List.of("Song A", "Song B", "Song C"));
+
+    // SOLUTION: Create path to first element using at(0)
+    AffinePath<Playlist, String> firstSongPath = FocusPath.of(songsLens).at(0);
+
+    // SOLUTION: Get the first song
+    Optional<String> firstSong = firstSongPath.getOptional(playlist);
+    assertThat(firstSong).contains("Song A");
+
+    AffinePath<Playlist, String> tenthSongPath = FocusPath.of(songsLens).at(10);
+
+    // SOLUTION: Out of bounds returns empty
+    Optional<String> noSong = tenthSongPath.getOptional(playlist);
+    assertThat(noSong).isEmpty();
+
+    // SOLUTION: Set a specific song
+    Playlist updated = firstSongPath.set("New First Song", playlist);
+    assertThat(updated.songs()).containsExactly("New First Song", "Song B", "Song C");
+  }
+
+  @Test
+  void exercise6_mapNavigation() {
+    record Settings(Map<String, String> values) {}
+
+    Lens<Settings, Map<String, String>> valuesLens =
+        Lens.of(Settings::values, (s, v) -> new Settings(v));
+
+    Settings settings =
+        new Settings(
+            Map.of(
+                "theme", "dark",
+                "language", "en",
+                "timezone", "UTC"));
+
+    // SOLUTION: Create path to map key using atKey()
+    AffinePath<Settings, String> themePath = FocusPath.of(valuesLens).atKey("theme");
+
+    // SOLUTION: Get the theme value
+    Optional<String> theme = themePath.getOptional(settings);
+    assertThat(theme).contains("dark");
+
+    AffinePath<Settings, String> missingPath = FocusPath.of(valuesLens).atKey("missing");
+    assertThat(missingPath.getOptional(settings)).isEmpty();
+  }
+
+  @Test
+  void exercise7_deepNavigation() {
+    record Department(String name, Optional<String> manager) {}
+
+    record Company(String name, List<Department> departments) {}
+
+    Lens<Company, List<Department>> deptLens =
+        Lens.of(Company::departments, (c, d) -> new Company(c.name(), d));
+    Lens<Department, Optional<String>> managerLens =
+        Lens.of(Department::manager, (d, m) -> new Department(d.name(), m));
+
+    Company company =
+        new Company(
+            "TechCorp",
+            List.of(
+                new Department("Engineering", Optional.of("Alice")),
+                new Department("Sales", Optional.empty()),
+                new Department("Marketing", Optional.of("Charlie"))));
+
+    TraversalPath<Company, String> managersPath =
+        FocusPath.of(deptLens).<Department>each().via(managerLens).<String>some();
+
+    // SOLUTION: Get all present managers
+    List<String> managers = managersPath.getAll(company);
+    assertThat(managers).containsExactly("Alice", "Charlie");
+
+    // SOLUTION: Modify all existing managers
+    Company updated = managersPath.modifyAll(String::toUpperCase, company);
+
+    List<String> updatedManagers =
+        FocusPath.of(deptLens).<Department>each().via(managerLens).<String>some().getAll(updated);
+    assertThat(updatedManagers).containsExactly("ALICE", "CHARLIE");
+  }
+
+  @Test
+  void exercise8_filteringTraversals() {
+    record Product(String name, double price) {}
+
+    record Inventory(List<Product> products) {}
+
+    Lens<Inventory, List<Product>> productsLens =
+        Lens.of(Inventory::products, (i, p) -> new Inventory(p));
+    Lens<Product, Double> priceLens = Lens.of(Product::price, (p, pr) -> new Product(p.name(), pr));
+
+    Inventory inventory =
+        new Inventory(
+            List.of(
+                new Product("Widget", 10.0),
+                new Product("Gadget", 150.0),
+                new Product("Gizmo", 75.0),
+                new Product("Thingamajig", 200.0)));
+
+    TraversalPath<Inventory, Product> allProducts = FocusPath.of(productsLens).each();
+
+    // SOLUTION: Filter to expensive products
+    TraversalPath<Inventory, Product> expensiveProducts = allProducts.filter(p -> p.price() > 100);
+
+    List<String> expensiveNames =
+        expensiveProducts.getAll(inventory).stream().map(Product::name).toList();
+    assertThat(expensiveNames).containsExactly("Gadget", "Thingamajig");
+
+    Inventory discounted =
+        expensiveProducts.modifyAll(p -> new Product(p.name(), p.price() * 0.9), inventory);
+
+    Product gadget =
+        discounted.products().stream().filter(p -> p.name().equals("Gadget")).findFirst().get();
+    assertThat(gadget.price()).isEqualTo(135.0);
+
+    Product widget =
+        discounted.products().stream().filter(p -> p.name().equals("Widget")).findFirst().get();
+    assertThat(widget.price()).isEqualTo(10.0);
+  }
+
+  @Test
+  void exercise9_pathConversion() {
+    record Box(String content) {}
+
+    Lens<Box, String> contentLens = Lens.of(Box::content, (b, c) -> new Box(c));
+
+    FocusPath<Box, String> contentPath = FocusPath.of(contentLens);
+
+    // SOLUTION: Convert to underlying Lens
+    Lens<Box, String> extractedLens = contentPath.toLens();
+    assertThat(extractedLens.get(new Box("hello"))).isEqualTo("hello");
+
+    AffinePath<Box, String> asAffine = contentPath.asAffine();
+    assertThat(asAffine.getOptional(new Box("world"))).contains("world");
+
+    TraversalPath<Box, String> asTraversal = contentPath.asTraversal();
+    assertThat(asTraversal.getAll(new Box("test"))).containsExactly("test");
+  }
+
+  @Test
+  void exercise10_focusPathsUtility() {
+    var listTraversal = FocusPaths.<String>listElements();
+    var firstElement = FocusPaths.<String>listAt(0);
+    var lastElement = FocusPaths.<String>listLast();
+
+    List<String> fruits = List.of("apple", "banana", "cherry");
+
+    List<String> allFruits = Traversals.getAll(listTraversal, fruits);
+    assertThat(allFruits).containsExactly("apple", "banana", "cherry");
+
+    // SOLUTION: Get first element
+    Optional<String> first = firstElement.getOptional(fruits);
+    assertThat(first).contains("apple");
+
+    // SOLUTION: Get last element
+    Optional<String> last = lastElement.getOptional(fruits);
+    assertThat(last).contains("cherry");
+
+    var someAffine = FocusPaths.<String>optionalSome();
+
+    Optional<String> maybeValue = Optional.of("present");
+    // SOLUTION: Unwrap optional
+    Optional<String> unwrapped = someAffine.getOptional(maybeValue);
+    assertThat(unwrapped).contains("present");
+
+    Optional<String> emptyValue = Optional.empty();
+    assertThat(someAffine.getOptional(emptyValue)).isEmpty();
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial13_AdvancedFocusDSL_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial13_AdvancedFocusDSL_Solution.java
@@ -1,0 +1,378 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 13: Advanced Focus DSL - Type Class Integration
+ *
+ * <p>These are the completed solutions for all exercises in Tutorial13_AdvancedFocusDSL.java
+ */
+public class Tutorial13_AdvancedFocusDSL_Solution {
+
+  // ========== Test Domain Types ==========
+
+  record Role(String name, int level) {
+    Role promote() {
+      return new Role(name, level + 1);
+    }
+  }
+
+  record User(String name, Kind<ListKind.Witness, Role> roles) {}
+
+  record Team(String name, List<User> members) {}
+
+  record Employee(String name, int yearsOfService, int salary) {
+    Employee withSalary(int newSalary) {
+      return new Employee(name, yearsOfService, newSalary);
+    }
+  }
+
+  record Department(List<Employee> employees) {}
+
+  sealed interface Shape permits Circle, Rectangle {}
+
+  record Circle(double radius) implements Shape {}
+
+  record Rectangle(double width, double height) implements Shape {}
+
+  record Drawing(List<Shape> shapes) {}
+
+  // ========== Lenses ==========
+
+  static final Lens<User, String> userNameLens =
+      Lens.of(User::name, (u, n) -> new User(n, u.roles()));
+
+  static final Lens<User, Kind<ListKind.Witness, Role>> userRolesLens =
+      Lens.of(User::roles, (u, r) -> new User(u.name(), r));
+
+  static final Lens<Role, Integer> roleLevelLens =
+      Lens.of(Role::level, (r, l) -> new Role(r.name(), l));
+
+  static final Lens<Team, List<User>> teamMembersLens =
+      Lens.of(Team::members, (t, m) -> new Team(t.name(), m));
+
+  static final Lens<Department, List<Employee>> deptEmployeesLens =
+      Lens.of(Department::employees, (d, e) -> new Department(e));
+
+  static final Lens<Employee, Integer> employeeSalaryLens =
+      Lens.of(Employee::salary, (e, s) -> new Employee(e.name(), e.yearsOfService(), s));
+
+  static final Lens<Employee, Integer> employeeYearsLens =
+      Lens.of(Employee::yearsOfService, (e, y) -> new Employee(e.name(), y, e.salary()));
+
+  static final Lens<Drawing, List<Shape>> drawingShapesLens =
+      Lens.of(Drawing::shapes, (d, s) -> new Drawing(s));
+
+  static final Lens<Circle, Double> circleRadiusLens =
+      Lens.of(Circle::radius, (c, r) -> new Circle(r));
+
+  @Test
+  void exercise1_effectfulModification() {
+    record Config(String apiKey) {}
+
+    Lens<Config, String> apiKeyLens = Lens.of(Config::apiKey, (c, k) -> new Config(k));
+
+    Config config = new Config("abc123");
+
+    FocusPath<Config, String> keyPath = FocusPath.of(apiKeyLens);
+
+    Function<String, Kind<MaybeKind.Witness, String>> validateAndTransform =
+        key -> {
+          if (key.length() >= 6) {
+            return MaybeKindHelper.MAYBE.widen(Maybe.just(key.toUpperCase()));
+          } else {
+            return MaybeKindHelper.MAYBE.widen(Maybe.nothing());
+          }
+        };
+
+    // SOLUTION: Use modifyF with MaybeMonad
+    Kind<MaybeKind.Witness, Config> result =
+        keyPath.modifyF(validateAndTransform, config, MaybeMonad.INSTANCE);
+
+    Maybe<Config> maybeConfig = MaybeKindHelper.MAYBE.narrow(result);
+    assertThat(maybeConfig.isJust()).isTrue();
+    assertThat(maybeConfig.get().apiKey()).isEqualTo("ABC123");
+
+    Config shortKeyConfig = new Config("abc");
+    // SOLUTION: Invalid key returns Nothing
+    Kind<MaybeKind.Witness, Config> invalidResult =
+        keyPath.modifyF(validateAndTransform, shortKeyConfig, MaybeMonad.INSTANCE);
+
+    Maybe<Config> invalidMaybe = MaybeKindHelper.MAYBE.narrow(invalidResult);
+    assertThat(invalidMaybe.isNothing()).isTrue();
+  }
+
+  @Test
+  void exercise2_monoidAggregation() {
+    Department dept =
+        new Department(
+            List.of(
+                new Employee("Alice", 5, 60000),
+                new Employee("Bob", 3, 50000),
+                new Employee("Charlie", 8, 75000)));
+
+    // Using intermediate step for type inference
+    TraversalPath<Department, Employee> employeesPath = FocusPath.of(deptEmployeesLens).each();
+    TraversalPath<Department, Integer> salariesPath = employeesPath.via(employeeSalaryLens);
+
+    Monoid<Integer> intAddition =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    // SOLUTION: Use foldMap to sum salaries
+    int totalSalary = salariesPath.foldMap(intAddition, salary -> salary, dept);
+    assertThat(totalSalary).isEqualTo(185000);
+
+    TraversalPath<Department, Integer> yearsPath = employeesPath.via(employeeYearsLens);
+
+    // SOLUTION: Sum years of service
+    int totalYears = yearsPath.foldMap(intAddition, years -> years, dept);
+    assertThat(totalYears).isEqualTo(16);
+
+    Monoid<Integer> intMax =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return Integer.MIN_VALUE;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return Math.max(a, b);
+          }
+        };
+
+    // SOLUTION: Find max salary using max monoid
+    int maxSalary = salariesPath.foldMap(intMax, salary -> salary, dept);
+    assertThat(maxSalary).isEqualTo(75000);
+  }
+
+  @Test
+  void exercise3_traverseTypeClassIntegration() {
+    User user =
+        new User(
+            "Alice",
+            ListKindHelper.LIST.widen(
+                List.of(new Role("Admin", 10), new Role("Developer", 5), new Role("Viewer", 1))));
+
+    FocusPath<User, Kind<ListKind.Witness, Role>> rolesKindPath = FocusPath.of(userRolesLens);
+
+    // SOLUTION: Use traverseOver with ListTraverse
+    TraversalPath<User, Role> allRolesPath =
+        rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // SOLUTION: Get all roles
+    List<Role> roles = allRolesPath.getAll(user);
+    assertThat(roles).hasSize(3);
+    assertThat(roles.stream().map(Role::name).toList())
+        .containsExactly("Admin", "Developer", "Viewer");
+
+    // SOLUTION: Modify all roles
+    User promoted = allRolesPath.modifyAll(Role::promote, user);
+
+    List<Role> promotedRoles =
+        rolesKindPath.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE).getAll(promoted);
+    assertThat(promotedRoles.stream().map(Role::level).toList()).containsExactly(11, 6, 2);
+  }
+
+  @Test
+  void exercise4_traverseOverComposition() {
+    User user =
+        new User(
+            "Bob",
+            ListKindHelper.LIST.widen(
+                List.of(new Role("Admin", 10), new Role("User", 3), new Role("Guest", 1))));
+
+    FocusPath<User, Kind<ListKind.Witness, Role>> step1 = FocusPath.of(userRolesLens);
+    TraversalPath<User, Role> step2 =
+        step1.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // SOLUTION: Compose with lens
+    TraversalPath<User, Integer> allLevelsPath = step2.via(roleLevelLens);
+
+    // SOLUTION: Get all levels
+    List<Integer> levels = allLevelsPath.getAll(user);
+    assertThat(levels).containsExactly(10, 3, 1);
+
+    // SOLUTION: Modify all levels
+    User doubled = allLevelsPath.modifyAll(level -> level * 2, user);
+
+    List<Integer> doubledLevels =
+        FocusPath.of(userRolesLens)
+            .<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE)
+            .via(roleLevelLens)
+            .getAll(doubled);
+    assertThat(doubledLevels).containsExactly(20, 6, 2);
+  }
+
+  @Test
+  void exercise5_conditionalModification() {
+    Department dept =
+        new Department(
+            List.of(
+                new Employee("Alice", 8, 60000),
+                new Employee("Bob", 2, 45000),
+                new Employee("Charlie", 6, 55000),
+                new Employee("Diana", 1, 40000)));
+
+    TraversalPath<Department, Employee> employeesPath = FocusPath.of(deptEmployeesLens).each();
+
+    // SOLUTION: Use modifyWhen for conditional modification
+    Department afterRaises =
+        employeesPath.modifyWhen(
+            e -> e.yearsOfService() >= 5, e -> e.withSalary((int) (e.salary() * 1.10)), dept);
+
+    List<Integer> updatedSalaries = employeesPath.via(employeeSalaryLens).getAll(afterRaises);
+
+    assertThat(updatedSalaries).containsExactly(66000, 45000, 60500, 40000);
+  }
+
+  @Test
+  void exercise6_sumTypeNavigation() {
+    Drawing drawing =
+        new Drawing(
+            List.of(
+                new Circle(5.0),
+                new Rectangle(10.0, 20.0),
+                new Circle(3.0),
+                new Rectangle(5.0, 5.0),
+                new Circle(7.0)));
+
+    TraversalPath<Drawing, Shape> allShapes = FocusPath.of(drawingShapesLens).each();
+
+    // SOLUTION: Create instanceOf for Circles
+    AffinePath<Shape, Circle> circlePrism = AffinePath.instanceOf(Circle.class);
+
+    // SOLUTION: Compose to get circles path
+    TraversalPath<Drawing, Circle> circlesPath = allShapes.via(circlePrism);
+
+    // SOLUTION: Get all circles
+    List<Circle> circles = circlesPath.getAll(drawing);
+    assertThat(circles).hasSize(3);
+    assertThat(circles.stream().map(Circle::radius).toList()).containsExactly(5.0, 3.0, 7.0);
+
+    // SOLUTION: Modify all circle radii
+    Drawing enlarged = circlesPath.via(circleRadiusLens).modifyAll(r -> r * 2, drawing);
+
+    List<Circle> enlargedCircles =
+        FocusPath.of(drawingShapesLens)
+            .each()
+            .via(AffinePath.instanceOf(Circle.class))
+            .getAll(enlarged);
+    assertThat(enlargedCircles.stream().map(Circle::radius).toList())
+        .containsExactly(10.0, 6.0, 14.0);
+  }
+
+  @Test
+  void exercise7_pathDebugging() {
+    Department dept =
+        new Department(List.of(new Employee("Alice", 5, 60000), new Employee("Bob", 3, 50000)));
+
+    List<String> observations = new ArrayList<>();
+
+    TraversalPath<Department, Employee> employeesPath = FocusPath.of(deptEmployeesLens).each();
+
+    BiConsumer<Department, List<Employee>> observer =
+        (source, employees) -> {
+          for (Employee e : employees) {
+            observations.add("Observed: " + e.name());
+          }
+        };
+
+    // SOLUTION: Create traced path
+    TraversalPath<Department, Employee> tracedPath = employeesPath.traced(observer);
+
+    // SOLUTION: Get triggers observer
+    List<Employee> employees = tracedPath.getAll(dept);
+
+    assertThat(employees).hasSize(2);
+    assertThat(observations).containsExactly("Observed: Alice", "Observed: Bob");
+
+    observations.clear();
+    tracedPath.modifyAll(e -> e.withSalary(e.salary() + 1000), dept);
+    assertThat(observations).isEmpty();
+  }
+
+  @Test
+  void exercise8_combiningFeatures() {
+    Team team =
+        new Team(
+            "Platform",
+            List.of(
+                new User(
+                    "Alice",
+                    ListKindHelper.LIST.widen(List.of(new Role("Admin", 10), new Role("Dev", 5)))),
+                new User("Bob", ListKindHelper.LIST.widen(List.of(new Role("User", 2)))),
+                new User(
+                    "Charlie",
+                    ListKindHelper.LIST.widen(
+                        List.of(new Role("Admin", 8), new Role("Dev", 6), new Role("User", 3))))));
+
+    FocusPath<Team, List<User>> step1 = FocusPath.of(teamMembersLens);
+    TraversalPath<Team, User> step2 = step1.each();
+    TraversalPath<Team, Kind<ListKind.Witness, Role>> step3 = step2.via(userRolesLens);
+    TraversalPath<Team, Role> allRoles =
+        step3.<ListKind.Witness, Role>traverseOver(ListTraverse.INSTANCE);
+
+    // SOLUTION: Count total roles
+    int totalRoles = allRoles.count(team);
+    assertThat(totalRoles).isEqualTo(6);
+
+    Monoid<Integer> intSum =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    TraversalPath<Team, Integer> allLevels = allRoles.via(roleLevelLens);
+
+    // SOLUTION: Sum all levels
+    int totalLevels = allLevels.foldMap(intSum, level -> level, team);
+    assertThat(totalLevels).isEqualTo(34);
+
+    // SOLUTION: Promote high-level admins
+    Team promotedTeam = allRoles.modifyWhen(r -> r.level() >= 8, Role::promote, team);
+
+    // Reuse allLevels path from above
+    List<Integer> updatedLevels = allLevels.getAll(promotedTeam);
+
+    assertThat(updatedLevels).containsExactly(11, 5, 2, 9, 6, 3);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -1,0 +1,373 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import com.google.auto.service.AutoService;
+import com.palantir.javapoet.*;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.annotations.GenerateFocus;
+
+/**
+ * Annotation processor for {@link GenerateFocus} that generates Focus DSL utility classes.
+ *
+ * <p>For each annotated record, this processor generates a companion class with the suffix "Focus"
+ * containing static methods that return {@code FocusPath} instances for each record component.
+ *
+ * <h2>Generated Code Structure</h2>
+ *
+ * <p>For a record like:
+ *
+ * <pre>{@code
+ * @GenerateFocus
+ * record User(String name, Address address) {}
+ * }</pre>
+ *
+ * <p>The processor generates:
+ *
+ * <pre>{@code
+ * @Generated
+ * public final class UserFocus {
+ *     private UserFocus() {}
+ *
+ *     public static FocusPath<User, String> name() {
+ *         return FocusPath.of(Lens.of(User::name, (source, newValue) -> new User(newValue, source.address())));
+ *     }
+ *
+ *     public static FocusPath<User, Address> address() {
+ *         return FocusPath.of(Lens.of(User::address, (source, newValue) -> new User(source.name(), newValue)));
+ *     }
+ * }
+ * }</pre>
+ */
+@AutoService(Processor.class)
+@SupportedAnnotationTypes("org.higherkindedj.optics.annotations.GenerateFocus")
+@SupportedSourceVersion(SourceVersion.RELEASE_25)
+public class FocusProcessor extends AbstractProcessor {
+
+  /** ClassName for FocusPath (in hkj-core, not available at processor compile time). */
+  private static final ClassName FOCUS_PATH_CLASS =
+      ClassName.get("org.higherkindedj.optics.focus", "FocusPath");
+
+  /** ClassName for AffinePath (for Optional field widening). */
+  private static final ClassName AFFINE_PATH_CLASS =
+      ClassName.get("org.higherkindedj.optics.focus", "AffinePath");
+
+  /** ClassName for TraversalPath (for collection field widening). */
+  private static final ClassName TRAVERSAL_PATH_CLASS =
+      ClassName.get("org.higherkindedj.optics.focus", "TraversalPath");
+
+  /** Optional types that widen to AffinePath via .some(). */
+  private static final Set<String> OPTIONAL_TYPES =
+      Set.of("java.util.Optional", "org.higherkindedj.hkt.maybe.Maybe");
+
+  /** Collection types that widen to TraversalPath via .each(). */
+  private static final Set<String> COLLECTION_TYPES =
+      Set.of("java.util.List", "java.util.Set", "java.util.Collection");
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    // First pass: collect all @GenerateFocus annotated types for navigator resolution
+    Set<String> navigableTypes = new HashSet<>();
+    Set<? extends Element> allAnnotated = roundEnv.getElementsAnnotatedWith(GenerateFocus.class);
+    for (Element element : allAnnotated) {
+      if (element.getKind() == ElementKind.RECORD) {
+        TypeElement typeElement = (TypeElement) element;
+        navigableTypes.add(typeElement.getQualifiedName().toString());
+      }
+    }
+
+    // Second pass: generate Focus classes
+    for (TypeElement annotation : annotations) {
+      Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
+      for (Element element : annotatedElements) {
+        if (element.getKind() != ElementKind.RECORD) {
+          error("The @GenerateFocus annotation can only be applied to records.", element);
+          continue;
+        }
+        try {
+          generateFocusFile((TypeElement) element, navigableTypes);
+        } catch (IOException e) {
+          error("Could not generate focus file: " + e.getMessage(), element);
+        }
+      }
+    }
+    return true;
+  }
+
+  private void generateFocusFile(TypeElement recordElement, Set<String> navigableTypes)
+      throws IOException {
+    String recordName = recordElement.getSimpleName().toString();
+    String defaultPackage =
+        processingEnv.getElementUtils().getPackageOf(recordElement).getQualifiedName().toString();
+
+    // Check for annotation attributes
+    GenerateFocus annotation = recordElement.getAnnotation(GenerateFocus.class);
+    String targetPackage = annotation.targetPackage();
+    String packageName = targetPackage.isEmpty() ? defaultPackage : targetPackage;
+    boolean generateNavigators = annotation.generateNavigators();
+    int maxNavigatorDepth = annotation.maxNavigatorDepth();
+    String[] includeFields = annotation.includeFields();
+    String[] excludeFields = annotation.excludeFields();
+
+    String focusClassName = recordName + "Focus";
+
+    final ClassName generatedAnnotation =
+        ClassName.get("org.higherkindedj.optics.annotations", "Generated");
+
+    String navigatorNote =
+        generateNavigators
+            ? "\n\n<p>This class includes navigator classes for fluent cross-type navigation."
+            : "";
+
+    TypeSpec.Builder focusClassBuilder =
+        TypeSpec.classBuilder(focusClassName)
+            .addAnnotation(generatedAnnotation)
+            .addJavadoc(
+                "Generated Focus DSL paths for {@link $T}.\n\n"
+                    + "<p>This class provides type-safe navigation paths for accessing and modifying\n"
+                    + "fields within {@code $L} instances using the Focus DSL.$L\n\n"
+                    + "<p>Do not edit this file; it is automatically generated.",
+                ClassName.get(recordElement),
+                recordName,
+                navigatorNote)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
+
+    List<? extends RecordComponentElement> components = recordElement.getRecordComponents();
+    TypeName recordTypeName = getParameterizedTypeName(recordElement);
+
+    // Create navigator generator if enabled
+    NavigatorClassGenerator navigatorGenerator = null;
+    if (generateNavigators) {
+      navigatorGenerator =
+          new NavigatorClassGenerator(
+              processingEnv, navigableTypes, maxNavigatorDepth, includeFields, excludeFields);
+    }
+
+    // Generate FocusPath methods for each component
+    for (RecordComponentElement component : components) {
+      MethodSpec method = null;
+
+      // Try to create a navigator method if navigators are enabled
+      if (navigatorGenerator != null) {
+        method =
+            navigatorGenerator.createNavigatorMethod(
+                component, recordElement, components, recordTypeName);
+      }
+
+      // Fall back to standard FocusPath method if no navigator method was created
+      if (method == null) {
+        method = createFocusPathMethod(component, recordElement, components, recordTypeName);
+      }
+
+      focusClassBuilder.addMethod(method);
+    }
+
+    // Generate navigator inner classes if enabled
+    if (navigatorGenerator != null) {
+      navigatorGenerator.generateNavigators(focusClassBuilder, recordElement, 0);
+    }
+
+    JavaFile javaFile =
+        JavaFile.builder(packageName, focusClassBuilder.build())
+            .addFileComment("Generated by hkj-optics-processor. Do not edit.")
+            .build();
+
+    javaFile.writeTo(processingEnv.getFiler());
+  }
+
+  private TypeName getParameterizedTypeName(TypeElement typeElement) {
+    List<? extends TypeParameterElement> typeParameters = typeElement.getTypeParameters();
+    if (typeParameters.isEmpty()) {
+      return ClassName.get(typeElement);
+    } else {
+      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      return ParameterizedTypeName.get(
+          ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
+    }
+  }
+
+  private MethodSpec createFocusPathMethod(
+      RecordComponentElement component,
+      TypeElement recordElement,
+      List<? extends RecordComponentElement> allComponents,
+      TypeName recordTypeName) {
+
+    String componentName = component.getSimpleName().toString();
+    TypeMirror componentType = component.asType();
+    TypeName componentTypeName = TypeName.get(componentType);
+
+    // Detect path type widening based on field type
+    PathTypeInfo pathTypeInfo = analyseFieldType(componentType);
+
+    // Determine return type and inner type based on widening
+    ClassName pathClass = pathTypeInfo.pathClass;
+    TypeName innerTypeName =
+        pathTypeInfo.innerType != null ? pathTypeInfo.innerType : componentTypeName.box();
+    ParameterizedTypeName returnTypeName =
+        ParameterizedTypeName.get(pathClass, recordTypeName, innerTypeName);
+
+    String pathDescription = getPathDescription(pathTypeInfo);
+    String getMethodName = getPathGetMethod(pathTypeInfo);
+
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(componentName)
+            .addJavadoc(
+                "Creates a {@link $T} for the {@code $L} field of a {@link $T}.\n\n"
+                    + "<p>The returned path can be composed with other optics for deep navigation:\n"
+                    + "<pre>{@code\n"
+                    + "$L.$L().$L(instance);  // Get the $L value\n"
+                    + "$L.$L().set(newValue, instance);  // Set the $L value\n"
+                    + "$L.$L().modify(fn, instance);  // Transform the $L value\n"
+                    + "}</pre>\n\n"
+                    + "@return A non-null {@code $L<$T, $T>}.",
+                pathClass,
+                componentName,
+                recordTypeName,
+                recordElement.getSimpleName() + "Focus",
+                componentName,
+                getMethodName,
+                componentName,
+                recordElement.getSimpleName() + "Focus",
+                componentName,
+                componentName,
+                recordElement.getSimpleName() + "Focus",
+                componentName,
+                componentName,
+                pathDescription,
+                recordTypeName,
+                innerTypeName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(returnTypeName);
+
+    // Add type parameters if the record is generic
+    for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+    }
+
+    // Build the constructor arguments for the setter lambda
+    String constructorArgs =
+        allComponents.stream()
+            .map(
+                c ->
+                    c.getSimpleName().toString().equals(componentName)
+                        ? "newValue"
+                        : "source." + c.getSimpleName() + "()")
+            .collect(Collectors.joining(", "));
+
+    // Generate code based on path type widening
+    String baseLens =
+        String.format(
+            "$T.of($T.of($T::%s, (source, newValue) -> new $T(%s)))",
+            componentName, constructorArgs);
+
+    switch (pathTypeInfo.wideningType) {
+      case OPTIONAL ->
+          methodBuilder.addStatement(
+              "return " + baseLens + ".some()",
+              FOCUS_PATH_CLASS,
+              Lens.class,
+              recordTypeName,
+              recordTypeName);
+      case COLLECTION ->
+          methodBuilder.addStatement(
+              "return " + baseLens + ".each()",
+              FOCUS_PATH_CLASS,
+              Lens.class,
+              recordTypeName,
+              recordTypeName);
+      default ->
+          methodBuilder.addStatement(
+              "return " + baseLens, FOCUS_PATH_CLASS, Lens.class, recordTypeName, recordTypeName);
+    }
+
+    return methodBuilder.build();
+  }
+
+  /** Represents the type of path widening to apply. */
+  private enum WideningType {
+    NONE,
+    OPTIONAL,
+    COLLECTION
+  }
+
+  /** Holds information about path type analysis. */
+  private record PathTypeInfo(ClassName pathClass, TypeName innerType, WideningType wideningType) {}
+
+  /** Analyses a field type to determine path widening. */
+  private PathTypeInfo analyseFieldType(TypeMirror type) {
+    if (type.getKind() != TypeKind.DECLARED) {
+      return new PathTypeInfo(FOCUS_PATH_CLASS, null, WideningType.NONE);
+    }
+
+    DeclaredType declaredType = (DeclaredType) type;
+    TypeElement typeElement = (TypeElement) declaredType.asElement();
+    String qualifiedName = typeElement.getQualifiedName().toString();
+
+    // Check for Optional types
+    if (OPTIONAL_TYPES.contains(qualifiedName)) {
+      TypeName innerType = extractTypeArgument(declaredType);
+      return new PathTypeInfo(AFFINE_PATH_CLASS, innerType, WideningType.OPTIONAL);
+    }
+
+    // Check for Collection types
+    if (COLLECTION_TYPES.contains(qualifiedName)) {
+      TypeName innerType = extractTypeArgument(declaredType);
+      return new PathTypeInfo(TRAVERSAL_PATH_CLASS, innerType, WideningType.COLLECTION);
+    }
+
+    return new PathTypeInfo(FOCUS_PATH_CLASS, null, WideningType.NONE);
+  }
+
+  /** Extracts the first type argument from a parameterised type. */
+  private TypeName extractTypeArgument(DeclaredType declaredType) {
+    List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+    if (typeArgs.isEmpty()) {
+      return ClassName.get(Object.class);
+    }
+    return TypeName.get(typeArgs.get(0)).box();
+  }
+
+  /** Gets the path class description for Javadoc. */
+  private String getPathDescription(PathTypeInfo info) {
+    return switch (info.wideningType) {
+      case OPTIONAL -> "AffinePath";
+      case COLLECTION -> "TraversalPath";
+      default -> "FocusPath";
+    };
+  }
+
+  /** Gets the appropriate get method name for Javadoc examples. */
+  private String getPathGetMethod(PathTypeInfo info) {
+    return switch (info.wideningType) {
+      case OPTIONAL -> "getOptional";
+      case COLLECTION -> "getAll";
+      default -> "get";
+    };
+  }
+
+  private void error(String msg, Element e) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, e);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -1,0 +1,781 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import com.palantir.javapoet.*;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.annotations.GenerateFocus;
+
+/**
+ * Generates navigator wrapper classes for fluent cross-type navigation.
+ *
+ * <p>Navigator classes wrap FocusPath instances and provide navigation methods for each field of
+ * nested types that are also annotated with {@code @GenerateFocus}.
+ *
+ * <p>This generator supports path type widening:
+ *
+ * <ul>
+ *   <li>{@code FocusPath} → {@code AffinePath} when navigating through optional fields
+ *   <li>{@code FocusPath}/{@code AffinePath} → {@code TraversalPath} when navigating through
+ *       collections
+ * </ul>
+ *
+ * <p>For example, given:
+ *
+ * <pre>{@code
+ * @GenerateFocus(generateNavigators = true)
+ * record Company(String name, Address headquarters, Optional<Address> backup) {}
+ *
+ * @GenerateFocus(generateNavigators = true)
+ * record Address(String street, String city) {}
+ * }</pre>
+ *
+ * <p>This generator creates navigators that return the appropriate path types:
+ *
+ * <ul>
+ *   <li>{@code headquarters().city()} returns {@code FocusPath<Company, String>}
+ *   <li>{@code backup().some().city()} returns {@code AffinePath<Company, String>}
+ * </ul>
+ */
+public class NavigatorClassGenerator {
+
+  /** Represents the kind of path being navigated. */
+  public enum PathKind {
+    /** FocusPath - exactly one element, always present. */
+    FOCUS,
+    /** AffinePath - zero or one element (optional). */
+    AFFINE,
+    /** TraversalPath - zero or more elements (collection). */
+    TRAVERSAL;
+
+    /** Returns the widened path kind when composing with another kind. */
+    public PathKind widen(PathKind other) {
+      if (this == TRAVERSAL || other == TRAVERSAL) {
+        return TRAVERSAL;
+      }
+      if (this == AFFINE || other == AFFINE) {
+        return AFFINE;
+      }
+      return FOCUS;
+    }
+  }
+
+  private static final ClassName FOCUS_PATH_CLASS =
+      ClassName.get("org.higherkindedj.optics.focus", "FocusPath");
+  private static final ClassName AFFINE_PATH_CLASS =
+      ClassName.get("org.higherkindedj.optics.focus", "AffinePath");
+  private static final ClassName TRAVERSAL_PATH_CLASS =
+      ClassName.get("org.higherkindedj.optics.focus", "TraversalPath");
+
+  // Optional types that widen to AffinePath
+  private static final Set<String> OPTIONAL_TYPES =
+      Set.of("java.util.Optional", "org.higherkindedj.hkt.maybe.Maybe");
+
+  // Collection types that widen to TraversalPath
+  private static final Set<String> COLLECTION_TYPES =
+      Set.of("java.util.List", "java.util.Set", "java.util.Collection");
+
+  private final ProcessingEnvironment processingEnv;
+  private final Set<String> navigableTypes;
+  private final int maxDepth;
+  private final Set<String> includeFields;
+  private final Set<String> excludeFields;
+
+  /**
+   * Creates a new navigator class generator.
+   *
+   * @param processingEnv the processing environment
+   * @param navigableTypes set of fully qualified type names that have @GenerateFocus
+   * @param maxDepth maximum depth for navigator chains
+   * @param includeFields fields to include (empty means all)
+   * @param excludeFields fields to exclude
+   */
+  public NavigatorClassGenerator(
+      ProcessingEnvironment processingEnv,
+      Set<String> navigableTypes,
+      int maxDepth,
+      String[] includeFields,
+      String[] excludeFields) {
+    this.processingEnv = processingEnv;
+    this.navigableTypes = navigableTypes;
+    this.maxDepth = Math.max(1, Math.min(10, maxDepth));
+    this.includeFields = new HashSet<>(Arrays.asList(includeFields));
+    this.excludeFields = new HashSet<>(Arrays.asList(excludeFields));
+  }
+
+  /** Returns the ClassName for a given PathKind. */
+  private ClassName getPathClassName(PathKind kind) {
+    return switch (kind) {
+      case FOCUS -> FOCUS_PATH_CLASS;
+      case AFFINE -> AFFINE_PATH_CLASS;
+      case TRAVERSAL -> TRAVERSAL_PATH_CLASS;
+    };
+  }
+
+  /**
+   * Determines what path kind a field type introduces.
+   *
+   * @param type the field type to analyze
+   * @return AFFINE for optional types, TRAVERSAL for collection types, FOCUS otherwise
+   */
+  private PathKind getFieldPathKind(TypeMirror type) {
+    if (type.getKind() != TypeKind.DECLARED) {
+      return PathKind.FOCUS;
+    }
+
+    DeclaredType declaredType = (DeclaredType) type;
+    TypeElement typeElement = (TypeElement) declaredType.asElement();
+    String qualifiedName = typeElement.getQualifiedName().toString();
+
+    if (OPTIONAL_TYPES.contains(qualifiedName)) {
+      return PathKind.AFFINE;
+    }
+    if (COLLECTION_TYPES.contains(qualifiedName)) {
+      return PathKind.TRAVERSAL;
+    }
+
+    // Check for subtypes of Collection
+    for (TypeMirror iface : typeElement.getInterfaces()) {
+      if (iface.getKind() == TypeKind.DECLARED) {
+        TypeElement ifaceElement = (TypeElement) ((DeclaredType) iface).asElement();
+        if (COLLECTION_TYPES.contains(ifaceElement.getQualifiedName().toString())) {
+          return PathKind.TRAVERSAL;
+        }
+      }
+    }
+
+    return PathKind.FOCUS;
+  }
+
+  /**
+   * Generates navigator inner classes for a Focus class.
+   *
+   * @param focusClassBuilder the builder for the Focus class
+   * @param recordElement the record being processed
+   * @param currentDepth current depth in the navigation chain
+   */
+  public void generateNavigators(
+      TypeSpec.Builder focusClassBuilder, TypeElement recordElement, int currentDepth) {
+
+    generateNavigatorsWithPathKind(focusClassBuilder, recordElement, currentDepth, PathKind.FOCUS);
+  }
+
+  /** Generates navigator inner classes with path kind tracking. */
+  private void generateNavigatorsWithPathKind(
+      TypeSpec.Builder focusClassBuilder,
+      TypeElement recordElement,
+      int currentDepth,
+      PathKind currentPathKind) {
+
+    if (currentDepth >= maxDepth) {
+      return;
+    }
+
+    List<? extends RecordComponentElement> components = recordElement.getRecordComponents();
+
+    for (RecordComponentElement component : components) {
+      if (!shouldGenerateNavigator(component)) {
+        continue;
+      }
+
+      TypeMirror fieldType = component.asType();
+      if (!isNavigableType(fieldType)) {
+        continue;
+      }
+
+      TypeElement fieldTypeElement = getTypeElement(fieldType);
+      if (fieldTypeElement == null) {
+        continue;
+      }
+
+      // Determine the path kind for this field
+      PathKind fieldKind = getFieldPathKind(fieldType);
+      PathKind widenedKind = currentPathKind.widen(fieldKind);
+
+      // Generate the navigator class for this field
+      TypeSpec navigatorClass =
+          generateNavigatorClass(
+              component, recordElement, fieldTypeElement, currentDepth, widenedKind);
+
+      focusClassBuilder.addType(navigatorClass);
+    }
+  }
+
+  /**
+   * Generates a navigator class for a specific field.
+   *
+   * @param component the record component (field)
+   * @param sourceRecord the source record type
+   * @param targetRecord the target record type (the field's type)
+   * @param currentDepth current depth
+   * @param pathKind the path kind for this navigator
+   * @return the generated navigator TypeSpec
+   */
+  private TypeSpec generateNavigatorClass(
+      RecordComponentElement component,
+      TypeElement sourceRecord,
+      TypeElement targetRecord,
+      int currentDepth,
+      PathKind pathKind) {
+
+    String componentName = component.getSimpleName().toString();
+    String navigatorClassName = capitalise(componentName) + "Navigator";
+    TypeName targetTypeName = TypeName.get(targetRecord.asType());
+
+    // Type parameter S for the source type in the navigator
+    TypeVariableName sourceTypeVar = TypeVariableName.get("S");
+
+    // The delegate type depends on the path kind
+    ClassName pathClass = getPathClassName(pathKind);
+    ParameterizedTypeName delegateType =
+        ParameterizedTypeName.get(pathClass, sourceTypeVar, targetTypeName);
+
+    String pathKindDescription =
+        switch (pathKind) {
+          case FOCUS -> "FocusPath";
+          case AFFINE -> "AffinePath (optional navigation)";
+          case TRAVERSAL -> "TraversalPath (collection navigation)";
+        };
+
+    TypeSpec.Builder navigatorBuilder =
+        TypeSpec.classBuilder(navigatorClassName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .addTypeVariable(sourceTypeVar)
+            .addJavadoc(
+                "Navigator for fluent access to {@code $L} fields.\n\n"
+                    + "<p>This navigator wraps a {@link $T} and provides direct navigation methods\n"
+                    + "for all fields of {@link $T}.\n\n"
+                    + "<p>Path type: $L\n\n"
+                    + "@param <S> the source type at the root of the navigation",
+                componentName,
+                pathClass,
+                targetTypeName,
+                pathKindDescription);
+
+    // Add delegate field
+    navigatorBuilder.addField(
+        FieldSpec.builder(delegateType, "delegate", Modifier.PRIVATE, Modifier.FINAL).build());
+
+    // Add constructor
+    navigatorBuilder.addMethod(
+        MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(delegateType, "delegate")
+            .addStatement("this.delegate = java.util.Objects.requireNonNull(delegate)")
+            .build());
+
+    // Add delegate accessor methods based on path kind
+    addDelegateMethods(navigatorBuilder, sourceTypeVar, targetTypeName, delegateType, pathKind);
+
+    // Add navigation methods for each field of the target record
+    addNavigationMethods(navigatorBuilder, targetRecord, sourceTypeVar, currentDepth + 1, pathKind);
+
+    return navigatorBuilder.build();
+  }
+
+  /** Adds delegate methods that forward to the underlying path. */
+  private void addDelegateMethods(
+      TypeSpec.Builder navigatorBuilder,
+      TypeVariableName sourceTypeVar,
+      TypeName targetTypeName,
+      ParameterizedTypeName delegateType,
+      PathKind pathKind) {
+
+    switch (pathKind) {
+      case FOCUS ->
+          addFocusPathDelegateMethods(
+              navigatorBuilder, sourceTypeVar, targetTypeName, delegateType);
+      case AFFINE ->
+          addAffinePathDelegateMethods(
+              navigatorBuilder, sourceTypeVar, targetTypeName, delegateType);
+      case TRAVERSAL ->
+          addTraversalPathDelegateMethods(
+              navigatorBuilder, sourceTypeVar, targetTypeName, delegateType);
+    }
+  }
+
+  /** Adds delegate methods for FocusPath navigators. */
+  private void addFocusPathDelegateMethods(
+      TypeSpec.Builder navigatorBuilder,
+      TypeVariableName sourceTypeVar,
+      TypeName targetTypeName,
+      ParameterizedTypeName delegateType) {
+
+    // get(S source) -> A
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("get")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(sourceTypeVar, "source")
+            .returns(targetTypeName)
+            .addStatement("return delegate.get(source)")
+            .addJavadoc(
+                "Extracts the focused value from the source.\n\n"
+                    + "@param source the source structure\n"
+                    + "@return the focused value")
+            .build());
+
+    // set(A value, S source) -> S
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("set")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(targetTypeName, "value")
+            .addParameter(sourceTypeVar, "source")
+            .returns(sourceTypeVar)
+            .addStatement("return delegate.set(value, source)")
+            .addJavadoc(
+                "Creates a new source with the focused value replaced.\n\n"
+                    + "@param value the new value\n"
+                    + "@param source the source structure\n"
+                    + "@return a new structure with the updated value")
+            .build());
+
+    // modify(Function<A, A> f, S source) -> S
+    ParameterizedTypeName functionType =
+        ParameterizedTypeName.get(ClassName.get(Function.class), targetTypeName, targetTypeName);
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("modify")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(functionType, "f")
+            .addParameter(sourceTypeVar, "source")
+            .returns(sourceTypeVar)
+            .addStatement("return delegate.modify(f, source)")
+            .addJavadoc(
+                "Creates a new source with the focused value transformed.\n\n"
+                    + "@param f the transformation function\n"
+                    + "@param source the source structure\n"
+                    + "@return a new structure with the modified value")
+            .build());
+
+    // toLens() -> Lens<S, A>
+    ParameterizedTypeName lensType =
+        ParameterizedTypeName.get(ClassName.get(Lens.class), sourceTypeVar, targetTypeName);
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("toLens")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(lensType)
+            .addStatement("return delegate.toLens()")
+            .addJavadoc("Extracts the underlying lens.\n\n" + "@return the wrapped Lens")
+            .build());
+
+    // toPath() -> FocusPath<S, A>
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("toPath")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(delegateType)
+            .addStatement("return delegate")
+            .addJavadoc("Returns the underlying FocusPath.\n\n" + "@return the wrapped FocusPath")
+            .build());
+  }
+
+  /** Adds delegate methods for AffinePath navigators. */
+  private void addAffinePathDelegateMethods(
+      TypeSpec.Builder navigatorBuilder,
+      TypeVariableName sourceTypeVar,
+      TypeName targetTypeName,
+      ParameterizedTypeName delegateType) {
+
+    // getOptional(S source) -> Optional<A>
+    ParameterizedTypeName optionalType =
+        ParameterizedTypeName.get(ClassName.get(Optional.class), targetTypeName);
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("getOptional")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(sourceTypeVar, "source")
+            .returns(optionalType)
+            .addStatement("return delegate.getOptional(source)")
+            .addJavadoc(
+                "Extracts the focused value if present.\n\n"
+                    + "@param source the source structure\n"
+                    + "@return Optional containing the value, or empty if not focused")
+            .build());
+
+    // set(A value, S source) -> S
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("set")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(targetTypeName, "value")
+            .addParameter(sourceTypeVar, "source")
+            .returns(sourceTypeVar)
+            .addStatement("return delegate.set(value, source)")
+            .addJavadoc(
+                "Creates a new source with the focused value replaced.\n\n"
+                    + "@param value the new value\n"
+                    + "@param source the source structure\n"
+                    + "@return a new structure with the updated value")
+            .build());
+
+    // modify(Function<A, A> f, S source) -> S
+    ParameterizedTypeName functionType =
+        ParameterizedTypeName.get(ClassName.get(Function.class), targetTypeName, targetTypeName);
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("modify")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(functionType, "f")
+            .addParameter(sourceTypeVar, "source")
+            .returns(sourceTypeVar)
+            .addStatement("return delegate.modify(f, source)")
+            .addJavadoc(
+                "Modifies the focused value if present.\n\n"
+                    + "@param f the transformation function\n"
+                    + "@param source the source structure\n"
+                    + "@return a new structure with the modified value, or original if not focused")
+            .build());
+
+    // matches(S source) -> boolean
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("matches")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(sourceTypeVar, "source")
+            .returns(TypeName.BOOLEAN)
+            .addStatement("return delegate.matches(source)")
+            .addJavadoc(
+                "Checks if this path focuses on a value in the given source.\n\n"
+                    + "@param source the source structure to test\n"
+                    + "@return true if a value is focused, false otherwise")
+            .build());
+
+    // toPath() -> AffinePath<S, A>
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("toPath")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(delegateType)
+            .addStatement("return delegate")
+            .addJavadoc("Returns the underlying AffinePath.\n\n" + "@return the wrapped AffinePath")
+            .build());
+  }
+
+  /** Adds delegate methods for TraversalPath navigators. */
+  private void addTraversalPathDelegateMethods(
+      TypeSpec.Builder navigatorBuilder,
+      TypeVariableName sourceTypeVar,
+      TypeName targetTypeName,
+      ParameterizedTypeName delegateType) {
+
+    // getAll(S source) -> List<A>
+    ParameterizedTypeName listType =
+        ParameterizedTypeName.get(ClassName.get(List.class), targetTypeName);
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("getAll")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(sourceTypeVar, "source")
+            .returns(listType)
+            .addStatement("return delegate.getAll(source)")
+            .addJavadoc(
+                "Extracts all focused values from the source.\n\n"
+                    + "@param source the source structure\n"
+                    + "@return list of all focused values (may be empty)")
+            .build());
+
+    // setAll(A value, S source) -> S
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("setAll")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(targetTypeName, "value")
+            .addParameter(sourceTypeVar, "source")
+            .returns(sourceTypeVar)
+            .addStatement("return delegate.setAll(value, source)")
+            .addJavadoc(
+                "Creates a new source with all focused values replaced.\n\n"
+                    + "@param value the new value for all focused elements\n"
+                    + "@param source the source structure\n"
+                    + "@return a new structure with all focused values updated")
+            .build());
+
+    // modifyAll(Function<A, A> f, S source) -> S
+    ParameterizedTypeName functionType =
+        ParameterizedTypeName.get(ClassName.get(Function.class), targetTypeName, targetTypeName);
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("modifyAll")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(functionType, "f")
+            .addParameter(sourceTypeVar, "source")
+            .returns(sourceTypeVar)
+            .addStatement("return delegate.modifyAll(f, source)")
+            .addJavadoc(
+                "Creates a new source with all focused values transformed.\n\n"
+                    + "@param f the transformation function\n"
+                    + "@param source the source structure\n"
+                    + "@return a new structure with all focused values modified")
+            .build());
+
+    // count(S source) -> int
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("count")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(sourceTypeVar, "source")
+            .returns(TypeName.INT)
+            .addStatement("return delegate.count(source)")
+            .addJavadoc(
+                "Counts the number of focused elements.\n\n"
+                    + "@param source the source structure\n"
+                    + "@return the number of focused elements")
+            .build());
+
+    // isEmpty(S source) -> boolean
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("isEmpty")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(sourceTypeVar, "source")
+            .returns(TypeName.BOOLEAN)
+            .addStatement("return delegate.isEmpty(source)")
+            .addJavadoc(
+                "Checks if the traversal focuses on no elements.\n\n"
+                    + "@param source the source structure\n"
+                    + "@return true if no elements are focused")
+            .build());
+
+    // toPath() -> TraversalPath<S, A>
+    navigatorBuilder.addMethod(
+        MethodSpec.methodBuilder("toPath")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(delegateType)
+            .addStatement("return delegate")
+            .addJavadoc(
+                "Returns the underlying TraversalPath.\n\n" + "@return the wrapped TraversalPath")
+            .build());
+  }
+
+  /** Adds navigation methods for each field of the target record. */
+  private void addNavigationMethods(
+      TypeSpec.Builder navigatorBuilder,
+      TypeElement targetRecord,
+      TypeVariableName sourceTypeVar,
+      int currentDepth,
+      PathKind currentPathKind) {
+
+    List<? extends RecordComponentElement> components = targetRecord.getRecordComponents();
+    String targetFocusClassName = targetRecord.getSimpleName().toString() + "Focus";
+    String targetPackage =
+        processingEnv.getElementUtils().getPackageOf(targetRecord).getQualifiedName().toString();
+    ClassName targetFocusClass = ClassName.get(targetPackage, targetFocusClassName);
+
+    for (RecordComponentElement component : components) {
+      String fieldName = component.getSimpleName().toString();
+      TypeMirror fieldType = component.asType();
+      TypeName fieldTypeName = TypeName.get(fieldType).box();
+
+      // Determine the path kind for this field and widen appropriately
+      PathKind fieldKind = getFieldPathKind(fieldType);
+      PathKind widenedKind = currentPathKind.widen(fieldKind);
+
+      // Return type based on widened path kind
+      ClassName pathClass = getPathClassName(widenedKind);
+      ParameterizedTypeName returnType =
+          ParameterizedTypeName.get(pathClass, sourceTypeVar, fieldTypeName);
+
+      String pathDescription =
+          switch (widenedKind) {
+            case FOCUS -> "FocusPath";
+            case AFFINE -> "AffinePath";
+            case TRAVERSAL -> "TraversalPath";
+          };
+
+      MethodSpec.Builder methodBuilder =
+          MethodSpec.methodBuilder(fieldName)
+              .addModifiers(Modifier.PUBLIC)
+              .returns(returnType)
+              .addJavadoc(
+                  "Navigates to the {@code $L} field.\n\n"
+                      + "@return a $L focusing on the {@code $L} field",
+                  fieldName,
+                  pathDescription,
+                  fieldName);
+
+      // Determine the via method and conversion needed based on path widening
+      String viaStatement =
+          buildViaStatement(currentPathKind, widenedKind, targetFocusClass, fieldName);
+
+      // Check if the field type is also navigable and we haven't exceeded depth
+      if (currentDepth < maxDepth && isNavigableType(fieldType)) {
+        TypeElement fieldTypeElement = getTypeElement(fieldType);
+        if (fieldTypeElement != null) {
+          // Return a navigator instead of plain path
+          String fieldNavigatorClassName = capitalise(fieldName) + "Navigator";
+          ClassName navigatorClass =
+              ClassName.get(targetPackage, targetFocusClassName, fieldNavigatorClassName);
+          ParameterizedTypeName navigatorType =
+              ParameterizedTypeName.get(navigatorClass, sourceTypeVar);
+
+          methodBuilder.returns(navigatorType);
+          methodBuilder.addStatement(
+              "return new $T.$L<>($L)", targetFocusClass, fieldNavigatorClassName, viaStatement);
+        } else {
+          methodBuilder.addStatement("return $L", viaStatement);
+        }
+      } else {
+        methodBuilder.addStatement("return $L", viaStatement);
+      }
+
+      navigatorBuilder.addMethod(methodBuilder.build());
+    }
+  }
+
+  /** Builds the via statement for navigating from current path kind to the widened kind. */
+  private String buildViaStatement(
+      PathKind currentKind, PathKind widenedKind, ClassName targetFocusClass, String fieldName) {
+    String baseVia =
+        String.format("delegate.via(%s.%s().toLens())", targetFocusClass.simpleName(), fieldName);
+
+    // If the path kind is widening, we need to add conversion
+    if (currentKind == PathKind.FOCUS && widenedKind == PathKind.AFFINE) {
+      // FocusPath.via() with AffinePath widens to AffinePath - handled automatically by via()
+      // overloads
+      return baseVia;
+    } else if (currentKind == PathKind.FOCUS && widenedKind == PathKind.TRAVERSAL) {
+      // FocusPath to TraversalPath - use asTraversal()
+      return baseVia + ".asTraversal()";
+    } else if (currentKind == PathKind.AFFINE && widenedKind == PathKind.TRAVERSAL) {
+      // AffinePath to TraversalPath - use asTraversal()
+      return baseVia + ".asTraversal()";
+    }
+
+    return baseVia;
+  }
+
+  /** Determines if a field should have a navigator generated. */
+  private boolean shouldGenerateNavigator(RecordComponentElement component) {
+    String fieldName = component.getSimpleName().toString();
+
+    // If includeFields is specified, only include those fields
+    if (!includeFields.isEmpty()) {
+      return includeFields.contains(fieldName);
+    }
+
+    // Otherwise, exclude fields in excludeFields
+    return !excludeFields.contains(fieldName);
+  }
+
+  /** Checks if a type is navigable (has @GenerateFocus annotation). */
+  private boolean isNavigableType(TypeMirror type) {
+    if (type.getKind() != TypeKind.DECLARED) {
+      return false;
+    }
+    DeclaredType declaredType = (DeclaredType) type;
+    TypeElement typeElement = (TypeElement) declaredType.asElement();
+    String qualifiedName = typeElement.getQualifiedName().toString();
+
+    // Check if the type is in our set of navigable types
+    if (navigableTypes.contains(qualifiedName)) {
+      return true;
+    }
+
+    // Also check if the type has @GenerateFocus annotation
+    return typeElement.getAnnotation(GenerateFocus.class) != null;
+  }
+
+  /** Gets the TypeElement for a TypeMirror. */
+  private TypeElement getTypeElement(TypeMirror type) {
+    if (type.getKind() != TypeKind.DECLARED) {
+      return null;
+    }
+    DeclaredType declaredType = (DeclaredType) type;
+    return (TypeElement) declaredType.asElement();
+  }
+
+  /** Capitalises the first letter of a string. */
+  private String capitalise(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+  }
+
+  /**
+   * Creates a method spec for a navigator-returning method (replaces the standard FocusPath
+   * method).
+   *
+   * @param component the record component
+   * @param recordElement the record being processed
+   * @param allComponents all components of the record
+   * @param recordTypeName the record's type name
+   * @return the method spec
+   */
+  public MethodSpec createNavigatorMethod(
+      RecordComponentElement component,
+      TypeElement recordElement,
+      List<? extends RecordComponentElement> allComponents,
+      TypeName recordTypeName) {
+
+    String componentName = component.getSimpleName().toString();
+    TypeMirror fieldType = component.asType();
+    TypeName componentTypeName = TypeName.get(fieldType).box();
+
+    // Check if this field should have a navigator generated (respects include/exclude filters)
+    if (!shouldGenerateNavigator(component)) {
+      return null; // Filtered out, use standard method
+    }
+
+    TypeElement fieldTypeElement = getTypeElement(fieldType);
+    if (fieldTypeElement == null || !isNavigableType(fieldType)) {
+      return null; // Not navigable, use standard method
+    }
+
+    // Navigator class name
+    String navigatorClassName = capitalise(componentName) + "Navigator";
+    String packageName =
+        processingEnv.getElementUtils().getPackageOf(recordElement).getQualifiedName().toString();
+    String focusClassName = recordElement.getSimpleName().toString() + "Focus";
+    ClassName navigatorClass = ClassName.get(packageName, focusClassName, navigatorClassName);
+
+    // Return type: ComponentNavigator<RecordType>
+    ParameterizedTypeName returnType = ParameterizedTypeName.get(navigatorClass, recordTypeName);
+
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(componentName)
+            .addJavadoc(
+                "Creates a navigator for the {@code $L} field of a {@link $T}.\n\n"
+                    + "<p>The returned navigator enables fluent navigation into the fields of\n"
+                    + "{@link $T}. For example:\n"
+                    + "<pre>{@code\n"
+                    + "$L.$L().fieldName().get(instance);\n"
+                    + "}</pre>\n\n"
+                    + "@return A navigator for the {@code $L} field.",
+                componentName,
+                recordTypeName,
+                componentTypeName,
+                recordElement.getSimpleName() + "Focus",
+                componentName,
+                componentName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(returnType);
+
+    // Add type parameters if the record is generic
+    for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+    }
+
+    // Build the constructor arguments for the setter lambda
+    String constructorArgs =
+        allComponents.stream()
+            .map(
+                c ->
+                    c.getSimpleName().toString().equals(componentName)
+                        ? "newValue"
+                        : "source." + c.getSimpleName() + "()")
+            .collect(Collectors.joining(", "));
+
+    // Generate: return new ComponentNavigator<>(FocusPath.of(Lens.of(...)));
+    methodBuilder.addStatement(
+        "return new $L<>($T.of($T.of($T::$L, (source, newValue) -> new $T($L))))",
+        navigatorClassName,
+        FOCUS_PATH_CLASS,
+        Lens.class,
+        recordTypeName,
+        componentName,
+        recordTypeName,
+        constructorArgs);
+
+    return methodBuilder.build();
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorIntegrationTest.java
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FocusProcessor Integration Tests")
+public class FocusProcessorIntegrationTest {
+
+  @Nested
+  @DisplayName("Basic Code Generation")
+  class BasicCodeGeneration {
+
+    @Test
+    @DisplayName("should generate FocusPath methods for each record component")
+    void shouldGenerateFocusPathMethodsForRecord() {
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.User",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record User(String name, int age) {}
+              """);
+
+      final String expectedNameFocusPath =
+          """
+          public static FocusPath<User, String> name() {
+              return FocusPath.of(Lens.of(User::name, (source, newValue) -> new User(newValue, source.age())));
+          }
+          """;
+      final String expectedAgeFocusPath =
+          """
+          public static FocusPath<User, Integer> age() {
+              return FocusPath.of(Lens.of(User::age, (source, newValue) -> new User(source.name(), newValue)));
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.UserFocus";
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedNameFocusPath);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedAgeFocusPath);
+    }
+
+    @Test
+    @DisplayName("should generate Focus class with correct name suffix")
+    void shouldGenerateFocusClassWithCorrectSuffix() {
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Address(String street, String city, String postcode) {}
+              """);
+
+      final String expectedStreetFocusPath =
+          """
+          public static FocusPath<Address, String> street() {
+              return FocusPath.of(Lens.of(Address::street, (source, newValue) -> new Address(newValue, source.city(), source.postcode())));
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.AddressFocus", expectedStreetFocusPath);
+    }
+  }
+
+  @Nested
+  @DisplayName("Error Handling")
+  class ErrorHandling {
+
+    @Test
+    @DisplayName("should report error when applied to non-record type")
+    void shouldReportErrorForNonRecordType() {
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.NotARecord",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public class NotARecord {
+                  private String name;
+              }
+              """);
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("@GenerateFocus annotation can only be applied to records");
+    }
+  }
+
+  @Nested
+  @DisplayName("Package Configuration")
+  class PackageConfiguration {
+
+    @Test
+    @DisplayName("should generate in custom target package when specified")
+    void shouldGenerateInCustomTargetPackage() {
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.model.Person",
+              """
+              package com.example.model;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(targetPackage = "com.example.optics")
+              public record Person(String firstName, String lastName) {}
+              """);
+
+      final String expectedFirstNameFocusPath =
+          """
+          public static FocusPath<Person, String> firstName() {
+              return FocusPath.of(Lens.of(Person::firstName, (source, newValue) -> new Person(newValue, source.lastName())));
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.optics.PersonFocus", expectedFirstNameFocusPath);
+    }
+  }
+
+  @Nested
+  @DisplayName("Generic Record Support")
+  class GenericRecordSupport {
+
+    @Test
+    @DisplayName("should generate FocusPath methods for generic record")
+    void shouldGenerateFocusPathMethodsForGenericRecord() {
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.Wrapper",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Wrapper<T>(T value, String label) {}
+              """);
+
+      final String expectedValueFocusPath =
+          """
+          public static <T> FocusPath<Wrapper<T>, T> value() {
+              return FocusPath.of(Lens.of(Wrapper<T>::value, (source, newValue) -> new Wrapper<T>(newValue, source.label())));
+          }
+          """;
+      final String expectedLabelFocusPath =
+          """
+          public static <T> FocusPath<Wrapper<T>, String> label() {
+              return FocusPath.of(Lens.of(Wrapper<T>::label, (source, newValue) -> new Wrapper<T>(source.value(), newValue)));
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.WrapperFocus";
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedValueFocusPath);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedLabelFocusPath);
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNavigatorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNavigatorTest.java
@@ -1,0 +1,557 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContainsRaw;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FocusProcessor Navigator Generation Tests")
+public class FocusProcessorNavigatorTest {
+
+  @Nested
+  @DisplayName("Basic Navigator Generation")
+  class BasicNavigatorGeneration {
+
+    @Test
+    @DisplayName("should generate navigator class for navigable field")
+    void shouldGenerateNavigatorClassForNavigableField() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Company(String name, Address headquarters) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Address(String street, String city) {}
+              """);
+
+      // Expected: Navigator method returns navigator instead of FocusPath
+      final String expectedNavigatorMethod =
+          """
+          public static HeadquartersNavigator<Company> headquarters() {
+          """;
+
+      // Expected: Navigator inner class
+      final String expectedNavigatorClass =
+          """
+          public static final class HeadquartersNavigator<S> {
+          """;
+
+      // Expected: Delegate field
+      final String expectedDelegateField =
+          """
+          private final FocusPath<S, Address> delegate;
+          """;
+
+      // Expected: Navigation methods for Address fields
+      final String expectedStreetNavigation =
+          """
+          public FocusPath<S, String> street() {
+          """;
+
+      final String expectedCityNavigation =
+          """
+          public FocusPath<S, String> city() {
+          """;
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.CompanyFocus";
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedNavigatorMethod);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedNavigatorClass);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedDelegateField);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedStreetNavigation);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedCityNavigation);
+    }
+
+    @Test
+    @DisplayName("should generate standard FocusPath for non-navigable fields")
+    void shouldGenerateStandardFocusPathForNonNavigableFields() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Company(String name, int employeeCount) {}
+              """);
+
+      // Non-navigable fields should still get standard FocusPath methods
+      final String expectedNameMethod =
+          """
+          public static FocusPath<Company, String> name() {
+          """;
+
+      final String expectedCountMethod =
+          """
+          public static FocusPath<Company, Integer> employeeCount() {
+          """;
+
+      Compilation compilation = javac().withProcessors(new FocusProcessor()).compile(companySource);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.CompanyFocus";
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedNameMethod);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedCountMethod);
+    }
+
+    @Test
+    @DisplayName("should not generate navigators when generateNavigators is false")
+    void shouldNotGenerateNavigatorsWhenDisabled() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = false)
+              public record Company(String name, Address headquarters) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Address(String street, String city) {}
+              """);
+
+      // Should generate standard FocusPath, not navigator
+      final String expectedStandardMethod =
+          """
+          public static FocusPath<Company, Address> headquarters() {
+          """;
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.CompanyFocus";
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedStandardMethod);
+    }
+  }
+
+  @Nested
+  @DisplayName("Navigator Delegate Methods")
+  class NavigatorDelegateMethods {
+
+    @Test
+    @DisplayName("should generate FocusPath delegate methods")
+    void shouldGenerateFocusPathDelegateMethods() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Company(String name, Address headquarters) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Address(String street, String city) {}
+              """);
+
+      // Expected delegate methods
+      final String expectedGetMethod =
+          """
+          public Address get(S source) {
+              return delegate.get(source);
+          }
+          """;
+
+      final String expectedSetMethod =
+          """
+          public S set(Address value, S source) {
+              return delegate.set(value, source);
+          }
+          """;
+
+      final String expectedModifyMethod =
+          """
+          public S modify(java.util.function.Function<Address, Address> f, S source) {
+              return delegate.modify(f, source);
+          }
+          """;
+
+      final String expectedToPathMethod =
+          """
+          public FocusPath<S, Address> toPath() {
+              return delegate;
+          }
+          """;
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.CompanyFocus";
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedGetMethod);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedSetMethod);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedModifyMethod);
+      assertGeneratedCodeContains(compilation, generatedClassName, expectedToPathMethod);
+    }
+  }
+
+  @Nested
+  @DisplayName("Depth Limiting")
+  class DepthLimiting {
+
+    @Test
+    @DisplayName("should respect maxNavigatorDepth setting")
+    void shouldRespectMaxNavigatorDepth() {
+      final JavaFileObject level1Source =
+          JavaFileObjects.forSourceString(
+              "com.example.Level1",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true, maxNavigatorDepth = 1)
+              public record Level1(String name, Level2 nested) {}
+              """);
+
+      final JavaFileObject level2Source =
+          JavaFileObjects.forSourceString(
+              "com.example.Level2",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Level2(String value, Level3 deeper) {}
+              """);
+
+      final JavaFileObject level3Source =
+          JavaFileObjects.forSourceString(
+              "com.example.Level3",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Level3(String data) {}
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new FocusProcessor())
+              .compile(level1Source, level2Source, level3Source);
+
+      assertThat(compilation).succeeded();
+
+      // Level1Focus should have a navigator for Level2
+      final String expectedNestedNavigator =
+          """
+          public static NestedNavigator<Level1> nested() {
+          """;
+
+      assertGeneratedCodeContains(compilation, "com.example.Level1Focus", expectedNestedNavigator);
+    }
+  }
+
+  @Nested
+  @DisplayName("Field Filtering")
+  class FieldFiltering {
+
+    @Test
+    @DisplayName("should only include fields specified in includeFields")
+    void shouldOnlyIncludeSpecifiedFields() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true, includeFields = {"headquarters"})
+              public record Company(String name, Address headquarters, Address backup) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Address(String street, String city) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      // Should have navigator for headquarters
+      final String expectedHeadquartersNavigator =
+          """
+          public static HeadquartersNavigator<Company> headquarters() {
+          """;
+
+      // backup should be standard FocusPath (not in includeFields)
+      final String expectedBackupStandard =
+          """
+          public static FocusPath<Company, Address> backup() {
+          """;
+
+      assertGeneratedCodeContains(
+          compilation, "com.example.CompanyFocus", expectedHeadquartersNavigator);
+      assertGeneratedCodeContains(compilation, "com.example.CompanyFocus", expectedBackupStandard);
+    }
+
+    @Test
+    @DisplayName("should exclude fields specified in excludeFields")
+    void shouldExcludeSpecifiedFields() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true, excludeFields = {"backup"})
+              public record Company(String name, Address headquarters, Address backup) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Address(String street, String city) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      // Should have navigator for headquarters (not excluded)
+      final String expectedHeadquartersNavigator =
+          """
+          public static HeadquartersNavigator<Company> headquarters() {
+          """;
+
+      // backup should be standard FocusPath (excluded)
+      final String expectedBackupStandard =
+          """
+          public static FocusPath<Company, Address> backup() {
+          """;
+
+      assertGeneratedCodeContains(
+          compilation, "com.example.CompanyFocus", expectedHeadquartersNavigator);
+      assertGeneratedCodeContains(compilation, "com.example.CompanyFocus", expectedBackupStandard);
+    }
+  }
+
+  @Nested
+  @DisplayName("Path Type Widening")
+  class PathTypeWidening {
+
+    @Test
+    @DisplayName("should detect PathKind correctly for regular types")
+    void shouldDetectPathKindForRegularTypes() {
+      // This tests that regular types result in FOCUS path kind
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Company(String name, Address headquarters) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Address(String street, String city) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      // Navigation through FocusPath should return FocusPath
+      final String expectedFocusPathReturn =
+          """
+          public FocusPath<S, String> street() {
+          """;
+
+      assertGeneratedCodeContains(compilation, "com.example.CompanyFocus", expectedFocusPathReturn);
+    }
+  }
+
+  @Nested
+  @DisplayName("Nested Navigation")
+  class NestedNavigation {
+
+    @Test
+    @DisplayName("should generate navigation for deeply nested types")
+    void shouldGenerateNavigationForDeeplyNestedTypes() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true, maxNavigatorDepth = 3)
+              public record Company(String name, Department mainDept) {}
+              """);
+
+      final JavaFileObject departmentSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Department",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Department(String name, Team leadTeam) {}
+              """);
+
+      final JavaFileObject teamSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Team",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Team(String name, int size) {}
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new FocusProcessor())
+              .compile(companySource, departmentSource, teamSource);
+
+      assertThat(compilation).succeeded();
+
+      // Company should have MainDeptNavigator
+      final String expectedMainDeptNavigator =
+          """
+          public static MainDeptNavigator<Company> mainDept() {
+          """;
+
+      assertGeneratedCodeContains(
+          compilation, "com.example.CompanyFocus", expectedMainDeptNavigator);
+    }
+  }
+
+  @Nested
+  @DisplayName("Javadoc Generation")
+  class JavadocGeneration {
+
+    @Test
+    @DisplayName("should include navigator note in class javadoc when enabled")
+    void shouldIncludeNavigatorNoteInJavadoc() {
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Company(String name, Address headquarters) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Address(String street, String city) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(companySource, addressSource);
+
+      assertThat(compilation).succeeded();
+
+      // The Javadoc should mention navigator classes (use raw assertion to preserve comments)
+      final String expectedJavadocNote = "navigator classes for fluent cross-type navigation";
+
+      assertGeneratedCodeContainsRaw(compilation, "com.example.CompanyFocus", expectedJavadocNote);
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratorTestHelper.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratorTestHelper.java
@@ -13,6 +13,39 @@ import javax.tools.JavaFileObject;
 public final class GeneratorTestHelper {
 
   /**
+   * Asserts that the generated file contains the expected raw text (without normalization). This is
+   * useful for checking Javadoc content and other documentation that would be stripped by the
+   * normalizer.
+   *
+   * @param compilation The result from the compiler.
+   * @param generatedFileName The fully qualified name of the generated file.
+   * @param expectedText The expected text to find.
+   */
+  public static void assertGeneratedCodeContainsRaw(
+      final Compilation compilation, final String generatedFileName, final String expectedText) {
+
+    Optional<JavaFileObject> generatedSourceFile =
+        compilation.generatedSourceFile(generatedFileName);
+
+    if (generatedSourceFile.isEmpty()) {
+      fail("Generated source file not found: " + generatedFileName);
+      return;
+    }
+
+    try {
+      final String actualGeneratedCode = generatedSourceFile.get().getCharContent(true).toString();
+
+      assertTrue(
+          actualGeneratedCode.contains(expectedText),
+          String.format(
+              "Expected generated code to contain (raw):%n---%n%s%n---%nBut was:%n---%n%s%n---",
+              expectedText, actualGeneratedCode));
+    } catch (IOException e) {
+      fail("Could not read content from generated file: " + generatedFileName, e);
+    }
+  }
+
+  /**
    * Asserts that the generated file contains the expected code snippet, after normalizing both for
    * whitespace and class name qualifications.
    *
@@ -68,15 +101,28 @@ public final class GeneratorTestHelper {
     normalized =
         normalized
             .replaceAll("java\\.util\\.Optional", "Optional")
+            .replaceAll("java\\.util\\.function\\.Function", "Function")
             .replaceAll("org\\.higherkindedj\\.optics\\.Prism", "Prism")
             .replaceAll("org\\.higherkindedj\\.optics\\.Lens", "Lens")
             .replaceAll("org\\.higherkindedj\\.optics\\.Traversal", "Traversal")
             .replaceAll("org\\.higherkindedj\\.optics\\.util\\.Traversals", "Traversals")
+            .replaceAll("org\\.higherkindedj\\.optics\\.focus\\.FocusPath", "FocusPath")
+            .replaceAll("org\\.higherkindedj\\.optics\\.focus\\.AffinePath", "AffinePath")
+            .replaceAll("org\\.higherkindedj\\.optics\\.focus\\.TraversalPath", "TraversalPath")
             .replaceAll("org\\.higherkindedj\\.hkt\\.Applicative", "Applicative")
             // Test-specific types
             .replaceAll("com\\.example\\.Shape", "Shape")
             .replaceAll("com\\.example\\.User", "User")
-            .replaceAll("com\\.example\\.Playlist", "Playlist");
+            .replaceAll("com\\.example\\.Address", "Address")
+            .replaceAll("com\\.example\\.Company", "Company")
+            .replaceAll("com\\.example\\.Department", "Department")
+            .replaceAll("com\\.example\\.Team", "Team")
+            .replaceAll("com\\.example\\.Level1", "Level1")
+            .replaceAll("com\\.example\\.Level2", "Level2")
+            .replaceAll("com\\.example\\.Level3", "Level3")
+            .replaceAll("com\\.example\\.Playlist", "Playlist")
+            .replaceAll("com\\.example\\.model\\.Person", "Person")
+            .replaceAll("com\\.example\\.Wrapper", "Wrapper");
 
     // Remove ALL whitespace to make the comparison robust.
     return normalized.replaceAll("\\s+", "").trim();


### PR DESCRIPTION
This commit introduces the Focus DSL, a comprehensive path-based API for working with optics in a type-safe, fluent manner.

## Core Features

### Path Types
- FocusPath<S, A>: Wraps Lens for exactly-one focus
- AffinePath<S, A>: Wraps Affine for zero-or-one focus
- TraversalPath<S, A>: Wraps Traversal for zero-or-more focus

### Type Class Integration
- modifyF(): Effectful modifications with any Applicative
- foldMap(): Monoid-based aggregation for TraversalPath
- traverseOver(): Generic collection traversal via Traverse type class

### Navigation Methods
- via(): Compose with existing optics (Lens, Prism, Affine, Traversal)
- each(): Traverse List/Set elements
- at(index): Access specific list index (returns AffinePath)
- some(): Unwrap Optional values
- instanceOf(): Focus on specific sum type variants
- modifyWhen(): Conditional modification with predicate
- traced(): Debug path navigation

### Enhanced Annotation Processor
- @GenerateFocus(generateNavigators = true): Enables fluent cross-type navigation without explicit .via() calls
- Navigator classes wrap FocusPath and provide direct field access
- Path type widening: FocusPath → AffinePath → TraversalPath
- Configurable depth limiting with maxNavigatorDepth
- Field filtering with includeFields/excludeFields

## Documentation & Examples
- Comprehensive book chapter: hkj-book/src/optics/focus_dsl.md
- NavigatorExample: Fluent cross-type navigation patterns
- TraverseIntegrationExample: Kind-wrapped collection traversal
- ValidationPipelineExample: Validation with modifyF and foldMap
- AsyncFetchExample: CompletableFuture integration
- Tutorial exercises with solutions
- Cookbook recipes for common patterns

## Testing
- Full test coverage for all path types
- Processor tests for navigator generation
- Path type widening tests
- Field filtering tests

Fixes #258 