### PR TITLE
Add comprehensive support for nullable field handling in the Focus DSL:

### DIFF
--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPath.java
@@ -394,6 +394,41 @@ public sealed interface FocusPath<S, A> permits LensFocusPath {
   }
 
   /**
+   * When the focused type may be null, creates an AffinePath that safely handles null values.
+   *
+   * <p>This is useful for working with legacy APIs or records that use null to represent absent
+   * values instead of {@link java.util.Optional}. The resulting AffinePath treats null as absent
+   * (empty Optional) and non-null as present.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * record LegacyUser(String name, @Nullable String nickname) {}
+   *
+   * // Generate focus for the record (nickname is nullable)
+   * FocusPath<LegacyUser, @Nullable String> nicknamePath = LegacyUserFocus.nickname();
+   *
+   * // Chain with nullable() to get null-safe access
+   * AffinePath<LegacyUser, String> safeNickname = nicknamePath.nullable();
+   *
+   * // Now use it like any other AffinePath
+   * LegacyUser user = new LegacyUser("Alice", null);
+   * Optional<String> result = safeNickname.getOptional(user);  // Optional.empty()
+   *
+   * LegacyUser withNick = new LegacyUser("Bob", "Bobby");
+   * Optional<String> present = safeNickname.getOptional(withNick);  // Optional.of("Bobby")
+   * }</pre>
+   *
+   * @param <E> the non-null element type
+   * @return an AffinePath that treats null as absent
+   * @see FocusPaths#nullable()
+   */
+  @SuppressWarnings("unchecked")
+  default <E> AffinePath<S, E> nullable() {
+    return via((Affine<A, E>) FocusPaths.nullable());
+  }
+
+  /**
    * When the focused value is a traversable container {@code Kind<F, E>}, creates a TraversalPath
    * that focuses on all elements within it.
    *

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPaths.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPaths.java
@@ -216,6 +216,39 @@ public final class FocusPaths {
         Function.identity(), (opt, value) -> Optional.of(value), opt -> Optional.empty());
   }
 
+  // ===== Nullable Optics =====
+
+  /**
+   * Creates an affine that treats null as absent.
+   *
+   * <p>This is useful for working with legacy APIs or records that use null to represent absent
+   * values instead of {@link Optional}. The affine wraps null checks in Optional semantics,
+   * allowing seamless integration with the Focus DSL.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * record LegacyUser(String name, @Nullable String nickname) {}
+   *
+   * // Create a path to the nullable nickname field
+   * FocusPath<LegacyUser, @Nullable String> nicknamePath = LegacyUserFocus.nickname();
+   *
+   * // Chain with nullable() to get an AffinePath that handles null safely
+   * AffinePath<LegacyUser, String> safeNickname = nicknamePath.nullable();
+   *
+   * // Now use it like any other AffinePath
+   * Optional<String> result = safeNickname.getOptional(user);  // Empty if null
+   * LegacyUser updated = safeNickname.set("Ally", user);       // Sets the nickname
+   * }</pre>
+   *
+   * @param <E> the element type (non-null)
+   * @return an affine that treats null as absent
+   */
+  @SuppressWarnings("nullness") // Intentionally working with nullable values
+  public static <E> Affine<E, E> nullable() {
+    return Affine.of(Optional::ofNullable, (ignored, value) -> value);
+  }
+
   // ===== Array Optics =====
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/FocusPathsTest.java
@@ -237,6 +237,58 @@ class FocusPathsTest {
   }
 
   @Nested
