### PR TITLE
Add toEither conversion methods to Maybe

### DIFF
--- a/hkj-book/src/monads/maybe_monad.md
+++ b/hkj-book/src/monads/maybe_monad.md
@@ -128,7 +128,28 @@ The `Maybe` interface itself provides useful methods:
 * `get()`: Returns the value if `Just`, otherwise throws `NoSuchElementException`. **Use with caution.**
 * `orElse(@NonNull T other)`: Returns the value if `Just`, otherwise returns `other`.
 * `orElseGet(@NonNull Supplier<? extends @NonNull T> other)`: Returns the value if `Just`, otherwise invokes `other.get()`.
+* `toEither(L leftValue)`: Converts to `Either<L, T>`. `Just(t)` becomes `Right(t)`, `Nothing` becomes `Left(leftValue)`.
+* `toEither(Supplier<L> leftSupplier)`: Lazy variant that only evaluates the supplier for `Nothing`.
 * The `Maybe` interface also has its own `map` and `flatMap` methods, which are similar in behaviour to those on `MaybeMonad` but operate directly on `Maybe` instances.
+
+~~~admonish example title="Converting Maybe to Either"
+The `toEither` methods bridge between `Maybe` and `Either`, useful when you need to provide error context for absent values:
+
+```java
+Maybe<User> maybeUser = findUser(userId);
+
+// Convert with a static error value
+Either<String, User> result = maybeUser.toEither("User not found");
+
+// Convert with a lazy error (only computed if Nothing)
+Either<UserError, User> result2 = maybeUser.toEither(
+    () -> new UserError("User " + userId + " not found")
+);
+
+// Just(user) -> Right(user)
+// Nothing    -> Left("User not found")
+```
+~~~
 
 ### Key Operations (via `MaybeMonad`)
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/natural/NaturalTransformationExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/natural/NaturalTransformationExample.java
@@ -43,6 +43,7 @@ public class NaturalTransformationExample {
 
     maybeToListExample();
     eitherToMaybeExample();
+    maybeToEitherExample();
     listHeadExample();
     compositionExample();
     identityExample();
@@ -120,6 +121,57 @@ public class NaturalTransformationExample {
     Kind<EitherKind.Witness<String>, Integer> left = EITHER.widen(Either.left("Error occurred"));
     Kind<MaybeKind.Witness, Integer> maybeFromLeft = eitherToMaybe.apply(left);
     System.out.println("Either.left(\"Error occurred\") -> " + MAYBE.narrow(maybeFromLeft));
+
+    System.out.println();
+  }
+
+  /**
+   * Example 2b: Maybe to Either transformation.
+   *
+   * <p>This is the complement to eitherToMaybeExample. Nothing becomes Left(error), Just(value)
+   * becomes Right(value). Unlike the reverse transformation, this requires providing an error value
+   * for the Nothing case.
+   *
+   * <p>Note: Maybe now has a direct toEither() method, but this example shows how to build it as a
+   * natural transformation for educational purposes.
+   */
+  private static void maybeToEitherExample() {
+    System.out.println("--- Example 2b: Maybe to Either ---");
+
+    // Using Maybe's built-in toEither method (preferred approach)
+    Maybe<Integer> justValue = Maybe.just(100);
+    Maybe<Integer> nothingValue = Maybe.nothing();
+
+    // Direct conversion using toEither
+    Either<String, Integer> eitherFromJust = justValue.toEither("No value present");
+    Either<String, Integer> eitherFromNothing = nothingValue.toEither("No value present");
+
+    System.out.println("Using Maybe.toEither():");
+    System.out.println("  Maybe.just(100).toEither(\"No value present\") -> " + eitherFromJust);
+    System.out.println("  Maybe.nothing().toEither(\"No value present\") -> " + eitherFromNothing);
+
+    // As a natural transformation (for educational purposes)
+    // Note: This requires a fixed error value, making it less flexible than the instance method
+    String defaultError = "Value was absent";
+    Natural<MaybeKind.Witness, EitherKind.Witness<String>> maybeToEither =
+        new Natural<>() {
+          @Override
+          public <A> Kind<EitherKind.Witness<String>, A> apply(Kind<MaybeKind.Witness, A> fa) {
+            Maybe<A> maybe = MAYBE.narrow(fa);
+            Either<String, A> either = maybe.toEither(defaultError);
+            return EITHER.widen(either);
+          }
+        };
+
+    System.out.println("\nUsing Natural Transformation:");
+    Kind<MaybeKind.Witness, Integer> justKind = MAYBE.widen(justValue);
+    Kind<EitherKind.Witness<String>, Integer> eitherFromJustKind = maybeToEither.apply(justKind);
+    System.out.println("  Maybe.just(100) -> " + EITHER.narrow(eitherFromJustKind));
+
+    Kind<MaybeKind.Witness, Integer> nothingKind = MAYBE.widen(nothingValue);
+    Kind<EitherKind.Witness<String>, Integer> eitherFromNothingKind =
+        maybeToEither.apply(nothingKind);
+    System.out.println("  Maybe.nothing() -> " + EITHER.narrow(eitherFromNothingKind));
 
     System.out.println();
   }


### PR DESCRIPTION
Add two overloaded toEither methods to Maybe for converting to Either:
- toEither(L leftValue) - uses provided value for Left case
- toEither(Supplier<L>) - lazily supplies Left value when needed

This provides API consistency with Try.toEither() and MaybePath.toEitherPath(), enabling seamless conversion between Maybe and Either types.

fixes #342 