### PR TITLE
Add TOC level colours matching heading theme colors

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -1,8 +1,7 @@
 # Summary
 [Introduction to Higher-Kinded-J](home.md)
 
-# Effect Path API
-- [Introduction](effect/ch_intro.md)
+- [Effect Path API](effect/ch_intro.md)
   - [Effect Path Overview](effect/effect_path_overview.md)
   - [Capability Interfaces](effect/capabilities.md)
   - [Path Types](effect/path_types.md)
@@ -31,23 +30,21 @@
     - [MutableContext](effect/effect_contexts_mutable.md)
   - [Advanced Topics](effect/advanced_topics.md)
 
-# Advanced Topics
-- [Introduction](transformers/ch_intro.md)
+- [Advanced Topics](transformers/ch_intro.md)
   - [Monad Transformers](transformers/transformers.md)
   - [EitherT](transformers/eithert_transformer.md)
   - [OptionalT](transformers/optionalt_transformer.md)
   - [MaybeT](transformers/maybet_transformer.md)
   - [ReaderT](transformers/readert_transformer.md)
   - [StateT](transformers/statet_transformer.md)
-# Complete HKT Examples
-  - [An Order Workflow](hkts/order-walkthrough.md)
+
+  - [An Order Workflow Example](hkts/order-walkthrough.md)
     - [Effect Composition](hkts/order-composition.md)
     - [Production Patterns](hkts/order-production.md)
     - [Concurrency and Scale](hkts/order-concurrency.md)
   - [Draughts Game](hkts/draughts.md)
 
-# Hands-On Learning
-- [Introduction](tutorials/ch_intro.md)
+- [Hands-On Learning](tutorials/ch_intro.md)
   - [Interactive Tutorials](tutorials/tutorials_intro.md)
   - [Core Types: Foundations](tutorials/coretypes/foundations_journey.md)
   - [Core Types: Error Handling](tutorials/coretypes/error_handling_journey.md)
@@ -63,8 +60,7 @@
   - [Solutions Guide](tutorials/solutions_guide.md)
   - [Troubleshooting](tutorials/troubleshooting.md)
 
-# Optics I: Fundamentals
-- [Introduction](optics/ch1_intro.md)
+- [Optics I: Fundamentals](optics/ch1_intro.md)
   - [What Are Optics?](optics/optics_intro.md)
   - [Lenses](optics/lenses.md)
   - [Prisms](optics/prisms.md)
@@ -73,8 +69,7 @@
   - [Composition Rules](optics/composition_rules.md)
   - [Coupled Fields](optics/coupled_fields.md)
 
-# Optics II: Collections
-- [Introduction](optics/ch2_intro.md)
+- [Optics II: Collections](optics/ch2_intro.md)
   - [Traversals](optics/traversals.md)
   - [Folds](optics/folds.md)
   - [Getters](optics/getters.md)
@@ -83,8 +78,7 @@
   - [Limiting Traversals](optics/limiting_traversals.md)
   - [List Decomposition](optics/list_decomposition.md)
 
-# Optics III: Precision and Filtering
-- [Introduction](optics/ch3_intro.md)
+- [Optics III: Precision and Filtering](optics/ch3_intro.md)
   - [Filtered Optics](optics/filtered_optics.md)
   - [Indexed Optics](optics/indexed_optics.md)
   - [Each Typeclass](optics/each_typeclass.md)
@@ -93,8 +87,7 @@
   - [Advanced Prism Patterns](optics/advanced_prism_patterns.md)
   - [Profunctor Optics](optics/profunctor_optics.md)
 
-# Optics IV: Java-Friendly APIs
-- [Introduction](optics/ch4_intro.md)
+- [Optics IV: Java-Friendly APIs](optics/ch4_intro.md)
   - [Focus DSL](optics/focus_dsl.md)
   - [Optics for External Types](optics/importing_optics.md)
     - [Taming JSON with Jackson](optics/optics_spec_interfaces.md)
