### PR TITLE
Add ForPath: Path-native for-comprehension builder

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -66,6 +66,7 @@
     - [FreePath](effect/path_free.md)
     - [FreeApPath](effect/path_freeap.md)
   - [Composition Patterns](effect/composition.md)
+  - [ForPath Comprehension](effect/forpath_comprehension.md)
   - [Type Conversions](effect/conversions.md)
   - [Focus-Effect Integration](effect/focus_integration.md)
   - [Patterns and Recipes](effect/patterns.md)

--- a/hkj-book/src/effect/composition.md
+++ b/hkj-book/src/effect/composition.md
@@ -573,7 +573,7 @@ The world remains understandable and lawful when each operation has a clear
 purpose and failures propagate predictably. Composition is the discipline
 that makes this possible.
 
-Continue to [Type Conversions](conversions.md) for detailed coverage of
+Continue to [ForPath Comprehension](forpath_comprehension.md) for detailed coverage of
 moving between Path types.
 
 ~~~admonish tip title="See Also"
@@ -585,4 +585,4 @@ moving between Path types.
 ---
 
 **Previous:** [Path Types](path_types.md)
-**Next:** [Type Conversions](conversions.md)
+**Next:** [ForPath Comprehension](forpath_comprehension.md)

--- a/hkj-book/src/effect/conversions.md
+++ b/hkj-book/src/effect/conversions.md
@@ -734,5 +734,5 @@ Continue to [Patterns and Recipes](patterns.md) for real-world usage patterns.
 
 ---
 
-**Previous:** [Composition Patterns](composition.md)
+**Previous:** [ForPath Comprehension](forpath_comprehension.md)
 **Next:** [Focus-Effect Integration](focus_integration.md)

--- a/hkj-book/src/effect/forpath_comprehension.md
+++ b/hkj-book/src/effect/forpath_comprehension.md
@@ -1,0 +1,298 @@
+# ForPath: For-Comprehensions with Effect Paths
+
+> *"Though this be madness, yet there is method in't."*
+>
+> — William Shakespeare, *Hamlet*
+
+And so it is with for-comprehensions: what appears to be arcane syntax hides a
+deeply methodical approach to composing sequential operations.
+
+~~~admonish info title="What You'll Learn"
+- How ForPath bridges the For comprehension system and the Effect Path API
+- Creating comprehensions directly with Path types (no manual `Kind` extraction)
+- Using generators (`.from()`), bindings (`.let()`), guards (`.when()`), and projections (`.yield()`)
+- Integrating optics with `.focus()` and `.match()` for structural navigation
+- Choosing between ForPath and the standard For class
+~~~
+
+~~~ admonish example title="See Example Code:"
+[ForPathExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/effect/ForPathExample.java)
+~~~
+
+---
+
+## The Problem: Bridging Two Worlds
+
+The standard [For](../functional/for_comprehension.md) class provides powerful for-comprehension
+syntax, but it operates on raw `Kind<M, A>` values and requires explicit `Monad` instances.
+When working with the Effect Path API, this creates friction:
+
+```java
+// Using standard For with Path types requires extraction and rewrapping
+Kind<MaybeKind.Witness, Integer> kindResult = For.from(maybeMonad, path1.run().kind())
+    .from(a -> path2.run().kind())
+    .yield((a, b) -> a + b);
+
+MaybePath<Integer> result = Path.maybe(MAYBE.narrow(kindResult));
+```
+
+The intent is clear, but the ceremony obscures it. `ForPath` eliminates this friction:
+
+```java
+// ForPath works directly with Path types
+MaybePath<Integer> result = ForPath.from(path1)
+    .from(a -> path2)
+    .yield((a, b) -> a + b);
+```
+
+The comprehension accepts Path types and returns Path types. No manual extraction,
+no rewrapping, no boilerplate.
+
+---
+
+## Entry Points
+
+`ForPath` provides entry points for each supported Path type:
+
+| Path Type | Entry Point | Supports `when()` |
+|-----------|-------------|-------------------|
+| `MaybePath<A>` | `ForPath.from(maybePath)` | Yes |
+| `OptionalPath<A>` | `ForPath.from(optionalPath)` | Yes |
+| `EitherPath<E, A>` | `ForPath.from(eitherPath)` | No |
+| `TryPath<A>` | `ForPath.from(tryPath)` | No |
+| `IOPath<A>` | `ForPath.from(ioPath)` | No |
+| `IdPath<A>` | `ForPath.from(idPath)` | No |
+| `NonDetPath<A>` | `ForPath.from(nonDetPath)` | Yes |
+| `GenericPath<F, A>` | `ForPath.from(genericPath)` | Optional |
+
+The `when()` guard operation is only available for Path types backed by `MonadZero`,
+which can represent emptiness or failure.
+
+---
+
+## Core Operations
+
+### Generators: `.from()`
+
+The `.from()` operation extracts a value from the current step and chains to a new
+Path-producing computation. This is the monadic bind (`flatMap`) in disguise.
+
+```java
+MaybePath<String> result = ForPath.from(Path.just("Alice"))
+    .from(name -> Path.just(name.length()))         // a = "Alice", b = 5
+    .from(t -> Path.just(t._1() + ":" + t._2()))    // t is Tuple2<String, Integer>
+    .yield((name, len, combined) -> combined);      // "Alice:5"
+```
+
+Each `.from()` adds a new value to the accumulating tuple, making all previous
+values available to subsequent steps.
+
+### Value Bindings: `.let()`
+
+The `.let()` operation computes a pure value from accumulated results without
+introducing a new effect. It's equivalent to `map` that carries the value forward.
+
+```java
+MaybePath<String> result = ForPath.from(Path.just(10))
+    .let(a -> a * 2)                    // b = 20 (pure calculation)
+    .let(t -> t._1() + t._2())          // c = 30 (can access tuple)
+    .yield((a, b, c) -> "Sum: " + c);   // "Sum: 30"
+```
+
+### Guards: `.when()`
+
+For Path types with `MonadZero` (MaybePath, OptionalPath, NonDetPath), the `.when()`
+operation filters results. When the predicate returns false, the computation
+short-circuits to the monad's zero value (Nothing, empty, etc.).
+
+```java
+MaybePath<Integer> evenOnly = ForPath.from(Path.just(4))
+    .when(n -> n % 2 == 0)              // passes: 4 is even
+    .yield(n -> n * 10);                // Just(40)
+
+MaybePath<Integer> filtered = ForPath.from(Path.just(3))
+    .when(n -> n % 2 == 0)              // fails: 3 is odd
+    .yield(n -> n * 10);                // Nothing
+```
+
+### Projection: `.yield()`
+
+Every comprehension ends with `.yield()`, which maps the accumulated values to a
+final result. You can access values individually or as a tuple:
+
+```java
+// Individual parameters
+.yield((a, b, c) -> a + b + c)
+
+// Or as a tuple for many values
+.yield(t -> t._1() + t._2() + t._3())
+```
+
+---
+
+## Optics Integration
+
+ForPath integrates with the [Focus DSL](../optics/focus_dsl.md) for structural
+navigation within comprehensions.
+
+### Extracting with `.focus()`
+
+The `.focus()` operation uses a `FocusPath` to extract a nested value:
+
+```java
+record User(String name, Address address) {}
+record Address(String city, String postcode) {}
+
+// Create lenses for each field
+Lens<User, Address> addressLens = Lens.of(
+    User::address, (u, a) -> new User(u.name(), a));
+Lens<Address, String> cityLens = Lens.of(
+    Address::city, (a, c) -> new Address(c, a.postcode()));
+
+// Compose paths with via() for nested access
+FocusPath<User, Address> addressPath = FocusPath.of(addressLens);
+FocusPath<User, String> userCityPath = addressPath.via(FocusPath.of(cityLens));
+
+MaybePath<String> result = ForPath.from(Path.just(user))
+    .focus(userCityPath)                        // extract city directly
+    .yield((user, city) -> city.toUpperCase());
+```
+
+Alternatively, chain focus operations where the second takes a function:
+
+```java
+FocusPath<User, Address> addressPath = FocusPath.of(addressLens);
+
+MaybePath<String> result = ForPath.from(Path.just(user))
+    .focus(addressPath)                         // extract address -> Steps2
+    .focus(t -> t._2().city())                  // extract city from tuple
+    .yield((user, address, city) -> city.toUpperCase());
+```
+
+### Pattern Matching with `.match()`
+
+The `.match()` operation uses an `AffinePath` for optional extraction. When the
+focus is absent, the comprehension short-circuits for `MonadZero` types:
+
+```java
+sealed interface Result permits Success, Failure {}
+record Success(String value) implements Result {}
+record Failure(String error) implements Result {}
+
+AffinePath<Result, Success> successPath = AffinePath.of(
+    Affine.of(
+        r -> r instanceof Success s ? Optional.of(s) : Optional.empty(),
+        (r, s) -> s
+    )
+);
+
+MaybePath<String> result = ForPath.from(Path.just((Result) new Success("data")))
+    .match(successPath)                         // extract Success
+    .yield((r, success) -> success.value().toUpperCase());
+// Just("DATA")
+
+MaybePath<String> empty = ForPath.from(Path.just((Result) new Failure("error")))
+    .match(successPath)                         // fails to match
+    .yield((r, success) -> success.value());
+// Nothing
+```
+
+---
+
+## EitherPath Example
+
+For error-handling scenarios, EitherPath comprehensions propagate failures automatically:
+
+```java
+record User(String id, String name) {}
+record Order(String orderId, User user) {}
+
+Function<String, EitherPath<String, User>> findUser = id ->
+    id.equals("user-1")
+        ? Path.right(new User("user-1", "Alice"))
+        : Path.left("User not found: " + id);
+
+Function<User, EitherPath<String, Order>> createOrder = user ->
+    Path.right(new Order("order-123", user));
+
+EitherPath<String, String> result = ForPath.from(findUser.apply("user-1"))
+    .from(user -> createOrder.apply(user))
+    .yield((user, order) -> "Created " + order.orderId() + " for " + user.name());
+// Right("Created order-123 for Alice")
+
+EitherPath<String, String> failed = ForPath.from(findUser.apply("unknown"))
+    .from(user -> createOrder.apply(user))
+    .yield((user, order) -> "Created " + order.orderId());
+// Left("User not found: unknown")
+```
+
+---
+
+## IOPath Example
+
+IOPath comprehensions compose deferred side-effectful computations:
+
+```java
+IOPath<String> readConfig = Path.io(() -> "production");
+IOPath<Integer> readPort = Path.io(() -> 8080);
+
+IOPath<String> serverInfo = ForPath.from(readConfig)
+    .from(env -> readPort)
+    .let(t -> t._1().toUpperCase())
+    .yield((env, port, upperEnv) -> upperEnv + " server on port " + port);
+
+// Nothing executes until:
+String result = serverInfo.unsafeRun();  // "PRODUCTION server on port 8080"
+```
+
+---
+
+## NonDetPath Example
+
+NonDetPath (backed by List) generates all combinations:
+
+```java
+NonDetPath<String> combinations = ForPath.from(Path.list("red", "blue"))
+    .from(c -> Path.list("S", "M", "L"))
+    .when(t -> !t._1().equals("blue") || !t._2().equals("S"))  // filter out blue-S
+    .yield((colour, size) -> colour + "-" + size);
+
+List<String> result = combinations.run();
+// ["red-S", "red-M", "red-L", "blue-M", "blue-L"]
+```
+
+---
+
+## When to Use ForPath vs For
+
+| Scenario | Use |
+|----------|-----|
+| Working with Effect Path API | `ForPath` |
+| Need Path types as output | `ForPath` |
+| Working with raw `Kind<M, A>` | `For` |
+| Using monad transformers (StateT, EitherT) | `For` |
+| Custom monads without Path wrappers | `For` with `GenericPath` adapter |
+
+For monad transformer stacks, the standard `For` class remains the appropriate choice
+as it works directly with the transformer's `Kind` representation.
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **ForPath eliminates boilerplate** when composing Path types in for-comprehension style
+* **Entry points accept Path types directly** and return Path types
+* **All For operations are supported**: `from()`, `let()`, `when()` (where applicable), `yield()`
+* **Optics integration** via `focus()` and `match()` enables structural navigation
+* **Type safety is preserved** throughout the comprehension
+~~~
+
+~~~admonish tip title="See Also"
+- [For Comprehension](../functional/for_comprehension.md) - The underlying For class for raw `Kind` values
+- [Effect Path Overview](effect_path_overview.md) - Introduction to the Effect Path API
+- [Focus DSL](../optics/focus_dsl.md) - Optics integration for structural navigation
+~~~
+
+---
+
+**Previous:** [Composition Patterns](composition.md)
+**Next:** [Type Conversions](conversions.md)

--- a/hkj-book/src/functional/for_comprehension.md
+++ b/hkj-book/src/functional/for_comprehension.md
@@ -441,6 +441,10 @@ Kind<IdKind.Witness, List<Pair<Integer, Player>>> indexed =
 For more details on indexed optics, see [Indexed Optics](../optics/indexed_optics.md).
 ~~~
 