+  @DisplayName("Nullable Optics")
+  class NullableOptics {
+
+    @Test
+    @DisplayName("nullable should return value when non-null")
+    void nullableShouldReturnValueWhenNonNull() {
+      Affine<String, String> affine = FocusPaths.nullable();
+
+      assertThat(affine.getOptional("hello")).contains("hello");
+    }
+
+    @Test
+    @DisplayName("nullable should return empty when null")
+    void nullableShouldReturnEmptyWhenNull() {
+      Affine<String, String> affine = FocusPaths.nullable();
+
+      assertThat(affine.getOptional(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("nullable should set value directly")
+    void nullableShouldSetValueDirectly() {
+      Affine<String, String> affine = FocusPaths.nullable();
+
+      assertThat(affine.set("world", "hello")).isEqualTo("world");
+      assertThat(affine.set("new", null)).isEqualTo("new");
+    }
+
+    @Test
+    @DisplayName("nullable should work with records containing nullable fields")
+    void nullableShouldWorkWithRecords() {
+      record UserWithNullable(String name, String nickname) {}
+
+      // Create lens for nickname field
+      Lens<UserWithNullable, String> nicknameLens =
+          Lens.of(UserWithNullable::nickname, (u, n) -> new UserWithNullable(u.name(), n));
+
+      // Create path with nullable
+      AffinePath<UserWithNullable, String> nicknamePath = FocusPath.of(nicknameLens).nullable();
+
+      UserWithNullable withNickname = new UserWithNullable("Alice", "Ally");
+      UserWithNullable withoutNickname = new UserWithNullable("Bob", null);
+
+      assertThat(nicknamePath.getOptional(withNickname)).contains("Ally");
+      assertThat(nicknamePath.getOptional(withoutNickname)).isEmpty();
+
+      UserWithNullable updated = nicknamePath.set("Bobby", withoutNickname);
+      assertThat(updated.nickname()).isEqualTo("Bobby");
+    }
+  }
+
+  @Nested
   @DisplayName("Array Optics")
   class ArrayOptics {
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -130,6 +130,22 @@ public class NavigatorClassGenerator {
    * @return AFFINE for optional types, TRAVERSAL for collection types, FOCUS otherwise
    */
   private PathKind getFieldPathKind(TypeMirror type) {
+    return getFieldPathKind(null, type);
+  }
+
+  /**
+   * Determines what path kind a field type introduces, considering annotations.
+   *
+   * @param component the record component (may be null for nested navigation)
+   * @param type the field type to analyze
+   * @return AFFINE for optional/nullable types, TRAVERSAL for collection types, FOCUS otherwise
+   */
+  private PathKind getFieldPathKind(RecordComponentElement component, TypeMirror type) {
+    // Check for @Nullable annotation first
+    if (component != null && NullableAnnotations.hasNullableAnnotation(component)) {
+      return PathKind.AFFINE;
+    }
+
     if (type.getKind() != TypeKind.DECLARED) {
       return PathKind.FOCUS;
     }
@@ -199,8 +215,8 @@ public class NavigatorClassGenerator {
         continue;
       }
 
-      // Determine the path kind for this field
-      PathKind fieldKind = getFieldPathKind(fieldType);
+      // Determine the path kind for this field (including @Nullable detection)
+      PathKind fieldKind = getFieldPathKind(component, fieldType);
       PathKind widenedKind = currentPathKind.widen(fieldKind);
 
       // Generate the navigator class for this field

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NullableAnnotations.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NullableAnnotations.java
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import java.util.Set;
+import javax.lang.model.element.RecordComponentElement;
+
+/**
+ * Utility class for detecting nullable annotations on record components.
+ *
+ * <p>This class provides shared functionality for identifying fields annotated with common
+ * {@code @Nullable} annotations from various libraries. It is used by annotation processors to
+ * determine when to generate null-safe optics.
+ */
+public final class NullableAnnotations {
+
+  /**
+   * Set of fully qualified names for common {@code @Nullable} annotations.
+   *
+   * <p>Supported annotations:
+   *
+   * <ul>
+   *   <li>{@code org.jspecify.annotations.Nullable} - JSpecify
+   *   <li>{@code javax.annotation.Nullable} - JSR-305
+   *   <li>{@code jakarta.annotation.Nullable} - Jakarta
+   *   <li>{@code org.jetbrains.annotations.Nullable} - JetBrains
+   *   <li>{@code androidx.annotation.Nullable} - AndroidX
+   *   <li>{@code edu.umd.cs.findbugs.annotations.Nullable} - FindBugs/SpotBugs
+   * </ul>
+   */
+  public static final Set<String> NULLABLE_ANNOTATION_NAMES =
+      Set.of(
+          "org.jspecify.annotations.Nullable",
+          "javax.annotation.Nullable",
+          "jakarta.annotation.Nullable",
+          "org.jetbrains.annotations.Nullable",
+          "androidx.annotation.Nullable",
+          "edu.umd.cs.findbugs.annotations.Nullable");
+
+  private NullableAnnotations() {
+    // Utility class - prevent instantiation
+  }
+
+  /**
+   * Checks if a record component has a {@code @Nullable} annotation.
+   *
+   * @param component the record component to check
+   * @return {@code true} if the component has a recognised nullable annotation
+   */
+  public static boolean hasNullableAnnotation(RecordComponentElement component) {
+    return component.getAnnotationMirrors().stream()
+        .map(am -> am.getAnnotationType().toString())
+        .anyMatch(NULLABLE_ANNOTATION_NAMES::contains);
+  }
+}


### PR DESCRIPTION
Core API additions:
- Add FocusPaths.nullable() affine for treating null as absent
- Add .nullable() method on FocusPath and AffinePath for chaining
- Add AffinePath.ofNullable() factory for direct nullable path creation

Processor enhancements:
- FocusProcessor now detects @Nullable annotations automatically
- Generates AffinePath with .nullable() for @Nullable annotated fields
- Supports JSpecify, JSR-305, JetBrains, and other @Nullable annotations
- NavigatorClassGenerator updated for nullable field widening

Documentation:
- Updated focus_dsl.md with comprehensive nullable handling guide
- Added .nullable() to collection navigation methods section
- Updated generated class structure examples
- Expanded FAQ with four approaches for nullable fields

Tests:
- Added FocusPathsTest.NullableOptics test class
- Added AffinePathTest.NullableFieldHandling test class
- Comprehensive coverage for ofNullable, nullable(), and composition



Fixes #272 