@@ -105,21 +98,18 @@
   - [Free Monad DSL](optics/free_monad_dsl.md)
   - [Interpreters](optics/interpreters.md)
 
-# Optics V: Integration and Recipes
-- [Introduction](optics/ch5_intro.md)
+- [Optics V: Integration and Recipes](optics/ch5_intro.md)
   - [Composing Optics](optics/composing_optics.md)
   - [Core Type Integration](optics/core_type_integration.md)
   - [Optics Extensions](optics/optics_extensions.md)
   - [Cookbook](optics/cookbook.md)
   - [Auditing Complex Data](optics/auditing_complex_data_example.md)
 
-# Integration Guides
-- [Introduction](spring/ch_intro.md)
+- [Integration Guides](spring/ch_intro.md)
   - [Spring Boot Integration](spring/spring_boot_integration.md)
   - [Migrating to Functional Errors](spring/migrating_to_functional_errors.md)
 
-# Foundations: Higher-Kinded Types
-- [Introduction](hkts/ch_intro.md)
+- [Foundations: Higher-Kinded Types](hkts/ch_intro.md)
   - [HKT Introduction](hkts/hkt_introduction.md)
   - [Concepts](hkts/core-concepts.md)
   - [Type Arity](hkts/type-arity.md)
@@ -128,8 +118,7 @@
   - [Quick Reference](hkts/quick_reference.md)
   - [Extending](hkts/extending-simulation.md)
 
-# Foundations: Type Classes
-- [Introduction](functional/ch_intro.md)
+- [Foundations: Type Classes](functional/ch_intro.md)
   - [Functional Api](functional/functional_api.md)
   - [Functor](functional/functor.md)
   - [Applicative](functional/applicative.md)
@@ -146,8 +135,7 @@
   - [For Comprehension](functional/for_comprehension.md)
   - [Choosing Abstraction Levels](functional/abstraction_levels.md)
 
-# Foundations: Core Types
-- [Introduction](monads/ch_intro.md)
+- [Foundations: Core Types](monads/ch_intro.md)
   - [Supported Types](monads/supported-types.md)
   - [CompletableFuture](monads/cf_monad.md)
   - [Either](monads/either_monad.md)
@@ -172,11 +160,9 @@
   - [Writer](monads/writer_monad.md)
   - [Const](monads/const_type.md)
 
-# More Functional Thinking
-- [Blog series](reading.md)
+- [More Functional Thinking](reading.md)
 
-# Glossary
-- [Functional Programming Terminology](glossary.md)
+- [Glossary](glossary.md)
 
 # Project Info
 - [Contributing](./CONTRIBUTING.md)

