### PR TITLE
Refresh home.md and README.md to highlight Effect Path API

### DIFF
--- a/.github/scripts/generate_sitemap.py
+++ b/.github/scripts/generate_sitemap.py
@@ -54,11 +54,25 @@ def generate_sitemap(start_dir, base_url, output_file):
         sitemap_content += f'    <loc>{html.escape(url)}</loc>\n' # Escape special characters in URL
         sitemap_content += f'    <lastmod>{today}</lastmod>\n'
         sitemap_content += '    <changefreq>weekly</changefreq>\n' # Default change frequency
-        # Determine priority based on URL depth or specific pages
-        if url.endswith("index.html") or url == base_url.rstrip('/'):
+        # Determine priority based on page importance
+        # Priority 1.0: Main landing pages
+        if url.endswith("index.html") or url.endswith("home.html") or url == base_url.rstrip('/'):
             sitemap_content += '    <priority>1.0</priority>\n'
-        elif "core-concepts.html" in url or "usage-guide.html" in url:
+        # Priority 0.9: Effect Path API and Optics intro pages (key selling points)
+        elif any(p in url for p in ["effect/ch_intro.html", "effect/effect_path_overview.html",
+                                     "optics/optics_intro.html", "optics/focus_dsl.html",
+                                     "effect/focus_integration.html"]):
+            sitemap_content += '    <priority>0.9</priority>\n'
+        # Priority 0.8: Core documentation and tutorials intro
+        elif any(p in url for p in ["core-concepts.html", "usage-guide.html", "hkt_introduction.html",
+                                     "tutorials_intro.html", "spring_boot_integration.html"]):
             sitemap_content += '    <priority>0.8</priority>\n'
+        # Priority 0.7: Other effect and optics pages
+        elif "/effect/" in url or "/optics/" in url:
+            sitemap_content += '    <priority>0.7</priority>\n'
+        # Priority 0.6: Tutorial pages and examples
+        elif "/tutorials/" in url or "/hkts/" in url:
+            sitemap_content += '    <priority>0.6</priority>\n'
         else:
             sitemap_content += '    <priority>0.5</priority>\n' # Default priority
         sitemap_content += '  </url>\n'

--- a/.github/scripts/robots.txt
+++ b/.github/scripts/robots.txt
@@ -1,0 +1,11 @@
+# Higher-Kinded-J Documentation
+# https://higher-kinded-j.github.io
+
+User-agent: *
+Allow: /
+
+# Sitemaps for each version
+Sitemap: https://higher-kinded-j.github.io/latest/sitemap.xml
+
+# AI-friendly documentation
+# See: https://higher-kinded-j.github.io/latest/llms.txt

--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -151,7 +151,7 @@ jobs:
           ls -la "$DEPLOY_PATH"
         shell: bash
 
-      - name: Create/update root index.html, 404.html, and social preview image
+      - name: Create/update root index.html, 404.html, robots.txt, llms.txt, and social preview image
         run: |
           # Always copy the redirect page to root to ensure it's up to date
           cp .github/scripts/root-index.html gh-pages-repo/index.html
@@ -160,6 +160,16 @@ jobs:
           # Copy 404 page that redirects old URLs to /latest/
           cp .github/scripts/404.html gh-pages-repo/404.html
           echo "404.html updated"
+
+          # Copy robots.txt for search engines
+          cp .github/scripts/robots.txt gh-pages-repo/robots.txt
+          echo "robots.txt updated"
+
+          # Copy llms.txt for AI discoverability (from latest build)
+          if [ -f "${{ env.BOOK_ROOT_DIR }}/book/llms.txt" ]; then
+            cp ${{ env.BOOK_ROOT_DIR }}/book/llms.txt gh-pages-repo/llms.txt
+            echo "llms.txt copied to root"
+          fi
 
           # Copy social preview image to root for Open Graph meta tags
           cp ${{ env.BOOK_ROOT_DIR }}/src/preview.png gh-pages-repo/preview.png

--- a/hkj-book/book.toml
+++ b/hkj-book/book.toml
@@ -1,6 +1,6 @@
 [book]