+~~~admonish tip title="See Also"
+- [ForPath Comprehension](../effect/forpath_comprehension.md) - For-comprehensions that work directly with Effect Path types
+~~~
+
 ---
 
 ~~~admonish tip title="Further Reading"

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/expression/ForPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/expression/ForPath.java
@@ -1,0 +1,1360 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.expression;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.GenericPath;
+import org.higherkindedj.hkt.effect.IOPath;
+import org.higherkindedj.hkt.effect.IdPath;
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.NonDetPath;
+import org.higherkindedj.hkt.effect.OptionalPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.TryPath;
+import org.higherkindedj.hkt.effect.capability.Chainable;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherKindHelper;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.function.Function3;
+import org.higherkindedj.hkt.function.Function4;
+import org.higherkindedj.hkt.function.Function5;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
+import org.higherkindedj.hkt.id.IdMonad;
+import org.higherkindedj.hkt.io.IOKind;
+import org.higherkindedj.hkt.io.IOKindHelper;
+import org.higherkindedj.hkt.io.IOMonad;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.higherkindedj.hkt.trymonad.TryKind;
+import org.higherkindedj.hkt.trymonad.TryKindHelper;
+import org.higherkindedj.hkt.trymonad.TryMonad;
+import org.higherkindedj.hkt.tuple.Tuple;
+import org.higherkindedj.hkt.tuple.Tuple2;
+import org.higherkindedj.hkt.tuple.Tuple3;
+import org.higherkindedj.hkt.tuple.Tuple4;
+import org.higherkindedj.hkt.tuple.Tuple5;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+
+/**
+ * Path-native for-comprehension builder that works directly with Effect Path types.
+ *
+ * <p>This class bridges the gap between the {@link For} comprehension system and the Effect Path
+ * API, allowing users to compose Path types using for-comprehension style while preserving Path
+ * semantics and returning Path types directly.
+ *
+ * <h2>Motivation</h2>
+ *
+ * <p>The standard {@link For} class works with raw {@link Kind} values and {@link Monad} instances,
+ * requiring manual extraction and rewrapping when working with Path types. {@code ForPath} provides
+ * a seamless experience:
+ *
+ * <ul>
+ *   <li>Entry points accept Path types directly
+ *   <li>All operations preserve Path types
+ *   <li>{@code yield} returns Path types
+ *   <li>Full FocusPath/AffinePath integration
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <h3>MaybePath Comprehension</h3>
+ *
+ * <pre>{@code
+ * MaybePath<String> result = ForPath.from(Path.just(user))
+ *     .from(u -> Path.maybe(u.getAddress()))       // flatMap
+ *     .let(addr -> addr.getCity())                  // map
+ *     .when(t -> !t._2().isEmpty())                 // filter
+ *     .yield((user, addr, city) -> city + ", " + addr.getCountry());
+ * }</pre>
+ *
+ * <h3>EitherPath Comprehension</h3>
+ *
+ * <pre>{@code
+ * EitherPath<Error, Order> result = ForPath.from(Path.<Error, User>right(user))
+ *     .from(u -> validateUser(u))                   // returns EitherPath
+ *     .from((u, valid) -> createOrder(u))           // returns EitherPath
+ *     .yield((user, validated, order) -> order);
+ * }</pre>
+ *
+ * <h3>With FocusPath Integration</h3>
+ *
+ * <pre>{@code
+ * FocusPath<User, Address> addressPath = UserFocus.address();
+ *
+ * MaybePath<String> city = ForPath.from(Path.just(user))
+ *     .focus(addressPath)                           // extract address
+ *     .yield((user, address) -> address.getCity());
+ * }</pre>
+ *
+ * <h3>With AffinePath (Optional Focus)</h3>
+ *
+ * <pre>{@code
+ * AffinePath<User, Email> emailPath = UserFocus.optionalEmail();
+ *
+ * MaybePath<String> email = ForPath.from(Path.just(user))
+ *     .match(emailPath)                             // extract optional email
+ *     .yield((user, email) -> email.toString());
+ * // Returns Nothing if user has no email
+ * }</pre>
+ *
+ * @see For
+ * @see Path
+ * @see Chainable
+ * @see FocusPath
+ * @see AffinePath
+ */
+public final class ForPath {
+
+  private static final String YIELD_CANNOT_RETURN_NULL = "The yield function must not return null.";
+
+  private ForPath() {} // Static access only
+
+  // ===== MaybePath Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with a MaybePath.
+   *
+   * <p>MaybePath supports filtering via {@code when()}, making it a filterable comprehension.
+   *
+   * @param source the initial MaybePath
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <A> MaybePathSteps1<A> from(MaybePath<A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new MaybePathSteps1<>(source);
+  }
+
+  // ===== OptionalPath Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with an OptionalPath.
+   *
+   * <p>OptionalPath supports filtering via {@code when()}, making it a filterable comprehension.
+   *
+   * @param source the initial OptionalPath
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <A> OptionalPathSteps1<A> from(OptionalPath<A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new OptionalPathSteps1<>(source);
+  }
+
+  // ===== EitherPath Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with an EitherPath.
+   *
+   * @param source the initial EitherPath
+   * @param <E> the error type
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <E, A> EitherPathSteps1<E, A> from(EitherPath<E, A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new EitherPathSteps1<>(source);
+  }
+
+  // ===== TryPath Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with a TryPath.
+   *
+   * @param source the initial TryPath
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <A> TryPathSteps1<A> from(TryPath<A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new TryPathSteps1<>(source);
+  }
+
+  // ===== IOPath Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with an IOPath.
+   *
+   * @param source the initial IOPath
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <A> IOPathSteps1<A> from(IOPath<A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new IOPathSteps1<>(source);
+  }
+
+  // ===== IdPath Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with an IdPath.
+   *
+   * @param source the initial IdPath
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <A> IdPathSteps1<A> from(IdPath<A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new IdPathSteps1<>(source);
+  }
+
+  // ===== NonDetPath (List) Entry Points =====
+
+  /**
+   * Initiates a for-comprehension with a NonDetPath (list with Cartesian product semantics).
+   *
+   * <p>NonDetPath supports filtering via {@code when()}, making it a filterable comprehension.
+   *
+   * @param source the initial NonDetPath
+   * @param <A> the element type
+   * @return the first step of the builder
+   */
+  public static <A> NonDetPathSteps1<A> from(NonDetPath<A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new NonDetPathSteps1<>(source);
+  }
+
+  // ===== Generic Entry Point =====
+
+  /**
+   * Initiates a for-comprehension with a GenericPath.
+   *
+   * <p>This is the escape hatch for custom monad types not covered by specific entry points.
+   *
+   * @param source the initial GenericPath
+   * @param <F> the witness type
+   * @param <A> the value type
+   * @return the first step of the builder
+   */
+  public static <F, A> GenericPathSteps1<F, A> from(GenericPath<F, A> source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new GenericPathSteps1<>(source);
+  }
+
+  // ========================================================================
+  // MaybePath Steps (Filterable)
+  // ========================================================================
+
+  /** First step in a MaybePath comprehension. */
+  public static final class MaybePathSteps1<A> {
+    private static final MaybeMonad MONAD = MaybeMonad.INSTANCE;
+    private final Kind<MaybeKind.Witness, A> computation;
+
+    private MaybePathSteps1(MaybePath<A> source) {
+      this.computation = MaybeKindHelper.MAYBE.widen(source.run());
+    }
+
+    private MaybePathSteps1(Kind<MaybeKind.Witness, A> computation) {
+      this.computation = computation;
+    }
+
+    /**
+     * Adds a generator that produces another MaybePath.
+     *
+     * @param next function producing the next MaybePath
+     * @param <B> the new value type
+     * @return the next step
+     */
+    public <B> MaybePathSteps2<A, B> from(Function<A, MaybePath<B>> next) {
+      Kind<MaybeKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a -> MONAD.map(b -> Tuple.of(a, b), MaybeKindHelper.MAYBE.widen(next.apply(a).run())),
+              computation);
+      return new MaybePathSteps2<>(newComp);
+    }
+
+    /**
+     * Binds the result of a pure computation.
+     *
+     * @param f the pure computation
+     * @param <B> the result type
+     * @return the next step
+     */
+    public <B> MaybePathSteps2<A, B> let(Function<A, B> f) {
+      Kind<MaybeKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new MaybePathSteps2<>(newComp);
+    }
+
+    /**
+     * Extracts a value using a FocusPath.
+     *
+     * @param focusPath the lens to apply
+     * @param <B> the focused type
+     * @return the next step
+     */
+    public <B> MaybePathSteps2<A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      Kind<MaybeKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new MaybePathSteps2<>(newComp);
+    }
+
+    /**
+     * Pattern matches using an AffinePath, short-circuiting if the match fails.
+     *
+     * @param affinePath the optional focus to apply
+     * @param <B> the focused type
+     * @return the next step
+     */
+    public <B> MaybePathSteps2<A, B> match(AffinePath<A, B> affinePath) {
+      Objects.requireNonNull(affinePath, "affinePath must not be null");
+      Kind<MaybeKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a ->
+                  affinePath
+                      .getOptional(a)
+                      .map(b -> MONAD.of(Tuple.of(a, b)))
+                      .orElseGet(MONAD::zero),
+              computation);
+      return new MaybePathSteps2<>(newComp);
+    }
+
+    /**
+     * Filters the value based on a predicate.
+     *
+     * @param predicate the filter condition
+     * @return this step with the filter applied
+     */
+    public MaybePathSteps1<A> when(Predicate<A> predicate) {
+      Kind<MaybeKind.Witness, A> newComp =
+          MONAD.flatMap(a -> predicate.test(a) ? MONAD.of(a) : MONAD.zero(), computation);
+      return new MaybePathSteps1<>(newComp);
+    }
+
+    /**
+     * Completes the comprehension by yielding a final result.
+     *
+     * @param f the yield function
+     * @param <R> the result type
+     * @return the resulting MaybePath
+     */
+    public <R> MaybePath<R> yield(Function<A, R> f) {
+      Kind<MaybeKind.Witness, R> result = MONAD.map(f, computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+  }
+
+  /** Second step in a MaybePath comprehension. */
+  public static final class MaybePathSteps2<A, B> {
+    private static final MaybeMonad MONAD = MaybeMonad.INSTANCE;
+    private final Kind<MaybeKind.Witness, Tuple2<A, B>> computation;
+
+    private MaybePathSteps2(Kind<MaybeKind.Witness, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> MaybePathSteps3<A, B, C> from(Function<Tuple2<A, B>, MaybePath<C>> next) {
+      Kind<MaybeKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  MONAD.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      MaybeKindHelper.MAYBE.widen(next.apply(ab).run())),
+              computation);
+      return new MaybePathSteps3<>(newComp);
+    }
+
+    public <C> MaybePathSteps3<A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<MaybeKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new MaybePathSteps3<>(newComp);
+    }
+
+    public <C> MaybePathSteps3<A, B, C> focus(Function<Tuple2<A, B>, C> extractor) {
+      Objects.requireNonNull(extractor, "extractor must not be null");
+      return let(extractor);
+    }
+
+    public <C> MaybePathSteps3<A, B, C> match(Function<Tuple2<A, B>, Optional<C>> matcher) {
+      Objects.requireNonNull(matcher, "matcher must not be null");
+      Kind<MaybeKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  matcher
+                      .apply(ab)
+                      .map(c -> MONAD.of(Tuple.of(ab._1(), ab._2(), c)))
+                      .orElseGet(MONAD::zero),
+              computation);
+      return new MaybePathSteps3<>(newComp);
+    }
+
+    public MaybePathSteps2<A, B> when(Predicate<Tuple2<A, B>> predicate) {
+      Kind<MaybeKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(ab -> predicate.test(ab) ? MONAD.of(ab) : MONAD.zero(), computation);
+      return new MaybePathSteps2<>(newComp);
+    }
+
+    public <R> MaybePath<R> yield(BiFunction<A, B, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+
+    public <R> MaybePath<R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+  }
+
+  /** Third step in a MaybePath comprehension. */
+  public static final class MaybePathSteps3<A, B, C> {
+    private static final MaybeMonad MONAD = MaybeMonad.INSTANCE;
+    private final Kind<MaybeKind.Witness, Tuple3<A, B, C>> computation;
+
+    private MaybePathSteps3(Kind<MaybeKind.Witness, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public <D> MaybePathSteps4<A, B, C, D> from(Function<Tuple3<A, B, C>, MaybePath<D>> next) {
+      Kind<MaybeKind.Witness, Tuple4<A, B, C, D>> newComp =
+          MONAD.flatMap(
+              abc ->
+                  MONAD.map(
+                      d -> Tuple.of(abc._1(), abc._2(), abc._3(), d),
+                      MaybeKindHelper.MAYBE.widen(next.apply(abc).run())),
+              computation);
+      return new MaybePathSteps4<>(newComp);
+    }
+
+    public <D> MaybePathSteps4<A, B, C, D> let(Function<Tuple3<A, B, C>, D> f) {
+      Kind<MaybeKind.Witness, Tuple4<A, B, C, D>> newComp =
+          MONAD.map(abc -> Tuple.of(abc._1(), abc._2(), abc._3(), f.apply(abc)), computation);
+      return new MaybePathSteps4<>(newComp);
+    }
+
+    public MaybePathSteps3<A, B, C> when(Predicate<Tuple3<A, B, C>> predicate) {
+      Kind<MaybeKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(abc -> predicate.test(abc) ? MONAD.of(abc) : MONAD.zero(), computation);
+      return new MaybePathSteps3<>(newComp);
+    }
+
+    public <R> MaybePath<R> yield(Function3<A, B, C, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+
+    public <R> MaybePath<R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+  }
+
+  /** Fourth step in a MaybePath comprehension. */
+  public static final class MaybePathSteps4<A, B, C, D> {
+    private static final MaybeMonad MONAD = MaybeMonad.INSTANCE;
+    private final Kind<MaybeKind.Witness, Tuple4<A, B, C, D>> computation;
+
+    private MaybePathSteps4(Kind<MaybeKind.Witness, Tuple4<A, B, C, D>> computation) {
+      this.computation = computation;
+    }
+
+    public <E> MaybePathSteps5<A, B, C, D, E> from(
+        Function<Tuple4<A, B, C, D>, MaybePath<E>> next) {
+      Kind<MaybeKind.Witness, Tuple5<A, B, C, D, E>> newComp =
+          MONAD.flatMap(
+              abcd ->
+                  MONAD.map(
+                      e -> Tuple.of(abcd._1(), abcd._2(), abcd._3(), abcd._4(), e),
+                      MaybeKindHelper.MAYBE.widen(next.apply(abcd).run())),
+              computation);
+      return new MaybePathSteps5<>(newComp);
+    }
+
+    public <E> MaybePathSteps5<A, B, C, D, E> let(Function<Tuple4<A, B, C, D>, E> f) {
+      Kind<MaybeKind.Witness, Tuple5<A, B, C, D, E>> newComp =
+          MONAD.map(
+              abcd -> Tuple.of(abcd._1(), abcd._2(), abcd._3(), abcd._4(), f.apply(abcd)),
+              computation);
+      return new MaybePathSteps5<>(newComp);
+    }
+
+    public MaybePathSteps4<A, B, C, D> when(Predicate<Tuple4<A, B, C, D>> predicate) {
+      Kind<MaybeKind.Witness, Tuple4<A, B, C, D>> newComp =
+          MONAD.flatMap(abcd -> predicate.test(abcd) ? MONAD.of(abcd) : MONAD.zero(), computation);
+      return new MaybePathSteps4<>(newComp);
+    }
+
+    public <R> MaybePath<R> yield(Function4<A, B, C, D, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(
+                      f.apply(t._1(), t._2(), t._3(), t._4()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+
+    public <R> MaybePath<R> yield(Function<Tuple4<A, B, C, D>, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+  }
+
+  /** Fifth step in a MaybePath comprehension. */
+  public static final class MaybePathSteps5<A, B, C, D, E> {
+    private static final MaybeMonad MONAD = MaybeMonad.INSTANCE;
+    private final Kind<MaybeKind.Witness, Tuple5<A, B, C, D, E>> computation;
+
+    private MaybePathSteps5(Kind<MaybeKind.Witness, Tuple5<A, B, C, D, E>> computation) {
+      this.computation = computation;
+    }
+
+    public MaybePathSteps5<A, B, C, D, E> when(Predicate<Tuple5<A, B, C, D, E>> predicate) {
+      Kind<MaybeKind.Witness, Tuple5<A, B, C, D, E>> newComp =
+          MONAD.flatMap(
+              abcde -> predicate.test(abcde) ? MONAD.of(abcde) : MONAD.zero(), computation);
+      return new MaybePathSteps5<>(newComp);
+    }
+
+    public <R> MaybePath<R> yield(Function5<A, B, C, D, E, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(
+                      f.apply(t._1(), t._2(), t._3(), t._4(), t._5()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+
+    public <R> MaybePath<R> yield(Function<Tuple5<A, B, C, D, E>, R> f) {
+      Kind<MaybeKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.maybe(MaybeKindHelper.MAYBE.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // OptionalPath Steps (Filterable)
+  // ========================================================================
+
+  /** First step in an OptionalPath comprehension. */
+  public static final class OptionalPathSteps1<A> {
+    private static final OptionalMonad MONAD = OptionalMonad.INSTANCE;
+    private final Kind<OptionalKind.Witness, A> computation;
+
+    private OptionalPathSteps1(OptionalPath<A> source) {
+      this.computation = OptionalKindHelper.OPTIONAL.widen(source.run());
+    }
+
+    private OptionalPathSteps1(Kind<OptionalKind.Witness, A> computation) {
+      this.computation = computation;
+    }
+
+    public <B> OptionalPathSteps2<A, B> from(Function<A, OptionalPath<B>> next) {
+      Kind<OptionalKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a ->
+                  MONAD.map(
+                      b -> Tuple.of(a, b), OptionalKindHelper.OPTIONAL.widen(next.apply(a).run())),
+              computation);
+      return new OptionalPathSteps2<>(newComp);
+    }
+
+    public <B> OptionalPathSteps2<A, B> let(Function<A, B> f) {
+      Kind<OptionalKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new OptionalPathSteps2<>(newComp);
+    }
+
+    public <B> OptionalPathSteps2<A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      Kind<OptionalKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new OptionalPathSteps2<>(newComp);
+    }
+
+    public <B> OptionalPathSteps2<A, B> match(AffinePath<A, B> affinePath) {
+      Objects.requireNonNull(affinePath, "affinePath must not be null");
+      Kind<OptionalKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a ->
+                  affinePath
+                      .getOptional(a)
+                      .map(b -> MONAD.of(Tuple.of(a, b)))
+                      .orElseGet(MONAD::zero),
+              computation);
+      return new OptionalPathSteps2<>(newComp);
+    }
+
+    public OptionalPathSteps1<A> when(Predicate<A> predicate) {
+      Kind<OptionalKind.Witness, A> newComp =
+          MONAD.flatMap(a -> predicate.test(a) ? MONAD.of(a) : MONAD.zero(), computation);
+      return new OptionalPathSteps1<>(newComp);
+    }
+
+    public <R> OptionalPath<R> yield(Function<A, R> f) {
+      Kind<OptionalKind.Witness, R> result = MONAD.map(f, computation);
+      return Path.optional(OptionalKindHelper.OPTIONAL.narrow(result));
+    }
+  }
+
+  /** Second step in an OptionalPath comprehension. */
+  public static final class OptionalPathSteps2<A, B> {
+    private static final OptionalMonad MONAD = OptionalMonad.INSTANCE;
+    private final Kind<OptionalKind.Witness, Tuple2<A, B>> computation;
+
+    private OptionalPathSteps2(Kind<OptionalKind.Witness, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> OptionalPathSteps3<A, B, C> from(Function<Tuple2<A, B>, OptionalPath<C>> next) {
+      Kind<OptionalKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  MONAD.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      OptionalKindHelper.OPTIONAL.widen(next.apply(ab).run())),
+              computation);
+      return new OptionalPathSteps3<>(newComp);
+    }
+
+    public <C> OptionalPathSteps3<A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<OptionalKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new OptionalPathSteps3<>(newComp);
+    }
+
+    public OptionalPathSteps2<A, B> when(Predicate<Tuple2<A, B>> predicate) {
+      Kind<OptionalKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(ab -> predicate.test(ab) ? MONAD.of(ab) : MONAD.zero(), computation);
+      return new OptionalPathSteps2<>(newComp);
+    }
+
+    public <R> OptionalPath<R> yield(BiFunction<A, B, R> f) {
+      Kind<OptionalKind.Witness, R> result =
+          MONAD.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.optional(OptionalKindHelper.OPTIONAL.narrow(result));
+    }
+
+    public <R> OptionalPath<R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<OptionalKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.optional(OptionalKindHelper.OPTIONAL.narrow(result));
+    }
+  }
+
+  /** Third step in an OptionalPath comprehension. */
+  public static final class OptionalPathSteps3<A, B, C> {
+    private static final OptionalMonad MONAD = OptionalMonad.INSTANCE;
+    private final Kind<OptionalKind.Witness, Tuple3<A, B, C>> computation;
+
+    private OptionalPathSteps3(Kind<OptionalKind.Witness, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public OptionalPathSteps3<A, B, C> when(Predicate<Tuple3<A, B, C>> predicate) {
+      Kind<OptionalKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(abc -> predicate.test(abc) ? MONAD.of(abc) : MONAD.zero(), computation);
+      return new OptionalPathSteps3<>(newComp);
+    }
+
+    public <R> OptionalPath<R> yield(Function3<A, B, C, R> f) {
+      Kind<OptionalKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.optional(OptionalKindHelper.OPTIONAL.narrow(result));
+    }
+
+    public <R> OptionalPath<R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<OptionalKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.optional(OptionalKindHelper.OPTIONAL.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // EitherPath Steps (Non-Filterable)
+  // ========================================================================
+
+  /** First step in an EitherPath comprehension. */
+  public static final class EitherPathSteps1<E, A> {
+    private final Kind<EitherKind.Witness<E>, A> computation;
+
+    private static <E> EitherMonad<E> monad() {
+      return EitherMonad.instance();
+    }
+
+    private EitherPathSteps1(EitherPath<E, A> source) {
+      this.computation = EitherKindHelper.EITHER.widen(source.run());
+    }
+
+    public <B> EitherPathSteps2<E, A, B> from(Function<A, EitherPath<E, B>> next) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, Tuple2<A, B>> newComp =
+          m.flatMap(
+              a -> m.map(b -> Tuple.of(a, b), EitherKindHelper.EITHER.widen(next.apply(a).run())),
+              computation);
+      return new EitherPathSteps2<>(newComp);
+    }
+
+    public <B> EitherPathSteps2<E, A, B> let(Function<A, B> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, Tuple2<A, B>> newComp =
+          m.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new EitherPathSteps2<>(newComp);
+    }
+
+    public <B> EitherPathSteps2<E, A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, Tuple2<A, B>> newComp =
+          m.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new EitherPathSteps2<>(newComp);
+    }
+
+    public <R> EitherPath<E, R> yield(Function<A, R> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, R> result = m.map(f, computation);
+      return Path.either(EitherKindHelper.EITHER.narrow(result));
+    }
+  }
+
+  /** Second step in an EitherPath comprehension. */
+  public static final class EitherPathSteps2<E, A, B> {
+    private final Kind<EitherKind.Witness<E>, Tuple2<A, B>> computation;
+
+    private static <E> EitherMonad<E> monad() {
+      return EitherMonad.instance();
+    }
+
+    private EitherPathSteps2(Kind<EitherKind.Witness<E>, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> EitherPathSteps3<E, A, B, C> from(Function<Tuple2<A, B>, EitherPath<E, C>> next) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, Tuple3<A, B, C>> newComp =
+          m.flatMap(
+              ab ->
+                  m.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      EitherKindHelper.EITHER.widen(next.apply(ab).run())),
+              computation);
+      return new EitherPathSteps3<>(newComp);
+    }
+
+    public <C> EitherPathSteps3<E, A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, Tuple3<A, B, C>> newComp =
+          m.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new EitherPathSteps3<>(newComp);
+    }
+
+    public <R> EitherPath<E, R> yield(BiFunction<A, B, R> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, R> result =
+          m.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.either(EitherKindHelper.EITHER.narrow(result));
+    }
+
+    public <R> EitherPath<E, R> yield(Function<Tuple2<A, B>, R> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, R> result =
+          m.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.either(EitherKindHelper.EITHER.narrow(result));
+    }
+  }
+
+  /** Third step in an EitherPath comprehension. */
+  public static final class EitherPathSteps3<E, A, B, C> {
+    private final Kind<EitherKind.Witness<E>, Tuple3<A, B, C>> computation;
+
+    private static <E> EitherMonad<E> monad() {
+      return EitherMonad.instance();
+    }
+
+    private EitherPathSteps3(Kind<EitherKind.Witness<E>, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public <R> EitherPath<E, R> yield(Function3<A, B, C, R> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, R> result =
+          m.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.either(EitherKindHelper.EITHER.narrow(result));
+    }
+
+    public <R> EitherPath<E, R> yield(Function<Tuple3<A, B, C>, R> f) {
+      EitherMonad<E> m = monad();
+      Kind<EitherKind.Witness<E>, R> result =
+          m.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.either(EitherKindHelper.EITHER.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // TryPath Steps
+  // ========================================================================
+
+  /** First step in a TryPath comprehension. */
+  public static final class TryPathSteps1<A> {
+    private static final TryMonad MONAD = TryMonad.INSTANCE;
+    private final Kind<TryKind.Witness, A> computation;
+
+    private TryPathSteps1(TryPath<A> source) {
+      this.computation = TryKindHelper.TRY.widen(source.run());
+    }
+
+    public <B> TryPathSteps2<A, B> from(Function<A, TryPath<B>> next) {
+      Kind<TryKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a -> MONAD.map(b -> Tuple.of(a, b), TryKindHelper.TRY.widen(next.apply(a).run())),
+              computation);
+      return new TryPathSteps2<>(newComp);
+    }
+
+    public <B> TryPathSteps2<A, B> let(Function<A, B> f) {
+      Kind<TryKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new TryPathSteps2<>(newComp);
+    }
+
+    public <B> TryPathSteps2<A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      Kind<TryKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new TryPathSteps2<>(newComp);
+    }
+
+    public <R> TryPath<R> yield(Function<A, R> f) {
+      Kind<TryKind.Witness, R> result = MONAD.map(f, computation);
+      return Path.tryPath(TryKindHelper.TRY.narrow(result));
+    }
+  }
+
+  /** Second step in a TryPath comprehension. */
+  public static final class TryPathSteps2<A, B> {
+    private static final TryMonad MONAD = TryMonad.INSTANCE;
+    private final Kind<TryKind.Witness, Tuple2<A, B>> computation;
+
+    private TryPathSteps2(Kind<TryKind.Witness, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> TryPathSteps3<A, B, C> from(Function<Tuple2<A, B>, TryPath<C>> next) {
+      Kind<TryKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  MONAD.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      TryKindHelper.TRY.widen(next.apply(ab).run())),
+              computation);
+      return new TryPathSteps3<>(newComp);
+    }
+
+    public <C> TryPathSteps3<A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<TryKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new TryPathSteps3<>(newComp);
+    }
+
+    public <R> TryPath<R> yield(BiFunction<A, B, R> f) {
+      Kind<TryKind.Witness, R> result =
+          MONAD.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.tryPath(TryKindHelper.TRY.narrow(result));
+    }
+
+    public <R> TryPath<R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<TryKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.tryPath(TryKindHelper.TRY.narrow(result));
+    }
+  }
+
+  /** Third step in a TryPath comprehension. */
+  public static final class TryPathSteps3<A, B, C> {
+    private static final TryMonad MONAD = TryMonad.INSTANCE;
+    private final Kind<TryKind.Witness, Tuple3<A, B, C>> computation;
+
+    private TryPathSteps3(Kind<TryKind.Witness, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public <R> TryPath<R> yield(Function3<A, B, C, R> f) {
+      Kind<TryKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.tryPath(TryKindHelper.TRY.narrow(result));
+    }
+
+    public <R> TryPath<R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<TryKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.tryPath(TryKindHelper.TRY.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // IOPath Steps
+  // ========================================================================
+
+  /** First step in an IOPath comprehension. */
+  public static final class IOPathSteps1<A> {
+    private static final IOMonad MONAD = IOMonad.INSTANCE;
+    private final Kind<IOKind.Witness, A> computation;
+
+    private IOPathSteps1(IOPath<A> source) {
+      this.computation = IOKindHelper.IO_OP.widen(source.run());
+    }
+
+    public <B> IOPathSteps2<A, B> from(Function<A, IOPath<B>> next) {
+      Kind<IOKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a -> MONAD.map(b -> Tuple.of(a, b), IOKindHelper.IO_OP.widen(next.apply(a).run())),
+              computation);
+      return new IOPathSteps2<>(newComp);
+    }
+
+    public <B> IOPathSteps2<A, B> let(Function<A, B> f) {
+      Kind<IOKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new IOPathSteps2<>(newComp);
+    }
+
+    public <B> IOPathSteps2<A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      Kind<IOKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new IOPathSteps2<>(newComp);
+    }
+
+    public <R> IOPath<R> yield(Function<A, R> f) {
+      Kind<IOKind.Witness, R> result = MONAD.map(f, computation);
+      return Path.ioPath(IOKindHelper.IO_OP.narrow(result));
+    }
+  }
+
+  /** Second step in an IOPath comprehension. */
+  public static final class IOPathSteps2<A, B> {
+    private static final IOMonad MONAD = IOMonad.INSTANCE;
+    private final Kind<IOKind.Witness, Tuple2<A, B>> computation;
+
+    private IOPathSteps2(Kind<IOKind.Witness, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> IOPathSteps3<A, B, C> from(Function<Tuple2<A, B>, IOPath<C>> next) {
+      Kind<IOKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  MONAD.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      IOKindHelper.IO_OP.widen(next.apply(ab).run())),
+              computation);
+      return new IOPathSteps3<>(newComp);
+    }
+
+    public <C> IOPathSteps3<A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<IOKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new IOPathSteps3<>(newComp);
+    }
+
+    public <R> IOPath<R> yield(BiFunction<A, B, R> f) {
+      Kind<IOKind.Witness, R> result =
+          MONAD.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.ioPath(IOKindHelper.IO_OP.narrow(result));
+    }
+
+    public <R> IOPath<R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<IOKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.ioPath(IOKindHelper.IO_OP.narrow(result));
+    }
+  }
+
+  /** Third step in an IOPath comprehension. */
+  public static final class IOPathSteps3<A, B, C> {
+    private static final IOMonad MONAD = IOMonad.INSTANCE;
+    private final Kind<IOKind.Witness, Tuple3<A, B, C>> computation;
+
+    private IOPathSteps3(Kind<IOKind.Witness, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public <R> IOPath<R> yield(Function3<A, B, C, R> f) {
+      Kind<IOKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.ioPath(IOKindHelper.IO_OP.narrow(result));
+    }
+
+    public <R> IOPath<R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<IOKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.ioPath(IOKindHelper.IO_OP.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // IdPath Steps
+  // ========================================================================
+
+  /** First step in an IdPath comprehension. */
+  public static final class IdPathSteps1<A> {
+    private static final IdMonad MONAD = IdMonad.instance();
+    private final Kind<IdKind.Witness, A> computation;
+
+    private IdPathSteps1(IdPath<A> source) {
+      this.computation = IdKindHelper.ID.widen(source.run());
+    }
+
+    public <B> IdPathSteps2<A, B> from(Function<A, IdPath<B>> next) {
+      Kind<IdKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a -> MONAD.map(b -> Tuple.of(a, b), IdKindHelper.ID.widen(next.apply(a).run())),
+              computation);
+      return new IdPathSteps2<>(newComp);
+    }
+
+    public <B> IdPathSteps2<A, B> let(Function<A, B> f) {
+      Kind<IdKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new IdPathSteps2<>(newComp);
+    }
+
+    public <B> IdPathSteps2<A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      Kind<IdKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new IdPathSteps2<>(newComp);
+    }
+
+    public <R> IdPath<R> yield(Function<A, R> f) {
+      Kind<IdKind.Witness, R> result = MONAD.map(f, computation);
+      return Path.idPath(IdKindHelper.ID.narrow(result));
+    }
+  }
+
+  /** Second step in an IdPath comprehension. */
+  public static final class IdPathSteps2<A, B> {
+    private static final IdMonad MONAD = IdMonad.instance();
+    private final Kind<IdKind.Witness, Tuple2<A, B>> computation;
+
+    private IdPathSteps2(Kind<IdKind.Witness, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> IdPathSteps3<A, B, C> from(Function<Tuple2<A, B>, IdPath<C>> next) {
+      Kind<IdKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  MONAD.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      IdKindHelper.ID.widen(next.apply(ab).run())),
+              computation);
+      return new IdPathSteps3<>(newComp);
+    }
+
+    public <C> IdPathSteps3<A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<IdKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new IdPathSteps3<>(newComp);
+    }
+
+    public <R> IdPath<R> yield(BiFunction<A, B, R> f) {
+      Kind<IdKind.Witness, R> result =
+          MONAD.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.idPath(IdKindHelper.ID.narrow(result));
+    }
+
+    public <R> IdPath<R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<IdKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.idPath(IdKindHelper.ID.narrow(result));
+    }
+  }
+
+  /** Third step in an IdPath comprehension. */
+  public static final class IdPathSteps3<A, B, C> {
+    private static final IdMonad MONAD = IdMonad.instance();
+    private final Kind<IdKind.Witness, Tuple3<A, B, C>> computation;
+
+    private IdPathSteps3(Kind<IdKind.Witness, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public <R> IdPath<R> yield(Function3<A, B, C, R> f) {
+      Kind<IdKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return Path.idPath(IdKindHelper.ID.narrow(result));
+    }
+
+    public <R> IdPath<R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<IdKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return Path.idPath(IdKindHelper.ID.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // NonDetPath Steps (Filterable, uses Cartesian product semantics)
+  // ========================================================================
+
+  /** First step in a NonDetPath comprehension. */
+  public static final class NonDetPathSteps1<A> {
+    private static final ListMonad MONAD = ListMonad.INSTANCE;
+    private final Kind<ListKind.Witness, A> computation;
+
+    private NonDetPathSteps1(NonDetPath<A> source) {
+      this.computation = ListKindHelper.LIST.widen(source.run());
+    }
+
+    private NonDetPathSteps1(Kind<ListKind.Witness, A> computation) {
+      this.computation = computation;
+    }
+
+    public <B> NonDetPathSteps2<A, B> from(Function<A, NonDetPath<B>> next) {
+      Kind<ListKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(
+              a -> MONAD.map(b -> Tuple.of(a, b), ListKindHelper.LIST.widen(next.apply(a).run())),
+              computation);
+      return new NonDetPathSteps2<>(newComp);
+    }
+
+    public <B> NonDetPathSteps2<A, B> let(Function<A, B> f) {
+      Kind<ListKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new NonDetPathSteps2<>(newComp);
+    }
+
+    public NonDetPathSteps1<A> when(Predicate<A> predicate) {
+      Kind<ListKind.Witness, A> newComp =
+          MONAD.flatMap(a -> predicate.test(a) ? MONAD.of(a) : MONAD.zero(), computation);
+      return new NonDetPathSteps1<>(newComp);
+    }
+
+    public <R> NonDetPath<R> yield(Function<A, R> f) {
+      Kind<ListKind.Witness, R> result = MONAD.map(f, computation);
+      return NonDetPath.of(ListKindHelper.LIST.narrow(result));
+    }
+  }
+
+  /** Second step in a NonDetPath comprehension. */
+  public static final class NonDetPathSteps2<A, B> {
+    private static final ListMonad MONAD = ListMonad.INSTANCE;
+    private final Kind<ListKind.Witness, Tuple2<A, B>> computation;
+
+    private NonDetPathSteps2(Kind<ListKind.Witness, Tuple2<A, B>> computation) {
+      this.computation = computation;
+    }
+
+    public <C> NonDetPathSteps3<A, B, C> from(Function<Tuple2<A, B>, NonDetPath<C>> next) {
+      Kind<ListKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(
+              ab ->
+                  MONAD.map(
+                      c -> Tuple.of(ab._1(), ab._2(), c),
+                      ListKindHelper.LIST.widen(next.apply(ab).run())),
+              computation);
+      return new NonDetPathSteps3<>(newComp);
+    }
+
+    public <C> NonDetPathSteps3<A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<ListKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new NonDetPathSteps3<>(newComp);
+    }
+
+    public NonDetPathSteps2<A, B> when(Predicate<Tuple2<A, B>> predicate) {
+      Kind<ListKind.Witness, Tuple2<A, B>> newComp =
+          MONAD.flatMap(ab -> predicate.test(ab) ? MONAD.of(ab) : MONAD.zero(), computation);
+      return new NonDetPathSteps2<>(newComp);
+    }
+
+    public <R> NonDetPath<R> yield(BiFunction<A, B, R> f) {
+      Kind<ListKind.Witness, R> result =
+          MONAD.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return NonDetPath.of(ListKindHelper.LIST.narrow(result));
+    }
+
+    public <R> NonDetPath<R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<ListKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return NonDetPath.of(ListKindHelper.LIST.narrow(result));
+    }
+  }
+
+  /** Third step in a NonDetPath comprehension. */
+  public static final class NonDetPathSteps3<A, B, C> {
+    private static final ListMonad MONAD = ListMonad.INSTANCE;
+    private final Kind<ListKind.Witness, Tuple3<A, B, C>> computation;
+
+    private NonDetPathSteps3(Kind<ListKind.Witness, Tuple3<A, B, C>> computation) {
+      this.computation = computation;
+    }
+
+    public NonDetPathSteps3<A, B, C> when(Predicate<Tuple3<A, B, C>> predicate) {
+      Kind<ListKind.Witness, Tuple3<A, B, C>> newComp =
+          MONAD.flatMap(abc -> predicate.test(abc) ? MONAD.of(abc) : MONAD.zero(), computation);
+      return new NonDetPathSteps3<>(newComp);
+    }
+
+    public <R> NonDetPath<R> yield(Function3<A, B, C, R> f) {
+      Kind<ListKind.Witness, R> result =
+          MONAD.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return NonDetPath.of(ListKindHelper.LIST.narrow(result));
+    }
+
+    public <R> NonDetPath<R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<ListKind.Witness, R> result =
+          MONAD.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return NonDetPath.of(ListKindHelper.LIST.narrow(result));
+    }
+  }
+
+  // ========================================================================
+  // GenericPath Steps (Escape Hatch)
+  // ========================================================================
+
+  /** First step in a GenericPath comprehension. */
+  public static final class GenericPathSteps1<F, A> {
+    private final Monad<F> monad;
+    private final Kind<F, A> computation;
+
+    private GenericPathSteps1(GenericPath<F, A> source) {
+      this.monad = source.monad();
+      this.computation = source.runKind();
+    }
+
+    public <B> GenericPathSteps2<F, A, B> from(Function<A, GenericPath<F, B>> next) {
+      Kind<F, Tuple2<A, B>> newComp =
+          monad.flatMap(a -> monad.map(b -> Tuple.of(a, b), next.apply(a).runKind()), computation);
+      return new GenericPathSteps2<>(monad, newComp);
+    }
+
+    public <B> GenericPathSteps2<F, A, B> let(Function<A, B> f) {
+      Kind<F, Tuple2<A, B>> newComp = monad.map(a -> Tuple.of(a, f.apply(a)), computation);
+      return new GenericPathSteps2<>(monad, newComp);
+    }
+
+    public <B> GenericPathSteps2<F, A, B> focus(FocusPath<A, B> focusPath) {
+      Objects.requireNonNull(focusPath, "focusPath must not be null");
+      Kind<F, Tuple2<A, B>> newComp = monad.map(a -> Tuple.of(a, focusPath.get(a)), computation);
+      return new GenericPathSteps2<>(monad, newComp);
+    }
+
+    public <R> GenericPath<F, R> yield(Function<A, R> f) {
+      Kind<F, R> result = monad.map(f, computation);
+      return GenericPath.of(result, monad);
+    }
+  }
+
+  /** Second step in a GenericPath comprehension. */
+  public static final class GenericPathSteps2<F, A, B> {
+    private final Monad<F> monad;
+    private final Kind<F, Tuple2<A, B>> computation;
+
+    private GenericPathSteps2(Monad<F> monad, Kind<F, Tuple2<A, B>> computation) {
+      this.monad = monad;
+      this.computation = computation;
+    }
+
+    public <C> GenericPathSteps3<F, A, B, C> from(Function<Tuple2<A, B>, GenericPath<F, C>> next) {
+      Kind<F, Tuple3<A, B, C>> newComp =
+          monad.flatMap(
+              ab -> monad.map(c -> Tuple.of(ab._1(), ab._2(), c), next.apply(ab).runKind()),
+              computation);
+      return new GenericPathSteps3<>(monad, newComp);
+    }
+
+    public <C> GenericPathSteps3<F, A, B, C> let(Function<Tuple2<A, B>, C> f) {
+      Kind<F, Tuple3<A, B, C>> newComp =
+          monad.map(ab -> Tuple.of(ab._1(), ab._2(), f.apply(ab)), computation);
+      return new GenericPathSteps3<>(monad, newComp);
+    }
+
+    public <R> GenericPath<F, R> yield(BiFunction<A, B, R> f) {
+      Kind<F, R> result =
+          monad.map(
+              t -> Objects.requireNonNull(f.apply(t._1(), t._2()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return GenericPath.of(result, monad);
+    }
+
+    public <R> GenericPath<F, R> yield(Function<Tuple2<A, B>, R> f) {
+      Kind<F, R> result =
+          monad.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return GenericPath.of(result, monad);
+    }
+  }
+
+  /** Third step in a GenericPath comprehension. */
+  public static final class GenericPathSteps3<F, A, B, C> {
+    private final Monad<F> monad;
+    private final Kind<F, Tuple3<A, B, C>> computation;
+
+    private GenericPathSteps3(Monad<F> monad, Kind<F, Tuple3<A, B, C>> computation) {
+      this.monad = monad;
+      this.computation = computation;
+    }
+
+    public <R> GenericPath<F, R> yield(Function3<A, B, C, R> f) {
+      Kind<F, R> result =
+          monad.map(
+              t ->
+                  Objects.requireNonNull(f.apply(t._1(), t._2(), t._3()), YIELD_CANNOT_RETURN_NULL),
+              computation);
+      return GenericPath.of(result, monad);
+    }
+
+    public <R> GenericPath<F, R> yield(Function<Tuple3<A, B, C>, R> f) {
+      Kind<F, R> result =
+          monad.map(t -> Objects.requireNonNull(f.apply(t), YIELD_CANNOT_RETURN_NULL), computation);
+      return GenericPath.of(result, monad);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/expression/ForPathTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/expression/ForPathTest.java
@@ -1,0 +1,1498 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.expression;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.GenericPath;
+import org.higherkindedj.hkt.effect.IOPath;
+import org.higherkindedj.hkt.effect.IdPath;
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.NonDetPath;
+import org.higherkindedj.hkt.effect.OptionalPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.TryPath;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeKindHelper;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Comprehensive tests for {@link ForPath} - the Path-native for-comprehension builder.
+ *
+ * <p>These tests verify that ForPath correctly bridges the For comprehension system with Effect
+ * Path types, allowing fluent composition while returning Path types directly.
+ */
+class ForPathTest {
+
+  // Test data classes
+  record User(String name, Address address, String email) {
+    User(String name, Address address) {
+      this(name, address, null);
+    }
+  }
+
+  record Address(String city, String country) {}
+
+  // Lenses for testing focus()
+  static final Lens<User, Address> addressLens =
+      Lens.of(User::address, (u, a) -> new User(u.name(), a, u.email()));
+
+  static final Lens<Address, String> cityLens =
+      Lens.of(Address::city, (a, c) -> new Address(c, a.country()));
+
+  // FocusPath for testing
+  static final FocusPath<User, Address> addressFocus = FocusPath.of(addressLens);
+
+  static final FocusPath<Address, String> cityFocus = FocusPath.of(cityLens);
+
+  // AffinePath for testing match()
+  static final AffinePath<User, String> emailAffine =
+      AffinePath.of(
+          Affine.of(
+              u -> Optional.ofNullable(u.email()), (u, e) -> new User(u.name(), u.address(), e)));
+
+  @Nested
+  @DisplayName("MaybePath Comprehension")
+  class MaybePathTests {
+
+    @Test
+    @DisplayName("should chain generators with from()")
+    void chainsGenerators() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(5)).from(a -> Path.just(a * 2)).yield((a, b) -> a + b);
+
+      assertEquals(Maybe.just(15), result.run()); // 5 + 10
+    }
+
+    @Test
+    @DisplayName("should short-circuit on Nothing")
+    void shortCircuitsOnNothing() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(5)).<Integer>from(a -> Path.nothing()).yield((a, b) -> a + b);
+
+      assertTrue(result.run().isNothing());
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      MaybePath<String> result =
+          ForPath.from(Path.just(10)).let(a -> a * 2).yield((a, b) -> "a=" + a + ", b=" + b);
+
+      assertEquals(Maybe.just("a=10, b=20"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() for filtering")
+    void supportsWhen() {
+      MaybePath<Integer> result = ForPath.from(Path.just(5)).when(a -> a > 10).yield(a -> a);
+
+      assertTrue(result.run().isNothing());
+
+      MaybePath<Integer> result2 = ForPath.from(Path.just(15)).when(a -> a > 10).yield(a -> a);
+
+      assertEquals(Maybe.just(15), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      MaybePath<String> result =
+          ForPath.from(Path.just(user)).focus(addressFocus).yield((u, addr) -> addr.city());
+
+      assertEquals(Maybe.just("NYC"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support match() with AffinePath")
+    void supportsMatch() {
+      User userWithEmail = new User("Alice", new Address("NYC", "USA"), "alice@example.com");
+      User userWithoutEmail = new User("Bob", new Address("LA", "USA"));
+
+      MaybePath<String> result1 =
+          ForPath.from(Path.just(userWithEmail)).match(emailAffine).yield((user, email) -> email);
+
+      assertEquals(Maybe.just("alice@example.com"), result1.run());
+
+      MaybePath<String> result2 =
+          ForPath.from(Path.just(userWithoutEmail))
+              .match(emailAffine)
+              .yield((user, email) -> email);
+
+      assertTrue(result2.run().isNothing());
+    }
+
+    @Test
+    @DisplayName("should support three generators")
+    void supportsThreeGenerators() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(a + 1))
+              .from(t -> Path.just(t._2() + 1))
+              .yield((a, b, c) -> a + b + c);
+
+      assertEquals(Maybe.just(6), result.run()); // 1 + 2 + 3
+    }
+
+    @Test
+    @DisplayName("should support four generators")
+    void supportsFourGenerators() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .yield((a, b, c, d) -> a + b + c + d);
+
+      assertEquals(Maybe.just(10), result.run());
+    }
+
+    @Test
+    @DisplayName("should support five generators")
+    void supportsFiveGenerators() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .from(t -> Path.just(5))
+              .yield((a, b, c, d, e) -> a + b + c + d + e);
+
+      assertEquals(Maybe.just(15), result.run());
+    }
+  }
+
+  @Nested
+  @DisplayName("OptionalPath Comprehension")
+  class OptionalPathTests {
+
+    @Test
+    @DisplayName("should chain generators")
+    void chainsGenerators() {
+      OptionalPath<Integer> result =
+          ForPath.from(Path.present(5)).from(a -> Path.present(a * 2)).yield((a, b) -> a + b);
+
+      assertEquals(Optional.of(15), result.run());
+    }
+
+    @Test
+    @DisplayName("should short-circuit on empty")
+    void shortCircuitsOnEmpty() {
+      OptionalPath<Integer> result =
+          ForPath.from(Path.present(5)).<Integer>from(a -> Path.absent()).yield((a, b) -> a + b);
+
+      assertTrue(result.run().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should support when() for filtering")
+    void supportsWhen() {
+      OptionalPath<Integer> result = ForPath.from(Path.present(5)).when(a -> a > 10).yield(a -> a);
+
+      assertTrue(result.run().isEmpty());
+
+      // Test success case where predicate passes
+      OptionalPath<Integer> result2 =
+          ForPath.from(Path.present(15)).when(a -> a > 10).yield(a -> a);
+
+      assertEquals(Optional.of(15), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      OptionalPath<String> result =
+          ForPath.from(Path.present(user)).focus(addressFocus).yield((u, addr) -> addr.city());
+
+      assertEquals(Optional.of("NYC"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support match() with AffinePath")
+    void supportsMatch() {
+      User userWithEmail = new User("Alice", new Address("NYC", "USA"), "alice@example.com");
+
+      OptionalPath<String> result =
+          ForPath.from(Path.present(userWithEmail))
+              .match(emailAffine)
+              .yield((user, email) -> email);
+
+      assertEquals(Optional.of("alice@example.com"), result.run());
+    }
+  }
+
+  @Nested
+  @DisplayName("EitherPath Comprehension")
+  class EitherPathTests {
+
+    @Test
+    @DisplayName("should chain generators on Right")
+    void chainsGeneratorsOnRight() {
+      EitherPath<String, Integer> result =
+          ForPath.from(Path.<String, Integer>right(5))
+              .from(a -> Path.<String, Integer>right(a * 2))
+              .yield((a, b) -> a + b);
+
+      assertTrue(result.run().isRight());
+      assertEquals(15, result.run().getRight());
+    }
+
+    @Test
+    @DisplayName("should short-circuit on Left")
+    void shortCircuitsOnLeft() {
+      EitherPath<String, Integer> result =
+          ForPath.from(Path.<String, Integer>right(5))
+              .from(a -> Path.<String, Integer>left("Error!"))
+              .yield((a, b) -> a + b);
+
+      assertTrue(result.run().isLeft());
+      assertEquals("Error!", result.run().getLeft());
+    }
+
+    @Test
+    @DisplayName("should propagate first Left")
+    void propagatesFirstLeft() {
+      EitherPath<String, Integer> result =
+          ForPath.from(Path.<String, Integer>left("First error"))
+              .from(a -> Path.<String, Integer>right(10))
+              .yield((a, b) -> a + b);
+
+      assertTrue(result.run().isLeft());
+      assertEquals("First error", result.run().getLeft());
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      EitherPath<String, String> result =
+          ForPath.from(Path.<String, Integer>right(10))
+              .let(a -> a * 2)
+              .yield((a, b) -> "a=" + a + ", b=" + b);
+
+      assertTrue(result.run().isRight());
+      assertEquals("a=10, b=20", result.run().getRight());
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      EitherPath<String, String> result =
+          ForPath.from(Path.<String, User>right(user))
+              .focus(addressFocus)
+              .yield((u, addr) -> addr.city());
+
+      assertTrue(result.run().isRight());
+      assertEquals("NYC", result.run().getRight());
+    }
+
+    @Test
+    @DisplayName("should support three generators")
+    void supportsThreeGenerators() {
+      EitherPath<String, Integer> result =
+          ForPath.from(Path.<String, Integer>right(1))
+              .from(a -> Path.<String, Integer>right(2))
+              .from(t -> Path.<String, Integer>right(3))
+              .yield((a, b, c) -> a + b + c);
+
+      assertTrue(result.run().isRight());
+      assertEquals(6, result.run().getRight());
+    }
+  }
+
+  @Nested
+  @DisplayName("TryPath Comprehension")
+  class TryPathTests {
+
+    @Test
+    @DisplayName("should chain generators on Success")
+    void chainsGeneratorsOnSuccess() {
+      TryPath<Integer> result =
+          ForPath.from(Path.success(5)).from(a -> Path.success(a * 2)).yield((a, b) -> a + b);
+
+      assertTrue(result.run().isSuccess());
+      assertEquals(15, result.run().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should short-circuit on Failure")
+    void shortCircuitsOnFailure() {
+      RuntimeException error = new RuntimeException("Test error");
+
+      TryPath<Integer> result =
+          ForPath.from(Path.success(5))
+              .from(a -> Path.<Integer>failure(error))
+              .yield((a, b) -> a + b);
+
+      assertTrue(result.run().isFailure());
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      TryPath<String> result =
+          ForPath.from(Path.success(10)).let(a -> a * 2).yield((a, b) -> "a=" + a + ", b=" + b);
+
+      assertTrue(result.run().isSuccess());
+      assertEquals("a=10, b=20", result.run().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      TryPath<String> result =
+          ForPath.from(Path.success(user)).focus(addressFocus).yield((u, addr) -> addr.city());
+
+      assertTrue(result.run().isSuccess());
+      assertEquals("NYC", result.run().orElse(null));
+    }
+  }
+
+  @Nested
+  @DisplayName("IOPath Comprehension")
+  class IOPathTests {
+
+    @Test
+    @DisplayName("should chain generators")
+    void chainsGenerators() {
+      IOPath<Integer> result =
+          ForPath.from(Path.ioPure(5)).from(a -> Path.ioPure(a * 2)).yield((a, b) -> a + b);
+
+      assertEquals(15, result.unsafeRun());
+    }
+
+    @Test
+    @DisplayName("should defer computations")
+    void defersComputations() {
+      int[] counter = {0};
+
+      IOPath<Integer> result =
+          ForPath.from(
+                  Path.io(
+                      () -> {
+                        counter[0]++;
+                        return 5;
+                      }))
+              .from(
+                  a ->
+                      Path.io(
+                          () -> {
+                            counter[0]++;
+                            return a * 2;
+                          }))
+              .yield((a, b) -> a + b);
+
+      // Nothing executed yet
+      assertEquals(0, counter[0]);
+
+      // Execute
+      assertEquals(15, result.unsafeRun());
+      assertEquals(2, counter[0]);
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      IOPath<String> result =
+          ForPath.from(Path.ioPure(10)).let(a -> a * 2).yield((a, b) -> "a=" + a + ", b=" + b);
+
+      assertEquals("a=10, b=20", result.unsafeRun());
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      IOPath<String> result =
+          ForPath.from(Path.ioPure(user)).focus(addressFocus).yield((u, addr) -> addr.city());
+
+      assertEquals("NYC", result.unsafeRun());
+    }
+
+    @Test
+    @DisplayName("should support three generators")
+    void supportsThreeGenerators() {
+      IOPath<Integer> result =
+          ForPath.from(Path.ioPure(1))
+              .from(a -> Path.ioPure(2))
+              .from(t -> Path.ioPure(3))
+              .yield((a, b, c) -> a + b + c);
+
+      assertEquals(6, result.unsafeRun());
+    }
+  }
+
+  @Nested
+  @DisplayName("IdPath Comprehension")
+  class IdPathTests {
+
+    @Test
+    @DisplayName("should chain generators")
+    void chainsGenerators() {
+      IdPath<Integer> result =
+          ForPath.from(Path.id(5)).from(a -> Path.id(a * 2)).yield((a, b) -> a + b);
+
+      assertEquals(15, result.run().value());
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      IdPath<String> result =
+          ForPath.from(Path.id(10)).let(a -> a * 2).yield((a, b) -> "a=" + a + ", b=" + b);
+
+      assertEquals("a=10, b=20", result.run().value());
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      IdPath<String> result =
+          ForPath.from(Path.id(user)).focus(addressFocus).yield((u, addr) -> addr.city());
+
+      assertEquals("NYC", result.run().value());
+    }
+  }
+
+  @Nested
+  @DisplayName("NonDetPath Comprehension (Cartesian Product)")
+  class NonDetPathTests {
+
+    @Test
+    @DisplayName("should produce Cartesian product")
+    void producesCartesianProduct() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2))
+              .from(a -> Path.list("a", "b"))
+              .yield((num, letter) -> num + letter);
+
+      assertEquals(List.of("1a", "1b", "2a", "2b"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() for filtering")
+    void supportsWhen() {
+      NonDetPath<Integer> result =
+          ForPath.from(Path.list(1, 2, 3, 4, 5)).when(a -> a % 2 == 0).yield(a -> a);
+
+      assertEquals(List.of(2, 4), result.run());
+    }
+
+    @Test
+    @DisplayName("should support filtering in multi-generator comprehensions")
+    void supportsFilteringMultiGenerator() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2, 3))
+              .from(a -> Path.list(10, 20, 30))
+              .when(t -> (t._1() + t._2()) > 20)
+              .yield((a, b) -> a + "+" + b);
+
+      assertEquals(List.of("1+20", "1+30", "2+20", "2+30", "3+20", "3+30"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2, 3)).let(a -> a * 10).yield((a, b) -> a + "->" + b);
+
+      assertEquals(List.of("1->10", "2->20", "3->30"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support three generators")
+    void supportsThreeGenerators() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2))
+              .from(a -> Path.list("a", "b"))
+              .from(t -> Path.list(true, false))
+              .yield((num, letter, bool) -> num + letter + (bool ? "!" : "?"));
+
+      assertEquals(List.of("1a!", "1a?", "1b!", "1b?", "2a!", "2a?", "2b!", "2b?"), result.run());
+    }
+  }
+
+  @Nested
+  @DisplayName("Complex Scenarios")
+  class ComplexScenarios {
+
+    @Test
+    @DisplayName("should handle nested path operations")
+    void handlesNestedOperations() {
+      // Simulate a multi-step validation flow
+      MaybePath<String> result =
+          ForPath.from(Path.just("alice"))
+              .from(
+                  name ->
+                      name.length() > 3 ? Path.just(name.toUpperCase()) : Path.<String>nothing())
+              .let(t -> t._2().length())
+              .when(t -> t._3() < 10)
+              .yield((name, upper, len) -> upper + " (" + len + " chars)");
+
+      assertEquals(Maybe.just("ALICE (5 chars)"), result.run());
+    }
+
+    @Test
+    @DisplayName("should compose focus paths")
+    void composesFocusPaths() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      // Compose two focus paths
+      FocusPath<User, String> userCityFocus = addressFocus.via(cityFocus);
+
+      MaybePath<String> result =
+          ForPath.from(Path.just(user)).focus(userCityFocus).yield((u, city) -> city);
+
+      assertEquals(Maybe.just("NYC"), result.run());
+    }
+
+    @Test
+    @DisplayName("should work with real-world validation scenario")
+    void worksWithValidationScenario() {
+      // Simulating: validate user -> get address -> validate address -> format result
+
+      Function<User, MaybePath<String>> formatUser =
+          user ->
+              ForPath.from(Path.just(user))
+                  .when(u -> u.name() != null && !u.name().isEmpty())
+                  .focus(addressFocus)
+                  .when(t -> t._2().city() != null)
+                  .yield((u, addr) -> u.name() + " from " + addr.city());
+
+      User validUser = new User("Alice", new Address("NYC", "USA"));
+      User invalidUser = new User("", new Address("NYC", "USA"));
+      User noCity = new User("Bob", new Address(null, "USA"));
+
+      assertEquals(Maybe.just("Alice from NYC"), formatUser.apply(validUser).run());
+      assertTrue(formatUser.apply(invalidUser).run().isNothing());
+      assertTrue(formatUser.apply(noCity).run().isNothing());
+    }
+  }
+
+  @Nested
+  @DisplayName("Error Handling")
+  class ErrorHandling {
+
+    @Test
+    @DisplayName("should throw on null MaybePath source")
+    void throwsOnNullMaybePathSource() {
+      assertThrows(NullPointerException.class, () -> ForPath.from((MaybePath<Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null OptionalPath source")
+    void throwsOnNullOptionalPathSource() {
+      assertThrows(NullPointerException.class, () -> ForPath.from((OptionalPath<Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null EitherPath source")
+    void throwsOnNullEitherPathSource() {
+      assertThrows(
+          NullPointerException.class, () -> ForPath.from((EitherPath<Object, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null TryPath source")
+    void throwsOnNullTryPathSource() {
+      assertThrows(NullPointerException.class, () -> ForPath.from((TryPath<Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null IOPath source")
+    void throwsOnNullIOPathSource() {
+      assertThrows(NullPointerException.class, () -> ForPath.from((IOPath<Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null IdPath source")
+    void throwsOnNullIdPathSource() {
+      assertThrows(NullPointerException.class, () -> ForPath.from((IdPath<Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null NonDetPath source")
+    void throwsOnNullNonDetPathSource() {
+      assertThrows(NullPointerException.class, () -> ForPath.from((NonDetPath<Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null GenericPath source")
+    void throwsOnNullGenericPathSource() {
+      assertThrows(
+          NullPointerException.class, () -> ForPath.from((GenericPath<Object, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in MaybePath")
+    void throwsOnNullFocusPath() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.just(1)).focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in OptionalPath")
+    void throwsOnNullFocusPathOptional() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.present(1)).focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in EitherPath")
+    void throwsOnNullFocusPathEither() {
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              ForPath.from(Path.<String, Integer>right(1))
+                  .focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in TryPath")
+    void throwsOnNullFocusPathTry() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.success(1)).focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in IOPath")
+    void throwsOnNullFocusPathIO() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.ioPure(1)).focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in IdPath")
+    void throwsOnNullFocusPathId() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.id(1)).focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null focusPath in GenericPath")
+    void throwsOnNullFocusPathGeneric() {
+      GenericPath<MaybeKind.Witness, Integer> genericPath =
+          GenericPath.of(MaybeKindHelper.MAYBE.just(1), MaybeMonad.INSTANCE);
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(genericPath).focus((FocusPath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null affinePath in MaybePath match")
+    void throwsOnNullAffinePath() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.just(1)).match((AffinePath<Integer, Object>) null));
+    }
+
+    @Test
+    @DisplayName("should throw on null affinePath in OptionalPath match")
+    void throwsOnNullAffinePathOptional() {
+      assertThrows(
+          NullPointerException.class,
+          () -> ForPath.from(Path.present(1)).match((AffinePath<Integer, Object>) null));
+    }
+  }
+
+  // ========================================================================
+  // Additional MaybePath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("MaybePath Steps2 Additional Tests")
+  class MaybePathSteps2Tests {
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(5))
+              .from(a -> Path.just(a * 2))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, c) -> c);
+
+      assertEquals(Maybe.just(15), result.run());
+    }
+
+    @Test
+    @DisplayName("should support focus() in Steps2 with extractor function")
+    void supportsFocusInSteps2() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      MaybePath<String> result =
+          ForPath.from(Path.just(user))
+              .let(u -> u.address())
+              .focus(t -> t._2().city())
+              .yield((u, addr, city) -> city);
+
+      assertEquals(Maybe.just("NYC"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support match() in Steps2 with Optional extractor")
+    void supportsMatchInSteps2() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(10))
+              .let(a -> a * 2)
+              .match(t -> t._1() > 5 ? Optional.of(t._2() * 2) : Optional.empty())
+              .yield((a, b, c) -> c);
+
+      assertEquals(Maybe.just(40), result.run());
+
+      // Test short-circuit case
+      MaybePath<Integer> result2 =
+          ForPath.from(Path.just(3))
+              .let(a -> a * 2)
+              .match(t -> t._1() > 5 ? Optional.of(t._2() * 2) : Optional.empty())
+              .yield((a, b, c) -> c);
+
+      assertTrue(result2.run().isNothing());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function")
+    void supportsYieldWithTupleFunction() {
+      MaybePath<String> result =
+          ForPath.from(Path.just(5))
+              .from(a -> Path.just(a * 2))
+              .yield(t -> "sum=" + (t._1() + t._2()));
+
+      assertEquals(Maybe.just("sum=15"), result.run());
+    }
+  }
+
+  @Nested
+  @DisplayName("MaybePath Steps3 Additional Tests")
+  class MaybePathSteps3Tests {
+
+    @Test
+    @DisplayName("should support let() in Steps3")
+    void supportsLetInSteps3() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .let(t -> t._1() + t._2() + t._3())
+              .yield((a, b, c, sum) -> sum);
+
+      assertEquals(Maybe.just(6), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() in Steps3")
+    void supportsWhenInSteps3() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .when(t -> t._1() + t._2() + t._3() > 10)
+              .yield((a, b, c) -> a + b + c);
+
+      assertTrue(result.run().isNothing());
+
+      MaybePath<Integer> result2 =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .when(t -> t._1() + t._2() + t._3() > 0)
+              .yield((a, b, c) -> a + b + c);
+
+      assertEquals(Maybe.just(6), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function")
+    void supportsYieldWithTupleFunction() {
+      MaybePath<String> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      assertEquals(Maybe.just("sum=6"), result.run());
+    }
+  }
+
+  @Nested
+  @DisplayName("MaybePath Steps4 Additional Tests")
+  class MaybePathSteps4Tests {
+
+    @Test
+    @DisplayName("should support let() in Steps4")
+    void supportsLetInSteps4() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .let(t -> t._1() + t._2() + t._3() + t._4())
+              .yield((a, b, c, d, sum) -> sum);
+
+      assertEquals(Maybe.just(10), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() in Steps4")
+    void supportsWhenInSteps4() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .when(t -> t._4() > 10)
+              .yield((a, b, c, d) -> a + b + c + d);
+
+      assertTrue(result.run().isNothing());
+
+      MaybePath<Integer> result2 =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .when(t -> t._4() < 10)
+              .yield((a, b, c, d) -> a + b + c + d);
+
+      assertEquals(Maybe.just(10), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function")
+    void supportsYieldWithTupleFunction() {
+      MaybePath<String> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3() + t._4()));
+
+      assertEquals(Maybe.just("sum=10"), result.run());
+    }
+  }
+
+  @Nested
+  @DisplayName("MaybePath Steps5 Additional Tests")
+  class MaybePathSteps5Tests {
+
+    @Test
+    @DisplayName("should support when() in Steps5")
+    void supportsWhenInSteps5() {
+      MaybePath<Integer> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .from(t -> Path.just(5))
+              .when(t -> t._5() > 10)
+              .yield((a, b, c, d, e) -> a + b + c + d + e);
+
+      assertTrue(result.run().isNothing());
+
+      MaybePath<Integer> result2 =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .from(t -> Path.just(5))
+              .when(t -> t._5() < 10)
+              .yield((a, b, c, d, e) -> a + b + c + d + e);
+
+      assertEquals(Maybe.just(15), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function")
+    void supportsYieldWithTupleFunction() {
+      MaybePath<String> result =
+          ForPath.from(Path.just(1))
+              .from(a -> Path.just(2))
+              .from(t -> Path.just(3))
+              .from(t -> Path.just(4))
+              .from(t -> Path.just(5))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3() + t._4() + t._5()));
+
+      assertEquals(Maybe.just("sum=15"), result.run());
+    }
+  }
+
+  // ========================================================================
+  // Additional OptionalPath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("OptionalPath Steps Additional Tests")
+  class OptionalPathStepsTests {
+
+    @Test
+    @DisplayName("should support let() in Steps1")
+    void supportsLetInSteps1() {
+      OptionalPath<String> result =
+          ForPath.from(Path.present(10)).let(a -> a * 2).yield((a, b) -> "a=" + a + ", b=" + b);
+
+      assertEquals(Optional.of("a=10, b=20"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support from() in Steps2")
+    void supportsFromInSteps2() {
+      OptionalPath<Integer> result =
+          ForPath.from(Path.present(1))
+              .from(a -> Path.present(2))
+              .from(t -> Path.present(3))
+              .yield((a, b, c) -> a + b + c);
+
+      assertEquals(Optional.of(6), result.run());
+    }
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      OptionalPath<Integer> result =
+          ForPath.from(Path.present(5))
+              .from(a -> Path.present(10))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, sum) -> sum);
+
+      assertEquals(Optional.of(15), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() in Steps2")
+    void supportsWhenInSteps2() {
+      OptionalPath<Integer> result =
+          ForPath.from(Path.present(5))
+              .from(a -> Path.present(10))
+              .when(t -> t._1() + t._2() > 20)
+              .yield((a, b) -> a + b);
+
+      assertTrue(result.run().isEmpty());
+
+      OptionalPath<Integer> result2 =
+          ForPath.from(Path.present(5))
+              .from(a -> Path.present(10))
+              .when(t -> t._1() + t._2() > 10)
+              .yield((a, b) -> a + b);
+
+      assertEquals(Optional.of(15), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      OptionalPath<String> result =
+          ForPath.from(Path.present(5))
+              .from(a -> Path.present(10))
+              .yield(t -> "sum=" + (t._1() + t._2()));
+
+      assertEquals(Optional.of("sum=15"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() in Steps3")
+    void supportsWhenInSteps3() {
+      OptionalPath<Integer> result =
+          ForPath.from(Path.present(1))
+              .from(a -> Path.present(2))
+              .from(t -> Path.present(3))
+              .when(t -> t._1() + t._2() + t._3() > 10)
+              .yield((a, b, c) -> a + b + c);
+
+      assertTrue(result.run().isEmpty());
+
+      // Test success case where predicate passes
+      OptionalPath<Integer> result2 =
+          ForPath.from(Path.present(1))
+              .from(a -> Path.present(2))
+              .from(t -> Path.present(3))
+              .when(t -> t._1() + t._2() + t._3() > 0)
+              .yield((a, b, c) -> a + b + c);
+
+      assertEquals(Optional.of(6), result2.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      OptionalPath<String> result =
+          ForPath.from(Path.present(1))
+              .from(a -> Path.present(2))
+              .from(t -> Path.present(3))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      assertEquals(Optional.of("sum=6"), result.run());
+    }
+  }
+
+  // ========================================================================
+  // Additional EitherPath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("EitherPath Steps Additional Tests")
+  class EitherPathStepsTests {
+
+    @Test
+    @DisplayName("should support simple yield in Steps1")
+    void supportsSimpleYieldInSteps1() {
+      EitherPath<String, Integer> result =
+          ForPath.from(Path.<String, Integer>right(10)).yield(a -> a * 2);
+
+      assertTrue(result.run().isRight());
+      assertEquals(20, result.run().getRight());
+    }
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      EitherPath<String, Integer> result =
+          ForPath.from(Path.<String, Integer>right(5))
+              .from(a -> Path.<String, Integer>right(10))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, sum) -> sum);
+
+      assertTrue(result.run().isRight());
+      assertEquals(15, result.run().getRight());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      EitherPath<String, String> result =
+          ForPath.from(Path.<String, Integer>right(5))
+              .from(a -> Path.<String, Integer>right(10))
+              .yield(t -> "sum=" + (t._1() + t._2()));
+
+      assertTrue(result.run().isRight());
+      assertEquals("sum=15", result.run().getRight());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      EitherPath<String, String> result =
+          ForPath.from(Path.<String, Integer>right(1))
+              .from(a -> Path.<String, Integer>right(2))
+              .from(t -> Path.<String, Integer>right(3))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      assertTrue(result.run().isRight());
+      assertEquals("sum=6", result.run().getRight());
+    }
+  }
+
+  // ========================================================================
+  // Additional TryPath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("TryPath Steps Additional Tests")
+  class TryPathStepsTests {
+
+    @Test
+    @DisplayName("should support simple yield in Steps1")
+    void supportsSimpleYieldInSteps1() {
+      TryPath<Integer> result = ForPath.from(Path.success(10)).yield(a -> a * 2);
+
+      assertTrue(result.run().isSuccess());
+      assertEquals(20, result.run().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should support from() in Steps2")
+    void supportsFromInSteps2() {
+      TryPath<Integer> result =
+          ForPath.from(Path.success(1))
+              .from(a -> Path.success(2))
+              .from(t -> Path.success(3))
+              .yield((a, b, c) -> a + b + c);
+
+      assertTrue(result.run().isSuccess());
+      assertEquals(6, result.run().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      TryPath<Integer> result =
+          ForPath.from(Path.success(5))
+              .from(a -> Path.success(10))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, sum) -> sum);
+
+      assertTrue(result.run().isSuccess());
+      assertEquals(15, result.run().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      TryPath<String> result =
+          ForPath.from(Path.success(5))
+              .from(a -> Path.success(10))
+              .yield(t -> "sum=" + (t._1() + t._2()));
+
+      assertTrue(result.run().isSuccess());
+      assertEquals("sum=15", result.run().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      TryPath<String> result =
+          ForPath.from(Path.success(1))
+              .from(a -> Path.success(2))
+              .from(t -> Path.success(3))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      assertTrue(result.run().isSuccess());
+      assertEquals("sum=6", result.run().orElse(null));
+    }
+  }
+
+  // ========================================================================
+  // Additional IOPath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("IOPath Steps Additional Tests")
+  class IOPathStepsTests {
+
+    @Test
+    @DisplayName("should support simple yield in Steps1")
+    void supportsSimpleYieldInSteps1() {
+      IOPath<Integer> result = ForPath.from(Path.ioPure(10)).yield(a -> a * 2);
+
+      assertEquals(20, result.unsafeRun());
+    }
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      IOPath<Integer> result =
+          ForPath.from(Path.ioPure(5))
+              .from(a -> Path.ioPure(10))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, sum) -> sum);
+
+      assertEquals(15, result.unsafeRun());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      IOPath<String> result =
+          ForPath.from(Path.ioPure(5))
+              .from(a -> Path.ioPure(10))
+              .yield(t -> "sum=" + (t._1() + t._2()));
+
+      assertEquals("sum=15", result.unsafeRun());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      IOPath<String> result =
+          ForPath.from(Path.ioPure(1))
+              .from(a -> Path.ioPure(2))
+              .from(t -> Path.ioPure(3))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      assertEquals("sum=6", result.unsafeRun());
+    }
+  }
+
+  // ========================================================================
+  // Additional IdPath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("IdPath Steps Additional Tests")
+  class IdPathStepsTests {
+
+    @Test
+    @DisplayName("should support simple yield in Steps1")
+    void supportsSimpleYieldInSteps1() {
+      IdPath<Integer> result = ForPath.from(Path.id(10)).yield(a -> a * 2);
+
+      assertEquals(20, result.run().value());
+    }
+
+    @Test
+    @DisplayName("should support from() in Steps2")
+    void supportsFromInSteps2() {
+      IdPath<Integer> result =
+          ForPath.from(Path.id(1))
+              .from(a -> Path.id(2))
+              .from(t -> Path.id(3))
+              .yield((a, b, c) -> a + b + c);
+
+      assertEquals(6, result.run().value());
+    }
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      IdPath<Integer> result =
+          ForPath.from(Path.id(5))
+              .from(a -> Path.id(10))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, sum) -> sum);
+
+      assertEquals(15, result.run().value());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      IdPath<String> result =
+          ForPath.from(Path.id(5)).from(a -> Path.id(10)).yield(t -> "sum=" + (t._1() + t._2()));
+
+      assertEquals("sum=15", result.run().value());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      IdPath<String> result =
+          ForPath.from(Path.id(1))
+              .from(a -> Path.id(2))
+              .from(t -> Path.id(3))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      assertEquals("sum=6", result.run().value());
+    }
+  }
+
+  // ========================================================================
+  // Additional NonDetPath Step Tests
+  // ========================================================================
+
+  @Nested
+  @DisplayName("NonDetPath Steps Additional Tests")
+  class NonDetPathStepsTests {
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2))
+              .from(a -> Path.list("a", "b"))
+              .let(t -> t._1() + t._2())
+              .yield((num, letter, combined) -> combined);
+
+      assertEquals(List.of("1a", "1b", "2a", "2b"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2))
+              .from(a -> Path.list("a", "b"))
+              .yield(t -> t._1() + "-" + t._2());
+
+      assertEquals(List.of("1-a", "1-b", "2-a", "2-b"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support when() in Steps3")
+    void supportsWhenInSteps3() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2))
+              .from(a -> Path.list(10, 20))
+              .from(t -> Path.list("x", "y"))
+              .when(t -> (t._1() + t._2()) > 15)
+              .yield((a, b, c) -> a + "+" + b + c);
+
+      // Filter: (a + b) > 15 -> 1+10=11(no), 1+20=21(yes), 2+10=12(no), 2+20=22(yes)
+      assertEquals(List.of("1+20x", "1+20y", "2+20x", "2+20y"), result.run());
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      NonDetPath<String> result =
+          ForPath.from(Path.list(1, 2))
+              .from(a -> Path.list("a", "b"))
+              .from(t -> Path.list(true))
+              .yield(t -> t._1() + t._2() + (t._3() ? "!" : "?"));
+
+      assertEquals(List.of("1a!", "1b!", "2a!", "2b!"), result.run());
+    }
+  }
+
+  // ========================================================================
+  // GenericPath Complete Test Suite
+  // ========================================================================
+
+  @Nested
+  @DisplayName("GenericPath Comprehension")
+  class GenericPathTests {
+
+    @Test
+    @DisplayName("should support simple yield in Steps1")
+    void supportsSimpleYieldInSteps1() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(10), MaybeMonad.INSTANCE))
+              .yield(a -> a * 2);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just(20), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should chain generators with from()")
+    void chainsGenerators() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(5), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(a * 2), MaybeMonad.INSTANCE))
+              .yield((a, b) -> a + b);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just(15), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support let() for pure computations")
+    void supportsLet() {
+      GenericPath<MaybeKind.Witness, String> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(10), MaybeMonad.INSTANCE))
+              .let(a -> a * 2)
+              .yield((a, b) -> "a=" + a + ", b=" + b);
+
+      Maybe<String> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just("a=10, b=20"), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support focus() with FocusPath")
+    void supportsFocus() {
+      User user = new User("Alice", new Address("NYC", "USA"));
+
+      GenericPath<MaybeKind.Witness, String> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(user), MaybeMonad.INSTANCE))
+              .focus(addressFocus)
+              .yield((u, addr) -> addr.city());
+
+      Maybe<String> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just("NYC"), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support three generators")
+    void supportsThreeGenerators() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(1), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(2), MaybeMonad.INSTANCE))
+              .from(t -> GenericPath.of(MaybeKindHelper.MAYBE.just(3), MaybeMonad.INSTANCE))
+              .yield((a, b, c) -> a + b + c);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just(6), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support yield with BiFunction in Steps2")
+    void supportsYieldWithBiFunctionInSteps2() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(5), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(10), MaybeMonad.INSTANCE))
+              .yield((a, b) -> a + b);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just(15), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps2")
+    void supportsYieldWithTupleInSteps2() {
+      GenericPath<MaybeKind.Witness, String> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(5), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(10), MaybeMonad.INSTANCE))
+              .yield(t -> "sum=" + (t._1() + t._2()));
+
+      Maybe<String> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just("sum=15"), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support let() in Steps2")
+    void supportsLetInSteps2() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(5), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(10), MaybeMonad.INSTANCE))
+              .let(t -> t._1() + t._2())
+              .yield((a, b, sum) -> sum);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just(15), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support from() in Steps2")
+    void supportsFromInSteps2() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(1), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(2), MaybeMonad.INSTANCE))
+              .from(t -> GenericPath.of(MaybeKindHelper.MAYBE.just(3), MaybeMonad.INSTANCE))
+              .yield((a, b, c) -> a + b + c);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just(6), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should support yield with tuple function in Steps3")
+    void supportsYieldWithTupleInSteps3() {
+      GenericPath<MaybeKind.Witness, String> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(1), MaybeMonad.INSTANCE))
+              .from(a -> GenericPath.of(MaybeKindHelper.MAYBE.just(2), MaybeMonad.INSTANCE))
+              .from(t -> GenericPath.of(MaybeKindHelper.MAYBE.just(3), MaybeMonad.INSTANCE))
+              .yield(t -> "sum=" + (t._1() + t._2() + t._3()));
+
+      Maybe<String> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertEquals(Maybe.just("sum=6"), maybeResult);
+    }
+
+    @Test
+    @DisplayName("should short-circuit on Nothing")
+    void shortCircuitsOnNothing() {
+      GenericPath<MaybeKind.Witness, Integer> result =
+          ForPath.from(GenericPath.of(MaybeKindHelper.MAYBE.just(5), MaybeMonad.INSTANCE))
+              .<Integer>from(
+                  a ->
+                      GenericPath.of(MaybeKindHelper.MAYBE.<Integer>nothing(), MaybeMonad.INSTANCE))
+              .yield((a, b) -> a + b);
+
+      Maybe<Integer> maybeResult = MaybeKindHelper.MAYBE.narrow(result.runKind());
+      assertTrue(maybeResult.isNothing());
+    }
+  }
+}

--- a/hkj-examples/EXAMPLES_GUIDE.md
+++ b/hkj-examples/EXAMPLES_GUIDE.md
@@ -138,6 +138,7 @@ The Effect Path API provides a fluent, type-safe approach to composing effect ty
 | [ServiceLayerExample.java](src/main/java/org/higherkindedj/example/effect/ServiceLayerExample.java) | Real-world service layer patterns with EitherPath and IOPath | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.effect.ServiceLayerExample` | [Patterns and Recipes](https://higher-kinded-j.github.io/latest/effect/patterns.html) |
 | [PathOpsExample.java](src/main/java/org/higherkindedj/example/effect/PathOpsExample.java) | PathOps utilities: sequence, traverse, and firstSuccess | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.effect.PathOpsExample` | [Composition Patterns](https://higher-kinded-j.github.io/latest/effect/composition.html) |
 | [CrossPathConversionsExample.java](src/main/java/org/higherkindedj/example/effect/CrossPathConversionsExample.java) | Converting between different Path types | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.effect.CrossPathConversionsExample` | [Type Conversions](https://higher-kinded-j.github.io/latest/effect/conversions.html) |
+| [ForPathExample.java](src/main/java/org/higherkindedj/example/effect/ForPathExample.java) | For-comprehensions that work directly with Path types | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.effect.ForPathExample` | [ForPath Comprehension](https://higher-kinded-j.github.io/latest/effect/forpath_comprehension.html) |
 
 ### Advanced Effects
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/effect/ForPathExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/effect/ForPathExample.java
@@ -1,0 +1,282 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.effect;
+
+import java.util.Optional;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.IOPath;
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.NonDetPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.expression.ForPath;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+
+/**
+ * Examples demonstrating ForPath: for-comprehensions that work directly with Effect Path types.
+ *
+ * <p>ForPath bridges the For comprehension system and the Effect Path API, allowing composition of
+ * Path types using for-comprehension style while preserving Path semantics.
+ *
+ * <p>This example shows:
+ *
+ * <ul>
+ *   <li>Basic MaybePath comprehensions with from(), let(), when(), yield()
+ *   <li>EitherPath comprehensions for error handling workflows
+ *   <li>IOPath comprehensions for deferred side-effectful operations
+ *   <li>NonDetPath comprehensions for generating combinations
+ *   <li>Optics integration with focus() and match()
+ * </ul>
+ *
+ * <p>Run with: {@code ./gradlew :hkj-examples:run
+ * -PmainClass=org.higherkindedj.example.effect.ForPathExample}
+ */
+public class ForPathExample {
+
+  // Record types for optics examples
+  record Address(String city, String postcode) {}
+
+  record User(String name, Address address, String email) {
+    User(String name, Address address) {
+      this(name, address, null);
+    }
+  }
+
+  // Sealed types for AffinePath pattern matching example
+  sealed interface Result permits Success, Failure {}
+
+  record Success(String value) implements Result {}
+
+  record Failure(String error) implements Result {}
+
+  // Lenses for optics integration
+  static final Lens<User, Address> addressLens =
+      Lens.of(User::address, (u, a) -> new User(u.name(), a, u.email()));
+
+  static final Lens<Address, String> cityLens =
+      Lens.of(Address::city, (a, c) -> new Address(c, a.postcode()));
+
+  // FocusPath from lenses
+  static final FocusPath<User, Address> addressPath = FocusPath.of(addressLens);
+  static final FocusPath<Address, String> cityPath = FocusPath.of(cityLens);
+
+  // AffinePath for optional email field
+  static final AffinePath<User, String> emailPath =
+      AffinePath.of(
+          Affine.of(
+              u -> Optional.ofNullable(u.email()), (u, e) -> new User(u.name(), u.address(), e)));
+
+  public static void main(String[] args) {
+    System.out.println("=== ForPath: For-Comprehensions with Effect Paths ===\n");
+
+    maybePathBasics();
+    maybePathWithGuards();
+    eitherPathWorkflow();
+    ioPathComposition();
+    nonDetPathCombinations();
+    opticsIntegration();
+  }
+
+  private static void maybePathBasics() {
+    System.out.println("--- MaybePath Basics ---");
+
+    // Simple comprehension: extract and combine values
+    MaybePath<Integer> result =
+        ForPath.from(Path.just(10))
+            .from(a -> Path.just(20))
+            .from(t -> Path.just(5)) // t is Tuple2<Integer, Integer>
+            .yield((a, b, c) -> a + b + c);
+
+    System.out.println("Sum of 10 + 20 + 5 = " + result.getOrElse(-1)); // 35
+
+    // Using let() for pure computations
+    MaybePath<String> withLet =
+        ForPath.from(Path.just(10))
+            .let(a -> a * 2) // b = 20 (pure calculation)
+            .let(t -> t._1() + t._2()) // c = 30 (sum via tuple)
+            .yield((a, b, c) -> "Original: " + a + ", Doubled: " + b + ", Sum: " + c);
+
+    System.out.println(withLet.getOrElse("no value"));
+    // Original: 10, Doubled: 20, Sum: 30
+
+    // Short-circuiting with Nothing
+    MaybePath<Integer> shortCircuit =
+        ForPath.from(Path.just(5))
+            .<Integer>from(a -> Path.nothing()) // stops here
+            .from(t -> Path.just(100)) // never executed
+            .yield((a, b, c) -> a + b + c);
+
+    System.out.println("Short-circuited result: " + shortCircuit.getOrElse(-1)); // -1
+
+    System.out.println();
+  }
+
+  private static void maybePathWithGuards() {
+    System.out.println("--- MaybePath with Guards (when) ---");
+
+    // Guard that passes
+    MaybePath<Integer> evenOnly =
+        ForPath.from(Path.just(4)).when(n -> n % 2 == 0).yield(n -> n * 10);
+
+    System.out.println("4 is even, result: " + evenOnly.getOrElse(-1)); // 40
+
+    // Guard that fails
+    MaybePath<Integer> oddFiltered =
+        ForPath.from(Path.just(3)).when(n -> n % 2 == 0).yield(n -> n * 10);
+
+    System.out.println("3 is odd, filtered out: " + oddFiltered.getOrElse(-1)); // -1
+
+    // Guard in multi-step comprehension
+    MaybePath<String> multiStepGuard =
+        ForPath.from(Path.just(5))
+            .from(a -> Path.just(10))
+            .when(t -> t._1() + t._2() > 10) // 5 + 10 = 15 > 10, passes
+            .yield((a, b) -> "Sum is " + (a + b));
+
+    System.out.println(multiStepGuard.getOrElse("filtered")); // Sum is 15
+
+    System.out.println();
+  }
+
+  private static void eitherPathWorkflow() {
+    System.out.println("--- EitherPath Workflow ---");
+
+    // Successful workflow using ForPath
+    EitherPath<String, String> successResult =
+        ForPath.from(Path.<String, String>right("Alice"))
+            .from(name -> Path.right("order-123"))
+            .yield((name, orderId) -> "Created " + orderId + " for " + name);
+
+    System.out.println("Success: " + successResult.run().getRight());
+
+    // Failed workflow - starts with Left
+    EitherPath<String, String> failedResult =
+        ForPath.from(Path.<String, String>left("User not found"))
+            .from(name -> Path.right("order-456"))
+            .yield((name, orderId) -> "Created " + orderId);
+
+    String leftValue = failedResult.run().getLeft();
+    System.out.println("Failure: " + leftValue);
+
+    System.out.println();
+  }
+
+  private static void ioPathComposition() {
+    System.out.println("--- IOPath Composition (Deferred Execution) ---");
+
+    // IOPath comprehensions are lazy - nothing executes until unsafeRun()
+    IOPath<String> readConfig = Path.io(() -> "production");
+    IOPath<Integer> readPort = Path.io(() -> 8080);
+
+    IOPath<String> serverInfo =
+        ForPath.from(readConfig)
+            .from(env -> readPort)
+            .let(t -> t._1().toUpperCase())
+            .yield((env, port, upperEnv) -> upperEnv + " server on port " + port);
+
+    System.out.println("IOPath created (nothing executed yet)");
+    String result = serverInfo.unsafeRun();
+    System.out.println("After unsafeRun(): " + result);
+    // PRODUCTION server on port 8080
+
+    // Chaining multiple IO operations
+    IOPath<String> multiStep =
+        ForPath.from(Path.io(() -> "Step 1"))
+            .from(s1 -> Path.io(() -> s1 + " -> Step 2"))
+            .from(t -> Path.io(() -> t._2() + " -> Step 3"))
+            .yield((s1, s2, s3) -> "Final: " + s3);
+
+    System.out.println(multiStep.unsafeRun());
+    // Final: Step 1 -> Step 2 -> Step 3
+
+    System.out.println();
+  }
+
+  private static void nonDetPathCombinations() {
+    System.out.println("--- NonDetPath Combinations ---");
+
+    // NonDetPath generates all combinations (like nested loops)
+    // Use Path.list() to create NonDetPath
+    NonDetPath<String> allCombinations =
+        ForPath.from(Path.list("red", "blue", "green"))
+            .from(c -> Path.list("S", "M", "L"))
+            .yield((colour, size) -> colour + "-" + size);
+
+    System.out.println("All combinations: " + allCombinations.run());
+    // [red-S, red-M, red-L, blue-S, blue-M, blue-L, green-S, green-M, green-L]
+
+    // With filtering using when()
+    NonDetPath<String> filteredCombinations =
+        ForPath.from(Path.list("red", "blue", "green"))
+            .from(c -> Path.list("S", "M", "L"))
+            .when(t -> !t._1().equals("blue") || !t._2().equals("S")) // filter out blue-S
+            .yield((colour, size) -> colour + "-" + size);
+
+    System.out.println("Filtered (no blue-S): " + filteredCombinations.run());
+    // [red-S, red-M, red-L, blue-M, blue-L, green-S, green-M, green-L]
+
+    // Number combinations with arithmetic filtering
+    NonDetPath<String> pairs =
+        ForPath.from(Path.list(1, 2, 3, 4, 5))
+            .from(a -> Path.list(1, 2, 3, 4, 5))
+            .when(t -> t._1() < t._2()) // only pairs where first < second
+            .yield((a, b) -> "(" + a + "," + b + ")");
+
+    System.out.println("Ordered pairs: " + pairs.run());
+    // [(1,2), (1,3), (1,4), (1,5), (2,3), (2,4), (2,5), (3,4), (3,5), (4,5)]
+
+    System.out.println();
+  }
+
+  private static void opticsIntegration() {
+    System.out.println("--- Optics Integration ---");
+
+    User user = new User("Alice", new Address("London", "SW1A 1AA"));
+
+    // Using focus() to extract nested values - compose paths with via()
+    FocusPath<User, String> userCityPath = addressPath.via(cityPath);
+    MaybePath<String> cityResult =
+        ForPath.from(Path.just(user))
+            .focus(userCityPath)
+            .yield((u, city) -> u.name() + " lives in " + city);
+
+    System.out.println(cityResult.getOrElse("no result"));
+    // Alice lives in London
+
+    // Alternative: use focus() then extract with function in second focus()
+    MaybePath<String> cityResult2 =
+        ForPath.from(Path.just(user))
+            .focus(addressPath)
+            .focus(t -> t._2().city()) // t is Tuple2<User, Address>
+            .yield((u, address, city) -> u.name() + " lives in " + city);
+
+    System.out.println(cityResult2.getOrElse("no result"));
+    // Alice lives in London
+
+    // Using match() with AffinePath for optional fields
+    User userWithEmail = new User("Bob", new Address("Paris", "75001"), "bob@example.com");
+    User userWithoutEmail = new User("Carol", new Address("Berlin", "10115"));
+
+    // User with email - successful match
+    MaybePath<String> matchSuccess =
+        ForPath.from(Path.just(userWithEmail))
+            .match(emailPath)
+            .yield((u, email) -> u.name() + "'s email: " + email);
+
+    System.out.println("Match with email: " + matchSuccess.getOrElse("no match"));
+    // Match with email: Bob's email: bob@example.com
+
+    // User without email - returns Nothing
+    MaybePath<String> matchFailure =
+        ForPath.from(Path.just(userWithoutEmail))
+            .match(emailPath)
+            .yield((u, email) -> u.name() + "'s email: " + email);
+
+    System.out.println("Match without email: " + matchFailure.getOrElse("no match"));
+    // Match without email: no match
+
+    System.out.println();
+  }
+}


### PR DESCRIPTION
ForPath bridges the For comprehension system and the Effect Path API, allowing composition of Path types using for-comprehension style while preserving Path semantics and returning Path types directly.

Features:
- Entry points for all Path types: MaybePath, EitherPath, IOPath, NonDetPath, OptionalPath, TryPath, IdPath, GenericPath
- Full comprehension operations: from(), let(), when(), yield()
- Optics integration with focus() and match() methods

Documentation:
- New forpath_comprehension.md page with examples
- Updated SUMMARY.md and for_comprehension.md with cross-references
- ForPathExample.java demonstrating all Path types and optics
- Updated EXAMPLES_GUIDE.md


Fixes #292