--- a/hkj-book/theme/additional-hkj.css
+++ b/hkj-book/theme/additional-hkj.css
@@ -1,9 +1,10 @@
-li:not(:last-of-type) {
+/* Content list spacing - scoped to .content to avoid affecting sidebar TOC */
+.content li:not(:last-of-type) {
     margin-block-end: 0.5em;
 }
 
-:is(ul, ol)+ :is(ul, ol),
-li :is(ul, ol) {
+.content :is(ul, ol) + :is(ul, ol),
+.content li :is(ul, ol) {
     margin-block-start: 0.5em;
 }
 
@@ -152,6 +153,48 @@ h1 + h2 {
     opacity: 0.5;
 }
 
+/* ===== Sidebar TOC Spacing Adjustments ===== */
+
+/* Style main chapter headings (1, 2, 3...) - slightly bigger with darker background */
+.sidebar .chapter > li.chapter-item > a {
+    font-size: 1.05em !important;
+    font-weight: 600 !important;
+    background-color: rgba(0, 0, 0, 0.08) !important;
+    padding: 0.25em 0.5em !important;
+    margin-left: -0.5em !important;
+    border-radius: 4px !important;
+    display: inline-block !important;
+}
+
+/* Increase space BEFORE main chapter headings only (li.chapter-item)
+   This creates visual separation between chapters (e.g., between 5 and 6) */
+.sidebar .chapter > li.chapter-item {
+    margin-top: 1.2em !important;
+}
+
+/* Remove space before the first chapter */
+.sidebar .chapter > li.chapter-item:first-child {
+    margin-top: 0 !important;
+}
+
+/* Remove space before section wrapper li (keeps sub-chapters tight to parent)
+   The section wrapper is a plain <li> without .chapter-item class */
+.sidebar .chapter > li:not(.chapter-item) {
+    margin-top: 0 !important;
+    padding: 0 !important;
+}
+
+/* Hide section wrapper when chapter is collapsed (no expanded class) */
+.sidebar .chapter > li.chapter-item:not(.expanded) + li:not(.chapter-item) {
+    display: none !important;
+}
+
+/* Tighten spacing between sub-chapter items */
+.sidebar .chapter .section > li {
+    margin-bottom: 0.15em !important;
+    margin-top: 0 !important;
+}
+
 /* ===== Heading Colors by Theme ===== */
 
 /* Latte (light theme) - uses darker, more saturated colors */
@@ -193,3 +236,25 @@ html.macchiato :is(h1, h2, h3, h4, h5, h6) > a,
 html.mocha :is(h1, h2, h3, h4, h5, h6) > a {
     color: inherit !important;
 }
+
+/* ===== Sidebar TOC Level Colors (matching heading colors) ===== */
+
+/* Latte theme - TOC colors */
+html.latte .sidebar .chapter > li.chapter-item > a:not(.active) { color: #1e66f5 !important; } /* Blue - Level 1 */
+html.latte .sidebar .chapter .section > li.chapter-item > a:not(.active) { color: #8839ef !important; } /* Mauve - Level 2 */
+html.latte .sidebar .chapter .section .section > li.chapter-item > a:not(.active) { color: #179299 !important; } /* Teal - Level 3 */
+
+/* Frappe theme - TOC colors */
+html.frappe .sidebar .chapter > li.chapter-item > a:not(.active) { color: #8caaee !important; } /* Blue - Level 1 */
+html.frappe .sidebar .chapter .section > li.chapter-item > a:not(.active) { color: #ca9ee6 !important; } /* Mauve - Level 2 */
+html.frappe .sidebar .chapter .section .section > li.chapter-item > a:not(.active) { color: #81c8be !important; } /* Teal - Level 3 */
+
+/* Macchiato theme - TOC colors */
+html.macchiato .sidebar .chapter > li.chapter-item > a:not(.active) { color: #8aadf4 !important; } /* Blue - Level 1 */
+html.macchiato .sidebar .chapter .section > li.chapter-item > a:not(.active) { color: #c6a0f6 !important; } /* Mauve - Level 2 */
+html.macchiato .sidebar .chapter .section .section > li.chapter-item > a:not(.active) { color: #8bd5ca !important; } /* Teal - Level 3 */
+
+/* Mocha theme - TOC colors */
+html.mocha .sidebar .chapter > li.chapter-item > a:not(.active) { color: #89b4fa !important; } /* Blue - Level 1 */
+html.mocha .sidebar .chapter .section > li.chapter-item > a:not(.active) { color: #cba6f7 !important; } /* Mauve - Level 2 */
+html.mocha .sidebar .chapter .section .section > li.chapter-item > a:not(.active) { color: #94e2d5 !important; } /* Teal - Level 3 */


### PR DESCRIPTION
Apply heading colours to TOC chapter levels for each theme:
- Level 1 (main chapters): Blue (h1 color)
- Level 2 (sub-chapters): Mauve (h2 color)
- Level 3 (sub-sub-chapters): Teal (h3 color) Adjust TOC spacing for better chapter grouping
- Add more space before chapter headings (1.5em) to visually separate sections
- Reduce space between chapter headings and sub-chapters (0.2em) for tighter grouping