-title = "Higher-Kinded Types and Optics for Java"
-description = "Explore Higher-Kinded Types (HKTs) and Optcs in Java with the Higher-Kinded-J library. Learn about Functors, Applicatives, Monads, Transformers, practical functional patterns, and how to write cleaner, more composable Java code for your projects using Optics."
+title = "Higher-Kinded-J: Composable Effects and Advanced Optics for Java"
+description = "The most comprehensive functional programming library for Java. Unify error handling, optional values, and immutable data navigation with the Effect Path API and Focus DSL. Features advanced optics with code generation for Java records, filtered traversals, indexed optics, and seamless Spring Boot integration."
 authors = ["The Higher-Kinded-J Team"]
 language = "en"
 multilingual = false

--- a/hkj-book/src/llms.txt
+++ b/hkj-book/src/llms.txt
@@ -1,0 +1,88 @@
+# Higher-Kinded-J
+
+> Unifying Composable Effects and Advanced Optics for Java
+
+Higher-Kinded-J is the most comprehensive functional programming library for Java, providing composable error handling through the Effect Path API and type-safe immutable data navigation through the Focus DSL.
+
+## Core Concepts
+
+### Effect Path API
+A railway model for computation where success travels one track and failure travels another. Operations like `map`, `via`, and `recover` work identically across all effect types.
+
+**Path Types:**
+- `MaybePath<A>` - Optional values where absence is normal
+- `EitherPath<E, A>` - Typed errors with structured information
+- `TryPath<A>` - Wrapping code that throws exceptions
+- `ValidationPath<E, A>` - Accumulating ALL errors, not just the first
+- `IOPath<A>` - Deferred side effects
+- `TrampolinePath<A>` - Stack-safe recursion
+- `CompletableFuturePath<A>` - Async operations
+- `FreePath<F, A>` / `FreeApPath<F, A>` - DSL building
+
+### Advanced Optics
+The most comprehensive optics implementation in Java:
+- **Lens** - Focus on a field in a product type
+- **Prism** - Focus on a case in a sum type
+- **Iso** - Bidirectional transformation
+- **Affine** - Optional focus (zero or one)
+- **Traversal** - Multiple focuses in a collection
+- **Filtered Traversals** - Predicate-based focusing
+- **Indexed Optics** - Position-aware transformations
+
+### Focus DSL
+Type-safe structural navigation that integrates with Effect Paths:
+- `FocusPath<S, A>` - Exactly one focus
+- `AffinePath<S, A>` - Zero or one focus
+- `TraversalPath<S, A>` - Zero or more focuses
+
+### Effect-Optics Bridge
+Navigate data structures within effect pipelines using `.focus()`:
+```java
+userService.findById(userId)           // EitherPath<Error, User>
+    .focus(UserFocus.address())        // EitherPath<Error, Address>
+    .focus(AddressFocus.postcode())    // EitherPath<Error, String>
+    .via(code -> validatePostcode(code));
+```
+
+## Installation
+
+```gradle
+dependencies {
+    implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
+    annotationProcessor("io.github.higher-kinded-j:hkj-processor:LATEST_VERSION")
+    annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
+}
+```
+
+The annotation processor generates Focus paths and Effect paths for Java records and sealed interfaces.
+
+## Key Features
+
+- **Java 25+** - Built for modern Java with records and sealed interfaces
+- **Code Generation** - Automatic optics generation via annotation processor
+- **Spring Boot Integration** - `hkj-spring-boot-starter` for REST APIs
+- **Type Classes** - Functor, Applicative, Monad, MonadError
+- **Monad Transformers** - EitherT, StateT, ReaderT for effect composition
+
+## Documentation
+
+- Main: https://higher-kinded-j.github.io/latest/home.html
+- Effect Path API: https://higher-kinded-j.github.io/latest/effect/ch_intro.html
+- Optics Guide: https://higher-kinded-j.github.io/latest/optics/optics_intro.html
+- Focus DSL: https://higher-kinded-j.github.io/latest/optics/focus_dsl.html
+- Tutorials: https://higher-kinded-j.github.io/latest/tutorials/tutorials_intro.html
+- Spring Boot: https://higher-kinded-j.github.io/latest/spring/spring_boot_integration.html
+
+## Source Code
+
+- Repository: https://github.com/higher-kinded-j/higher-kinded-j
+- License: Apache 2.0
+
+## When to Use Higher-Kinded-J
+
+Use this library when you need:
+- Composable error handling without exception pyramids
+- Type-safe immutable data updates with optics
+- Integration between effect handling and data navigation
+- Code generation for lenses/prisms on Java records
+- Functional patterns in Spring Boot applications

