### PR TITLE
Implement @ImportOptics annotation for external optics generation (Part1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Higher-Kinded-J provides the most comprehensive optics implementation available 
 
 * **Complete optic hierarchy:** Lenses, Prisms, Isos, Affines, Traversals, Folds, and Setters
 * **Automatic generation** via annotation processor for Java records and sealed interfaces
+* **External type import** via `@ImportOptics` for types you don't own (e.g., `java.time.LocalDate`)
 * **Filtered traversals** for predicate-based focusing within collections
 * **Indexed optics** for position-aware transformations
 * **Focus DSL** for type-safe, fluent path navigation
@@ -152,6 +153,7 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 | **Filtered Traversals** | ✓ | ✗ | ✗ | ✗ |
 | **Indexed Optics** | ✓ | ✗ | ✗ | ✗ |
 | **Code Generation** | ✓ | ✗ | ✗ | ✓* |
+| **External Type Import** | ✓ | ✗ | ✗ | ✗ |
 | **Java Records Support** | ✓ | ✗ | ✗ | ✗ |
 | **Sealed Interface Support** | ✓ | ✗ | ✗ | ✗ |
 | **Effect Integration** | ✓ | ✗ | ✗ | ✗ |

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/ImportOptics.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/ImportOptics.java
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Imports optics for external types into your codebase.
+ *
+ * <p>Apply this annotation to a package (via {@code package-info.java}) or type to generate optics
+ * for classes you do not own. The processor will analyse each class and generate appropriate optics
+ * based on its structure:
+ *
+ * <ul>
+ *   <li>Records → Lens per component
+ *   <li>Sealed interfaces → Prism per permitted subtype
+ *   <li>Enums → Prism per constant
+ *   <li>Classes with {@code withX()} methods → Lens per wither
+ * </ul>
+ *
+ * <p>Example usage in {@code package-info.java}:
+ *
+ * <pre>{@code
+ * @ImportOptics({
+ *     java.time.LocalDate.class,
+ *     com.external.CustomerRecord.class
+ * })
+ * package com.mycompany.optics;
+ *
+ * import org.higherkindedj.optics.annotations.ImportOptics;
+ * }</pre>
+ *
+ * <p>For records, the generated class will be named by appending "Lenses" to the record name (e.g.,
+ * {@code CustomerRecordLenses}). For sealed interfaces and enums, the generated class will be named
+ * by appending "Prisms" (e.g., {@code ShapePrisms}). For classes with wither methods, lenses are
+ * generated similarly (e.g., {@code LocalDateLenses}).
+ *
+ * @see GenerateLenses
+ * @see GeneratePrisms
+ */
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+public @interface ImportOptics {
+
+  /**
+   * External classes to generate optics for.
+   *
+   * <p>Each class will be analysed and appropriate optics generated based on its structure.
+   *
+   * @return array of classes to import optics for
+   */
+  Class<?>[] value() default {};
+
+  /**
+   * Target package for generated classes.
+   *
+   * <p>If empty (the default), generated classes are placed in the annotated package. When the
+   * annotation is applied to a type, this defaults to that type's package.
+   *
+   * @return the target package name, or empty to use the annotated package
+   */
+  String targetPackage() default "";
+
+  /**
+   * Allow generation for mutable classes (with setters).
+   *
+   * <p>By default, the processor refuses to generate lenses for mutable classes because lens laws
+   * may not hold when the source object can be mutated. Set this to {@code true} to acknowledge
+   * this limitation and generate lenses anyway.
+   *
+   * <p>Note: This option has no effect on immutable types like records or classes using only wither
+   * methods.
+   *
+   * @return {@code true} to allow mutable class support, {@code false} (default) to reject them
+   */
+  boolean allowMutable() default false;
+}

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -96,6 +96,8 @@
 # Optics IV: Java-Friendly APIs
 - [Introduction](optics/ch4_intro.md)
   - [Focus DSL](optics/focus_dsl.md)
+  - [Importing External Optics](optics/importing_optics.md)
+    - [@ImportOptics Reference](optics/import_optics_reference.md)
   - [Kind Field Support](optics/kind_field_support.md)
   - [Fluent API](optics/fluent_api.md)
   - [Free Monad DSL](optics/free_monad_dsl.md)

--- a/hkj-book/src/optics/ch4_intro.md
+++ b/hkj-book/src/optics/ch4_intro.md
@@ -156,10 +156,12 @@ Same program, different execution strategies.
 ## Chapter Contents
 
 1. [Focus DSL](focus_dsl.md) - Path-based navigation with type safety and IDE support
-2. [Kind Field Support](kind_field_support.md) - Automatic traversal for Kind<F, A> record fields
-3. [Fluent API](fluent_api.md) - Static methods and builders for validation-aware modifications
-4. [Free Monad DSL](free_monad_dsl.md) - Building optic programs as composable data
-5. [Interpreters](interpreters.md) - Multiple execution strategies for the same program
+2. [Importing External Optics](importing_optics.md) - Generate optics for types you don't own
+3. [@ImportOptics Reference](import_optics_reference.md) - Complete annotation reference
+4. [Kind Field Support](kind_field_support.md) - Automatic traversal for Kind<F, A> record fields
+5. [Fluent API](fluent_api.md) - Static methods and builders for validation-aware modifications
+6. [Free Monad DSL](free_monad_dsl.md) - Building optic programs as composable data
+7. [Interpreters](interpreters.md) - Multiple execution strategies for the same program
 
 ---
 

--- a/hkj-book/src/optics/import_optics_reference.md
+++ b/hkj-book/src/optics/import_optics_reference.md
@@ -1,0 +1,300 @@
+# @ImportOptics Reference
+
+## _Complete Annotation Reference for External Type Optics_
+
+~~~admonish info title="What You'll Learn"
+- All annotation elements and their usage
+- Supported type patterns and requirements
+- Error messages and how to resolve them
+- Best practices for organising imported optics
+~~~
+
+---
+
+## Annotation Definition
+
+```java
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+public @interface ImportOptics {
+    Class<?>[] value() default {};
+    String targetPackage() default "";
+    boolean allowMutable() default false;
+}
+```
+
+---
+
+## Annotation Elements
+
+### value
+
+**Type:** `Class<?>[]`
+**Default:** Empty array
+**Required:** Yes (at least one class)
+
+The external classes to generate optics for. Each class is analysed and appropriate optics are generated based on its structure.
+
+```java
+@ImportOptics({
+    java.time.LocalDate.class,
+    java.time.LocalTime.class,
+    com.external.CustomerRecord.class
+})
+package com.myapp.optics;
+```
+
+### targetPackage
+
+**Type:** `String`
+**Default:** Empty string (uses annotated package)
+
+The package where generated classes should be placed. If empty, uses the package of the annotated element.
+
+```java
+@ImportOptics(
+    value = {java.time.LocalDate.class},
+    targetPackage = "com.myapp.generated"
+)
+package com.myapp.config;
+
+// LocalDateLenses will be generated in com.myapp.generated
+```
+
+### allowMutable
+
+**Type:** `boolean`
+**Default:** `false`
+
+Whether to allow generation for classes that have setter methods. By default, mutable classes are rejected because lens laws may not hold.
+
+```java
+@ImportOptics(
+    value = {SomeMutableClass.class},
+    allowMutable = true  // Acknowledge lens law limitations
+)
+package com.myapp.optics;
+```
+
+---
+
+## Supported Type Patterns
+
+### Records
+
+**Detection:** `ElementKind.RECORD`
+**Generated:** Lenses + convenience with methods
+**Naming:** `<RecordName>Lenses`
+
+Requirements:
+- Must be a Java record
+- All components generate lenses
+- Uses canonical constructor for updates
+
+```java
+public record Person(String name, int age) {}
+// Generates: PersonLenses with name(), age(), withName(), withAge()
+```
+
+### Sealed Interfaces
+
+**Detection:** Interface with `sealed` modifier
+**Generated:** Prisms for each permitted subtype
+**Naming:** `<InterfaceName>Prisms`
+
+Requirements:
+- Must be a sealed interface
+- All permitted subtypes must be accessible
+
+```java
+public sealed interface Result<T> permits Success, Failure {}
+// Generates: ResultPrisms with success(), failure()
+```
+
+### Enums
+
+**Detection:** `ElementKind.ENUM`
+**Generated:** Prisms for each constant
+**Naming:** `<EnumName>Prisms`
+
+Requirements:
+- Must be an enum type
+- Constants are converted to camelCase method names
+
+```java
+public enum Status { PENDING, IN_PROGRESS, COMPLETED }
+// Generates: StatusPrisms with pending(), inProgress(), completed()
+```
+
+### Wither Classes
+
+**Detection:** Class with `withX()` methods matching getters
+**Generated:** Lenses for each wither/getter pair
+**Naming:** `<ClassName>Lenses`
+
+Requirements:
+- Must have at least one wither method
+- Wither method pattern: `T withX(V value)` where T is the class type
+- Corresponding getter pattern: `V getX()` or `V x()` (record-style)
+- Wither must return same type (or subtype) as declaring class
+
+```java
+public class ImmutableConfig {
+    public String getHost() { ... }
+    public ImmutableConfig withHost(String host) { ... }
+}
+// Generates: ImmutableConfigLenses with host()
+```
+
+---
+
+## Container Type Support
+
+Container fields automatically generate additional traversal methods:
+
+| Container Type | Traversal Method Suffix |
+|----------------|------------------------|
+| `List<E>` | `<field>Traversal()` |
+| `Set<E>` | `<field>Traversal()` |
+| `Optional<E>` | `<field>Traversal()` |
+| `E[]` | `<field>Traversal()` |
+| `Map<K, V>` | `<field>Traversal()` (values only) |
+
+---
+
+## Error Messages
+
+### Mutable Class Rejected
+
+```
+Type 'com.example.MutablePerson' has mutable fields (setters).
+Lens laws may not hold for mutable types.
+Either use allowMutable = true to acknowledge this limitation,
+or create a spec interface for explicit control.
+```
+
+**Resolution:** Add `allowMutable = true` or use a spec interface (Phase 2 feature).
+
+### Unsupported Type
+
+```
+Type 'com.example.PlainClass' is not a record, sealed interface, enum,
+or class with wither methods. Cannot determine how to generate optics.
+```
+
+**Resolution:** The type doesn't match any supported pattern. Consider:
+- Adding wither methods to the source if you control it
+- Using a spec interface (Phase 2 feature)
+- Manual optic creation
+
+### Missing Getter for Wither
+
+Wither methods without corresponding getters are silently skipped. Ensure your class has matching getter methods.
+
+---
+
+## Generated Class Structure
+
+### Lenses Class
+
+```java
+@Generated
+public final class CustomerLenses {
+    private CustomerLenses() {}  // Utility class
+
+    // Lens methods
+    public static Lens<Customer, String> name() { ... }
+    public static Lens<Customer, Integer> age() { ... }
+
+    // Convenience with methods
+    public static Customer withName(Customer source, String newName) { ... }
+    public static Customer withAge(Customer source, int newAge) { ... }
+
+    // Traversals for container fields
+    public static Traversal<Customer, Order> ordersTraversal() { ... }
+}
+```
+
+### Prisms Class
+
+```java
+@Generated
+public final class ShapePrisms {
+    private ShapePrisms() {}  // Utility class
+
+    // Prism methods for each subtype
+    public static Prism<Shape, Circle> circle() { ... }
+    public static Prism<Shape, Rectangle> rectangle() { ... }
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Organise by Domain
+
+Create separate packages for different external libraries:
+
+```
+com.myapp.optics.javatime/    # java.time types
+com.myapp.optics.jackson/     # Jackson types
+com.myapp.optics.external/    # Other external types
+```
+
+### 2. Use package-info.java
+
+Prefer package-info.java over type-level annotations for clarity:
+
+```java
+// Preferred: Clear and discoverable
+@ImportOptics({...})
+package com.myapp.optics.javatime;
+```
+
+### 3. Document Mutable Type Usage
+
+When using `allowMutable = true`, document why it's acceptable:
+
+```java
+/**
+ * Optics for legacy domain types.
+ * Note: These types are mutable. Use with caution in concurrent contexts.
+ */
+@ImportOptics(value = {...}, allowMutable = true)
+package com.myapp.optics.legacy;
+```
+
+### 4. Combine with Local Optics
+
+Import optics can be composed with locally generated optics:
+
+```java
+// Local record with generated optics
+@GenerateLenses
+public record Order(LocalDate createdDate, Customer customer) {}
+
+// Compose imported and local optics
+Lens<Order, Integer> orderYearLens =
+    OrderLenses.createdDate().andThen(LocalDateLenses.year());
+```
+
+---
+
+~~~admonish info title="Key Takeaways"
+* Use `value` to specify classes, `targetPackage` for output location
+* Mutable classes require explicit `allowMutable = true`
+* Generated classes follow consistent naming: `<Type>Lenses` or `<Type>Prisms`
+* Container fields get additional traversal methods
+* Organise imports by domain for maintainability
+~~~
+
+~~~admonish tip title="See Also"
+- [Importing Optics](importing_optics.md) - Usage guide with examples
+- [Composing Optics](composing_optics.md) - Combining generated optics
+- [Traversals](traversals.md) - Working with generated traversals
+~~~
+
+---
+
+**Previous:** [Importing Optics](importing_optics.md)

--- a/hkj-book/src/optics/importing_optics.md
+++ b/hkj-book/src/optics/importing_optics.md
@@ -1,0 +1,295 @@
+# Importing Optics for External Types
+
+## _Generating Lenses and Prisms for Types You Don't Own_
+
+~~~admonish info title="What You'll Learn"
+- How to generate optics for types you cannot annotate directly
+- Auto-detection rules for records, sealed types, enums, and wither-based classes
+- How to use generated optics with third-party library types
+- Handling mutable classes and edge cases
+~~~
+
+When working with external libraries, you often encounter types that would benefit from optics but cannot be annotated directly. The `@ImportOptics` annotation solves this problem by allowing you to generate optics for types you don't own.
+
+---
+
+## The Problem
+
+Normally, to generate optics for a type, you annotate it with `@GenerateLenses`, `@GeneratePrisms`, or similar annotations:
+
+```java
+@GenerateLenses
+public record Customer(String name, int age) {}
+```
+
+But what about types from external libraries like `java.time.LocalDate` or a third-party domain model? You cannot modify those source files.
+
+---
+
+## The Solution: @ImportOptics
+
+The `@ImportOptics` annotation lets you generate optics for any accessible type. Apply it to a `package-info.java` file or a configuration class:
+
+```java
+// In package-info.java
+@ImportOptics({
+    java.time.LocalDate.class,
+    com.external.CustomerRecord.class
+})
+package com.mycompany.optics;
+
+import org.higherkindedj.optics.annotations.ImportOptics;
+```
+
+The processor analyses each class and generates appropriate optics:
+
+| Source Type | Generated Optics |
+|-------------|------------------|
+| Record | Lenses via canonical constructor |
+| Sealed interface | Prisms for each permitted subtype |
+| Enum | Prisms for each constant |
+| Class with withers | Lenses via wither methods |
+
+---
+
+## What Gets Generated
+
+### Records → Lenses
+
+For external records, the processor generates lenses for each component:
+
+```java
+// External record
+package com.external;
+public record Point(int x, int y) {}
+
+// Your package-info.java
+@ImportOptics({com.external.Point.class})
+package com.myapp.optics;
+```
+
+This generates `PointLenses` with:
+
+```java
+// Generated: com.myapp.optics.PointLenses
+public static Lens<Point, Integer> x() { ... }
+public static Lens<Point, Integer> y() { ... }
+public static Point withX(Point source, int newX) { ... }
+public static Point withY(Point source, int newY) { ... }
+```
+
+### Sealed Interfaces → Prisms
+
+For sealed interfaces, prisms are generated for each permitted subtype:
+
+```java
+// External sealed interface
+package com.external;
+public sealed interface Shape permits Circle, Rectangle {}
+public record Circle(double radius) implements Shape {}
+public record Rectangle(double width, double height) implements Shape {}
+
+// Your package-info.java
+@ImportOptics({com.external.Shape.class})
+package com.myapp.optics;
+```
+
+This generates `ShapePrisms` with:
+
+```java
+// Generated: com.myapp.optics.ShapePrisms
+public static Prism<Shape, Circle> circle() { ... }
+public static Prism<Shape, Rectangle> rectangle() { ... }
+```
+
+### Enums → Prisms
+
+For enums, prisms are generated for each constant:
+
+```java
+// External enum
+package com.external;
+public enum Status { PENDING, ACTIVE, COMPLETED }
+
+// Your package-info.java
+@ImportOptics({com.external.Status.class})
+package com.myapp.optics;
+```
+
+This generates `StatusPrisms` with:
+
+```java
+// Generated: com.myapp.optics.StatusPrisms
+public static Prism<Status, Status> pending() { ... }
+public static Prism<Status, Status> active() { ... }
+public static Prism<Status, Status> completed() { ... }
+```
+
+### Classes with Withers → Lenses
+
+For immutable classes that use the wither pattern (like `java.time.LocalDate`), lenses are generated via the wither methods:
+
+```java
+// java.time.LocalDate has:
+// - getYear() / withYear(int)
+// - getMonth() / withMonth(Month)
+// - getDayOfMonth() / withDayOfMonth(int)
+
+@ImportOptics({java.time.LocalDate.class})
+package com.myapp.optics;
+```
+
+This generates `LocalDateLenses` with:
+
+```java
+// Generated: com.myapp.optics.LocalDateLenses
+public static Lens<LocalDate, Integer> year() { ... }
+public static Lens<LocalDate, Integer> dayOfMonth() { ... }
+// etc.
+```
+
+---
+
+## Container Field Traversals
+
+When a record has container fields (List, Set, Optional, arrays, Map), the processor automatically generates traversal methods:
+
+```java
+// External record with container field
+public record Order(String id, List<String> items) {}
+
+// Your package-info.java
+@ImportOptics({Order.class})
+package com.myapp.optics;
+```
+
+This generates both lenses and traversals:
+
+```java
+// Generated: com.myapp.optics.OrderLenses
+public static Lens<Order, String> id() { ... }
+public static Lens<Order, List<String>> items() { ... }
+public static Traversal<Order, String> itemsTraversal() { ... }
+```
+
+---
+
+## Generic Type Support
+
+Generic types like `Pair<A, B>` generate parameterised optics:
+
+```java
+// External generic record
+public record Pair<A, B>(A first, B second) {}
+
+@ImportOptics({Pair.class})
+package com.myapp.optics;
+```
+
+This generates:
+
+```java
+// Generated: com.myapp.optics.PairLenses
+public static <A, B> Lens<Pair<A, B>, A> first() { ... }
+public static <A, B> Lens<Pair<A, B>, B> second() { ... }
+```
+
+---
+
+## Handling Mutable Classes
+
+By default, the processor refuses to generate lenses for mutable classes (those with setter methods) because lens laws may not hold when the source object can be mutated:
+
+```java
+// This will produce a compile-time error
+@ImportOptics({MutablePerson.class})  // Error: has mutable fields
+package com.myapp.optics;
+```
+
+To acknowledge this limitation and generate anyway, use `allowMutable = true`:
+
+```java
+@ImportOptics(
+    value = {MutablePerson.class},
+    allowMutable = true  // Acknowledge lens law limitations
+)
+package com.myapp.optics;
+```
+
+---
+
+## Target Package Configuration
+
+By default, generated classes are placed in the annotated package. Use `targetPackage` to specify a different location:
+
+```java
+@ImportOptics(
+    value = {java.time.LocalDate.class},
+    targetPackage = "com.myapp.generated.optics"
+)
+package com.myapp.config;
+```
+
+---
+
+## Type-Level Annotation
+
+You can also apply `@ImportOptics` to a class instead of package-info:
+
+```java
+@ImportOptics({java.time.LocalDate.class, java.time.LocalTime.class})
+public class TimeOptics {
+    // Generated optics appear in the same package
+}
+```
+
+---
+
+## Complete Example
+
+```java
+// package-info.java
+@ImportOptics({
+    java.time.LocalDate.class,
+    java.time.LocalTime.class,
+    java.util.UUID.class
+})
+package com.mycompany.optics.external;
+
+import org.higherkindedj.optics.annotations.ImportOptics;
+```
+
+```java
+// Usage
+import com.mycompany.optics.external.LocalDateLenses;
+
+LocalDate date = LocalDate.of(2024, 6, 15);
+
+// Use generated lens to update year
+LocalDate nextYear = LocalDateLenses.year().modify(y -> y + 1, date);
+// Result: 2025-06-15
+
+// Or use the convenience method
+LocalDate specificYear = LocalDateLenses.withYear(date, 2030);
+// Result: 2030-06-15
+```
+
+---
+
+~~~admonish info title="Key Takeaways"
+* `@ImportOptics` generates optics for external types you cannot annotate directly
+* Records, sealed interfaces, enums, and wither-based classes are auto-detected
+* Container fields automatically get traversal methods
+* Mutable classes require explicit `allowMutable = true` acknowledgement
+* Generic types generate parameterised optics preserving type safety
+~~~
+
+~~~admonish tip title="See Also"
+- [@ImportOptics Reference](import_optics_reference.md) - Complete annotation reference
+- [Focus DSL](focus_dsl.md) - Using generated optics with Focus paths
+- [Composing Optics](composing_optics.md) - Combining generated optics
+~~~
+
+---
+
+**Next:** [@ImportOptics Reference](import_optics_reference.md)

--- a/hkj-examples/EXAMPLES-GUIDE.md
+++ b/hkj-examples/EXAMPLES-GUIDE.md
@@ -269,6 +269,17 @@ Ready-to-use patterns for common optics use cases.
 | [CompositionRecipes.java](src/main/java/org/higherkindedj/example/optics/cookbook/CompositionRecipes.java) | Recipes for optic composition | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.cookbook.CompositionRecipes` | [Cookbook](https://higher-kinded-j.github.io/latest/optics/cookbook.html) |
 | [ConditionalUpdateRecipes.java](src/main/java/org/higherkindedj/example/optics/cookbook/ConditionalUpdateRecipes.java) | Recipes for conditional updates | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.cookbook.ConditionalUpdateRecipes` | [Cookbook](https://higher-kinded-j.github.io/latest/optics/cookbook.html) |
 
+### Importing External Optics
+
+Examples demonstrating the `@ImportOptics` annotation for generating optics for external types you don't own.
+
+| Example | Description | Run Command | Documentation |
+|---------|-------------|-------------|---------------|
+| [ImportOpticsBasicExample.java](src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsBasicExample.java) | Basic usage with java.time types (LocalDate, LocalTime) | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.importoptics.ImportOpticsBasicExample` | [Importing Optics](https://higher-kinded-j.github.io/latest/optics/importing_optics.html) |
+| [ImportOpticsCompositionExample.java](src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsCompositionExample.java) | Composing imported optics with local optics | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.importoptics.ImportOpticsCompositionExample` | [Importing Optics](https://higher-kinded-j.github.io/latest/optics/importing_optics.html) |
+| [ImportOpticsRecordExample.java](src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsRecordExample.java) | Generating lenses for external record types | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.importoptics.ImportOpticsRecordExample` | [Importing Optics](https://higher-kinded-j.github.io/latest/optics/importing_optics.html) |
+| [ImportOpticsSealedExample.java](src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsSealedExample.java) | Generating prisms for sealed interfaces, enums, and JDK types | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.importoptics.ImportOpticsSealedExample` | [Importing Optics](https://higher-kinded-j.github.io/latest/optics/importing_optics.html) |
+
 ### Real-World Optics Scenarios
 
 | Example | Description | Run Command | Documentation |

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsBasicExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsBasicExample.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.higherkindedj.optics.Lens;
+
+/**
+ * A runnable example demonstrating how to use {@code @ImportOptics} to generate lenses for external
+ * types like {@link java.time.LocalDate}.
+ *
+ * <p>The {@code @ImportOptics} annotation in the package-info.java file generates lenses for {@code
+ * LocalDate} and {@code LocalTime}, allowing immutable updates via their wither methods.
+ */
+public class ImportOpticsBasicExample {
+
+  public static void main(String[] args) {
+    System.out.println("=== ImportOptics Basic Example ===\n");
+
+    // 1. Working with LocalDate
+    LocalDate today = LocalDate.of(2024, 6, 15);
+    System.out.println("Original date: " + today);
+
+    // Get the generated lens for the year field
+    Lens<LocalDate, Integer> yearLens = LocalDateLenses.year();
+
+    // Use the lens to read the year
+    int year = yearLens.get(today);
+    System.out.println("Year via lens: " + year);
+
+    // Use the lens to update the year immutably
+    LocalDate nextYear = yearLens.modify(y -> y + 1, today);
+    System.out.println("Next year: " + nextYear);
+
+    // Use the convenience with method
+    LocalDate specificYear = LocalDateLenses.withYear(today, 2030);
+    System.out.println("Year 2030: " + specificYear);
+
+    System.out.println();
+
+    // 2. Composing multiple field updates
+    // Update multiple fields by chaining lens operations
+    LocalDate modified = LocalDateLenses.withYear(LocalDateLenses.withDayOfMonth(today, 1), 2025);
+    System.out.println("Modified (Jan 1, 2025): " + modified);
+
+    System.out.println();
+
+    // 3. Working with LocalTime
+    LocalTime time = LocalTime.of(14, 30, 0);
+    System.out.println("Original time: " + time);
+
+    // Get the hour lens
+    Lens<LocalTime, Integer> hourLens = LocalTimeLenses.hour();
+    int hour = hourLens.get(time);
+    System.out.println("Hour via lens: " + hour);
+
+    // Modify the hour
+    LocalTime evening = hourLens.set(20, time);
+    System.out.println("Evening time: " + evening);
+
+    System.out.println();
+
+    // 4. Using modify for calculations
+    // Add 2 hours to the time
+    LocalTime laterTime = hourLens.modify(h -> (h + 2) % 24, time);
+    System.out.println("Two hours later: " + laterTime);
+
+    System.out.println("\n=== Example Complete ===");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsCompositionExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsCompositionExample.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics;
+
+import java.time.LocalDate;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+
+/**
+ * A runnable example demonstrating how to compose imported optics with locally generated optics.
+ *
+ * <p>This example shows how optics generated via {@code @ImportOptics} can be seamlessly composed
+ * with optics generated via {@code @GenerateLenses} on your own types.
+ */
+public class ImportOpticsCompositionExample {
+
+  // Local domain records with generated lenses
+  @GenerateLenses
+  public record Event(String name, LocalDate date, String location) {}
+
+  @GenerateLenses
+  public record Calendar(String owner, Event nextEvent) {}
+
+  public static void main(String[] args) {
+    System.out.println("=== ImportOptics Composition Example ===\n");
+
+    // 1. Create sample data
+    Event conference = new Event("Java Conference", LocalDate.of(2024, 9, 15), "London");
+    Calendar myCalendar = new Calendar("Alice", conference);
+
+    System.out.println("Original calendar: " + myCalendar);
+    System.out.println();
+
+    // 2. Compose local lenses with imported lenses
+    // Create a lens from Calendar -> Event -> LocalDate -> year
+    Lens<Calendar, Event> calendarToEvent = CalendarLenses.nextEvent();
+    Lens<Event, LocalDate> eventToDate = EventLenses.date();
+    Lens<LocalDate, Integer> dateToYear = LocalDateLenses.year();
+
+    // Compose into a deep lens
+    Lens<Calendar, Integer> calendarToYear =
+        calendarToEvent.andThen(eventToDate).andThen(dateToYear);
+
+    // 3. Use the composed lens to read
+    int eventYear = calendarToYear.get(myCalendar);
+    System.out.println("Event year: " + eventYear);
+
+    // 4. Use the composed lens to update deeply
+    Calendar updatedCalendar = calendarToYear.set(2025, myCalendar);
+    System.out.println("Updated calendar (year 2025): " + updatedCalendar);
+    System.out.println("Original unchanged: " + myCalendar);
+    System.out.println();
+
+    // 5. Modify using a function
+    Calendar postponedCalendar = calendarToYear.modify(y -> y + 1, myCalendar);
+    System.out.println("Postponed by 1 year: " + postponedCalendar);
+    System.out.println();
+
+    // 6. Combine multiple updates
+    // Update both the event name and postpone by 2 years
+    Lens<Calendar, String> calendarToEventName = calendarToEvent.andThen(EventLenses.name());
+
+    Calendar fullyUpdated =
+        calendarToEventName.set("Java Summit", calendarToYear.modify(y -> y + 2, myCalendar));
+
+    System.out.println("Renamed and postponed: " + fullyUpdated);
+
+    // 7. Create a lens to the day of month for more precise control
+    Lens<Calendar, Integer> calendarToDay =
+        calendarToEvent.andThen(eventToDate).andThen(LocalDateLenses.dayOfMonth());
+
+    Calendar movedToFirstDay = calendarToDay.set(1, myCalendar);
+    System.out.println("Moved to 1st of month: " + movedToFirstDay);
+
+    System.out.println("\n=== Example Complete ===");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsRecordExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsRecordExample.java
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics;
+
+import org.higherkindedj.example.optics.importoptics.external.Customer;
+import org.higherkindedj.optics.Lens;
+
+/**
+ * A runnable example demonstrating how to use {@code @ImportOptics} to generate lenses for external
+ * record types.
+ *
+ * <p>This example shows that records from external libraries (simulated here by the {@code
+ * external} package) can have lenses generated via the {@code @ImportOptics} annotation in
+ * package-info.java.
+ */
+public class ImportOpticsRecordExample {
+
+  public static void main(String[] args) {
+    System.out.println("=== ImportOptics Record Example ===\n");
+
+    // 1. Create an external record instance
+    Customer customer = new Customer("C001", "Alice Smith", "alice@example.com", 150);
+    System.out.println("Original customer: " + customer);
+    System.out.println();
+
+    // 2. Use generated lenses to access fields
+    // The annotation processor generates CustomerLenses with lenses for each component
+    Lens<Customer, String> nameLens = CustomerLenses.name();
+    Lens<Customer, String> emailLens = CustomerLenses.email();
+    Lens<Customer, Integer> loyaltyPointsLens = CustomerLenses.loyaltyPoints();
+
+    String name = nameLens.get(customer);
+    String email = emailLens.get(customer);
+    int points = loyaltyPointsLens.get(customer);
+
+    System.out.println("Name via lens: " + name);
+    System.out.println("Email via lens: " + email);
+    System.out.println("Loyalty points via lens: " + points);
+    System.out.println();
+
+    // 3. Use lenses to create updated copies immutably
+    Customer updatedName = nameLens.set("Alice Johnson", customer);
+    System.out.println("After name change: " + updatedName);
+
+    Customer updatedEmail = emailLens.set("alice.johnson@newdomain.com", customer);
+    System.out.println("After email change: " + updatedEmail);
+    System.out.println();
+
+    // 4. Use modify for computed updates
+    // Add 50 loyalty points
+    Customer withBonusPoints = loyaltyPointsLens.modify(p -> p + 50, customer);
+    System.out.println("After bonus points: " + withBonusPoints);
+
+    // Double the loyalty points
+    Customer doubledPoints = loyaltyPointsLens.modify(p -> p * 2, customer);
+    System.out.println("After doubling points: " + doubledPoints);
+    System.out.println();
+
+    // 5. Use generated convenience methods
+    // The processor also generates withX() helper methods
+    Customer viaWithMethod = CustomerLenses.withName(customer, "Bob Williams");
+    System.out.println("Via withName method: " + viaWithMethod);
+
+    // 6. Chain multiple updates
+    Customer fullyUpdated =
+        CustomerLenses.withLoyaltyPoints(
+            CustomerLenses.withEmail(
+                CustomerLenses.withName(customer, "Carol Davis"), "carol@business.com"),
+            500);
+    System.out.println("Fully updated customer: " + fullyUpdated);
+    System.out.println();
+
+    // 7. Original remains unchanged (immutability)
+    System.out.println("Original unchanged: " + customer);
+
+    System.out.println("\n=== Example Complete ===");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsSealedExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/ImportOpticsSealedExample.java
@@ -1,0 +1,204 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.higherkindedj.example.optics.importoptics.external.BankTransfer;
+import org.higherkindedj.example.optics.importoptics.external.CreditCard;
+import org.higherkindedj.example.optics.importoptics.external.DigitalWallet;
+import org.higherkindedj.example.optics.importoptics.external.OrderStatus;
+import org.higherkindedj.example.optics.importoptics.external.PaymentMethod;
+import org.higherkindedj.optics.Prism;
+
+/**
+ * A runnable example demonstrating how to use {@code @ImportOptics} to generate prisms for external
+ * sealed interfaces and enums.
+ *
+ * <p>This example shows that sealed interfaces and enums from external libraries can have prisms
+ * generated via the {@code @ImportOptics} annotation. It demonstrates:
+ *
+ * <ul>
+ *   <li>JDK enums: {@link DayOfWeek}, {@link Month}, {@link TimeUnit}
+ *   <li>Custom sealed interfaces: PaymentMethod
+ *   <li>Custom enums: OrderStatus
+ * </ul>
+ */
+public class ImportOpticsSealedExample {
+
+  public static void main(String[] args) {
+    System.out.println("=== ImportOptics Sealed Interface & Enum Example ===\n");
+
+    // ===== JDK ENUM PRISMS =====
+    demonstrateJdkEnums();
+
+    // ===== SEALED INTERFACE PRISMS =====
+    System.out.println("--- Sealed Interface Prisms (Custom Types) ---\n");
+
+    // 1. Create instances of the sealed interface subtypes
+    PaymentMethod creditCard = new CreditCard("4111-1111-1111-1111", "12/25");
+    PaymentMethod bankTransfer = new BankTransfer("12345678", "00-11-22");
+    PaymentMethod digitalWallet = new DigitalWallet("PayPal", "user@paypal.com");
+
+    // 2. Get the generated prisms for each subtype
+    Prism<PaymentMethod, CreditCard> creditCardPrism = PaymentMethodPrisms.creditCard();
+    Prism<PaymentMethod, BankTransfer> bankTransferPrism = PaymentMethodPrisms.bankTransfer();
+    Prism<PaymentMethod, DigitalWallet> digitalWalletPrism = PaymentMethodPrisms.digitalWallet();
+
+    // 3. Use getOptional to safely extract subtypes
+    Optional<CreditCard> asCreditCard = creditCardPrism.getOptional(creditCard);
+    System.out.println("Credit card as CreditCard: " + asCreditCard);
+
+    Optional<BankTransfer> asBankTransfer = bankTransferPrism.getOptional(creditCard);
+    System.out.println("Credit card as BankTransfer: " + asBankTransfer); // Empty
+
+    // 4. Use getOrModify for pattern matching
+    System.out.println("\nProcessing payments:");
+    for (PaymentMethod payment : new PaymentMethod[] {creditCard, bankTransfer, digitalWallet}) {
+      String description = describePayment(payment);
+      System.out.println("  " + description);
+    }
+
+    // 5. Use build to construct values (upcast)
+    CreditCard newCard = new CreditCard("5500-0000-0000-0004", "06/28");
+    PaymentMethod asPaymentMethod = creditCardPrism.build(newCard);
+    System.out.println("\nBuilt credit card: " + asPaymentMethod);
+
+    System.out.println();
+
+    // ===== CUSTOM ENUM PRISMS =====
+    System.out.println("--- Custom Enum Prisms ---\n");
+
+    // 6. Get prisms for enum constants
+    Prism<OrderStatus, OrderStatus> pendingPrism = OrderStatusPrisms.pending();
+    Prism<OrderStatus, OrderStatus> shippedPrism = OrderStatusPrisms.shipped();
+    Prism<OrderStatus, OrderStatus> cancelledPrism = OrderStatusPrisms.cancelled();
+
+    // 7. Use getOptional to check specific status
+    OrderStatus status1 = OrderStatus.PENDING;
+    OrderStatus status2 = OrderStatus.SHIPPED;
+
+    System.out.println("Is PENDING pending? " + pendingPrism.getOptional(status1).isPresent());
+    System.out.println("Is SHIPPED pending? " + pendingPrism.getOptional(status2).isPresent());
+    System.out.println("Is SHIPPED shipped? " + shippedPrism.getOptional(status2).isPresent());
+    System.out.println();
+
+    // 8. Filter orders by status using prisms
+    OrderStatus[] orders = {
+      OrderStatus.PENDING,
+      OrderStatus.CONFIRMED,
+      OrderStatus.SHIPPED,
+      OrderStatus.PENDING,
+      OrderStatus.DELIVERED,
+      OrderStatus.CANCELLED
+    };
+
+    long pendingCount =
+        Arrays.stream(orders).filter(s -> pendingPrism.getOptional(s).isPresent()).count();
+
+    long cancelledCount =
+        Arrays.stream(orders).filter(s -> cancelledPrism.getOptional(s).isPresent()).count();
+
+    System.out.println("Pending orders: " + pendingCount);
+    System.out.println("Cancelled orders: " + cancelledCount);
+
+    System.out.println("\n=== Example Complete ===");
+  }
+
+  /**
+   * Demonstrates using prisms generated for JDK enums.
+   *
+   * <p>This shows that @ImportOptics works with real external types from the Java standard library,
+   * not just custom types.
+   */
+  private static void demonstrateJdkEnums() {
+    System.out.println("--- JDK Enum Prisms (Real External Types) ---\n");
+
+    // 1. DayOfWeek prisms - useful for scheduling logic
+    Prism<DayOfWeek, DayOfWeek> mondayPrism = DayOfWeekPrisms.monday();
+    Prism<DayOfWeek, DayOfWeek> saturdayPrism = DayOfWeekPrisms.saturday();
+    Prism<DayOfWeek, DayOfWeek> sundayPrism = DayOfWeekPrisms.sunday();
+
+    DayOfWeek today = DayOfWeek.SATURDAY;
+    boolean isWeekend =
+        saturdayPrism.getOptional(today).isPresent() || sundayPrism.getOptional(today).isPresent();
+    System.out.println("Is " + today + " a weekend? " + isWeekend);
+
+    // Count weekdays in a schedule
+    DayOfWeek[] schedule = {
+      DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY
+    };
+    long mondayCount =
+        Arrays.stream(schedule).filter(d -> mondayPrism.getOptional(d).isPresent()).count();
+    System.out.println("Mondays in schedule: " + mondayCount);
+    System.out.println();
+
+    // 2. Month prisms - useful for seasonal logic
+    Prism<Month, Month> januaryPrism = MonthPrisms.january();
+    Prism<Month, Month> decemberPrism = MonthPrisms.december();
+    Prism<Month, Month> julyPrism = MonthPrisms.july();
+
+    Month currentMonth = Month.DECEMBER;
+    boolean isYearEnd = decemberPrism.getOptional(currentMonth).isPresent();
+    boolean isYearStart = januaryPrism.getOptional(currentMonth).isPresent();
+    System.out.println("Is " + currentMonth + " year-end? " + isYearEnd);
+    System.out.println("Is " + currentMonth + " year-start? " + isYearStart);
+
+    // Find summer months
+    Month[] fiscalYear = {Month.APRIL, Month.MAY, Month.JUNE, Month.JULY, Month.AUGUST};
+    boolean hasSummerPeak =
+        Arrays.stream(fiscalYear).anyMatch(m -> julyPrism.getOptional(m).isPresent());
+    System.out.println("Fiscal year includes July (summer peak)? " + hasSummerPeak);
+    System.out.println();
+
+    // 3. TimeUnit prisms - useful for duration handling
+    Prism<TimeUnit, TimeUnit> millisPrism = TimeUnitPrisms.milliseconds();
+    Prism<TimeUnit, TimeUnit> secondsPrism = TimeUnitPrisms.seconds();
+    Prism<TimeUnit, TimeUnit> daysPrism = TimeUnitPrisms.days();
+
+    TimeUnit unit = TimeUnit.SECONDS;
+    boolean isSmallUnit =
+        millisPrism.getOptional(unit).isPresent() || secondsPrism.getOptional(unit).isPresent();
+    System.out.println("Is " + unit + " a small time unit? " + isSmallUnit);
+
+    // Check if a timeout unit is appropriate for human interaction
+    TimeUnit[] timeoutUnits = {TimeUnit.MILLISECONDS, TimeUnit.SECONDS, TimeUnit.MINUTES};
+    boolean hasDayTimeout =
+        Arrays.stream(timeoutUnits).anyMatch(u -> daysPrism.getOptional(u).isPresent());
+    System.out.println("Any day-level timeouts? " + hasDayTimeout + " (good for UX!)");
+
+    System.out.println();
+  }
+
+  /**
+   * Describes a payment method using prisms for type-safe pattern matching.
+   *
+   * @param payment the payment method to describe
+   * @return a description of the payment method
+   */
+  private static String describePayment(PaymentMethod payment) {
+    Prism<PaymentMethod, CreditCard> ccPrism = PaymentMethodPrisms.creditCard();
+    Prism<PaymentMethod, BankTransfer> btPrism = PaymentMethodPrisms.bankTransfer();
+    Prism<PaymentMethod, DigitalWallet> dwPrism = PaymentMethodPrisms.digitalWallet();
+
+    return ccPrism
+        .getOptional(payment)
+        .map(
+            cc ->
+                "Credit Card ending in " + cc.cardNumber().substring(cc.cardNumber().length() - 4))
+        .or(
+            () ->
+                btPrism
+                    .getOptional(payment)
+                    .map(bt -> "Bank Transfer to account " + bt.accountNumber()))
+        .or(
+            () ->
+                dwPrism
+                    .getOptional(payment)
+                    .map(dw -> dw.provider() + " wallet (" + dw.accountEmail() + ")"))
+        .orElse("Unknown payment method");
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/BankTransfer.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/BankTransfer.java
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics.external;
+
+/** A bank transfer payment method. */
+public record BankTransfer(String accountNumber, String sortCode) implements PaymentMethod {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/CreditCard.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/CreditCard.java
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics.external;
+
+/** A credit card payment method. */
+public record CreditCard(String cardNumber, String expiryDate) implements PaymentMethod {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/Customer.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/Customer.java
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics.external;
+
+/**
+ * External record types used to demonstrate {@code @ImportOptics} with records.
+ *
+ * <p>These types simulate external library types that cannot be annotated directly.
+ */
+public record Customer(String id, String name, String email, int loyaltyPoints) {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/DigitalWallet.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/DigitalWallet.java
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics.external;
+
+/** A digital wallet payment method. */
+public record DigitalWallet(String provider, String accountEmail) implements PaymentMethod {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/OrderStatus.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/OrderStatus.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics.external;
+
+/**
+ * External enum used to demonstrate {@code @ImportOptics} with enums.
+ *
+ * <p>This simulates an external library enum that cannot be annotated directly.
+ */
+public enum OrderStatus {
+  PENDING,
+  CONFIRMED,
+  PROCESSING,
+  SHIPPED,
+  DELIVERED,
+  CANCELLED
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/PaymentMethod.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/external/PaymentMethod.java
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.importoptics.external;
+
+/**
+ * External sealed interface used to demonstrate {@code @ImportOptics} with sum types.
+ *
+ * <p>These types simulate external library types that cannot be annotated directly.
+ */
+public sealed interface PaymentMethod permits CreditCard, BankTransfer, DigitalWallet {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/package-info.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/importoptics/package-info.java
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+/**
+ * Examples demonstrating the {@code @ImportOptics} annotation for generating optics for external
+ * types.
+ *
+ * <p>This package contains examples of how to use the {@code @ImportOptics} annotation to generate
+ * lenses and prisms for types you do not own. It demonstrates:
+ *
+ * <ul>
+ *   <li>Wither-based classes: {@link java.time.LocalDate}, {@link java.time.LocalTime}
+ *   <li>JDK enums: {@link java.time.DayOfWeek}, {@link java.time.Month}, {@link
+ *       java.util.concurrent.TimeUnit}
+ *   <li>External records: {@link org.higherkindedj.example.optics.importoptics.external.Customer}
+ *   <li>Sealed interfaces: {@link
+ *       org.higherkindedj.example.optics.importoptics.external.PaymentMethod}
+ *   <li>Custom enums: {@link org.higherkindedj.example.optics.importoptics.external.OrderStatus}
+ * </ul>
+ */
+@ImportOptics({
+  // Wither-based classes from java.time
+  LocalDate.class,
+  LocalTime.class,
+  // JDK enums - real external types from the standard library
+  DayOfWeek.class,
+  Month.class,
+  TimeUnit.class,
+  // External record (simulated third-party library)
+  Customer.class,
+  // External sealed interface (simulated third-party library)
+  PaymentMethod.class,
+  // External enum (simulated third-party library)
+  OrderStatus.class
+})
+package org.higherkindedj.example.optics.importoptics;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.util.concurrent.TimeUnit;
+import org.higherkindedj.example.optics.importoptics.external.Customer;
+import org.higherkindedj.example.optics.importoptics.external.OrderStatus;
+import org.higherkindedj.example.optics.importoptics.external.PaymentMethod;
+import org.higherkindedj.optics.annotations.ImportOptics;

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/EitherGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/EitherGenerator.java
@@ -29,6 +29,11 @@ public class EitherGenerator extends BaseTraversableGenerator {
   }
 
   @Override
+  public int getFocusTypeArgumentIndex() {
+    return 1; // Either<L, R> focuses on R (the second type argument)
+  }
+
+  @Override
   public CodeBlock generateModifyF(
       final RecordComponentElement component,
       final ClassName recordClassName,

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/MapValueGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/MapValueGenerator.java
@@ -33,6 +33,11 @@ public class MapValueGenerator extends BaseTraversableGenerator {
   }
 
   @Override
+  public int getFocusTypeArgumentIndex() {
+    return 1; // Map<K, V> focuses on V (the second type argument)
+  }
+
+  @Override
   public CodeBlock generateModifyF(
       final RecordComponentElement component,
       final ClassName recordClassName,

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/ValidatedGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/ValidatedGenerator.java
@@ -34,6 +34,11 @@ public class ValidatedGenerator extends BaseTraversableGenerator {
   }
 
   @Override
+  public int getFocusTypeArgumentIndex() {
+    return 1; // Validated<E, A> focuses on A (the second type argument)
+  }
+
+  @Override
   public CodeBlock generateModifyF(
       final RecordComponentElement component,
       final ClassName recordClassName,

--- a/hkj-processor/src/main/java/module-info.java
+++ b/hkj-processor/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.higherkindedj.processor {
       org.higherkindedj.optics.processing.LensProcessor,
       org.higherkindedj.optics.processing.PrismProcessor,
       org.higherkindedj.optics.processing.TraversalProcessor,
+      org.higherkindedj.optics.processing.ImportOpticsProcessor,
       org.higherkindedj.optics.processing.effect.PathProcessor;
 
   // It exports the SPI so the plugins module can implement it.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import com.google.auto.service.AutoService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
+import org.higherkindedj.optics.annotations.ImportOptics;
+import org.higherkindedj.optics.processing.external.ExternalLensGenerator;
+import org.higherkindedj.optics.processing.external.ExternalPrismGenerator;
+import org.higherkindedj.optics.processing.external.TypeAnalysis;
+import org.higherkindedj.optics.processing.external.TypeKindAnalyser;
+
+/**
+ * Annotation processor for {@link ImportOptics}.
+ *
+ * <p>This processor generates optics for external types that you do not own. When applied to a
+ * package (via {@code package-info.java}) or type, it analyses each referenced class and generates
+ * appropriate optics:
+ *
+ * <ul>
+ *   <li>Records → Lens per component (in {@code <TypeName>Lenses.java})
+ *   <li>Sealed interfaces → Prism per permitted subtype (in {@code <TypeName>Prisms.java})
+ *   <li>Enums → Prism per constant (in {@code <TypeName>Prisms.java})
+ *   <li>Classes with wither methods → Lens per wither (in {@code <TypeName>Lenses.java})
+ * </ul>
+ */
+@AutoService(Processor.class)
+@SupportedAnnotationTypes("org.higherkindedj.optics.annotations.ImportOptics")
+@SupportedSourceVersion(SourceVersion.RELEASE_25)
+public class ImportOpticsProcessor extends AbstractProcessor {
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    for (Element element : roundEnv.getElementsAnnotatedWith(ImportOptics.class)) {
+      if (element.getKind() == ElementKind.PACKAGE) {
+        processPackageAnnotation((PackageElement) element);
+      } else if (element.getKind() == ElementKind.CLASS
+          || element.getKind() == ElementKind.INTERFACE) {
+        processTypeAnnotation((TypeElement) element);
+      } else {
+        error("@ImportOptics can only be applied to packages or types.", element);
+      }
+    }
+    return true;
+  }
+
+  private void processPackageAnnotation(PackageElement packageElement) {
+    ImportOptics annotation = packageElement.getAnnotation(ImportOptics.class);
+
+    String targetPackage = annotation.targetPackage();
+    if (targetPackage.isEmpty()) {
+      targetPackage = packageElement.getQualifiedName().toString();
+    }
+
+    boolean allowMutable = annotation.allowMutable();
+
+    List<TypeElement> classesToProcess = getClassArrayFromAnnotation(packageElement);
+    for (TypeElement typeElement : classesToProcess) {
+      processType(typeElement, targetPackage, allowMutable, packageElement);
+    }
+  }
+
+  private void processTypeAnnotation(TypeElement typeElement) {
+    ImportOptics annotation = typeElement.getAnnotation(ImportOptics.class);
+
+    String targetPackage = annotation.targetPackage();
+    if (targetPackage.isEmpty()) {
+      targetPackage =
+          processingEnv.getElementUtils().getPackageOf(typeElement).getQualifiedName().toString();
+    }
+
+    boolean allowMutable = annotation.allowMutable();
+
+    List<TypeElement> classesToProcess = getClassArrayFromAnnotation(typeElement);
+    for (TypeElement externalType : classesToProcess) {
+      processType(externalType, targetPackage, allowMutable, typeElement);
+    }
+  }
+
+  private void processType(
+      TypeElement typeElement, String targetPackage, boolean allowMutable, Element sourceElement) {
+
+    TypeKindAnalyser typeAnalyser = new TypeKindAnalyser(processingEnv.getTypeUtils());
+    ExternalLensGenerator lensGenerator =
+        new ExternalLensGenerator(processingEnv.getFiler(), processingEnv.getMessager());
+    ExternalPrismGenerator prismGenerator =
+        new ExternalPrismGenerator(processingEnv.getFiler(), processingEnv.getMessager());
+
+    TypeAnalysis analysis = typeAnalyser.analyseType(typeElement);
+
+    switch (analysis.typeKind()) {
+      case RECORD -> lensGenerator.generateForRecord(analysis, targetPackage);
+
+      case SEALED_INTERFACE -> prismGenerator.generateForSealedInterface(analysis, targetPackage);
+
+      case ENUM -> prismGenerator.generateForEnum(analysis, targetPackage);
+
+      case WITHER_CLASS -> {
+        if (analysis.hasMutableFields() && !allowMutable) {
+          error(
+              "Type '"
+                  + typeElement.getQualifiedName()
+                  + "' has mutable fields (setters). "
+                  + "Lens laws may not hold for mutable types. "
+                  + "Either use allowMutable = true to acknowledge this limitation, "
+                  + "or create a spec interface for explicit control.",
+              sourceElement);
+          return;
+        }
+        lensGenerator.generateForWitherClass(analysis, targetPackage);
+      }
+
+      case UNSUPPORTED -> {
+        if (analysis.hasMutableFields()) {
+          error(
+              "Type '"
+                  + typeElement.getQualifiedName()
+                  + "' is a mutable class without wither methods. "
+                  + "Cannot generate lenses for types that don't support immutable updates. "
+                  + "Consider using a spec interface to define custom copy logic.",
+              sourceElement);
+        } else {
+          error(
+              "Type '"
+                  + typeElement.getQualifiedName()
+                  + "' is not a record, sealed interface, enum, or class with wither methods. "
+                  + "Cannot determine how to generate optics for this type.",
+              sourceElement);
+        }
+      }
+    }
+  }
+
+  /**
+   * Extracts the Class<?>[] value from an @ImportOptics annotation using the mirror API.
+   *
+   * <p>We cannot directly access the Class objects at compile time, so we use the annotation mirror
+   * API to extract the TypeMirrors and convert them to TypeElements.
+   */
+  private List<TypeElement> getClassArrayFromAnnotation(Element element) {
+    List<TypeElement> result = new ArrayList<>();
+
+    // Find the @ImportOptics annotation mirror
+    AnnotationMirror importOpticsMirror = null;
+    for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
+      DeclaredType annotationType = mirror.getAnnotationType();
+      TypeElement annotationElement = (TypeElement) annotationType.asElement();
+      if (annotationElement
+          .getQualifiedName()
+          .contentEquals("org.higherkindedj.optics.annotations.ImportOptics")) {
+        importOpticsMirror = mirror;
+        break;
+      }
+    }
+
+    if (importOpticsMirror == null) {
+      return result;
+    }
+
+    // Find the "value" element
+    for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
+        importOpticsMirror.getElementValues().entrySet()) {
+      if (entry.getKey().getSimpleName().contentEquals("value")) {
+        AnnotationValue value = entry.getValue();
+
+        // The value is a List<AnnotationValue> where each item is a TypeMirror
+        @SuppressWarnings("unchecked")
+        List<? extends AnnotationValue> classValues =
+            (List<? extends AnnotationValue>) value.getValue();
+
+        for (AnnotationValue classValue : classValues) {
+          TypeMirror typeMirror = (TypeMirror) classValue.getValue();
+          TypeElement typeElement =
+              (TypeElement) processingEnv.getTypeUtils().asElement(typeMirror);
+          if (typeElement != null) {
+            result.add(typeElement);
+          }
+        }
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  private void error(String msg, Element e) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, e);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/PrismProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/PrismProcessor.java
@@ -27,6 +27,7 @@ import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Prism;
 import org.higherkindedj.optics.annotations.GeneratePrisms;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * An annotation processor that generates a companion 'Prisms' class for any sealed interface or
@@ -136,7 +137,7 @@ public class PrismProcessor extends AbstractProcessor {
    * @return A complete {@code MethodSpec} for the prism factory method.
    */
   private MethodSpec createPrismMethodForSubtype(TypeElement sumType, TypeElement subtype) {
-    String methodName = toCamelCase(subtype.getSimpleName().toString());
+    String methodName = ProcessorUtils.toCamelCase(subtype.getSimpleName().toString());
     ClassName sumTypeName = ClassName.get(sumType);
     ClassName subTypeName = ClassName.get(subtype);
 
@@ -175,7 +176,7 @@ public class PrismProcessor extends AbstractProcessor {
    * @return A complete {@code MethodSpec} for the prism factory method.
    */
   private MethodSpec createPrismMethodForEnum(TypeElement enumType, VariableElement enumConstant) {
-    String methodName = toCamelCase(enumConstant.getSimpleName().toString());
+    String methodName = ProcessorUtils.toCamelCase(enumConstant.getSimpleName().toString());
     ClassName enumClassName = ClassName.get(enumType);
 
     ParameterizedTypeName prismTypeName =
@@ -201,39 +202,6 @@ public class PrismProcessor extends AbstractProcessor {
             Optional.class,
             Optional.class)
         .build();
-  }
-
-  /**
-   * A utility method to convert a String from PascalCase or SNAKE_CASE to camelCase.
-   *
-   * @param s The input string (e.g., "MyRecord" or "MY_CONSTANT").
-   * @return The converted camelCase string (e.g., "myRecord" or "myConstant").
-   */
-  private static String toCamelCase(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-
-    // Handle SNAKE_CASE
-    if (s.contains("_")) {
-      String[] parts = s.split("_");
-      StringBuilder camelCaseString = new StringBuilder(parts[0].toLowerCase());
-      for (int i = 1; i < parts.length; i++) {
-        if (!parts[i].isEmpty()) {
-          camelCaseString
-              .append(parts[i].substring(0, 1).toUpperCase())
-              .append(parts[i].substring(1).toLowerCase());
-        }
-      }
-      return camelCaseString.toString();
-    }
-
-    // Handle PascalCase
-    if (Character.isUpperCase(s.charAt(0))) {
-      return Character.toLowerCase(s.charAt(0)) + s.substring(1);
-    }
-
-    return s;
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ContainerType.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ContainerType.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Represents a detected container type for traversal generation.
+ *
+ * <p>This record captures information about container fields (List, Set, Optional, arrays, Map)
+ * that can have traversals generated for them.
+ *
+ * @param kind the kind of container
+ * @param elementType the type of elements in the container
+ * @param keyType for Map containers, the key type; null otherwise
+ */
+public record ContainerType(Kind kind, TypeMirror elementType, TypeMirror keyType) {
+
+  /** The kind of container. */
+  public enum Kind {
+    /** A {@code java.util.List<E>} container. */
+    LIST,
+
+    /** A {@code java.util.Set<E>} container. */
+    SET,
+
+    /** A {@code java.util.Optional<E>} container. */
+    OPTIONAL,
+
+    /** A Java array type {@code E[]}. */
+    ARRAY,
+
+    /** A {@code java.util.Map<K, V>} container. Traversal is over values only. */
+    MAP
+  }
+
+  /**
+   * Creates a ContainerType for a single-element container (List, Set, Optional, array).
+   *
+   * @param kind the container kind
+   * @param elementType the element type
+   * @return a new ContainerType
+   */
+  public static ContainerType of(Kind kind, TypeMirror elementType) {
+    return new ContainerType(kind, elementType, null);
+  }
+
+  /**
+   * Creates a ContainerType for a Map container.
+   *
+   * @param keyType the key type
+   * @param valueType the value type (used as element type for traversal)
+   * @return a new ContainerType for Map
+   */
+  public static ContainerType forMap(TypeMirror keyType, TypeMirror valueType) {
+    return new ContainerType(Kind.MAP, valueType, keyType);
+  }
+
+  /**
+   * Returns whether this is a Map container.
+   *
+   * @return true if this is a Map container
+   */
+  public boolean isMap() {
+    return kind == Kind.MAP;
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/CopyStrategy.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/CopyStrategy.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+/**
+ * Describes the strategy used to create modified copies of a type.
+ *
+ * <p>Different types require different approaches to creating updated copies:
+ *
+ * <ul>
+ *   <li>Records use their canonical constructor
+ *   <li>Wither-based classes use {@code withX()} methods
+ *   <li>Builder-based classes use a builder pattern (Phase 2)
+ * </ul>
+ */
+public enum CopyStrategy {
+  /**
+   * Use the record's canonical constructor to create copies.
+   *
+   * <p>This is the default strategy for Java records. All components are passed to the constructor
+   * with the modified value substituted.
+   */
+  CANONICAL_CONSTRUCTOR,
+
+  /**
+   * Use wither methods ({@code withX()}) to create copies.
+   *
+   * <p>Each lens will call the corresponding wither method on the source object. This is suitable
+   * for immutable classes like {@link java.time.LocalDate}.
+   */
+  WITHER,
+
+  /**
+   * Use a builder pattern to create copies (Phase 2).
+   *
+   * <p>This strategy requires a {@code toBuilder()} method or similar mechanism to create a builder
+   * pre-populated with the current values.
+   */
+  BUILDER
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
@@ -1,0 +1,432 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import com.palantir.javapoet.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * Generates lens classes for external types (records and wither-based classes).
+ *
+ * <p>This generator creates a utility class with static methods that return {@link Lens} instances
+ * for each field/component of the target type. For record types, the canonical constructor is used
+ * for immutable updates. For wither-based classes, the corresponding wither method is used.
+ */
+public class ExternalLensGenerator {
+
+  private static final ClassName GENERATED_ANNOTATION =
+      ClassName.get("org.higherkindedj.optics.annotations", "Generated");
+
+  private final Filer filer;
+  private final Messager messager;
+  private final List<TraversableGenerator> traversalGenerators;
+
+  /**
+   * Creates a new ExternalLensGenerator.
+   *
+   * @param filer the filer for writing generated files
+   * @param messager the messager for reporting diagnostics
+   */
+  public ExternalLensGenerator(Filer filer, Messager messager) {
+    this.filer = filer;
+    this.messager = messager;
+
+    // Load traversal generators via SPI
+    this.traversalGenerators = new ArrayList<>();
+    ServiceLoader.load(TraversableGenerator.class, getClass().getClassLoader())
+        .forEach(traversalGenerators::add);
+  }
+
+  /**
+   * Generates a lenses class for an external record.
+   *
+   * @param analysis the type analysis for the record
+   * @param targetPackage the target package for the generated class
+   */
+  public void generateForRecord(TypeAnalysis analysis, String targetPackage) {
+    TypeElement recordElement = analysis.typeElement();
+    String recordName = recordElement.getSimpleName().toString();
+    String lensesClassName = recordName + "Lenses";
+
+    TypeName recordTypeName = getParameterisedTypeName(recordElement);
+
+    TypeSpec.Builder lensesClassBuilder =
+        TypeSpec.classBuilder(lensesClassName)
+            .addAnnotation(GENERATED_ANNOTATION)
+            .addJavadoc(
+                "Generated optics for {@link $T}. Do not edit.", ClassName.get(recordElement))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
+
+    List<? extends RecordComponentElement> components = recordElement.getRecordComponents();
+
+    // Generate lens methods
+    for (FieldInfo field : analysis.fields()) {
+      lensesClassBuilder.addMethod(
+          createRecordLensMethod(field, recordElement, components, recordTypeName));
+    }
+
+    // Generate with methods
+    for (FieldInfo field : analysis.fields()) {
+      lensesClassBuilder.addMethod(createWithMethod(field, recordElement, recordTypeName));
+    }
+
+    // Generate traversal methods for container fields
+    for (FieldInfo field : analysis.fields()) {
+      if (field.hasTraversal()) {
+        MethodSpec traversalMethod =
+            createTraversalMethod(field, recordElement, components, recordTypeName);
+        if (traversalMethod != null) {
+          lensesClassBuilder.addMethod(traversalMethod);
+        }
+      }
+    }
+
+    writeFile(targetPackage, lensesClassBuilder.build());
+  }
+
+  /**
+   * Generates a lenses class for a wither-based class.
+   *
+   * @param analysis the type analysis for the class
+   * @param targetPackage the target package for the generated class
+   */
+  public void generateForWitherClass(TypeAnalysis analysis, String targetPackage) {
+    TypeElement classElement = analysis.typeElement();
+    String className = classElement.getSimpleName().toString();
+    String lensesClassName = className + "Lenses";
+
+    TypeName classTypeName = getParameterisedTypeName(classElement);
+
+    TypeSpec.Builder lensesClassBuilder =
+        TypeSpec.classBuilder(lensesClassName)
+            .addAnnotation(GENERATED_ANNOTATION)
+            .addJavadoc(
+                "Generated optics for {@link $T}. Do not edit.", ClassName.get(classElement))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
+
+    // Generate lens methods using wither pattern
+    for (int i = 0; i < analysis.fields().size(); i++) {
+      FieldInfo field = analysis.fields().get(i);
+      WitherInfo wither = analysis.witherMethods().get(i);
+      lensesClassBuilder.addMethod(
+          createWitherLensMethod(field, wither, classElement, classTypeName));
+    }
+
+    // Generate with methods
+    for (int i = 0; i < analysis.fields().size(); i++) {
+      FieldInfo field = analysis.fields().get(i);
+      lensesClassBuilder.addMethod(createWithMethod(field, classElement, classTypeName));
+    }
+
+    writeFile(targetPackage, lensesClassBuilder.build());
+  }
+
+  private MethodSpec createRecordLensMethod(
+      FieldInfo field,
+      TypeElement recordElement,
+      List<? extends RecordComponentElement> allComponents,
+      TypeName recordTypeName) {
+
+    TypeName componentTypeName = TypeName.get(field.type());
+
+    ParameterizedTypeName lensTypeName =
+        ParameterizedTypeName.get(
+            ClassName.get(Lens.class), recordTypeName, componentTypeName.box());
+
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(field.name())
+            .addJavadoc(
+                "Creates a {@link $T} for the {@code $L} field of a {@link $T}.\n\n"
+                    + "@return A non-null {@code Lens<$T, $T>}.",
+                Lens.class,
+                field.name(),
+                recordTypeName,
+                recordTypeName,
+                componentTypeName.box())
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(lensTypeName);
+
+    for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+    }
+
+    String constructorArgs =
+        allComponents.stream()
+            .map(
+                c ->
+                    c.getSimpleName().toString().equals(field.name())
+                        ? "newValue"
+                        : "source." + c.getSimpleName() + "()")
+            .collect(Collectors.joining(", "));
+
+    methodBuilder.addStatement(
+        "return $T.of($T::$L, (source, newValue) -> new $T($L))",
+        Lens.class,
+        recordTypeName,
+        field.accessorMethod(),
+        recordTypeName,
+        constructorArgs);
+
+    return methodBuilder.build();
+  }
+
+  private MethodSpec createWitherLensMethod(
+      FieldInfo field, WitherInfo wither, TypeElement classElement, TypeName classTypeName) {
+
+    TypeName fieldTypeName = TypeName.get(field.type());
+
+    ParameterizedTypeName lensTypeName =
+        ParameterizedTypeName.get(ClassName.get(Lens.class), classTypeName, fieldTypeName.box());
+
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(field.name())
+            .addJavadoc(
+                "Creates a {@link $T} for the {@code $L} field of a {@link $T}.\n\n"
+                    + "@return A non-null {@code Lens<$T, $T>}.",
+                Lens.class,
+                field.name(),
+                classTypeName,
+                classTypeName,
+                fieldTypeName.box())
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(lensTypeName);
+
+    for (TypeParameterElement typeParam : classElement.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+    }
+
+    // Use wither method for setting: source.withYear(newValue)
+    methodBuilder.addStatement(
+        "return $T.of($T::$L, (source, newValue) -> source.$L(newValue))",
+        Lens.class,
+        classTypeName,
+        wither.getterMethodName(),
+        wither.witherMethodName());
+
+    return methodBuilder.build();
+  }
+
+  private MethodSpec createWithMethod(FieldInfo field, TypeElement typeElement, TypeName typeName) {
+
+    TypeName fieldTypeName = TypeName.get(field.type());
+    String methodName = "with" + capitalise(field.name());
+    String parameterName = "new" + capitalise(field.name());
+    String lensesClassName = typeElement.getSimpleName().toString() + "Lenses";
+
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(methodName)
+            .addJavadoc(
+                "Creates a new {@link $T} instance with an updated {@code $L} field.\n"
+                    + "<p>This is a convenience method that uses the {@link #$L()} lens.\n\n"
+                    + "@param source The original {@code $T} instance.\n"
+                    + "@param $L The new value for the {@code $L} field.\n"
+                    + "@return A new, updated {@code $T} instance.",
+                typeName,
+                field.name(),
+                field.name(),
+                typeName,
+                parameterName,
+                field.name(),
+                typeName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(typeName)
+            .addParameter(typeName, "source")
+            .addParameter(fieldTypeName, parameterName);
+
+    List<? extends TypeParameterElement> typeParameters = typeElement.getTypeParameters();
+    for (TypeParameterElement typeParam : typeParameters) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+    }
+
+    String typeArguments =
+        typeParameters.stream()
+            .map(p -> p.getSimpleName().toString())
+            .collect(Collectors.joining(", "));
+
+    if (typeArguments.isEmpty()) {
+      methodBuilder.addStatement("return $L().set($L, source)", field.name(), parameterName);
+    } else {
+      methodBuilder.addStatement(
+          "return $L.<$L>$L().set($L, source)",
+          lensesClassName,
+          typeArguments,
+          field.name(),
+          parameterName);
+    }
+
+    return methodBuilder.build();
+  }
+
+  private MethodSpec createTraversalMethod(
+      FieldInfo field,
+      TypeElement recordElement,
+      List<? extends RecordComponentElement> allComponents,
+      TypeName recordTypeName) {
+
+    // Find the appropriate traversal generator
+    TraversableGenerator generator = null;
+    for (TraversableGenerator g : traversalGenerators) {
+      if (g.supports(field.type())) {
+        generator = g;
+        break;
+      }
+    }
+
+    if (generator == null) {
+      return null; // No generator found for this container type
+    }
+
+    // Find the matching record component
+    RecordComponentElement component = null;
+    for (RecordComponentElement c : allComponents) {
+      if (c.getSimpleName().toString().equals(field.name())) {
+        component = c;
+        break;
+      }
+    }
+
+    if (component == null) {
+      return null;
+    }
+
+    final TypeName focusType = getFocusType(field.type(), generator);
+    if (focusType == null) {
+      return null;
+    }
+
+    final ClassName recordClassName = ClassName.get(recordElement);
+    final ParameterizedTypeName traversalTypeName =
+        ParameterizedTypeName.get(ClassName.get(Traversal.class), recordClassName, focusType);
+
+    final CodeBlock modifyFBody =
+        generator.generateModifyF(component, recordClassName, allComponents);
+
+    // Create F extends WitnessArity<TypeArity.Unary>
+    final ParameterizedTypeName witnessArityBound =
+        ParameterizedTypeName.get(
+            ClassName.get(WitnessArity.class), ClassName.get(TypeArity.class).nestedClass("Unary"));
+
+    final TypeSpec traversalImpl =
+        TypeSpec.anonymousClassBuilder("")
+            .addSuperinterface(traversalTypeName)
+            .addMethod(
+                MethodSpec.methodBuilder("modifyF")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addTypeVariable(TypeVariableName.get("F", witnessArityBound))
+                    .addParameter(
+                        ParameterizedTypeName.get(
+                            ClassName.get(Function.class),
+                            focusType,
+                            ParameterizedTypeName.get(
+                                ClassName.get(Kind.class), TypeVariableName.get("F"), focusType)),
+                        "f")
+                    .addParameter(recordClassName, "source")
+                    .addParameter(
+                        ParameterizedTypeName.get(
+                            ClassName.get(Applicative.class), TypeVariableName.get("F")),
+                        "applicative")
+                    .returns(
+                        ParameterizedTypeName.get(
+                            ClassName.get(Kind.class), TypeVariableName.get("F"), recordClassName))
+                    .addCode(modifyFBody)
+                    .build())
+            .build();
+
+    String methodName = field.name() + "Traversal";
+
+    return MethodSpec.methodBuilder(methodName)
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addJavadoc(
+            "Creates a {@link $T} for the {@code $L} field of a {@link $T}.\n"
+                + "<p>This traversal focuses on all items within the {@code $L} collection,"
+                + " allowing an effectful function\n"
+                + "to be applied to each one.\n\n"
+                + "@return A non-null {@code Traversal<$T, $T>}.",
+            ClassName.get(Traversal.class),
+            field.name(),
+            recordClassName,
+            field.name(),
+            recordClassName,
+            focusType.box())
+        .returns(traversalTypeName)
+        .addStatement("return $L", traversalImpl)
+        .build();
+  }
+
+  private TypeName getFocusType(TypeMirror type, TraversableGenerator generator) {
+    if (type instanceof ArrayType arrayType) {
+      return TypeName.get(arrayType.getComponentType()).box();
+    } else if (type instanceof DeclaredType declaredType) {
+      if (declaredType.getTypeArguments().isEmpty()) {
+        return null; // Cannot traverse a raw type.
+      }
+
+      // Use the generator's SPI method to determine which type argument to focus on.
+      // For most types (List, Optional, etc.) this is 0.
+      // For types like Either<L,R>, Validated<E,A>, Map<K,V> this is 1.
+      int typeArgumentIndex = generator.getFocusTypeArgumentIndex();
+
+      if (declaredType.getTypeArguments().size() <= typeArgumentIndex) {
+        return null; // Not enough type arguments for this generator.
+      }
+      return TypeName.get(declaredType.getTypeArguments().get(typeArgumentIndex)).box();
+    }
+    return null;
+  }
+
+  private TypeName getParameterisedTypeName(TypeElement typeElement) {
+    List<? extends TypeParameterElement> typeParameters = typeElement.getTypeParameters();
+    if (typeParameters.isEmpty()) {
+      return ClassName.get(typeElement);
+    } else {
+      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      return ParameterizedTypeName.get(
+          ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
+    }
+  }
+
+  private void writeFile(String packageName, TypeSpec typeSpec) {
+    try {
+      JavaFile.builder(packageName, typeSpec)
+          .addFileComment("Generated by hkj-optics-processor. Do not edit.")
+          .build()
+          .writeTo(filer);
+    } catch (IOException e) {
+      messager.printMessage(
+          Diagnostic.Kind.ERROR, "Could not write generated file: " + e.getMessage());
+    }
+  }
+
+  private String capitalise(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalPrismGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalPrismGenerator.java
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import com.palantir.javapoet.*;
+import java.io.IOException;
+import java.util.Optional;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
+
+/**
+ * Generates prism classes for external types (sealed interfaces and enums).
+ *
+ * <p>This generator creates a utility class with static methods that return {@link Prism} instances
+ * for each permitted subtype of a sealed interface or each constant of an enum.
+ */
+public class ExternalPrismGenerator {
+
+  private static final ClassName GENERATED_ANNOTATION =
+      ClassName.get("org.higherkindedj.optics.annotations", "Generated");
+
+  private final Filer filer;
+  private final Messager messager;
+
+  /**
+   * Creates a new ExternalPrismGenerator.
+   *
+   * @param filer the filer for writing generated files
+   * @param messager the messager for reporting diagnostics
+   */
+  public ExternalPrismGenerator(Filer filer, Messager messager) {
+    this.filer = filer;
+    this.messager = messager;
+  }
+
+  /**
+   * Generates a prisms class for an external sealed interface.
+   *
+   * @param analysis the type analysis for the sealed interface
+   * @param targetPackage the target package for the generated class
+   */
+  public void generateForSealedInterface(TypeAnalysis analysis, String targetPackage) {
+    TypeElement sealedInterface = analysis.typeElement();
+    String interfaceName = sealedInterface.getSimpleName().toString();
+    String prismsClassName = interfaceName + "Prisms";
+
+    ClassName sumTypeName = ClassName.get(sealedInterface);
+
+    TypeSpec.Builder prismsClassBuilder =
+        TypeSpec.classBuilder(prismsClassName)
+            .addAnnotation(GENERATED_ANNOTATION)
+            .addJavadoc(
+                "Generated optics for {@link $T}. Do not edit.", ClassName.get(sealedInterface))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
+
+    // Generate prism methods for each permitted subtype
+    for (TypeElement subtype : analysis.permittedSubtypes()) {
+      prismsClassBuilder.addMethod(createPrismMethodForSubtype(sumTypeName, subtype));
+    }
+
+    writeFile(targetPackage, prismsClassBuilder.build());
+  }
+
+  /**
+   * Generates a prisms class for an external enum.
+   *
+   * @param analysis the type analysis for the enum
+   * @param targetPackage the target package for the generated class
+   */
+  public void generateForEnum(TypeAnalysis analysis, String targetPackage) {
+    TypeElement enumElement = analysis.typeElement();
+    String enumName = enumElement.getSimpleName().toString();
+    String prismsClassName = enumName + "Prisms";
+
+    ClassName enumClassName = ClassName.get(enumElement);
+
+    TypeSpec.Builder prismsClassBuilder =
+        TypeSpec.classBuilder(prismsClassName)
+            .addAnnotation(GENERATED_ANNOTATION)
+            .addJavadoc("Generated optics for {@link $T}. Do not edit.", ClassName.get(enumElement))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
+
+    // Generate prism methods for each enum constant
+    for (String constantName : analysis.enumConstants()) {
+      prismsClassBuilder.addMethod(createPrismMethodForEnumConstant(enumClassName, constantName));
+    }
+
+    writeFile(targetPackage, prismsClassBuilder.build());
+  }
+
+  private MethodSpec createPrismMethodForSubtype(ClassName sumTypeName, TypeElement subtype) {
+    String methodName = ProcessorUtils.toCamelCase(subtype.getSimpleName().toString());
+    ClassName subTypeName = ClassName.get(subtype);
+
+    ParameterizedTypeName prismTypeName =
+        ParameterizedTypeName.get(ClassName.get(Prism.class), sumTypeName, subTypeName);
+
+    return MethodSpec.methodBuilder(methodName)
+        .addJavadoc(
+            "Creates a {@link $T} that focuses on the {@link $T} subtype of the {@link $T} sum"
+                + " type.\n\n"
+                + "@return A non-null {@code Prism<$T, $T>}.",
+            Prism.class,
+            subTypeName,
+            sumTypeName,
+            sumTypeName,
+            subTypeName)
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(prismTypeName)
+        .addStatement(
+            "return $T.of(source -> source instanceof $T ? $T.of(($T) source) : $T.empty(), value"
+                + " -> value)",
+            Prism.class,
+            subTypeName,
+            Optional.class,
+            subTypeName,
+            Optional.class)
+        .build();
+  }
+
+  private MethodSpec createPrismMethodForEnumConstant(
+      ClassName enumClassName, String constantName) {
+    String methodName = ProcessorUtils.toCamelCase(constantName);
+
+    ParameterizedTypeName prismTypeName =
+        ParameterizedTypeName.get(ClassName.get(Prism.class), enumClassName, enumClassName);
+
+    return MethodSpec.methodBuilder(methodName)
+        .addJavadoc(
+            "Creates a {@link $T} that focuses on the {@code $L} constant of the {@link $T}"
+                + " enum.\n\n"
+                + "@return A non-null {@code Prism<$T, $T>}.",
+            Prism.class,
+            constantName,
+            enumClassName,
+            enumClassName,
+            enumClassName)
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(prismTypeName)
+        .addStatement(
+            "return $T.of(source -> source == $T.$L ? $T.of(source) : $T.empty(), value -> value)",
+            Prism.class,
+            enumClassName,
+            constantName,
+            Optional.class,
+            Optional.class)
+        .build();
+  }
+
+  private void writeFile(String packageName, TypeSpec typeSpec) {
+    try {
+      JavaFile.builder(packageName, typeSpec)
+          .addFileComment("Generated by hkj-optics-processor. Do not edit.")
+          .build()
+          .writeTo(filer);
+    } catch (IOException e) {
+      messager.printMessage(
+          Diagnostic.Kind.ERROR, "Could not write generated file: " + e.getMessage());
+    }
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/FieldInfo.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/FieldInfo.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import java.util.Optional;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Information about a field for which a lens or traversal can be generated.
+ *
+ * <p>This record captures the essential details needed to generate optics for a single field,
+ * including its name, type, accessor method, and optional container type information.
+ *
+ * @param name the field name (also used as the generated method name)
+ * @param type the field's type as a TypeMirror
+ * @param accessorMethod the name of the method to access this field (e.g., "name" for records)
+ * @param copyStrategy the strategy for creating modified copies
+ * @param containerType if the field is a container, details about the container type
+ */
+public record FieldInfo(
+    String name,
+    TypeMirror type,
+    String accessorMethod,
+    CopyStrategy copyStrategy,
+    Optional<ContainerType> containerType) {
+
+  /**
+   * Creates a FieldInfo for a record component.
+   *
+   * @param name the component name
+   * @param type the component type
+   * @return a new FieldInfo configured for a record component
+   */
+  public static FieldInfo forRecordComponent(String name, TypeMirror type) {
+    return new FieldInfo(name, type, name, CopyStrategy.CANONICAL_CONSTRUCTOR, Optional.empty());
+  }
+
+  /**
+   * Creates a FieldInfo for a record component with container type.
+   *
+   * @param name the component name
+   * @param type the component type
+   * @param containerType the detected container type
+   * @return a new FieldInfo configured for a record component with container
+   */
+  public static FieldInfo forRecordComponent(
+      String name, TypeMirror type, ContainerType containerType) {
+    return new FieldInfo(
+        name, type, name, CopyStrategy.CANONICAL_CONSTRUCTOR, Optional.of(containerType));
+  }
+
+  /**
+   * Creates a FieldInfo for a field accessed via a getter method.
+   *
+   * @param name the field name
+   * @param type the field type
+   * @param getterName the name of the getter method
+   * @param copyStrategy the strategy for copying
+   * @return a new FieldInfo configured for a getter-based field
+   */
+  public static FieldInfo forGetter(
+      String name, TypeMirror type, String getterName, CopyStrategy copyStrategy) {
+    return new FieldInfo(name, type, getterName, copyStrategy, Optional.empty());
+  }
+
+  /**
+   * Creates a FieldInfo for a field accessed via a getter method with container type.
+   *
+   * @param name the field name
+   * @param type the field type
+   * @param getterName the name of the getter method
+   * @param copyStrategy the strategy for copying
+   * @param containerType the detected container type
+   * @return a new FieldInfo configured for a getter-based field with container
+   */
+  public static FieldInfo forGetter(
+      String name,
+      TypeMirror type,
+      String getterName,
+      CopyStrategy copyStrategy,
+      ContainerType containerType) {
+    return new FieldInfo(name, type, getterName, copyStrategy, Optional.of(containerType));
+  }
+
+  /**
+   * Returns whether this field should also have a traversal generated.
+   *
+   * @return true if the field is a container type that supports traversal
+   */
+  public boolean hasTraversal() {
+    return containerType.isPresent();
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/TypeAnalysis.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/TypeAnalysis.java
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import java.util.List;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Result of analysing an external type to determine what optics to generate.
+ *
+ * <p>The analysis captures the kind of type (record, sealed interface, enum, or wither-based class)
+ * along with the relevant information needed for optics generation.
+ *
+ * @param typeElement the analysed type element
+ * @param typeKind the determined kind of the type
+ * @param fields field information for lens generation (records and wither classes)
+ * @param witherMethods wither method information for wither-based classes
+ * @param permittedSubtypes permitted subtypes for sealed interfaces
+ * @param enumConstants enum constants for enum types
+ * @param hasMutableFields whether the type has mutable fields (setters)
+ */
+public record TypeAnalysis(
+    TypeElement typeElement,
+    TypeKind typeKind,
+    List<FieldInfo> fields,
+    List<WitherInfo> witherMethods,
+    List<TypeElement> permittedSubtypes,
+    List<String> enumConstants,
+    boolean hasMutableFields) {
+
+  /** The kind of type that was analysed. */
+  public enum TypeKind {
+    /** A Java record type. Lenses are generated via canonical constructor. */
+    RECORD,
+
+    /** A sealed interface. Prisms are generated for each permitted subtype. */
+    SEALED_INTERFACE,
+
+    /** An enum type. Prisms are generated for each constant. */
+    ENUM,
+
+    /** A class with wither methods. Lenses are generated via withX() methods. */
+    WITHER_CLASS,
+
+    /** A type that cannot have optics generated (e.g., mutable class without withers). */
+    UNSUPPORTED
+  }
+
+  /**
+   * Creates an analysis result for a record type.
+   *
+   * @param typeElement the record type element
+   * @param fields the record components as field info
+   * @return a new TypeAnalysis for the record
+   */
+  public static TypeAnalysis forRecord(TypeElement typeElement, List<FieldInfo> fields) {
+    return new TypeAnalysis(
+        typeElement, TypeKind.RECORD, fields, List.of(), List.of(), List.of(), false);
+  }
+
+  /**
+   * Creates an analysis result for a sealed interface.
+   *
+   * @param typeElement the sealed interface element
+   * @param permittedSubtypes the permitted subtypes
+   * @return a new TypeAnalysis for the sealed interface
+   */
+  public static TypeAnalysis forSealedInterface(
+      TypeElement typeElement, List<TypeElement> permittedSubtypes) {
+    return new TypeAnalysis(
+        typeElement,
+        TypeKind.SEALED_INTERFACE,
+        List.of(),
+        List.of(),
+        permittedSubtypes,
+        List.of(),
+        false);
+  }
+
+  /**
+   * Creates an analysis result for an enum type.
+   *
+   * @param typeElement the enum type element
+   * @param enumConstants the enum constant names
+   * @return a new TypeAnalysis for the enum
+   */
+  public static TypeAnalysis forEnum(TypeElement typeElement, List<String> enumConstants) {
+    return new TypeAnalysis(
+        typeElement, TypeKind.ENUM, List.of(), List.of(), List.of(), enumConstants, false);
+  }
+
+  /**
+   * Creates an analysis result for a class with wither methods.
+   *
+   * @param typeElement the class type element
+   * @param fields the fields derived from wither methods
+   * @param witherMethods the detected wither methods
+   * @param hasMutableFields whether the class also has setter methods
+   * @return a new TypeAnalysis for the wither class
+   */
+  public static TypeAnalysis forWitherClass(
+      TypeElement typeElement,
+      List<FieldInfo> fields,
+      List<WitherInfo> witherMethods,
+      boolean hasMutableFields) {
+    return new TypeAnalysis(
+        typeElement,
+        TypeKind.WITHER_CLASS,
+        fields,
+        witherMethods,
+        List.of(),
+        List.of(),
+        hasMutableFields);
+  }
+
+  /**
+   * Creates an analysis result for an unsupported type.
+   *
+   * @param typeElement the unsupported type element
+   * @param hasMutableFields whether the type has mutable fields
+   * @return a new TypeAnalysis indicating the type is unsupported
+   */
+  public static TypeAnalysis unsupported(TypeElement typeElement, boolean hasMutableFields) {
+    return new TypeAnalysis(
+        typeElement,
+        TypeKind.UNSUPPORTED,
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        hasMutableFields);
+  }
+
+  /**
+   * Returns whether this type supports lens generation.
+   *
+   * @return true if lenses can be generated for this type
+   */
+  public boolean supportsLenses() {
+    return typeKind == TypeKind.RECORD || typeKind == TypeKind.WITHER_CLASS;
+  }
+
+  /**
+   * Returns whether this type supports prism generation.
+   *
+   * @return true if prisms can be generated for this type
+   */
+  public boolean supportsPrisms() {
+    return typeKind == TypeKind.SEALED_INTERFACE || typeKind == TypeKind.ENUM;
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/TypeKindAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/TypeKindAnalyser.java
@@ -1,0 +1,357 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+/**
+ * Analyses external types to determine what kind of optics can be generated.
+ *
+ * <p>This class examines a {@link TypeElement} and produces a {@link TypeAnalysis} that describes:
+ *
+ * <ul>
+ *   <li>The kind of type (record, sealed interface, enum, wither class)
+ *   <li>Fields and their accessors
+ *   <li>Wither methods for immutable update
+ *   <li>Container fields that need traversals
+ *   <li>Whether the type has mutable fields
+ * </ul>
+ */
+public class TypeKindAnalyser {
+
+  private final Types typeUtils;
+
+  /**
+   * Creates a new TypeKindAnalyser.
+   *
+   * @param typeUtils the type utilities from the processing environment
+   */
+  public TypeKindAnalyser(Types typeUtils) {
+    this.typeUtils = typeUtils;
+  }
+
+  /**
+   * Analyses a type element to determine what optics can be generated.
+   *
+   * @param typeElement the type to analyse
+   * @return the analysis result
+   */
+  public TypeAnalysis analyseType(TypeElement typeElement) {
+    // Check for record first
+    if (typeElement.getKind() == ElementKind.RECORD) {
+      return analyseRecord(typeElement);
+    }
+
+    // Check for sealed interface
+    if (typeElement.getKind() == ElementKind.INTERFACE
+        && typeElement.getModifiers().contains(Modifier.SEALED)) {
+      return analyseSealedInterface(typeElement);
+    }
+
+    // Check for enum
+    if (typeElement.getKind() == ElementKind.ENUM) {
+      return analyseEnum(typeElement);
+    }
+
+    // Check for class with wither methods
+    if (typeElement.getKind() == ElementKind.CLASS) {
+      return analyseClass(typeElement);
+    }
+
+    // Unsupported type
+    return TypeAnalysis.unsupported(typeElement, false);
+  }
+
+  private TypeAnalysis analyseRecord(TypeElement recordElement) {
+    List<FieldInfo> fields = new ArrayList<>();
+
+    for (RecordComponentElement component : recordElement.getRecordComponents()) {
+      String name = component.getSimpleName().toString();
+      TypeMirror type = component.asType();
+
+      Optional<ContainerType> containerType = detectContainerType(type);
+      if (containerType.isPresent()) {
+        fields.add(FieldInfo.forRecordComponent(name, type, containerType.get()));
+      } else {
+        fields.add(FieldInfo.forRecordComponent(name, type));
+      }
+    }
+
+    return TypeAnalysis.forRecord(recordElement, fields);
+  }
+
+  private TypeAnalysis analyseSealedInterface(TypeElement sealedInterface) {
+    List<TypeElement> permittedSubtypes = new ArrayList<>();
+
+    for (TypeMirror permittedType : sealedInterface.getPermittedSubclasses()) {
+      TypeElement subtypeElement = (TypeElement) typeUtils.asElement(permittedType);
+      permittedSubtypes.add(subtypeElement);
+    }
+
+    return TypeAnalysis.forSealedInterface(sealedInterface, permittedSubtypes);
+  }
+
+  private TypeAnalysis analyseEnum(TypeElement enumElement) {
+    List<String> constants = new ArrayList<>();
+
+    for (var enclosed : enumElement.getEnclosedElements()) {
+      if (enclosed.getKind() == ElementKind.ENUM_CONSTANT) {
+        constants.add(enclosed.getSimpleName().toString());
+      }
+    }
+
+    return TypeAnalysis.forEnum(enumElement, constants);
+  }
+
+  private TypeAnalysis analyseClass(TypeElement classElement) {
+    List<WitherInfo> witherMethods = detectWitherMethods(classElement);
+    boolean hasMutableFields = detectMutableFields(classElement);
+
+    if (witherMethods.isEmpty()) {
+      // No withers found - this is an unsupported class
+      return TypeAnalysis.unsupported(classElement, hasMutableFields);
+    }
+
+    // Convert wither methods to field info
+    List<FieldInfo> fields = new ArrayList<>();
+    for (WitherInfo wither : witherMethods) {
+      Optional<ContainerType> containerType = detectContainerType(wither.parameterType());
+      if (containerType.isPresent()) {
+        fields.add(
+            FieldInfo.forGetter(
+                wither.fieldName(),
+                wither.parameterType(),
+                wither.getterMethodName(),
+                CopyStrategy.WITHER,
+                containerType.get()));
+      } else {
+        fields.add(
+            FieldInfo.forGetter(
+                wither.fieldName(),
+                wither.parameterType(),
+                wither.getterMethodName(),
+                CopyStrategy.WITHER));
+      }
+    }
+
+    return TypeAnalysis.forWitherClass(classElement, fields, witherMethods, hasMutableFields);
+  }
+
+  /**
+   * Detects wither methods on a class.
+   *
+   * <p>A wither method must:
+   *
+   * <ul>
+   *   <li>Be named {@code withXxx} where {@code xxx} is the field name
+   *   <li>Take exactly one parameter
+   *   <li>Return the same type as the declaring class
+   *   <li>Be public and non-static
+   * </ul>
+   *
+   * @param classElement the class to analyse
+   * @return list of detected wither methods
+   */
+  public List<WitherInfo> detectWitherMethods(TypeElement classElement) {
+    List<WitherInfo> withers = new ArrayList<>();
+    TypeMirror classType = classElement.asType();
+
+    for (var enclosed : classElement.getEnclosedElements()) {
+      if (enclosed.getKind() != ElementKind.METHOD) {
+        continue;
+      }
+
+      ExecutableElement method = (ExecutableElement) enclosed;
+      String methodName = method.getSimpleName().toString();
+
+      // Must start with "with" and have more characters
+      if (!methodName.startsWith("with") || methodName.length() <= 4) {
+        continue;
+      }
+
+      // Must be public and non-static
+      if (!method.getModifiers().contains(Modifier.PUBLIC)
+          || method.getModifiers().contains(Modifier.STATIC)) {
+        continue;
+      }
+
+      // Must take exactly one parameter
+      if (method.getParameters().size() != 1) {
+        continue;
+      }
+
+      // Must return the same type (or a subtype) as the declaring class
+      TypeMirror returnType = method.getReturnType();
+      if (!typeUtils.isAssignable(returnType, typeUtils.erasure(classType))) {
+        continue;
+      }
+
+      // Extract field name from withXxx -> xxx
+      String fieldName = extractFieldName(methodName);
+
+      // Find corresponding getter method
+      String getterName = findGetterMethod(classElement, fieldName, method.getParameters().get(0));
+      if (getterName == null) {
+        continue; // No getter found, skip this wither
+      }
+
+      withers.add(WitherInfo.of(method, fieldName, getterName));
+    }
+
+    return withers;
+  }
+
+  private String extractFieldName(String witherMethodName) {
+    // withYear -> year, withDayOfMonth -> dayOfMonth
+    String afterWith = witherMethodName.substring(4);
+    return afterWith.substring(0, 1).toLowerCase(Locale.ROOT) + afterWith.substring(1);
+  }
+
+  private String findGetterMethod(
+      TypeElement classElement, String fieldName, VariableElement witherParam) {
+    TypeMirror expectedType = witherParam.asType();
+
+    // Try various getter naming conventions
+    String[] getterCandidates = {
+      fieldName, // record-style: year()
+      "get" + capitalise(fieldName), // JavaBean: getYear()
+      "is" + capitalise(fieldName) // boolean: isActive()
+    };
+
+    for (var enclosed : classElement.getEnclosedElements()) {
+      if (enclosed.getKind() != ElementKind.METHOD) {
+        continue;
+      }
+
+      ExecutableElement method = (ExecutableElement) enclosed;
+      String methodName = method.getSimpleName().toString();
+
+      // Check if method name matches any getter pattern
+      for (String candidate : getterCandidates) {
+        if (methodName.equals(candidate)) {
+          // Must be public, non-static, take no parameters
+          if (!method.getModifiers().contains(Modifier.PUBLIC)
+              || method.getModifiers().contains(Modifier.STATIC)
+              || !method.getParameters().isEmpty()) {
+            continue;
+          }
+
+          // Return type must match wither parameter type
+          if (typeUtils.isSameType(method.getReturnType(), expectedType)) {
+            return methodName;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Detects whether a class has mutable fields (setters).
+   *
+   * @param classElement the class to analyse
+   * @return true if the class has setter methods
+   */
+  public boolean detectMutableFields(TypeElement classElement) {
+    for (var enclosed : classElement.getEnclosedElements()) {
+      if (enclosed.getKind() != ElementKind.METHOD) {
+        continue;
+      }
+
+      ExecutableElement method = (ExecutableElement) enclosed;
+      String methodName = method.getSimpleName().toString();
+
+      // Check for setter pattern: setXxx with void return
+      if (methodName.startsWith("set")
+          && methodName.length() > 3
+          && method.getModifiers().contains(Modifier.PUBLIC)
+          && !method.getModifiers().contains(Modifier.STATIC)
+          && method.getParameters().size() == 1
+          && method.getReturnType().getKind() == TypeKind.VOID) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Detects if a type is a container type that can have a traversal generated.
+   *
+   * @param type the type to check
+   * @return the container type info if detected, empty otherwise
+   */
+  public Optional<ContainerType> detectContainerType(TypeMirror type) {
+    // Check for array
+    if (type.getKind() == TypeKind.ARRAY) {
+      ArrayType arrayType = (ArrayType) type;
+      return Optional.of(ContainerType.of(ContainerType.Kind.ARRAY, arrayType.getComponentType()));
+    }
+
+    // Check for declared types (List, Set, Optional, Map)
+    if (type.getKind() != TypeKind.DECLARED) {
+      return Optional.empty();
+    }
+
+    DeclaredType declaredType = (DeclaredType) type;
+    TypeElement typeElement = (TypeElement) declaredType.asElement();
+    String qualifiedName = typeElement.getQualifiedName().toString();
+
+    // Check for List
+    if (qualifiedName.equals("java.util.List")) {
+      if (!declaredType.getTypeArguments().isEmpty()) {
+        return Optional.of(
+            ContainerType.of(ContainerType.Kind.LIST, declaredType.getTypeArguments().get(0)));
+      }
+    }
+
+    // Check for Set
+    if (qualifiedName.equals("java.util.Set")) {
+      if (!declaredType.getTypeArguments().isEmpty()) {
+        return Optional.of(
+            ContainerType.of(ContainerType.Kind.SET, declaredType.getTypeArguments().get(0)));
+      }
+    }
+
+    // Check for Optional
+    if (qualifiedName.equals("java.util.Optional")) {
+      if (!declaredType.getTypeArguments().isEmpty()) {
+        return Optional.of(
+            ContainerType.of(ContainerType.Kind.OPTIONAL, declaredType.getTypeArguments().get(0)));
+      }
+    }
+
+    // Check for Map (traverse values)
+    if (qualifiedName.equals("java.util.Map")) {
+      if (declaredType.getTypeArguments().size() >= 2) {
+        return Optional.of(
+            ContainerType.forMap(
+                declaredType.getTypeArguments().get(0), declaredType.getTypeArguments().get(1)));
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private String capitalise(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/WitherInfo.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/WitherInfo.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Information about a wither method detected on a class.
+ *
+ * <p>A wither method follows the pattern {@code withX(T newValue)} that returns a new instance of
+ * the class with the specified field updated. This is the immutable update pattern used by types
+ * like {@link java.time.LocalDate}.
+ *
+ * @param fieldName the derived field name (from "withFieldName" → "fieldName")
+ * @param witherMethodName the full name of the wither method (e.g., "withYear")
+ * @param parameterType the type of the wither method's parameter
+ * @param witherMethod the executable element representing the wither method
+ * @param getterMethodName the name of the corresponding getter method (e.g., "getYear" or "year")
+ */
+public record WitherInfo(
+    String fieldName,
+    String witherMethodName,
+    TypeMirror parameterType,
+    ExecutableElement witherMethod,
+    String getterMethodName) {
+
+  /**
+   * Creates a WitherInfo from a detected wither method.
+   *
+   * @param witherMethod the wither method element
+   * @param fieldName the derived field name
+   * @param getterMethodName the corresponding getter method name
+   * @return a new WitherInfo for the method
+   */
+  public static WitherInfo of(
+      ExecutableElement witherMethod, String fieldName, String getterMethodName) {
+    return new WitherInfo(
+        fieldName,
+        witherMethod.getSimpleName().toString(),
+        witherMethod.getParameters().getFirst().asType(),
+        witherMethod,
+        getterMethodName);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/spi/TraversableGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/spi/TraversableGenerator.java
@@ -23,6 +23,19 @@ public interface TraversableGenerator {
   boolean supports(TypeMirror type);
 
   /**
+   * Returns the index of the type argument that this generator focuses on for traversal.
+   *
+   * <p>For most container types like {@code List<T>} or {@code Optional<T>}, this is 0 (the first
+   * type argument). For types like {@code Either<L, R>}, {@code Validated<E, A>}, or {@code Map<K,
+   * V>} where the traversal focuses on the second type argument, this should return 1.
+   *
+   * @return the zero-based index of the focused type argument
+   */
+  default int getFocusTypeArgumentIndex() {
+    return 0;
+  }
+
+  /**
    * Generates the body of the `modifyF` method for a Traversal.
    *
    * @param component The record component being processed (e.g., the 'items' field).

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.util;
+
+import java.util.Locale;
+
+/**
+ * Shared utility methods for annotation processors in the optics module.
+ *
+ * <p>This class provides common string manipulation utilities used across multiple processors.
+ */
+public final class ProcessorUtils {
+
+  private ProcessorUtils() {
+    // Utility class - prevent instantiation
+  }
+
+  /**
+   * Converts a string to camelCase.
+   *
+   * <p>Handles various input formats:
+   *
+   * <ul>
+   *   <li>SNAKE_CASE: "MY_CONSTANT" → "myConstant"
+   *   <li>ALL_CAPS: "MONDAY" → "monday"
+   *   <li>PascalCase: "MyClass" → "myClass"
+   *   <li>Already camelCase: "myMethod" → "myMethod"
+   * </ul>
+   *
+   * @param s the string to convert
+   * @return the camelCase version of the string
+   */
+  public static String toCamelCase(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+
+    // Handle SNAKE_CASE (with underscores)
+    if (s.contains("_")) {
+      String[] parts = s.split("_");
+      StringBuilder camelCaseString = new StringBuilder(parts[0].toLowerCase(Locale.ROOT));
+      for (int i = 1; i < parts.length; i++) {
+        if (!parts[i].isEmpty()) {
+          camelCaseString
+              .append(parts[i].substring(0, 1).toUpperCase(Locale.ROOT))
+              .append(parts[i].substring(1).toLowerCase(Locale.ROOT));
+        }
+      }
+      return camelCaseString.toString();
+    }
+
+    // Handle ALL_CAPS (no underscores but all uppercase letters)
+    if (isAllUpperCase(s)) {
+      return s.toLowerCase(Locale.ROOT);
+    }
+
+    // Handle PascalCase
+    if (Character.isUpperCase(s.charAt(0))) {
+      return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+    }
+
+    return s;
+  }
+
+  /**
+   * Checks if a string contains only uppercase letters.
+   *
+   * <p>Non-letter characters are ignored in the check.
+   *
+   * @param s the string to check
+   * @return true if all letter characters are uppercase, false otherwise
+   */
+  public static boolean isAllUpperCase(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (Character.isLetter(c) && !Character.isUpperCase(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratorTestHelper.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratorTestHelper.java
@@ -122,7 +122,22 @@ public final class GeneratorTestHelper {
             .replaceAll("com\\.example\\.Level3", "Level3")
             .replaceAll("com\\.example\\.Playlist", "Playlist")
             .replaceAll("com\\.example\\.model\\.Person", "Person")
-            .replaceAll("com\\.example\\.Wrapper", "Wrapper");
+            .replaceAll("com\\.example\\.Wrapper", "Wrapper")
+            // External types for ImportOptics tests
+            .replaceAll("com\\.external\\.Customer", "Customer")
+            .replaceAll("com\\.external\\.Pair", "Pair")
+            .replaceAll("com\\.external\\.Point", "Point")
+            .replaceAll("com\\.external\\.Order", "Order")
+            .replaceAll("com\\.external\\.Item", "Item")
+            .replaceAll("com\\.external\\.Product", "Product")
+            .replaceAll("com\\.external\\.Shape", "Shape")
+            .replaceAll("com\\.external\\.Circle", "Circle")
+            .replaceAll("com\\.external\\.Rectangle", "Rectangle")
+            .replaceAll("com\\.external\\.Status", "Status")
+            .replaceAll("com\\.external\\.HttpStatus", "HttpStatus")
+            .replaceAll("com\\.external\\.ImmutableDate", "ImmutableDate")
+            .replaceAll("com\\.external\\.MutablePerson", "MutablePerson")
+            .replaceAll("com\\.external\\.PlainClass", "PlainClass");
 
     // Remove ALL whitespace to make the comparison robust.
     return normalised.replaceAll("\\s+", "").trim();

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
@@ -1,0 +1,598 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link ImportOpticsProcessor}.
+ *
+ * <p>These tests verify that the processor correctly generates optics for various external types
+ * including records, sealed interfaces, enums, and classes with wither methods.
+ */
+@DisplayName("ImportOpticsProcessor")
+class ImportOpticsProcessorTest {
+
+  @Nested
+  @DisplayName("Record Processing")
+  class RecordProcessing {
+
+    @Test
+    @DisplayName("should generate lenses for external record via package-info")
+    void shouldGenerateLensesForExternalRecord() {
+      // External record to import
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Customer",
+              """
+              package com.external;
+
+              public record Customer(String name, int age) {}
+              """);
+
+      // Package-info with @ImportOptics
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Customer.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      final String expectedNameLens =
+          """
+          public static Lens<Customer, String> name() {
+              return Lens.of(Customer::name, (source, newValue) -> new Customer(newValue, source.age()));
+          }
+          """;
+
+      final String expectedAgeLens =
+          """
+          public static Lens<Customer, Integer> age() {
+              return Lens.of(Customer::age, (source, newValue) -> new Customer(source.name(), newValue));
+          }
+          """;
+
+      assertGeneratedCodeContains(compilation, "com.myapp.optics.CustomerLenses", expectedNameLens);
+      assertGeneratedCodeContains(compilation, "com.myapp.optics.CustomerLenses", expectedAgeLens);
+    }
+
+    @Test
+    @DisplayName("should generate lenses with type parameters for generic record")
+    void shouldGenerateLensesForGenericRecord() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Pair",
+              """
+              package com.external;
+
+              public record Pair<A, B>(A first, B second) {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Pair.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      final String expectedFirstLens =
+          """
+          public static <A, B> Lens<Pair<A, B>, A> first()
+          """;
+
+      assertGeneratedCodeContains(compilation, "com.myapp.optics.PairLenses", expectedFirstLens);
+    }
+
+    @Test
+    @DisplayName("should generate with methods for record")
+    void shouldGenerateWithMethodsForRecord() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Point",
+              """
+              package com.external;
+
+              public record Point(int x, int y) {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Point.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      final String expectedWithX =
+          """
+          public static Point withX(Point source, int newX) {
+              return x().set(newX, source);
+          }
+          """;
+
+      assertGeneratedCodeContains(compilation, "com.myapp.optics.PointLenses", expectedWithX);
+    }
+  }
+
+  @Nested
+  @DisplayName("Sealed Interface Processing")
+  class SealedInterfaceProcessing {
+
+    @Test
+    @DisplayName("should generate prisms for sealed interface subtypes")
+    void shouldGeneratePrismsForSealedInterface() {
+      final var sealedInterface =
+          JavaFileObjects.forSourceString(
+              "com.external.Shape",
+              """
+              package com.external;
+
+              public sealed interface Shape permits Circle, Rectangle {}
+              """);
+
+      final var circleSubtype =
+          JavaFileObjects.forSourceString(
+              "com.external.Circle",
+              """
+              package com.external;
+
+              public record Circle(double radius) implements Shape {}
+              """);
+
+      final var rectangleSubtype =
+          JavaFileObjects.forSourceString(
+              "com.external.Rectangle",
+              """
+              package com.external;
+
+              public record Rectangle(double width, double height) implements Shape {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Shape.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(sealedInterface, circleSubtype, rectangleSubtype, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      final String expectedCirclePrism =
+          """
+          public static Prism<Shape, Circle> circle() {
+              return Prism.of(source -> source instanceof Circle ? Optional.of((Circle) source) : Optional.empty(), value -> value);
+          }
+          """;
+
+      final String expectedRectanglePrism =
+          """
+          public static Prism<Shape, Rectangle> rectangle() {
+              return Prism.of(source -> source instanceof Rectangle ? Optional.of((Rectangle) source) : Optional.empty(), value -> value);
+          }
+          """;
+
+      assertGeneratedCodeContains(compilation, "com.myapp.optics.ShapePrisms", expectedCirclePrism);
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.optics.ShapePrisms", expectedRectanglePrism);
+    }
+  }
+
+  @Nested
+  @DisplayName("Enum Processing")
+  class EnumProcessing {
+
+    @Test
+    @DisplayName("should generate prisms for enum constants")
+    void shouldGeneratePrismsForEnum() {
+      final var enumType =
+          JavaFileObjects.forSourceString(
+              "com.external.Status",
+              """
+              package com.external;
+
+              public enum Status { PENDING, ACTIVE, COMPLETED }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Status.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(enumType, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      final String expectedPendingPrism =
+          """
+          public static Prism<Status, Status> pending() {
+              return Prism.of(source -> source == Status.PENDING ? Optional.of(source) : Optional.empty(), value -> value);
+          }
+          """;
+
+      final String expectedActivePrism =
+          """
+          public static Prism<Status, Status> active() {
+              return Prism.of(source -> source == Status.ACTIVE ? Optional.of(source) : Optional.empty(), value -> value);
+          }
+          """;
+
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.optics.StatusPrisms", expectedPendingPrism);
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.optics.StatusPrisms", expectedActivePrism);
+    }
+
+    @Test
+    @DisplayName("should convert SNAKE_CASE enum constants to camelCase method names")
+    void shouldConvertSnakeCaseToCamelCase() {
+      final var enumType =
+          JavaFileObjects.forSourceString(
+              "com.external.HttpStatus",
+              """
+              package com.external;
+
+              public enum HttpStatus { OK, NOT_FOUND, INTERNAL_SERVER_ERROR }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.HttpStatus.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(enumType, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      // NOT_FOUND -> notFound
+      final String expectedNotFoundPrism = "public static Prism<HttpStatus, HttpStatus> notFound()";
+
+      // INTERNAL_SERVER_ERROR -> internalServerError
+      final String expectedInternalServerErrorPrism =
+          "public static Prism<HttpStatus, HttpStatus> internalServerError()";
+
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.optics.HttpStatusPrisms", expectedNotFoundPrism);
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.optics.HttpStatusPrisms", expectedInternalServerErrorPrism);
+    }
+  }
+
+  @Nested
+  @DisplayName("Wither Class Processing")
+  class WitherClassProcessing {
+
+    @Test
+    @DisplayName("should generate lenses for class with wither methods")
+    void shouldGenerateLensesForWitherClass() {
+      final var witherClass =
+          JavaFileObjects.forSourceString(
+              "com.external.ImmutableDate",
+              """
+              package com.external;
+
+              public final class ImmutableDate {
+                  private final int year;
+                  private final int month;
+                  private final int day;
+
+                  public ImmutableDate(int year, int month, int day) {
+                      this.year = year;
+                      this.month = month;
+                      this.day = day;
+                  }
+
+                  public int getYear() { return year; }
+                  public int getMonth() { return month; }
+                  public int getDay() { return day; }
+
+                  public ImmutableDate withYear(int year) {
+                      return new ImmutableDate(year, this.month, this.day);
+                  }
+
+                  public ImmutableDate withMonth(int month) {
+                      return new ImmutableDate(this.year, month, this.day);
+                  }
+
+                  public ImmutableDate withDay(int day) {
+                      return new ImmutableDate(this.year, this.month, day);
+                  }
+              }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.ImmutableDate.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(witherClass, packageInfo);
+
+      assertThat(compilation).succeeded();
+
+      final String expectedYearLens =
+          """
+          public static Lens<ImmutableDate, Integer> year() {
+              return Lens.of(ImmutableDate::getYear, (source, newValue) -> source.withYear(newValue));
+          }
+          """;
+
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.optics.ImmutableDateLenses", expectedYearLens);
+    }
+  }
+
+  @Nested
+  @DisplayName("Error Cases")
+  class ErrorCases {
+
+    @Test
+    @DisplayName("should reject mutable class without allowMutable flag")
+    void shouldRejectMutableClassWithoutFlag() {
+      final var mutableClass =
+          JavaFileObjects.forSourceString(
+              "com.external.MutablePerson",
+              """
+              package com.external;
+
+              public class MutablePerson {
+                  private String name;
+
+                  public String getName() { return name; }
+                  public void setName(String name) { this.name = name; }
+
+                  public MutablePerson withName(String name) {
+                      MutablePerson copy = new MutablePerson();
+                      copy.name = name;
+                      return copy;
+                  }
+              }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.MutablePerson.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(mutableClass, packageInfo);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("has mutable fields").inFile(packageInfo);
+    }
+
+    @Test
+    @DisplayName("should allow mutable class with allowMutable = true")
+    void shouldAllowMutableClassWithFlag() {
+      final var mutableClass =
+          JavaFileObjects.forSourceString(
+              "com.external.MutablePerson",
+              """
+              package com.external;
+
+              public class MutablePerson {
+                  private String name;
+
+                  public String getName() { return name; }
+                  public void setName(String name) { this.name = name; }
+
+                  public MutablePerson withName(String name) {
+                      MutablePerson copy = new MutablePerson();
+                      copy.name = name;
+                      return copy;
+                  }
+              }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics(value = {com.external.MutablePerson.class}, allowMutable = true)
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(mutableClass, packageInfo);
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should reject unsupported type without withers")
+    void shouldRejectUnsupportedType() {
+      final var plainClass =
+          JavaFileObjects.forSourceString(
+              "com.external.PlainClass",
+              """
+              package com.external;
+
+              public class PlainClass {
+                  private String value;
+
+                  public String getValue() { return value; }
+              }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.PlainClass.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(plainClass, packageInfo);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("not a record, sealed interface, enum, or class with wither methods")
+          .inFile(packageInfo);
+    }
+  }
+
+  @Nested
+  @DisplayName("Target Package Configuration")
+  class TargetPackageConfiguration {
+
+    @Test
+    @DisplayName("should use custom target package when specified")
+    void shouldUseCustomTargetPackage() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Order",
+              """
+              package com.external;
+
+              public record Order(String id, int quantity) {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics(value = {com.external.Order.class}, targetPackage = "com.myapp.generated")
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.myapp.generated.OrderLenses").isNotNull();
+    }
+
+    @Test
+    @DisplayName("should use annotated package when targetPackage is empty")
+    void shouldUseAnnotatedPackageByDefault() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Item",
+              """
+              package com.external;
+
+              public record Item(String name) {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.custom.package-info",
+              """
+              @ImportOptics({com.external.Item.class})
+              package com.myapp.custom;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.myapp.custom.ItemLenses").isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("Type-Level Annotation")
+  class TypeLevelAnnotation {
+
+    @Test
+    @DisplayName("should support @ImportOptics on a class")
+    void shouldSupportAnnotationOnClass() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Product",
+              """
+              package com.external;
+
+              public record Product(String sku, double price) {}
+              """);
+
+      final var importerClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ProductOptics",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics({com.external.Product.class})
+              public class ProductOptics {}
+              """);
+
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(externalRecord, importerClass);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.myapp.ProductLenses").isNotNull();
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/TypeKindAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/TypeKindAnalyserTest.java
@@ -1,0 +1,550 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TypeKindAnalyser}.
+ *
+ * <p>These tests verify that the analyser correctly identifies different type kinds and extracts
+ * the appropriate information for optics generation.
+ */
+@DisplayName("TypeKindAnalyser")
+class TypeKindAnalyserTest {
+
+  /**
+   * A helper processor that runs the TypeKindAnalyser and captures the result. This allows us to
+   * test the analyser within the annotation processing environment.
+   */
+  private static class AnalyserTestProcessor extends AbstractProcessor {
+    private final String targetTypeName;
+    private TypeAnalysis result;
+
+    AnalyserTestProcessor(String targetTypeName) {
+      this.targetTypeName = targetTypeName;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+      return Set.of("*");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.RELEASE_25;
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      if (roundEnv.processingOver()) {
+        return false;
+      }
+
+      TypeElement typeElement = processingEnv.getElementUtils().getTypeElement(targetTypeName);
+      if (typeElement != null) {
+        TypeKindAnalyser analyser = new TypeKindAnalyser(processingEnv.getTypeUtils());
+        result = analyser.analyseType(typeElement);
+      }
+
+      return false;
+    }
+
+    TypeAnalysis getResult() {
+      return result;
+    }
+  }
+
+  private TypeAnalysis analyseType(String typeName, JavaFileObject... sources) {
+    AnalyserTestProcessor processor = new AnalyserTestProcessor(typeName);
+    Compilation compilation = javac().withProcessors(processor).compile(sources);
+    assertThat(compilation).succeeded();
+    return processor.getResult();
+  }
+
+  @Nested
+  @DisplayName("Record Analysis")
+  class RecordAnalysis {
+
+    @Test
+    @DisplayName("should identify record type")
+    void shouldIdentifyRecord() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.TestRecord",
+              """
+              package com.test;
+
+              public record TestRecord(String name, int age) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.TestRecord", source);
+
+      assertThat(analysis).isNotNull();
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.RECORD);
+      assertThat(analysis.supportsLenses()).isTrue();
+      assertThat(analysis.supportsPrisms()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should extract field info from record")
+    void shouldExtractFieldInfo() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.Person",
+              """
+              package com.test;
+
+              public record Person(String firstName, String lastName, int age) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.Person", source);
+
+      assertThat(analysis.fields()).hasSize(3);
+      assertThat(analysis.fields().get(0).name()).isEqualTo("firstName");
+      assertThat(analysis.fields().get(1).name()).isEqualTo("lastName");
+      assertThat(analysis.fields().get(2).name()).isEqualTo("age");
+    }
+
+    @Test
+    @DisplayName("should detect container fields in record")
+    void shouldDetectContainerFields() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.Order",
+              """
+              package com.test;
+
+              import java.util.List;
+
+              public record Order(String id, List<String> items) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.Order", source);
+
+      assertThat(analysis.fields()).hasSize(2);
+      assertThat(analysis.fields().get(0).hasTraversal()).isFalse();
+      assertThat(analysis.fields().get(1).hasTraversal()).isTrue();
+      assertThat(analysis.fields().get(1).containerType()).isPresent();
+      assertThat(analysis.fields().get(1).containerType().get().kind())
+          .isEqualTo(ContainerType.Kind.LIST);
+    }
+  }
+
+  @Nested
+  @DisplayName("Sealed Interface Analysis")
+  class SealedInterfaceAnalysis {
+
+    @Test
+    @DisplayName("should identify sealed interface")
+    void shouldIdentifySealedInterface() {
+      var sealedInterface =
+          JavaFileObjects.forSourceString(
+              "com.test.Result",
+              """
+              package com.test;
+
+              public sealed interface Result permits Success, Failure {}
+              """);
+
+      var success =
+          JavaFileObjects.forSourceString(
+              "com.test.Success",
+              """
+              package com.test;
+
+              public record Success(String value) implements Result {}
+              """);
+
+      var failure =
+          JavaFileObjects.forSourceString(
+              "com.test.Failure",
+              """
+              package com.test;
+
+              public record Failure(String error) implements Result {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.Result", sealedInterface, success, failure);
+
+      assertThat(analysis).isNotNull();
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.SEALED_INTERFACE);
+      assertThat(analysis.supportsLenses()).isFalse();
+      assertThat(analysis.supportsPrisms()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should extract permitted subtypes")
+    void shouldExtractPermittedSubtypes() {
+      var sealedInterface =
+          JavaFileObjects.forSourceString(
+              "com.test.Shape",
+              """
+              package com.test;
+
+              public sealed interface Shape permits Circle, Square, Triangle {}
+              """);
+
+      var circle =
+          JavaFileObjects.forSourceString(
+              "com.test.Circle",
+              """
+              package com.test;
+
+              public record Circle(double radius) implements Shape {}
+              """);
+
+      var square =
+          JavaFileObjects.forSourceString(
+              "com.test.Square",
+              """
+              package com.test;
+
+              public record Square(double side) implements Shape {}
+              """);
+
+      var triangle =
+          JavaFileObjects.forSourceString(
+              "com.test.Triangle",
+              """
+              package com.test;
+
+              public record Triangle(double base, double height) implements Shape {}
+              """);
+
+      TypeAnalysis analysis =
+          analyseType("com.test.Shape", sealedInterface, circle, square, triangle);
+
+      assertThat(analysis.permittedSubtypes()).hasSize(3);
+      assertThat(analysis.permittedSubtypes())
+          .extracting(te -> te.getSimpleName().toString())
+          .containsExactly("Circle", "Square", "Triangle");
+    }
+  }
+
+  @Nested
+  @DisplayName("Enum Analysis")
+  class EnumAnalysis {
+
+    @Test
+    @DisplayName("should identify enum type")
+    void shouldIdentifyEnum() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.Colour",
+              """
+              package com.test;
+
+              public enum Colour { RED, GREEN, BLUE }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.Colour", source);
+
+      assertThat(analysis).isNotNull();
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.ENUM);
+      assertThat(analysis.supportsLenses()).isFalse();
+      assertThat(analysis.supportsPrisms()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should extract enum constants")
+    void shouldExtractEnumConstants() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.Day",
+              """
+              package com.test;
+
+              public enum Day { MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.Day", source);
+
+      assertThat(analysis.enumConstants())
+          .containsExactly(
+              "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY");
+    }
+  }
+
+  @Nested
+  @DisplayName("Wither Class Analysis")
+  class WitherClassAnalysis {
+
+    @Test
+    @DisplayName("should identify class with wither methods")
+    void shouldIdentifyWitherClass() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.ImmutablePoint",
+              """
+              package com.test;
+
+              public final class ImmutablePoint {
+                  private final int x;
+                  private final int y;
+
+                  public ImmutablePoint(int x, int y) {
+                      this.x = x;
+                      this.y = y;
+                  }
+
+                  public int getX() { return x; }
+                  public int getY() { return y; }
+
+                  public ImmutablePoint withX(int x) { return new ImmutablePoint(x, this.y); }
+                  public ImmutablePoint withY(int y) { return new ImmutablePoint(this.x, y); }
+              }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.ImmutablePoint", source);
+
+      assertThat(analysis).isNotNull();
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.WITHER_CLASS);
+      assertThat(analysis.supportsLenses()).isTrue();
+      assertThat(analysis.supportsPrisms()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should extract wither method info")
+    void shouldExtractWitherInfo() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.Config",
+              """
+              package com.test;
+
+              public final class Config {
+                  private final String host;
+                  private final int port;
+
+                  public Config(String host, int port) {
+                      this.host = host;
+                      this.port = port;
+                  }
+
+                  public String getHost() { return host; }
+                  public int getPort() { return port; }
+
+                  public Config withHost(String host) { return new Config(host, this.port); }
+                  public Config withPort(int port) { return new Config(this.host, port); }
+              }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.Config", source);
+
+      assertThat(analysis.witherMethods()).hasSize(2);
+      assertThat(analysis.witherMethods().get(0).fieldName()).isEqualTo("host");
+      assertThat(analysis.witherMethods().get(0).witherMethodName()).isEqualTo("withHost");
+      assertThat(analysis.witherMethods().get(0).getterMethodName()).isEqualTo("getHost");
+    }
+
+    @Test
+    @DisplayName("should detect mutable fields on wither class")
+    void shouldDetectMutableFields() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.MutableConfig",
+              """
+              package com.test;
+
+              public class MutableConfig {
+                  private String host;
+                  private int port;
+
+                  public String getHost() { return host; }
+                  public void setHost(String host) { this.host = host; }
+
+                  public int getPort() { return port; }
+                  public void setPort(int port) { this.port = port; }
+
+                  public MutableConfig withHost(String host) {
+                      MutableConfig copy = new MutableConfig();
+                      copy.host = host;
+                      copy.port = this.port;
+                      return copy;
+                  }
+              }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.MutableConfig", source);
+
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.WITHER_CLASS);
+      assertThat(analysis.hasMutableFields()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("Unsupported Type Analysis")
+  class UnsupportedTypeAnalysis {
+
+    @Test
+    @DisplayName("should identify class without withers as unsupported")
+    void shouldIdentifyUnsupportedClass() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.PlainClass",
+              """
+              package com.test;
+
+              public class PlainClass {
+                  private String value;
+
+                  public String getValue() { return value; }
+              }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.PlainClass", source);
+
+      assertThat(analysis).isNotNull();
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.UNSUPPORTED);
+      assertThat(analysis.supportsLenses()).isFalse();
+      assertThat(analysis.supportsPrisms()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should detect mutable class as unsupported with mutable flag")
+    void shouldDetectMutableClassAsUnsupported() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.MutablePojo",
+              """
+              package com.test;
+
+              public class MutablePojo {
+                  private String name;
+
+                  public String getName() { return name; }
+                  public void setName(String name) { this.name = name; }
+              }
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.MutablePojo", source);
+
+      assertThat(analysis.typeKind()).isEqualTo(TypeAnalysis.TypeKind.UNSUPPORTED);
+      assertThat(analysis.hasMutableFields()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("Container Type Detection")
+  class ContainerTypeDetection {
+
+    @Test
+    @DisplayName("should detect List container")
+    void shouldDetectListContainer() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.WithList",
+              """
+              package com.test;
+
+              import java.util.List;
+
+              public record WithList(List<String> items) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.WithList", source);
+
+      assertThat(analysis.fields().getFirst().containerType()).isPresent();
+      assertThat(analysis.fields().getFirst().containerType().get().kind())
+          .isEqualTo(ContainerType.Kind.LIST);
+    }
+
+    @Test
+    @DisplayName("should detect Set container")
+    void shouldDetectSetContainer() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.WithSet",
+              """
+              package com.test;
+
+              import java.util.Set;
+
+              public record WithSet(Set<Integer> numbers) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.WithSet", source);
+
+      assertThat(analysis.fields().getFirst().containerType()).isPresent();
+      assertThat(analysis.fields().getFirst().containerType().get().kind())
+          .isEqualTo(ContainerType.Kind.SET);
+    }
+
+    @Test
+    @DisplayName("should detect Optional container")
+    void shouldDetectOptionalContainer() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.WithOptional",
+              """
+              package com.test;
+
+              import java.util.Optional;
+
+              public record WithOptional(Optional<String> maybeValue) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.WithOptional", source);
+
+      assertThat(analysis.fields().getFirst().containerType()).isPresent();
+      assertThat(analysis.fields().getFirst().containerType().get().kind())
+          .isEqualTo(ContainerType.Kind.OPTIONAL);
+    }
+
+    @Test
+    @DisplayName("should detect array container")
+    void shouldDetectArrayContainer() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.WithArray",
+              """
+              package com.test;
+
+              public record WithArray(int[] values) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.WithArray", source);
+
+      assertThat(analysis.fields().getFirst().containerType()).isPresent();
+      assertThat(analysis.fields().getFirst().containerType().get().kind())
+          .isEqualTo(ContainerType.Kind.ARRAY);
+    }
+
+    @Test
+    @DisplayName("should detect Map container")
+    void shouldDetectMapContainer() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.WithMap",
+              """
+              package com.test;
+
+              import java.util.Map;
+
+              public record WithMap(Map<String, Integer> mapping) {}
+              """);
+
+      TypeAnalysis analysis = analyseType("com.test.WithMap", source);
+
+      assertThat(analysis.fields().getFirst().containerType()).isPresent();
+      ContainerType container = analysis.fields().getFirst().containerType().get();
+      assertThat(container.kind()).isEqualTo(ContainerType.Kind.MAP);
+      assertThat(container.isMap()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
Part 1

Add support for generating optics for external types that users don't own:

Core Implementation:
- @ImportOptics annotation in hkj-annotations
- ImportOpticsProcessor for annotation processing
- TypeKindAnalyser for analysing external types
- ExternalLensGenerator for records and wither classes
- ExternalPrismGenerator for sealed interfaces and enums

Supported Type Kinds:
- Records → Lenses (with wither-based setters)
- Sealed interfaces → Prisms (one per permitted subtype)
- Enums → Prisms (one per constant)
- Classes with wither methods → Lenses

Documentation:
- hkj-book: importing_optics.md guide and import_optics_reference.md
- EXAMPLES-GUIDE.md updated with new examples
- Design documents and phase plans in docs/design/

Examples:
- ImportOpticsBasicExample: java.time types (LocalDate, LocalTime)
- ImportOpticsCompositionExample: composing with local optics
- ImportOpticsRecordExample: external record lenses
- ImportOpticsSealedExample: sealed interfaces, enums, JDK types

Also includes:
- Processor testing improvements plan document
- Unit tests for TypeKindAnalyser
- Integration tests via Google Compile Testing

 Relates to #322 Fixes #326