--- a/hkj-book/theme/head.hbs
+++ b/hkj-book/theme/head.hbs
@@ -18,25 +18,27 @@
     <meta name="author" content="{{ book_authors }}">
 {{/if}}
 
-{{! You can add other global meta tags here as well }}
-<meta name="keywords" content="Higher-Kinded Types, Higher-Kinded-J, Higher-Kinded Java, Higher Kinded Java, HKT, Java, Optics, Lens, Prism, Traversal, Iso, Functional Programming, Monad, Functor, Applicative, Transformer, Monoid, Traverse, higherkindedj">
+{{! Keywords for search engines }}
+<meta name="keywords" content="Higher-Kinded Types, Higher-Kinded-J, HKT, Java, Optics, Lens, Prism, Traversal, Iso, Affine, Focus DSL, Effect Path API, Functional Programming, Monad, Functor, Applicative, EitherPath, MaybePath, TryPath, ValidationPath, Java Records, Sealed Interface, Error Handling, Immutable Data">
 
-{{! Example Open Graph tags for better social media sharing (using site-wide info) }}
-<meta property="og:title" content="{{ title }}"> {{! This uses mdbook's generated page title }}
+{{! Open Graph tags for social media sharing }}
+<meta property="og:title" content="{{ title }}">
 {{#if description}}
     <meta property="og:description" content="{{ description }}">
+{{else}}
+    <meta property="og:description" content="Unifying Composable Effects and Advanced Optics for Java. The most comprehensive functional programming library with Effect Path API, Focus DSL, and code generation for Java records.">
 {{/if}}
 <meta property="og:type" content="website">
-{{! Add an og:image meta tag if you have a suitable image for sharing }}
-{{! <meta property="og:image" content="https://higher-kinded-j.github.io/path/to/your/image.png"> }}
-<meta property="og:url" content="https://higher-kinded-j.github.io/{{ path_in_book }}"> {{! mdbook provides path_in_book }}
+<meta property="og:url" content="https://higher-kinded-j.github.io/{{ path_in_book }}">
+<meta property="og:image" content="https://higher-kinded-j.github.io/preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="Higher-Kinded-J Documentation">
+<meta property="og:locale" content="en_GB">
 
-<meta property="og:image" content="https://higher-kinded-j.github.io/preview.png" />
-{{! mdBook will still include its default head elements like charset, viewport,
-    its own CSS links, and JS links. This file primarily ADDS to the head. }}
-<meta property="og:site_name" content="Higher-Kinded-J Documentation" />
-
-
-<meta name="twitter:card" content="summary_large_image" /> <meta name="twitter:title" content="{{ title }} - Higher-Kinded-J" />
-<meta name="twitter:description" content="Bringing Higher-Kinded Types and Optics to Java functional patterns" />
-<meta name="twitter:image" content="https://higher-kinded-j.github.io/preview.png" />
+{{! Twitter Card tags }}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ title }}">
+<meta name="twitter:description" content="Unifying Composable Effects and Advanced Optics for Java. Effect Path API, Focus DSL, and the most comprehensive optics implementation in the Java ecosystem.">
+<meta name="twitter:image" content="https://higher-kinded-j.github.io/preview.png">
+<meta name="twitter:image:alt" content="Higher-Kinded-J: Composable Effects and Advanced Optics for Java">


### PR DESCRIPTION
- Update tagline: "Unifying Composable Effects and Advanced Optics for Java"
- Rewrite opening with benefit-led professional prose
- Add ASCII diagram showing Effect-Optics bridge
- Rename "Composable Optics" to "Advanced Optics" with expanded feature list
- Add "Why Higher-Kinded-J?" section with competitor comparison table
- Restore Spring Boot bullet list with full selling points
- Unify Getting Started with single dependency set
- Fix em-dashes to British English punctuation throughout

Add SEO and AI discoverability improvements

- Update book.toml with improved title and description emphasizing Effect Path API and Advanced Optics
- Update head.hbs with improved Open Graph and Twitter Card meta tags
- Add llms.txt for AI crawler discoverability
- Add robots.txt with sitemap reference
- Improve sitemap priorities for key pages (Effect Path API, Optics, Focus DSL get higher priority)
- Update deployment workflow to copy robots.txt and llms.txt to root
Fixes #289 