### PR TITLE
Refresh transformers documentation with problem-first structure 

### DIFF
--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -330,6 +330,17 @@ Within a chapter, pages should follow this order:
 2. Core concepts in logical order
 3. More advanced topics towards the end
 
+## Problem-First Structure for Advanced Topics
+
+Pages in advanced topic chapters should lead with a concrete problem before introducing the abstraction:
+
+1. **Show the pain** – A short code snippet (5-15 lines) demonstrating the problem the reader faces without this tool
+2. **Name the problem** – One or two sentences explaining why this hurts
+3. **Show the solution** – The same scenario using the documented tool
+4. **Explain** – How and why the solution works
+
+This structure ensures readers understand *why* they need a concept before learning *how* it works. Reference material (type signatures, witness types, helper utilities) should still be present but positioned after the narrative arc, typically inside admonishments so the teaching flow is not interrupted.
+
 ## Checklist for New Pages
 
 When creating a new documentation page, ensure:

--- a/hkj-book/src/transformers/eithert_transformer.md
+++ b/hkj-book/src/transformers/eithert_transformer.md
@@ -1,5 +1,11 @@
-# The EitherT Transformer: 
-## _Combining Monadic Effects_
+# The EitherT Transformer:
+## _Typed Errors in Any Context_
+
+> *"It is not down on any map; true places never are."*
+>
+> – Herman Melville, *Moby-Dick*
+
+The Either inside a Future exists in a place Java's type system cannot natively map to. EitherT creates the map.
 
 ~~~admonish info title="What You'll Learn"
 - How to combine async operations (CompletableFuture) with typed error handling (Either)
@@ -13,447 +19,305 @@
 [EitherTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java)
 ~~~
 
-## `EitherT` Monad Transformer.
+---
+
+## The Problem: Nested Async Errors
+
+Consider a typical order processing flow. Each step is asynchronous and can fail with a domain error:
+
+```java
+// Without EitherT: manual nesting
+CompletableFuture<Either<DomainError, Receipt>> processOrder(OrderData data) {
+    return validateOrder(data).thenCompose(eitherValidated ->
+        eitherValidated.fold(
+            error -> CompletableFuture.completedFuture(Either.left(error)),
+            validated -> checkInventory(validated).thenCompose(eitherInventory ->
+                eitherInventory.fold(
+                    error -> CompletableFuture.completedFuture(Either.left(error)),
+                    inventory -> processPayment(inventory).thenCompose(eitherPayment ->
+                        eitherPayment.fold(
+                            error -> CompletableFuture.completedFuture(Either.left(error)),
+                            payment -> createReceipt(payment)
+                        ))
+                ))
+        ));
+}
+```
+
+Four steps, four levels of nesting, identical error-propagation boilerplate at every level. The actual business logic is buried inside the structure. Add error recovery for a specific step and this becomes nearly unreadable.
+
+## The Solution: EitherT
+
+```java
+// With EitherT: flat composition
+Kind<W, Receipt> processOrder(OrderData data) {
+    return For.from(eitherTMonad, EitherT.fromKind(validateOrder(data)))
+        .from(validated -> EitherT.fromKind(checkInventory(validated)))
+        .from(inventory -> EitherT.fromKind(processPayment(inventory)))
+        .from(payment -> EitherT.fromKind(createReceipt(payment)))
+        .yield((v, i, p, r) -> r);
+}
+```
+
+Same four steps. No manual error propagation. If any step returns `Left`, subsequent steps are skipped automatically. The error type `DomainError` flows through the entire chain.
+
+---
+
+## How EitherT Works
+
+`EitherT<F, L, R>` wraps a value of type `Kind<F, Either<L, R>>`. It represents a computation within the context `F` that will eventually yield an `Either<L, R>`.
+
+```
+    ┌──────────────────────────────────────────────────────────┐
+    │  EitherT<CompletableFutureKind.Witness, Error, Value>    │
+    │                                                          │
+    │  ┌─── CompletableFuture ──────────────────────────────┐  │
+    │  │                                                    │  │
+    │  │  ┌─── Either ──────────────────────────────────┐   │  │
+    │  │  │                                             │   │  │
+    │  │  │   Left(error)       │     Right(value)      │   │  │
+    │  │  │                     │                       │   │  │
+    │  │  └─────────────────────────────────────────────┘   │  │
+    │  │                                                    │  │
+    │  └────────────────────────────────────────────────────┘  │
+    │                                                          │
+    │  flatMap ──▶ sequences F, then routes on Either          │
+    │  map ──────▶ transforms Right(value) only                │
+    │  raiseError ──▶ creates Left(error) in F                 │
+    │  handleErrorWith ──▶ recovers from Left                  │
+    └──────────────────────────────────────────────────────────┘
+```
 
 ![eithert_transformer.svg](../images/puml/eithert_transformer.svg)
 
-## `EitherT<F, L, R>`: Combining any Monad `F` with `Either<L, R>`
-
-The `EitherT` monad transformer allows you to combine the error-handling capabilities of `Either<L, R>` with another outer monad `F`. It transforms a computation that results in `Kind<F, Either<L, R>>` into a single monadic structure that can be easily composed. This is particularly useful when dealing with operations that can fail (represented by `Left<L>`) within an effectful context `F` (like asynchronous operations using `CompletableFutureKind` or computations involving state with `StateKind`).
-
-* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`, `OptionalKind.Witness`). This monad handles the primary effect (e.g., asynchronicity, optionality).
-* **`L`**: The **Left type** of the inner `Either`. This typically represents the *error* type for the computation or alternative result.
-* **`R`**: The **Right type** of the inner `Either`. This typically represents the *success* value type.
+* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`). This monad handles the primary effect.
+* **`L`**: The **Left type** of the inner `Either`, typically the error type.
+* **`R`**: The **Right type** of the inner `Either`, typically the success value.
 
 ```java
-public record EitherT<F, L, R>(@NonNull Kind<F, Either<L, R>> value) { 
+public record EitherT<F, L, R>(@NonNull Kind<F, Either<L, R>> value) {
   /* ... static factories ... */ }
 ```
 
-It holds a value of type `Kind<F, Either<L, R>>`. The real power comes from its associated type class instance, `EitherTMonad`.
+---
 
-Essentially, `EitherT<F, L, R>` wraps a value of type `Kind<F, Either<L, R>>`. It represents a computation within the context `F` that will eventually yield an `Either<L, R>`.
+## Setting Up EitherTMonad
 
-The primary goal of `EitherT` is to provide a unified `Monad` interface (specifically `MonadError` for the `L` type) for this nested structure, hiding the complexity of manually handling both the outer `F` context and the inner `Either` context.
-
-## `EitherTKind<F, L, R>`: The Witness Type
-
-Just like other types in the Higher-Kinded-J, `EitherT` needs a corresponding `Kind` interface to act as its witness type in generic functions. This is `EitherTKind<F, L, R>`. 
-
-* It extends `Kind<G, R>` where `G` (the witness for the combined monad) is `EitherTKind.Witness<F, L>`.
-* `F` and `L` are fixed for a specific `EitherT` context, while `R` is the variable type parameter `A` in `Kind<G, A>`.
-
-You'll primarily interact with this type when providing type signatures or receiving results from `EitherTMonad` methods.
-
-## `EitherTKindHelper` 
-* Provides widen and narrow methods to safely convert between the concrete `EitherT<F, L, R>` and its Kind representation (`Kind<EitherTKind<F, L, ?>, R>`).
-
-## `EitherTMonad<F, L>`: Operating on `EitherT`
-
-* The EitherTMonad class implements `MonadError<EitherTKind.Witness<F, L>, L>`.
-
-- It requires a `Monad<F>` instance for the outer monad `F` (where `F extends WitnessArity<TypeArity.Unary>`) to be provided during construction. This outer monad instance is used internally to handle the effects of `F`.
-- It uses `EITHER_T.widen` and `EITHER_T.narrow` internally to manage the conversion between the `Kind` and the concrete `EitherT`.
-- The error type E for MonadError is fixed to L, the 'Left' type of the inner Either. Error handling operations like `raiseError(L l)` will create an `EitherT` representing `F<Left(l)>`, and `handleErrorWith` allows recovering from such Left states.
-
-
+The `EitherTMonad<F, L>` class implements `MonadError<EitherTKind.Witness<F, L>, L>`, providing the standard monadic operations for the combined structure. It requires a `Monad<F>` instance for the outer monad:
 
 ```java
-// Example: F = CompletableFutureKind.Witness, L = DomainError
-// 1. Get the MonadError instance for the outer monad F
+// F = CompletableFutureKind.Witness, L = DomainError
 MonadError<CompletableFutureKind.Witness, Throwable> futureMonad = CompletableFutureMonad.INSTANCE;
 
-// 2. Create the EitherTMonad, providing the outer monad instance
-//    This EitherTMonad handles DomainError for the inner Either.
 MonadError<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, DomainError> eitherTMonad =
     new EitherTMonad<>(futureMonad);
-
-// Now 'eitherTMonad' can be used to operate on Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, A> values.
 ```
 
+~~~admonish note title="Type Witness and Helpers"
+**Witness Type:** `EitherTKind<F, L, R>` extends `Kind<EitherTKind.Witness<F, L>, R>`. The types `F` and `L` are fixed for a given context; `R` is the variable value type.
+
+**KindHelper:** `EitherTKindHelper` provides `EITHER_T.widen` and `EITHER_T.narrow` for safe conversion between the concrete `EitherT<F, L, R>` and its `Kind` representation.
+
+```java
+// Widen: concrete → Kind
+Kind<EitherTKind.Witness<F, L>, R> kind = EITHER_T.widen(eitherT);
+
+// Narrow: Kind → concrete
+EitherT<F, L, R> concrete = EITHER_T.narrow(kind);
+```
+~~~
+
+---
+
+## Key Operations
 
 ~~~admonish info title="Key Operations with _EitherTMonad_:"
 * **`eitherTMonad.of(value)`:** Lifts a pure value `A` into the `EitherT` context. Result: `F<Right(A)>`.
-* **`eitherTMonad.map(f, eitherTKind)`:** Applies function `A -> B` to the `Right` value inside the nested structure, preserving both `F` and `Either` contexts (if Right). Result: `F<Either<L, B>>`.
-* **`eitherTMonad.flatMap(f, eitherTKind)`:** The core sequencing operation. Takes a function `A -> Kind<EitherTKind.Witness<F, L>, B>` (i.e., `A -> EitherT<F, L, B>`). It unwraps the input `EitherT`, handles the `F` context, checks the inner `Either`:
-  * If `Left(l)`, it propagates `F<Left(l)>`.
-  * If `Right(a)`, it applies `f(a)` to get the next `EitherT<F, L, B>`, and extracts its inner `Kind<F, Either<L, B>>`, effectively chaining the `F` contexts and the `Either` logic.
-* **`eitherTMonad.raiseError(errorL)`:** Creates an `EitherT` representing a failure in the inner `Either`. Result: `F<Left(L)>`.
-* **`eitherTMonad.handleErrorWith(eitherTKind, handler)`:** Handles a failure `L` from the *inner* `Either`. Takes a handler `L -> Kind<EitherTKind.Witness<F, L>, A>`. It unwraps the input `EitherT`, checks the inner `Either`:
-  * If `Right(a)`, propagates `F<Right(a)>`.
-  * If `Left(l)`, applies `handler(l)` to get a recovery `EitherT<F, L, A>`, and extracts its inner `Kind<F, Either<L, A>>`.
+* **`eitherTMonad.map(f, eitherTKind)`:** Applies function `A -> B` to the `Right` value inside the nested structure. If `Left`, the error propagates unchanged. Result: `F<Either<L, B>>`.
+* **`eitherTMonad.flatMap(f, eitherTKind)`:** The core sequencing operation. Takes `A -> Kind<EitherTKind.Witness<F, L>, B>`:
+  * If `Left(l)`, propagates `F<Left(l)>` (subsequent steps skipped)
+  * If `Right(a)`, applies `f(a)` to get the next `EitherT<F, L, B>`
+* **`eitherTMonad.raiseError(errorL)`:** Creates an `EitherT` representing a failure. Result: `F<Left(L)>`.
+* **`eitherTMonad.handleErrorWith(eitherTKind, handler)`:** Handles a failure `L` from the inner `Either`. If `Right(a)`, propagates unchanged. If `Left(l)`, applies `handler(l)` to attempt recovery.
 ~~~
 
+---
 
+## Creating EitherT Instances
 
 ~~~admonish title="Creating _EitherT_ Instances"
-You typically create `EitherT` instances using its static factory methods, providing the necessary outer `Monad<F>` instance:
+`EitherT` provides several factory methods for different starting points:
 
 ```java
-// Assume:
-Monad<OptionalKind.Witness> optMonad = OptionalMonad.INSTANCE; // Outer Monad F=Optional
-String errorL = "FAILED";
-String successR = "OK";
-Integer otherR = 123;
+Monad<OptionalKind.Witness> optMonad = OptionalMonad.INSTANCE;
 
-// 1. Lifting a pure 'Right' value: Optional<Right(R)>
-EitherT<OptionalKind.Witness, String, String> etRight = EitherT.right(optMonad, successR);
-// Resulting wrapped value: Optional.of(Either.right("OK"))
+// 1. From a pure Right value: F<Right(value)>
+EitherT<OptionalKind.Witness, String, String> etRight =
+    EitherT.right(optMonad, "OK");
 
-// 2. Lifting a pure 'Left' value: Optional<Left(L)>
-EitherT<OptionalKind.Witness, String, Integer> etLeft = EitherT.left(optMonad, errorL);
-// Resulting wrapped value: Optional.of(Either.left("FAILED"))
+// 2. From a pure Left value: F<Left(error)>
+EitherT<OptionalKind.Witness, String, Integer> etLeft =
+    EitherT.left(optMonad, "FAILED");
 
-// 3. Lifting a plain Either: Optional<Either(input)>
-Either<String, String> plainEither = Either.left(errorL);
-EitherT<OptionalKind.Witness, String, String> etFromEither = EitherT.fromEither(optMonad, plainEither);
-// Resulting wrapped value: Optional.of(Either.left("FAILED"))
+// 3. From an existing Either: F<Either(input)>
+Either<String, String> plainEither = Either.left("FAILED");
+EitherT<OptionalKind.Witness, String, String> etFromEither =
+    EitherT.fromEither(optMonad, plainEither);
 
-// 4. Lifting an outer monad value F<R>: Optional<Right(R)>
-Kind<OptionalKind.Witness, Integer> outerOptional = OPTIONAL.widen(Optional.of(otherR));
-EitherT<OptionalKind.Witness, String, Integer> etLiftF = EitherT.liftF(optMonad, outerOptional);
-// Resulting wrapped value: Optional.of(Either.right(123))
+// 4. Lifting an outer monad value F<R> → F<Right(R)>
+Kind<OptionalKind.Witness, Integer> outerOptional =
+    OPTIONAL.widen(Optional.of(123));
+EitherT<OptionalKind.Witness, String, Integer> etLiftF =
+    EitherT.liftF(optMonad, outerOptional);
 
-// 5. Wrapping an existing nested Kind: F<Either<L, R>>
+// 5. Wrapping an existing nested Kind F<Either<L, R>>
 Kind<OptionalKind.Witness, Either<String, String>> nestedKind =
-    OPTIONAL.widen(Optional.of(Either.right(successR)));
-EitherT<OptionalKind.Witness, String, String> etFromKind = EitherT.fromKind(nestedKind);
-// Resulting wrapped value: Optional.of(Either.right("OK"))
+    OPTIONAL.widen(Optional.of(Either.right("OK")));
+EitherT<OptionalKind.Witness, String, String> etFromKind =
+    EitherT.fromKind(nestedKind);
 
 // Accessing the wrapped value:
 Kind<OptionalKind.Witness, Either<String, String>> wrappedValue = etRight.value();
 Optional<Either<String, String>> unwrappedOptional = OPTIONAL.narrow(wrappedValue);
-// unwrappedOptional is Optional.of(Either.right("OK"))
+// → Optional.of(Either.right("OK"))
 ```
 ~~~
 
-----
+---
+
+## Real-World Example: Async Workflow with Error Handling
 
 ~~~admonish Example title="Async Workflow with Error Handling"
 
 - [EitherTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java)
 
-The most common use case for `EitherT` is combining asynchronous operations (`CompletableFuture`) with domain error handling (`Either`).  The `OrderWorkflowRunner` class provides a detailed example.
+**The problem:** You need to validate input, process it asynchronously, and handle domain-specific errors at each step, all without nested `thenCompose`/`fold` chains.
 
-Here's a simplified conceptual structure based on that example:
+**The solution:**
 
 ```java
 public class EitherTExample {
 
-  // --- Setup ---
-
-  // Assume DomainError is a sealed interface for specific errors
-  // Re-defining a local DomainError to avoid dependency on the full DomainError hierarchy for this isolated example.
-  // In a real scenario, you would use the shared DomainError.
   record DomainError(String message) {}
   record ValidatedData(String data) {}
   record ProcessedData(String data) {}
 
-  MonadError<CompletableFutureKind.Witness, Throwable> futureMonad = CompletableFutureMonad.INSTANCE;
-  MonadError<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, DomainError> eitherTMonad =
-          new EitherTMonad<>(futureMonad);
+  MonadError<CompletableFutureKind.Witness, Throwable> futureMonad =
+      CompletableFutureMonad.INSTANCE;
+  MonadError<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>,
+      DomainError> eitherTMonad = new EitherTMonad<>(futureMonad);
 
-  // --- Workflow Steps (returning Kinds) ---
-
-  // Simulates a sync validation returning Either
+  // Sync validation returning Either
   Kind<EitherKind.Witness<DomainError>, ValidatedData> validateSync(String input) {
-    System.out.println("Validating synchronously...");
     if (input.isEmpty()) {
       return EITHER.widen(Either.left(new DomainError("Input empty")));
     }
     return EITHER.widen(Either.right(new ValidatedData("Validated:" + input)));
   }
 
-  // Simulates an async processing step returning Future<Either>
-  Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>> processAsync(ValidatedData vd) {
-    System.out.println("Processing asynchronously for: " + vd.data());
+  // Async processing returning Future<Either>
+  Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>>
+      processAsync(ValidatedData vd) {
     CompletableFuture<Either<DomainError, ProcessedData>> future =
-            CompletableFuture.supplyAsync(() -> {
-              try {
-                Thread.sleep(50);
-              } catch (InterruptedException e) { /* ignore */ }
-              if (vd.data().contains("fail")) {
-                return Either.left(new DomainError("Processing failed"));
-              }
-              return Either.right(new ProcessedData("Processed:" + vd.data()));
-            });
+        CompletableFuture.supplyAsync(() -> {
+          if (vd.data().contains("fail")) {
+            return Either.left(new DomainError("Processing failed"));
+          }
+          return Either.right(new ProcessedData("Processed:" + vd.data()));
+        });
     return FUTURE.widen(future);
   }
 
-  // Function to run the workflow for given input
-  Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>> runWorkflow(String initialInput) {
+  Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>>
+      runWorkflow(String input) {
+    // Lift initial value into EitherT
+    var initialET = eitherTMonad.of(input);
 
-    // Start with initial data lifted into EitherT
-    Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, String> initialET = eitherTMonad.of(initialInput);
+    // Step 1: Validate (sync Either → EitherT)
+    var validatedET = eitherTMonad.flatMap(
+        in -> EitherT.fromEither(futureMonad, EITHER.narrow(validateSync(in))),
+        initialET);
 
-    // Step 1: Validate (Sync Either lifted into EitherT)
-    Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, ValidatedData> validatedET =
-            eitherTMonad.flatMap(
-                    input -> {
-                      // Call sync step returning Kind<EitherKind.Witness,...>
-                      // Correction 1: Use EitherKind.Witness here
-                      Kind<EitherKind.Witness<DomainError>, ValidatedData> validationResult = validateSync(input);
-                      // Lift the Either result into EitherT using fromEither
-                      return EitherT.fromEither(futureMonad, EITHER.narrow(validationResult));
-                    },
-                    initialET
-            );
+    // Step 2: Process (async Future<Either> → EitherT)
+    var processedET = eitherTMonad.flatMap(
+        vd -> EitherT.fromKind(processAsync(vd)),
+        validatedET);
 
-    // Step 2: Check Inventory (Asynchronous - returns Future<Either<DomainError, Unit>>) 
-    Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, WorkflowContext> inventoryET =
-        eitherTMonad.flatMap( // Chain from validation result
-            ctx -> { // Executed only if validatedET was F<Right(...)>
-                // Call async step -> Kind<CompletableFutureKind.Witness, Either<DomainError, Unit>> 
-                Kind<CompletableFutureKind.Witness, Either<DomainError, Unit>> inventoryCheckFutureKind =
-                    steps.checkInventoryAsync(ctx.validatedOrder().productId(), ctx.validatedOrder().quantity());
-    
-                // Lift the F<Either> directly into EitherT using fromKind
-                Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Unit> inventoryCheckET = 
-                    EitherT.fromKind(inventoryCheckFutureKind);
-    
-                // If inventory check resolves to Right (now Right(Unit.INSTANCE)), update context.
- 
-                return eitherTMonad.map(unitInstance -> ctx.withInventoryChecked(), inventoryCheckET);
-            },
-            validatedET // Input is result of validation step
-        );
-
-    // Unwrap the final EitherT to get the underlying Future<Either>
-    return ((EitherT<CompletableFutureKind.Witness, DomainError, ProcessedData>) processedET).value();
+    // Unwrap to get Future<Either>
+    return EITHER_T.narrow(processedET).value();
   }
-
-  public void asyncWorkflowErrorHandlingExample(){
-    // --- Workflow Definition using EitherT ---
-
-    // Input data
-    String inputData = "Data";
-    String badInputData = "";
-    String processingFailData = "Data-fail";
-
-    // --- Execution ---
-    System.out.println("--- Running Good Workflow ---");
-
-    Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>> resultGoodKind = runWorkflow(inputData);
-    System.out.println("Good Result: "+FUTURE.join(resultGoodKind));
-    // Expected: Right(ProcessedData[data=Processed:Validated:Data])
-
-    System.out.println("\n--- Running Bad Input Workflow ---");
-
-    Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>> resultBadInputKind = runWorkflow(badInputData);
-    System.out.println("Bad Input Result: "+ FUTURE.join(resultBadInputKind));
-    // Expected: Left(DomainError[message=Input empty])
-
-    System.out.println("\n--- Running Processing Failure Workflow ---");
-
-    Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>> resultProcFailKind = runWorkflow(processingFailData);
-    System.out.println("Processing Fail Result: "+FUTURE.join(resultProcFailKind));
-    // Expected: Left(DomainError[message=Processing failed])
-
-  }
-  public static void main(String[] args){
-    EitherTExample example = new EitherTExample();
-    example.asyncWorkflowErrorHandlingExample();
-
-  }
-
 }
-
 ```
 
-This example demonstrates:
-
-1. Instantiating `EitherTMonad` with the outer `CompletableFutureMonad`.
-2. Lifting the initial value using `eitherTMonad.of`.
-3. Using `eitherTMonad.flatMap` to sequence steps.
-4. Lifting a synchronous `Either` result into `EitherT` using `EitherT.fromEither`.
-5. Lifting an asynchronous `Kind<F, Either<L,R>>` result using `EitherT.fromKind`.
-6. Automatic short-circuiting: If validation returns `Left`, the processing step is skipped.
-7. Unwrapping the final `EitherT` using `.value()` to get the `Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>>` result.
+**Why this works:** Each step produces an `EitherT` value. The `flatMap` handles both the `CompletableFuture` sequencing and the `Either` error propagation. If validation returns `Left`, processing is skipped entirely. No manual error checking at any point.
 ~~~
 
+---
+
+## Advanced Example: Error Recovery
 
 ~~~admonish Example title="Using _EitherTMonad_ for Sequencing and Error Handling"
 
 - [OrderWorkflowRunner.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflowRunner.java)
 
-The primary use is chaining operations using `flatMap` and handling errors using `handleErrorWith` or related methods. The `OrderWorkflowRunner` is the best example. Let's break down a key part:
+**The problem:** A shipping step might fail with a temporary error, and you want to recover by using a default shipping option rather than failing the entire workflow.
+
+**The solution:**
 
 ```java
-// --- From OrderWorkflowRunner.java ---
-// Assume setup:
-// F = CompletableFutureKind<?>
-// L = DomainError
-// futureMonad = CompletableFutureMonad.INSTANCE;
-// eitherTMonad = new EitherTMonad<>(futureMonad);
-// steps = new OrderWorkflowSteps(dependencies); // Contains workflow logic
+// Attempt shipment
+Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>,
+    ShipmentInfo> shipmentAttemptET =
+    EitherT.fromKind(steps.createShipmentAsync(orderId, address));
 
-// Initial Context (lifted)
-WorkflowContext initialContext = WorkflowContext.start(orderData);
-Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, WorkflowContext> initialET =
-    eitherTMonad.of(initialContext); // F<Right(initialContext)>
+// Recover from specific errors
+Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>,
+    ShipmentInfo> recoveredShipmentET =
+    eitherTMonad.handleErrorWith(
+        shipmentAttemptET,
+        error -> {
+            if (error instanceof DomainError.ShippingError se
+                    && "Temporary Glitch".equals(se.reason())) {
+                // Recoverable: use default shipping
+                return eitherTMonad.of(new ShipmentInfo("DEFAULT_SHIPPING_USED"));
+            } else {
+                // Non-recoverable: re-raise
+                return eitherTMonad.raiseError(error);
+            }
+        });
+```
 
-// Step 1: Validate Order (Synchronous - returns Either)
-Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, WorkflowContext> validatedET =
-    eitherTMonad.flatMap( // Use flatMap on EitherTMonad
-        ctx -> { // Lambda receives WorkflowContext if initialET was Right
-            // Call sync step -> Either<DomainError, ValidatedOrder>
-            Either<DomainError, ValidatedOrder> syncResultEither =
-                EITHER.narrow(steps.validateOrder(ctx.initialData()));
-
-            // Lift sync Either into EitherT: -> F<Either<DomainError, ValidatedOrder>>
-            Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, ValidatedOrder>
-                validatedOrderET = EitherT.fromEither(futureMonad, syncResultEither);
-
-            // If validation produced Left, map is skipped.
-            // If validation produced Right(vo), map updates the context: F<Right(ctx.withValidatedOrder(vo))>
-            return eitherTMonad.map(ctx::withValidatedOrder, validatedOrderET);
-        },
-        initialET // Input to the flatMap
-    );
-
-// Step 2: Check Inventory (Asynchronous - returns Future<Either<DomainError, Void>>)
-Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, WorkflowContext> inventoryET =
-    eitherTMonad.flatMap( // Chain from validation result
-        ctx -> { // Executed only if validatedET was F<Right(...)>
-            // Call async step -> Kind<CompletableFutureKind.Witness, Either<DomainError, Void>>
-            Kind<CompletableFutureKind.Witness, Either<DomainError, Void>> inventoryCheckFutureKind =
-                steps.checkInventoryAsync(ctx.validatedOrder().productId(), ctx.validatedOrder().quantity());
-
-            // Lift the F<Either> directly into EitherT using fromKind
-            Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Void> inventoryCheckET =
-                EitherT.fromKind(inventoryCheckFutureKind);
-
-            // If inventory check resolves to Right, update context. If Left, map is skipped.
-            return eitherTMonad.map(ignored -> ctx.withInventoryChecked(), inventoryCheckET);
-        },
-        validatedET // Input is result of validation step
-    );
-
-// Step 4: Create Shipment (Asynchronous with Recovery)
-Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, WorkflowContext> shipmentET =
-    eitherTMonad.flatMap( // Chain from previous step
-        ctx -> {
-            // Call async shipment step -> F<Either<DomainError, ShipmentInfo>>
-            Kind<CompletableFutureKind.Witness, Either<DomainError, ShipmentInfo>> shipmentAttemptFutureKind =
-                steps.createShipmentAsync(ctx.validatedOrder().orderId(), ctx.validatedOrder().shippingAddress());
-
-            // Lift into EitherT
-            Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, ShipmentInfo> shipmentAttemptET =
-                 EitherT.fromKind(shipmentAttemptFutureKind);
-
-            // *** Error Handling using MonadError ***
-            Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, ShipmentInfo> recoveredShipmentET =
-                eitherTMonad.handleErrorWith( // Operates on the EitherT value
-                    shipmentAttemptET,
-                    error -> { // Lambda receives DomainError if shipmentAttemptET resolves to Left(error)
-                        if (error instanceof DomainError.ShippingError se && "Temporary Glitch".equals(se.reason())) {
-                           // Specific recoverable error: Return a *successful* EitherT
-                           return eitherTMonad.of(new ShipmentInfo("DEFAULT_SHIPPING_USED"));
-                        } else {
-                           // Non-recoverable error: Re-raise it within EitherT
-                           return eitherTMonad.raiseError(error); // Returns F<Left(error)>
-                        }
-                    });
-
-            // Map the potentially recovered result to update context
-            return eitherTMonad.map(ctx::withShipmentInfo, recoveredShipmentET);
-        },
-        paymentET // Assuming paymentET was the previous step
-    );
-
-// ... rest of workflow ...
-
-// Final unwrap
-// EitherT<CompletableFutureKind.Witness, DomainError, FinalResult> finalET = ...;
-// Kind<CompletableFutureKind.Witness, Either<DomainError, FinalResult>> finalResultKind = finalET.value();
-````
-
-This demonstrates how `EitherTMonad.flatMap` sequences the steps, while `EitherT.fromEither`, `EitherT.fromKind`, and `eitherTMonad.of/raiseError/handleErrorWith` manage the lifting and error handling within the combined `Future<Either<...>>` context.
+The `handleErrorWith` only fires when the inner `Either` is `Left`. The outer `CompletableFuture` context is preserved throughout.
 ~~~
 
-~~~admonish important  title="Key Points:"
+---
 
-The `Higher-Kinded-J` library simplifies the implementation and usage of concepts like monad transformers (e.g., `EitherT`) in Java precisely *because* it simulates Higher-Kinded Types (HKTs). Here's how:
+~~~admonish warning title="Common Mistakes"
+- **Mixing up `fromEither` and `fromKind`:** Use `fromEither` when you have a plain `Either<L, R>` (e.g., from a synchronous validation). Use `fromKind` when you have `Kind<F, Either<L, R>>` (e.g., from an async operation that already returns `Future<Either>`).
+- **Forgetting `.value()`:** The final result of an `EitherT` chain is still an `EitherT`. Call `.value()` to extract the underlying `Kind<F, Either<L, R>>` when you need to interact with the outer monad directly.
+~~~
 
-1. **The Core Problem Without HKTs:** Java's type system doesn't allow you to directly parameterize a type by a *type constructor* like `List`, `Optional`, or `CompletableFuture`. You can write `List<String>`, but you cannot easily write a generic class `Transformer<F, A>` where `F` itself represents *any* container type (like `List<_>`) and `A` is the value type.
-   This limitation makes defining *general* monad transformers rather difficult. A monad transformer like `EitherT` needs to combine an *arbitrary* outer monad `F` with the inner `Either` monad. Without HKTs, you would typically have to:
+---
 
-   * Create separate, specific transformers for each outer monad (e.g., `EitherTOptional`, `EitherTFuture`, `EitherTIO`). This leads to significant code duplication.
-   * Resort to complex, often unsafe casting or reflection.
-   * Write extremely verbose code manually handling the nested structure for every combination.
-2. **How this helps with simulating HKTs):** `Higher-Kinded-J` introduces the `Kind<F, A>` interface. This interface, along with specific "witness types" (like `OptionalKind.Witness`, `CompletableFutureKind.Witness`, `EitherKind.Witness<L>`), simulates the concept of `F<A>`. It allows you to pass `F` (the type constructor, represented by its witness type) as a type parameter, even though Java doesn't support it natively.
-3. **Simplifying Transformer Definition (`EitherT<F, L, R>`):** Because we can now simulate `F<A>` using `Kind<F, A>`, we can define the `EitherT` data structure generically:
+~~~admonish note title="Why Higher-Kinded Types Matter Here"
+Without HKT simulation, you would need a separate transformer for each outer monad: `EitherTOptional`, `EitherTFuture`, `EitherTIO`, and so on. Higher-Kinded-J's `Kind<F, A>` interface means there is **one** `EitherT` and **one** `EitherTMonad` that works generically for any outer monad `F` for which a `Monad<F>` instance exists. You provide the outer monad at construction time; the transformer does the rest.
+~~~
 
-   ```java
-   // Simplified from EitherT.java
-   public record EitherT<F, L, R>(@NonNull Kind<F, Either<L, R>> value)
-       implements EitherTKind<F, L, R> { /* ... */ }
-   ```
+---
 
-   Here, `F` is a type parameter representing the *witness type* of the outer monad. `EitherT` doesn't need to know *which* specific monad `F` is at compile time; it just knows it holds a `Kind<F, ...>`. This makes the `EitherT` structure itself general-purpose.
-4. **Simplifying Transformer Operations (`EitherTMonad<F, L>`):** The real benefit comes with the type class instance `EitherTMonad`. This class implements `MonadError<EitherTKind.Witness<F, L>, L>`, providing the standard monadic operations (`map`, `flatMap`, `of`, `ap`, `raiseError`, `handleErrorWith`) for the combined `EitherT` structure.
-
-   Critically, `EitherTMonad` takes the `Monad<F>` instance for the *specific outer monad*`F` as a constructor argument:
-
-   ```java
-   // From EitherTMonad.java
-   public class EitherTMonad<F, L> implements MonadError<EitherTKind.Witness<F, L>, L> {
-       private final @NonNull Monad<F> outerMonad; // <-- Holds the specific outer monad instance
-
-       public EitherTMonad(@NonNull Monad<F> outerMonad) {
-           this.outerMonad = Objects.requireNonNull(outerMonad, "Outer Monad instance cannot be null");
-       }
-       // ... implementation of map, flatMap etc. ...
-   }
-   ```
-
-   Inside its `map`, `flatMap`, etc., implementations, `EitherTMonad` uses the provided `outerMonad` instance (via its `map` and `flatMap` methods) to handle the outer context `F`, while also managing the inner `Either` logic (checking for `Left`/`Right`, applying functions, propagating `Left`).
-   **This is where the Higher-Kinded-J drastically simplifies things:**
-
-* You only need **one**`EitherTMonad` implementation.
-* It works **generically** for any outer monad `F`*for which you have a `Monad<F>` instance* (like `OptionalMonad`, `CompletableFutureMonad`, `IOMonad`, etc.).
-* The complex logic of combining the two monads' behaviours (e.g., how `flatMap` should work on `F<Either<L, R>>`) is encapsulated *within*`EitherTMonad`, leveraging the simulated HKTs and the provided `outerMonad` instance.
-* As a user, you just instantiate `EitherTMonad` with the appropriate outer monad instance and then use its standard methods (`map`, `flatMap`, etc.) on your `EitherT` values, as seen in the `OrderWorkflowRunner` example. You don't need to manually handle the nesting.
-
-In essence, the HKT simulation provided by `Higher-Kinded-J` allows defining the structure (`EitherT`) and the operations (`EitherTMonad`) generically over the outer monad `F`, overcoming Java's native limitations and making monad transformers feasible and much less boilerplate-heavy than they would otherwise be.
+~~~admonish tip title="See Also"
+- [Monad Transformers](transformers.md) - General concept and choosing the right transformer
+- [OptionalT](optionalt_transformer.md) - When your inner effect is absence rather than typed errors
+- [Either Monad](../monads/either_monad.md) - The underlying Either type
+- [Order Processing Walkthrough](../hkts/order-walkthrough.md) - Complete EitherT example with CompletableFuture
 ~~~
 
 ---
 
 ~~~admonish tip title="Further Reading"
-Start with the **Java-focused** resources to see practical applications, then explore **General FP concepts** for deeper understanding, and finally check **Related Libraries** to see alternative approaches.
+- [Railway Oriented Programming](https://dev.tube/video/fYo3LN9Vf_M) - Scott Wlaschin's classic talk on functional error handling (60 min watch)
 ~~~
 
-### Java-Focused Resources
-
-**Beginner Level:**
--[Error Handling with Either in Java](https://www.baeldung.com/java-either) - Baeldung's introduction to Either (10 min read)
--[CompletableFuture Error Handling Patterns](https://www.nurkiewicz.com/2013/05/java-8-completablefuture-in-practice.html) - Tomasz Nurkiewicz's comparison to traditional async error handling (15 min read)
--[Railway Oriented Programming in Java](https://vimeo.com/113707214) - Scott Wlaschin's classic talk adapted to Java contexts (60 min watch)
-
-**Intermediate Level:**
--[Combining Async and Error Handling in Java](https://medium.com/@johnmcclean/reactive-error-handling-with-cyclops-e2e82a3e5f5) - Real-world async error workflows (20 min read)
-
-**Advanced:**
--[Type-Safe Error Handling at Scale](https://www.youtube.com/watch?v=3VSdGPQXoZ0) - Zalando's production experience (conference talk, 40 min)
-
-### General FP Concepts
-
--[Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) - F# for Fun and Profit's accessible explanation (20 min read)
--[Handling Errors Without Exceptions](https://www.manning.com/books/functional-programming-in-scala) - Chapter 4 from "Functional Programming in Scala" (free excerpt)
--[Either Type - Wikipedia](https://en.wikipedia.org/wiki/Either_type) - Formal definition and language comparisons
-
-### Related Libraries & Comparisons
-
--[Arrow Either](https://apidocs.arrow-kt.io/arrow-core/arrow.core/-either/index.html) - Kotlin's excellent API design
--[Result Type in Rust](https://doc.rust-lang.org/std/result/) - See how a systems language solves this problem
-
-### Community & Discussion
-
--[Either vs Exceptions in Java](https://stackoverflow.com/questions/39868580/either-vs-exceptions-in-java) - Stack Overflow debate with practical insights
--[Using Either in Production Java Code](https://news.ycombinator.com/item?id=15716149) - Hacker News discussion with war stories
-
----
 
 **Previous:** [Monad Transformers](transformers.md)
 **Next:** [OptionalT](optionalt_transformer.md)

--- a/hkj-book/src/transformers/optionalt_transformer.md
+++ b/hkj-book/src/transformers/optionalt_transformer.md
@@ -1,5 +1,5 @@
-# The OptionalT Transformer: 
-## _Combining Monadic Effects with `java.util.Optional`_
+# The OptionalT Transformer:
+## _When Absence Meets Other Effects_
 
 ~~~admonish info title="What You'll Learn"
 - How to integrate Java's Optional with other monadic contexts
@@ -13,19 +13,76 @@
 [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
 ~~~
 
-## `OptionalT` Monad Transformer
+---
 
-The `OptionalT` monad transformer (short for Optional Transformer) is designed to combine the semantics of `java.util.Optional<A>` (representing a value that might be present or absent) with an arbitrary outer monad `F`. It effectively allows you to work with computations of type `Kind<F, Optional<A>>` as a single, unified monadic structure.
+## The Problem: Nested Async Lookups
 
-This is particularly useful when operations within an effectful context `F` (such as asynchronicity with `CompletableFutureKind`, non-determinism with `ListKind`, or dependency injection with `ReaderKind`) can also result in an absence of a value (represented by `Optional.empty()`).
+Consider fetching a user, then their profile, then their preferences. Each step is async and might return empty:
 
-## Structure
+```java
+// Without OptionalT: manual nesting
+CompletableFuture<Optional<UserPreferences>> getPreferences(String userId) {
+    return fetchUserAsync(userId).thenCompose(optUser ->
+        optUser.map(user ->
+            fetchProfileAsync(user.id()).thenCompose(optProfile ->
+                optProfile.map(profile ->
+                    fetchPrefsAsync(profile.userId())
+                ).orElse(CompletableFuture.completedFuture(Optional.empty()))
+            )
+        ).orElse(CompletableFuture.completedFuture(Optional.empty()))
+    );
+}
+```
+
+Each step requires checking the `Optional`, providing a fallback `CompletableFuture.completedFuture(Optional.empty())` for the absent case, and nesting deeper. Three lookups; three layers of `map`/`orElse`. The fallback expression is identical every time.
+
+## The Solution: OptionalT
+
+```java
+// With OptionalT: flat composition
+OptionalT<CompletableFutureKind.Witness, UserPreferences> getPreferences(String userId) {
+    var userOT = OPTIONAL_T.widen(OptionalT.fromKind(fetchUserAsync(userId)));
+    var workflow = For.from(optionalTMonad, userOT)
+        .from(user -> OPTIONAL_T.widen(OptionalT.fromKind(fetchProfileAsync(user.id()))))
+        .from(profile -> OPTIONAL_T.widen(OptionalT.fromKind(fetchPrefsAsync(profile.userId()))))
+        .yield((user, profile, prefs) -> prefs);
+    return OPTIONAL_T.narrow(workflow);
+}
+```
+
+If any step returns empty, subsequent steps are skipped. No manual `orElse` fallbacks, no repeated `Optional.empty()` wrapping.
+
+---
+
+## How OptionalT Works
+
+`OptionalT<F, A>` wraps a computation yielding `Kind<F, Optional<A>>`. It represents an effectful computation in `F` that may or may not produce a value.
+
+```
+    ┌──────────────────────────────────────────────────────────┐
+    │  OptionalT<CompletableFutureKind.Witness, Value>         │
+    │                                                          │
+    │  ┌─── CompletableFuture ──────────────────────────────┐  │
+    │  │                                                    │  │
+    │  │  ┌─── Optional ────────────────────────────────┐   │  │
+    │  │  │                                             │   │  │
+    │  │  │   empty()            │   of(value)          │   │  │
+    │  │  │                      │                      │   │  │
+    │  │  └─────────────────────────────────────────────┘   │  │
+    │  │                                                    │  │
+    │  └────────────────────────────────────────────────────┘  │
+    │                                                          │
+    │  flatMap ──▶ sequences F, then routes on Optional        │
+    │  map ──────▶ transforms present value only               │
+    │  raiseError(Unit) ──▶ creates empty() in F               │
+    │  handleErrorWith ──▶ recovers from empty                 │
+    └──────────────────────────────────────────────────────────┘
+```
 
 ![optional_t_transformer.svg](../images/puml/optional_t_transformer.svg)
 
-## `OptionalT<F, A>`: The Core Data Type
-
-`OptionalT<F, A>` is a record that wraps a computation yielding `Kind<F, Optional<A>>`.
+* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`).
+* **`A`**: The type of the value that might be present within the `Optional`.
 
 ```java
 public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value)
@@ -34,340 +91,184 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value)
 }
 ```
 
-* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`, `ListKind.Witness`). This monad encapsulates the primary effect of the computation.
-* **`A`**: The type of the value that might be present within the **`Optional`, which itself is within the context of `F`.
-* **`value`**: The core wrapped value of type **`Kind<F, Optional<A>>`. This represents an effectful computation `F` that, upon completion, yields a `java.util.Optional<A>`.
+---
 
-## `OptionalTKind<F, A>`: The Witness Type
+## Setting Up OptionalTMonad
 
-**For integration with Higher-Kinded-J's generic programming model,** `OptionalTKind<F, A>` acts as the higher-kinded type witness.
-
-* **It extends** `Kind<G, A>`, where `G` (the witness for the combined `OptionalT` monad) is `OptionalTKind.Witness<F>`.
-* **The outer monad** `F` is fixed for a particular `OptionalT` context, while `A` is the variable type parameter representing the value inside the `Optional`.
+The `OptionalTMonad<F>` class implements `MonadError<OptionalTKind.Witness<F>, Unit>`. The error type is `Unit`, signifying that an "error" is the `Optional.empty()` state (absence carries no information beyond its occurrence).
 
 ```java
-public interface OptionalTKind<F, A> extends Kind<OptionalTKind.Witness<F>, A> {
-  // Witness type G = OptionalTKind.Witness<F>
-  // Value type A = A (from Optional<A>)
-}
-```
-
-## `OptionalTKindHelper`: Utility for Wrapping and Unwrapping
-
-`OptionalTKindHelper` is a final utility class providing static methods to seamlessly convert between the concrete `OptionalT<F, A>` type and its `Kind` representation (`Kind<OptionalTKind.Witness<F>, A>`).
-
-```java
-
-public enum OptionalTKindHelper {
-   
-  OPTIONAL_T;
-  
-    // Unwraps Kind<OptionalTKind.Witness<F>, A> to OptionalT<F, A>
-    public  <F, A> @NonNull OptionalT<F, A> narrow(
-        @Nullable Kind<OptionalTKind.Witness<F>, A> kind);
-
-    // Wraps OptionalT<F, A> into OptionalTKind<F, A>
-    public  <F, A> @NonNull OptionalTKind<F, A> widen(
-        @NonNull OptionalT<F, A> optionalT);
-}
-```
-
-**Internally, it uses a private record** `OptionalTHolder` to implement `OptionalTKind`, but this is an implementation detail.
-
-## `OptionalTMonad<F>`: Operating on `OptionalT`
-
-**The** `OptionalTMonad<F>` class implements `MonadError<OptionalTKind.Witness<F>, Unit>`. This provides the standard monadic operations (`of`, `map`, `flatMap`, `ap`) and error handling capabilities for the `OptionalT` structure. The error type `E` for `MonadError` is fixed to `Unit` signifying that an "error" in this context is the `Optional.empty()` state within `F<Optional<A>>`.
-
-* **It requires a** `Monad<F>` instance for the outer monad `F` (where `F extends WitnessArity<TypeArity.Unary>`), which must be supplied during construction. This `outerMonad` is used to manage and sequence the effects of `F`.
-
-```java
-// Example: F = CompletableFutureKind.Witness
-// 1. Get the Monad instance for the outer monad F
 Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
 
-// 2. Create the OptionalTMonad
 OptionalTMonad<CompletableFutureKind.Witness> optionalTFutureMonad =
     new OptionalTMonad<>(futureMonad);
-
-// Now 'optionalTFutureMonad' can be used to operate on
-// Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, A> values.
-
 ```
 
-~~~admonish info title="Key Operations with _OptionalTMonad_:"
+~~~admonish note title="Type Witness and Helpers"
+**Witness Type:** `OptionalTKind<F, A>` extends `Kind<OptionalTKind.Witness<F>, A>`. The outer monad `F` is fixed; `A` is the variable value type.
 
-* **`optionalTMonad.of(value)`**: Lifts a (nullable) value `A` into the `OptionalT` context. The underlying operation is `r -> outerMonad.of(Optional.ofNullable(value))`. Result: `OptionalT(F<Optional<A>>)`.
-* **`optionalTMonad.map(func, optionalTKind)`**: Applies a function `A -> B` to the value `A` if it's present within the `Optional` and the `F` context is successful. The transformation occurs within `outerMonad.map`. If `func` returns `null`, the result becomes `F<Optional.empty()>`. Result: `OptionalT(F<Optional<B>>)`.
-* **`optionalTMonad.flatMap(func, optionalTKind)`**: The primary sequencing operation. It takes a function `A -> Kind<OptionalTKind.Witness<F>, B>` (which effectively means `A -> OptionalT<F, B>`). It runs the initial `OptionalT` to get `Kind<F, Optional<A>>`. Using `outerMonad.flatMap`, if this yields an `Optional.of(a)`, `func` is applied to `a` to get the next `OptionalT<F, B>`. The `value` of this new `OptionalT` (`Kind<F, Optional<B>>`) becomes the result. If at any point an `Optional.empty()` is encountered within `F`, it short-circuits and propagates `F<Optional.empty()>`. Result: `OptionalT(F<Optional<B>>)`.
-* **`optionalTMonad.raiseError(error)`** (where error is `Unit`): Creates an `OptionalT` representing absence. Result: `OptionalT(F<Optional.empty()>)`.
-* **`optionalTMonad.handleErrorWith(optionalTKind, handler)`**: Handles an empty state from the _inner_ `Optional`. Takes a handler `Function<Unit, Kind<OptionalTKind.Witness<F>, A>>`.
+**KindHelper:** `OptionalTKindHelper` provides `OPTIONAL_T.widen` and `OPTIONAL_T.narrow` for safe conversion between `OptionalT<F, A>` and its `Kind` representation.
+
+```java
+Kind<OptionalTKind.Witness<F>, A> kind = OPTIONAL_T.widen(optionalT);
+OptionalT<F, A> concrete = OPTIONAL_T.narrow(kind);
+```
 ~~~
 
-----
+---
+
+## Key Operations
+
+~~~admonish info title="Key Operations with _OptionalTMonad_:"
+* **`optionalTMonad.of(value)`**: Lifts a nullable value `A` into `OptionalT`. Result: `F<Optional.ofNullable(value)>`.
+* **`optionalTMonad.map(func, optionalTKind)`**: Applies `A -> B` to the present value. If `func` returns `null`, the result becomes `F<Optional.empty()>`. Result: `OptionalT(F<Optional<B>>)`.
+* **`optionalTMonad.flatMap(func, optionalTKind)`**: Sequences operations. If present, applies `func` to get the next `OptionalT`. If empty at any point, short-circuits to `F<Optional.empty()>`.
+* **`optionalTMonad.raiseError(Unit.INSTANCE)`**: Creates an `OptionalT` representing absence. Result: `F<Optional.empty()>`.
+* **`optionalTMonad.handleErrorWith(optionalTKind, handler)`**: Handles an empty state. The handler `Unit -> Kind<OptionalTKind.Witness<F>, A>` is invoked when the inner `Optional` is empty.
+~~~
+
+---
+
+## Creating OptionalT Instances
 
 ~~~admonish title="Creating _OptionalT_ Instances"
 
 - [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
 
-`OptionalT` instances are typically created using its static factory methods. These often require a `Monad<F>` instance for the outer monad.
-
 ```java
-public void createExample() {
-    // --- Setup ---
-    // Outer Monad F = CompletableFutureKind.Witness
-    Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-    String presentValue = "Data";
-    Integer numericValue = 123;
+Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
 
-    // 1. `OptionalT.fromKind(Kind<F, Optional<A>> value)`
-    //    Wraps an existing F<Optional<A>>.
-    Kind<CompletableFutureKind.Witness, Optional<String>> fOptional =
-        FUTURE.widen(CompletableFuture.completedFuture(Optional.of(presentValue)));
-    OptionalT<CompletableFutureKind.Witness, String> ot1 = OptionalT.fromKind(fOptional);
-    // Value: CompletableFuture<Optional.of("Data")>
+// 1. From an existing F<Optional<A>>
+Kind<CompletableFutureKind.Witness, Optional<String>> fOptional =
+    FUTURE.widen(CompletableFuture.completedFuture(Optional.of("Data")));
+OptionalT<CompletableFutureKind.Witness, String> ot1 = OptionalT.fromKind(fOptional);
 
-    // 2. `OptionalT.some(Monad<F> monad, A a)`
-    //    Creates an OptionalT with a present value, F<Optional.of(a)>.
-    OptionalT<CompletableFutureKind.Witness, String> ot2 = OptionalT.some(futureMonad, presentValue);
-    // Value: CompletableFuture<Optional.of("Data")>
+// 2. From a present value: F<Optional.of(a)>
+OptionalT<CompletableFutureKind.Witness, String> ot2 =
+    OptionalT.some(futureMonad, "Data");
 
-    // 3. `OptionalT.none(Monad<F> monad)`
-    //    Creates an OptionalT representing an absent value, F<Optional.empty()>.
-    OptionalT<CompletableFutureKind.Witness, String> ot3 = OptionalT.none(futureMonad);
-    // Value: CompletableFuture<Optional.empty()>
+// 3. Empty: F<Optional.empty()>
+OptionalT<CompletableFutureKind.Witness, String> ot3 = OptionalT.none(futureMonad);
 
-    // 4. `OptionalT.fromOptional(Monad<F> monad, Optional<A> optional)`
-    //    Lifts a plain java.util.Optional into OptionalT, F<Optional<A>>.
-    Optional<Integer> optInt = Optional.of(numericValue);
-    OptionalT<CompletableFutureKind.Witness, Integer> ot4 = OptionalT.fromOptional(futureMonad, optInt);
-    // Value: CompletableFuture<Optional.of(123)>
+// 4. From a plain java.util.Optional: F<Optional<A>>
+OptionalT<CompletableFutureKind.Witness, Integer> ot4 =
+    OptionalT.fromOptional(futureMonad, Optional.of(123));
 
+// 5. Lifting F<A> into OptionalT (null → empty, non-null → present)
+Kind<CompletableFutureKind.Witness, String> fValue =
+    FUTURE.widen(CompletableFuture.completedFuture("Data"));
+OptionalT<CompletableFutureKind.Witness, String> ot5 =
+    OptionalT.liftF(futureMonad, fValue);
 
-    Optional<Integer> optEmpty = Optional.empty();
-    OptionalT<CompletableFutureKind.Witness, Integer> ot4Empty = OptionalT.fromOptional(futureMonad, optEmpty);
-    // Value: CompletableFuture<Optional.empty()>
-
-
-    // 5. `OptionalT.liftF(Monad<F> monad, Kind<F, A> fa)`
-    //    Lifts an F<A> into OptionalT. If A is null, it becomes F<Optional.empty()>, otherwise F<Optional.of(A)>.
-    Kind<CompletableFutureKind.Witness, String> fValue =
-        FUTURE.widen(CompletableFuture.completedFuture(presentValue));
-    OptionalT<CompletableFutureKind.Witness, String> ot5 = OptionalT.liftF(futureMonad, fValue);
-    // Value: CompletableFuture<Optional.of("Data   ")>
-
-    Kind<CompletableFutureKind.Witness, String> fNullValue =
-        FUTURE.widen(CompletableFuture.completedFuture(null)); // F<null>
-    OptionalT<CompletableFutureKind.Witness, String> ot5Null = OptionalT.liftF(futureMonad, fNullValue);
-    // Value: CompletableFuture<Optional.empty()> (because the value inside F was null)
-
-
-    // Accessing the wrapped value:
-    Kind<CompletableFutureKind.Witness, Optional<String>> wrappedFVO = ot1.value();
-    CompletableFuture<Optional<String>> futureOptional = FUTURE.narrow(wrappedFVO);
-    futureOptional.thenAccept(optStr -> System.out.println("ot1 result: " + optStr));
-  }
+// Accessing the wrapped value:
+Kind<CompletableFutureKind.Witness, Optional<String>> wrappedFVO = ot1.value();
+CompletableFuture<Optional<String>> futureOptional = FUTURE.narrow(wrappedFVO);
 ```
 ~~~
 
+---
+
+## Real-World Example: Async Multi-Step Data Retrieval
 
 ~~~admonish Example title="Asynchronous Multi-Step Data Retrieval"
 
 - [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
 
-Consider a scenario where you need to fetch a userLogin, then their profile, and finally their preferences. Each step is asynchronous (`CompletableFuture`) and might return an empty `Optional` if the data is not found. `OptionalT` helps manage this composition cleanly.
+**The problem:** You need to fetch a user, then their profile, then their preferences. Each step is async and might not find data. You want the chain to short-circuit on the first empty result.
+
+**The solution:**
 
 ```java
-public static class OptionalTAsyncExample {
+static final Monad<CompletableFutureKind.Witness> futureMonad =
+    CompletableFutureMonad.INSTANCE;
+static final OptionalTMonad<CompletableFutureKind.Witness> optionalTFutureMonad =
+    new OptionalTMonad<>(futureMonad);
 
-    // --- Monad Setup ---
-    static final Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-    static final OptionalTMonad<CompletableFutureKind.Witness> optionalTFutureMonad =
-        new OptionalTMonad<>(futureMonad);
-    static final ExecutorService executor = Executors.newFixedThreadPool(2);
+// Service stubs return Future<Optional<T>>
+static Kind<CompletableFutureKind.Witness, Optional<User>> fetchUserAsync(String userId) {
+    return FUTURE.widen(CompletableFuture.supplyAsync(() ->
+        "user1".equals(userId) ? Optional.of(new User(userId, "Alice"))
+                               : Optional.empty()));
+}
 
-    public static Kind<CompletableFutureKind.Witness, Optional<User>> fetchUserAsync(String userId) {
-      return FUTURE.widen(CompletableFuture.supplyAsync(() -> {
-        System.out.println("Fetching userLogin " + userId + " on " + Thread.currentThread().getName());
-        try {
-          TimeUnit.MILLISECONDS.sleep(50);
-        } catch (InterruptedException e) { /* ignore */ }
-        return "user1".equals(userId) ? Optional.of(new User(userId, "Alice")) : Optional.empty();
-      }, executor));
-    }
+// Workflow: user → profile → preferences
+static OptionalT<CompletableFutureKind.Witness, UserPreferences>
+    getFullUserPreferences(String userId) {
 
-    public static Kind<CompletableFutureKind.Witness, Optional<UserProfile>> fetchProfileAsync(String userId) {
-      return FUTURE.widen(CompletableFuture.supplyAsync(() -> {
-        System.out.println("Fetching profile for " + userId + " on " + Thread.currentThread().getName());
-        try {
-          TimeUnit.MILLISECONDS.sleep(50);
-        } catch (InterruptedException e) { /* ignore */ }
-        return "user1".equals(userId) ? Optional.of(new UserProfile(userId, "Loves HKJ")) : Optional.empty();
-      }, executor));
-    }
+  OptionalT<CompletableFutureKind.Witness, User> userOT =
+      OptionalT.fromKind(fetchUserAsync(userId));
 
-    public static Kind<CompletableFutureKind.Witness, Optional<UserPreferences>> fetchPrefsAsync(String userId) {
-      return FUTURE.widen(CompletableFuture.supplyAsync(() -> {
-        System.out.println("Fetching preferences for " + userId + " on " + Thread.currentThread().getName());
-        try {
-          TimeUnit.MILLISECONDS.sleep(50);
-        } catch (InterruptedException e) { /* ignore */ }
-        // Simulate preferences sometimes missing even for a valid userLogin
-        return "user1".equals(userId) && Math.random() > 0.3 ? Optional.of(new UserPreferences(userId, "dark")) : Optional.empty();
-      }, executor));
-    }
+  OptionalT<CompletableFutureKind.Witness, UserProfile> profileOT =
+      OPTIONAL_T.narrow(optionalTFutureMonad.flatMap(
+          user -> OPTIONAL_T.widen(
+              OptionalT.fromKind(fetchProfileAsync(user.id()))),
+          OPTIONAL_T.widen(userOT)));
 
-    // --- Service Stubs (simulating async calls returning Future<Optional<T>>) ---
-
-    // --- Workflow using OptionalT ---
-    public static OptionalT<CompletableFutureKind.Witness, UserPreferences> getFullUserPreferences(String userId) {
-      // Start by fetching the userLogin, lifting into OptionalT
-      OptionalT<CompletableFutureKind.Witness, User> userOT =
-          OptionalT.fromKind(fetchUserAsync(userId));
-
-      // If userLogin exists, fetch profile
-      OptionalT<CompletableFutureKind.Witness, UserProfile> profileOT =
-          OPTIONAL_T.narrow(
-              optionalTFutureMonad.flatMap(
-                  userLogin -> OPTIONAL_T.widen(OptionalT.fromKind(fetchProfileAsync(userLogin.id()))),
-                  OPTIONAL_T.widen(userOT)
-              )
-          );
-
-      // If profile exists, fetch preferences
-      OptionalT<CompletableFutureKind.Witness, UserPreferences> preferencesOT =
-          OPTIONAL_T.narrow(
-              optionalTFutureMonad.flatMap(
-                  profile -> OPTIONAL_T.widen(OptionalT.fromKind(fetchPrefsAsync(profile.userId()))),
-                  OPTIONAL_T.widen(profileOT)
-              )
-          );
-      return preferencesOT;
-    }
-
-    // Workflow with recovery / default
-    public static OptionalT<CompletableFutureKind.Witness, UserPreferences> getPrefsWithDefault(String userId) {
-      OptionalT<CompletableFutureKind.Witness, UserPreferences> prefsAttemptOT = getFullUserPreferences(userId);
-
-      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, UserPreferences> recoveredPrefsOTKind =
-          optionalTFutureMonad.handleErrorWith(
-              OPTIONAL_T.widen(prefsAttemptOT),
-              (Unit v) -> { // This lambda is called if prefsAttemptOT results in F<Optional.empty()>
-                System.out.println("Preferences not found for " + userId + ", providing default.");
-                // Lift a default preference into OptionalT
-                UserPreferences defaultPrefs = new UserPreferences(userId, "default-light");
-                return OPTIONAL_T.widen(OptionalT.some(futureMonad, defaultPrefs));
-              }
-          );
-      return OPTIONAL_T.narrow(recoveredPrefsOTKind);
-    }
-
-    public static void main(String[] args) {
-      System.out.println("--- Attempting to get preferences for existing userLogin (user1) ---");
-      OptionalT<CompletableFutureKind.Witness, UserPreferences> resultUser1OT = getFullUserPreferences("user1");
-      CompletableFuture<Optional<UserPreferences>> future1 =
-          FUTURE.narrow(resultUser1OT.value());
-
-      future1.whenComplete((optPrefs, ex) -> {
-        if (ex != null) {
-          System.err.println("Error for user1: " + ex.getMessage());
-        } else {
-          System.out.println("User1 Preferences: " + optPrefs.map(UserPreferences::toString).orElse("NOT FOUND"));
-        }
-      });
-
-
-      System.out.println("\n--- Attempting to get preferences for non-existing userLogin (user2) ---");
-      OptionalT<CompletableFutureKind.Witness, UserPreferences> resultUser2OT = getFullUserPreferences("user2");
-      CompletableFuture<Optional<UserPreferences>> future2 =
-          FUTURE.narrow(resultUser2OT.value());
-
-      future2.whenComplete((optPrefs, ex) -> {
-        if (ex != null) {
-          System.err.println("Error for user2: " + ex.getMessage());
-        } else {
-          System.out.println("User2 Preferences: " + optPrefs.map(UserPreferences::toString).orElse("NOT FOUND (as expected)"));
-        }
-      });
-
-      System.out.println("\n--- Attempting to get preferences for user1 WITH DEFAULT ---");
-      OptionalT<CompletableFutureKind.Witness, UserPreferences> resultUser1WithDefaultOT = getPrefsWithDefault("user1");
-      CompletableFuture<Optional<UserPreferences>> future3 =
-          FUTURE.narrow(resultUser1WithDefaultOT.value());
-
-      future3.whenComplete((optPrefs, ex) -> {
-        if (ex != null) {
-          System.err.println("Error for user1 (with default): " + ex.getMessage());
-        } else {
-          // This will either be the fetched prefs or the default.
-          System.out.println("User1 Preferences (with default): " + optPrefs.map(UserPreferences::toString).orElse("THIS SHOULD NOT HAPPEN if default works"));
-        }
-        // Wait for async operations to complete for demonstration
-        try {
-          TimeUnit.SECONDS.sleep(1);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-        executor.shutdown();
-      });
-    }
-
-    // --- Domain Model ---
-    record User(String id, String name) {
-    }
-
-    record UserProfile(String userId, String bio) {
-    }
-
-    record UserPreferences(String userId, String theme) {
-    }
-  }
+  return OPTIONAL_T.narrow(optionalTFutureMonad.flatMap(
+      profile -> OPTIONAL_T.widen(
+          OptionalT.fromKind(fetchPrefsAsync(profile.userId()))),
+      OPTIONAL_T.widen(profileOT)));
+}
 ```
 
+**Why this works:** Each `flatMap` only executes its lambda if the previous step produced a present value. If `fetchUserAsync` returns empty, neither `fetchProfileAsync` nor `fetchPrefsAsync` are called.
+~~~
 
-**This example demonstrates:**
+---
 
-1. **Setting up** `OptionalTMonad` with `CompletableFutureMonad`.
-2. **Using** `OptionalT.fromKind` to lift an existing `Kind<F, Optional<A>>` (the result of async service calls) into the `OptionalT` context.
-3. **Sequencing operations with** `optionalTFutureMonad.flatMap`. If any step in the chain (e.g., `fetchUserAsync`) results in `F<Optional.empty()>`, subsequent `flatMap` lambdas are short-circuited, and the overall result becomes `F<Optional.empty()>`.
-4. **Using** `handleErrorWith` to provide a default `UserPreferences` if the chain of operations results in an empty `Optional`.
-5. **Finally,** `.value()` is used to extract the underlying `Kind<CompletableFutureKind.Witness, Optional<UserPreferences>>` to interact with the `CompletableFuture` directly.
+## Providing Defaults with Error Recovery
 
-`OptionalT` simplifies managing sequences of operations where each step might not yield a value.
+~~~admonish Example title="Recovery with Default Values"
+
+**The problem:** When the preference chain returns empty, you want to provide default preferences rather than propagating the absence.
+
+**The solution:**
+
+```java
+static OptionalT<CompletableFutureKind.Witness, UserPreferences>
+    getPrefsWithDefault(String userId) {
+
+  OptionalT<CompletableFutureKind.Witness, UserPreferences> prefsAttempt =
+      getFullUserPreferences(userId);
+
+  Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, UserPreferences>
+      recovered = optionalTFutureMonad.handleErrorWith(
+          OPTIONAL_T.widen(prefsAttempt),
+          (Unit v) -> {
+              UserPreferences defaultPrefs =
+                  new UserPreferences(userId, "default-light");
+              return OPTIONAL_T.widen(OptionalT.some(futureMonad, defaultPrefs));
+          });
+
+  return OPTIONAL_T.narrow(recovered);
+}
+```
+
+The `handleErrorWith` handler receives `Unit` (since absence carries no information) and returns an `OptionalT` containing the default preferences.
+~~~
+
+---
+
+~~~admonish warning title="Common Mistakes"
+- **Null vs. empty confusion:** `OptionalT.liftF` treats a `null` value inside `F<A>` as `Optional.empty()`. If you want to explicitly signal absence, use `OptionalT.none` rather than relying on null propagation.
+- **Unit as error type:** When using `handleErrorWith`, the handler function receives `Unit.INSTANCE`, not a descriptive error. If you need typed error information, consider `EitherT` instead.
+~~~
+
+---
+
+~~~admonish tip title="See Also"
+- [Monad Transformers](transformers.md) - General concept and choosing the right transformer
+- [MaybeT](maybet_transformer.md) - Equivalent functionality for Higher-Kinded-J's Maybe type
+- [EitherT](eithert_transformer.md) - When you need typed errors, not just absence
 ~~~
 
 ---
 
 ~~~admonish tip title="Further Reading"
-Start with the **Java-focused** resources to understand Optional patterns, then explore **General FP concepts** for deeper understanding, and finally check **Related Libraries** to see alternative approaches.
+- [Java Optional Best Practices](https://www.baeldung.com/java-optional) - Comprehensive Baeldung guide (20 min read)
+- [Null References: The Billion Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare/) - Tony Hoare's historic talk on why Optional matters (60 min watch)
 ~~~
 
-### Java-Focused Resources
-
-**Beginner Level:**
--[Java Optional Best Practices](https://www.baeldung.com/java-optional) - Comprehensive Baeldung guide (20 min read)
--[The Mother of All Bikesheds: Optional.orElse vs orElseGet](https://www.nurkiewicz.com/2013/08/optional-in-java-8-cheat-sheet.html) - Tomasz Nurkiewicz's practical guide (10 min read)
--[Java Optional - A Practical Guide](https://www.youtube.com/watch?v=vKVzRbsMnTQ) - Stuart Marks (Oracle) on proper Optional usage (60 min watch)
-
-**Intermediate Level:**
--[Chaining Optional in Java](https://www.baeldung.com/java-optional-chaining) - flatMap patterns and composition (15 min read)
--[Optional Anti-Patterns](https://blog.softwaremill.com/12-recipes-for-using-the-optional-class-as-its-meant-to-be-used-2da0d7f0b6a8) - What NOT to do (12 min read)
-
-### General FP Concepts
-
--[Maybe Monad Explained](https://wiki.haskell.org/Maybe) - Haskell's Maybe (Java's Optional equivalent)
--[Null References: The Billion Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare/) - Tony Hoare's historic talk on why Optional matters (10 min read)
-
-### Related Libraries & Comparisons
-
--[Guava's Optional](https://github.com/google/guava/wiki/UsingAndAvoidingNullExplained) - Pre-Java 8 approach, still relevant
--[Kotlin Null Safety](https://kotlinlang.org/docs/null-safety.html) - Language-level solution to the same problem
-
-### Community & Discussion
-
--[When to Return Optional vs Throw Exception](https://stackoverflow.com/questions/39754106/when-to-return-optional-instead-of-throwing-an-exception) - Stack Overflow debate
--[Optional Performance Considerations](https://shipilev.net/jvm/anatomy-quarks/11-optional-sequential-guards/) - Aleksey Shipilëv's JVM deep dive
-
----
 
 **Previous:** [EitherT](eithert_transformer.md)
 **Next:** [MaybeT](maybet_transformer.md)

--- a/hkj-book/src/transformers/readert_transformer.md
+++ b/hkj-book/src/transformers/readert_transformer.md
@@ -1,5 +1,11 @@
-# The ReaderT Transformer: 
-## _Combining Monadic Effects with a Read-Only Environment_
+# The ReaderT Transformer:
+## _Threading Configuration Through Effects_
+
+> *"No man is an island, entire of itself."*
+>
+> – John Donne, *Meditation XVII*
+
+No computation is independent of its environment. ReaderT makes that dependency explicit and composable.
 
 ~~~admonish info title="What You'll Learn"
 - How to combine dependency injection (Reader) with other effects like async operations
@@ -17,21 +23,94 @@
 - [ReaderTAsyncUnitExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncUnitExample.java)
 ~~~
 
-## `ReaderT` Monad Transformer
+---
 
-The `ReaderT` monad transformer (short for Reader Transformer) allows you to combine the capabilities of the `Reader` monad (providing a read-only environment `R`) with another outer monad `F`. It encapsulates a computation that, given an environment `R`, produces a result within the monadic context `F` (i.e., `Kind<F, A>`).
+## The Problem: Configuration Everywhere
 
-This is particularly useful when you have operations that require some configuration or context (`R`) and also involve other effects managed by `F`, such as asynchronicity (`CompletableFutureKind`), optionality (`OptionalKind`, `MaybeKind`), or error handling (`EitherKind`).
+Consider a service that needs API keys and URLs for every operation:
 
-The `ReaderT<F, R, A>` structure essentially wraps a function `R -> Kind<F, A>`.
+```java
+// Without ReaderT: passing config through every function
+CompletableFuture<ServiceData> fetchData(AppConfig config, String itemId) {
+    return CompletableFuture.supplyAsync(() ->
+        callApi(config.apiKey(), config.serviceUrl(), itemId));
+}
 
-## Structure
+CompletableFuture<ProcessedData> processData(AppConfig config, ServiceData data) {
+    return CompletableFuture.supplyAsync(() ->
+        transform(data, config.apiKey()));
+}
+
+// Every call requires explicit config passing:
+CompletableFuture<ProcessedData> workflow(AppConfig config) {
+    return fetchData(config, "item123")
+        .thenCompose(data -> processData(config, data));
+}
+```
+
+The `config` parameter threads through every function signature, every call site, every test. It's noise that obscures the actual logic. Rename a config field, and you touch every function in the chain.
+
+## The Solution: ReaderT
+
+```java
+// With ReaderT: config is implicit
+ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData>
+    fetchDataRT(String itemId) {
+  return ReaderT.of(config ->
+      FUTURE.widen(CompletableFuture.supplyAsync(() ->
+          callApi(config.apiKey(), config.serviceUrl(), itemId))));
+}
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData>
+    processDataRT(ServiceData data) {
+  return ReaderT.reader(futureMonad,
+      config -> transform(data, config.apiKey()));
+}
+
+// Config provided once, at the end:
+Kind<CompletableFutureKind.Witness, ProcessedData> result =
+    composedWorkflow.run().apply(prodConfig);
+```
+
+The `AppConfig` is threaded implicitly through `flatMap`. Each operation declares its dependency on `AppConfig` in its return type, but never receives it as a parameter. The config is provided once, when you run the computation.
+
+```
+    ┌──────────────────────────────────────────────────────────┐
+    │  ReaderT<CompletableFutureKind.Witness, AppConfig, A>    │
+    │                                                          │
+    │        ┌── AppConfig ──┐                                 │
+    │        │               │                                 │
+    │        │  apiKey       │                                 │
+    │        │  serviceUrl   │                                 │
+    │        │  executor     │                                 │
+    │        └───────┬───────┘                                 │
+    │                │                                         │
+    │                ▼                                         │
+    │   ┌─── Function: R → Kind<F, A> ───────────────────┐     │
+    │   │                                                │     │
+    │   │  config → CompletableFuture<result>            │     │
+    │   │                                                │     │
+    │   └────────────────────────────────────────────────┘     │
+    │                                                          │
+    │  flatMap ──▶ threads same config to next operation       │
+    │  map ──────▶ transforms result, config unchanged         │
+    │  ask ──────▶ gives you the config itself                 │
+    │  run ──────▶ provides config, returns F<A>               │
+    └──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## How ReaderT Works
+
+`ReaderT<F, R, A>` wraps a function `R -> Kind<F, A>`. When you supply an environment of type `R`, you get back a monadic value `Kind<F, A>`.
 
 ![readert_transformer.svg](../images/puml/readert_transformer.svg)
 
-## `ReaderT<F, R, A>`: The Core Data Type
-
-`ReaderT<F, R, A>` is a record that encapsulates the core computation.
+* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`).
+* **`R`**: The type of the **read-only environment** (configuration, dependencies).
+* **`A`**: The type of the value produced, within the outer monad `F`.
+* **`run`**: The core function `R -> Kind<F, A>`.
 
 ```java
 public record ReaderT<F, R, A>(@NonNull Function<R, Kind<F, A>> run)
@@ -40,387 +119,212 @@ public record ReaderT<F, R, A>(@NonNull Function<R, Kind<F, A>> run)
 }
 ```
 
-* **`F`**: The witness type of the **outer monad** (e.g., `OptionalKind.Witness`, `CompletableFutureKind.Witness`). This monad handles an effect such as optionality or asynchronicity.
-* **`R`**: The type of the **read-only environment** (context or configuration) that the computation depends on.
-* **`A`**: The type of the value produced by the computation, wrapped within the outer monad `F`.
-* **`run`**: The essential function `R -> Kind<F, A>`. When this function is applied to an environment of type `R`, it yields a monadic value `Kind<F, A>`.
+---
 
-## `ReaderTKind<F, R, A>`: The Witness Type
+## Setting Up ReaderTMonad
 
-To integrate with Higher-Kinded-J's generic programming capabilities, `ReaderTKind<F, R, A>` serves as the witness type.
-
-* It extends `Kind<G, A>`, where `G` (the witness for the combined `ReaderT` monad) is `ReaderTKind.Witness<F, R>`.
-* The types `F` (outer monad) and `R` (environment) are fixed for a specific `ReaderT` context, while `A` is the variable value type.
+The `ReaderTMonad<F, R>` class implements `Monad<ReaderTKind.Witness<F, R>>`, providing standard monadic operations. It requires a `Monad<F>` instance for the outer monad:
 
 ```java
-public interface ReaderTKind<F, R, A> extends Kind<ReaderTKind.Witness<F, R>, A> {
-  // Witness type G = ReaderTKind.Witness<F, R>
-  // Value type A = A
-}
-```
-
-## `ReaderTKindHelper`: Utility for Wrapping and Unwrapping
-
-`ReaderTKindHelper` provides READER_T enum essential utility methods to convert between the concrete `ReaderT<F, R, A>` type and its `Kind` representation (`Kind<ReaderTKind.Witness<F, R>, A>`).
-
-```java
-public enum ReaderTKindHelper {
-   READER_T;
-  
-    // Unwraps Kind<ReaderTKind.Witness<F, R>, A> to ReaderT<F, R, A>
-    public <F, R, A> @NonNull ReaderT<F, R, A> narrow(
-        @Nullable Kind<ReaderTKind.Witness<F, R>, A> kind);
-
-    // Wraps ReaderT<F, R, A> into ReaderTKind<F, R, A>
-    public <F, R, A> @NonNull ReaderTKind<F, R, A> widen(
-        @NonNull ReaderT<F, R, A> readerT);
-}
-```
-
-
-## `ReaderTMonad<F, R>`: Operating on `ReaderT`
-
-The `ReaderTMonad<F, R>` class implements the `Monad<ReaderTKind.Witness<F, R>>` interface, providing the standard monadic operations (`of`, `map`, `flatMap`, `ap`) for the `ReaderT` structure.
-
-* It requires a `Monad<F>` instance for the outer monad `F` (where `F extends WitnessArity<TypeArity.Unary>`) to be provided during its construction. This `outerMonad` is used internally to sequence operations within the `F` context.
-* `R` is the fixed environment type for this monad instance.
-
-```java
-// Example: F = OptionalKind.Witness, R = AppConfig
-// 1. Get the Monad instance for the outer monad F
 OptionalMonad optionalMonad = OptionalMonad.INSTANCE;
-
-// 2. Define your environment type
 record AppConfig(String apiKey) {}
 
-// 3. Create the ReaderTMonad
 ReaderTMonad<OptionalKind.Witness, AppConfig> readerTOptionalMonad =
     new ReaderTMonad<>(optionalMonad);
-
-// Now 'readerTOptionalMonad' can be used to operate on 
-// Kind<ReaderTKind.Witness<OptionalKind.Witness, AppConfig>, A> values.
 ```
-~~~admonish info title="Key Operations with _ReaderTMonad_"
 
-* **`readerTMonad.of(value)`**: Lifts a pure value `A` into the `ReaderT` context. The underlying function becomes `r -> outerMonad.of(value)`. Result: `ReaderT(r -> F<A>)`.
-* **`readerTMonad.map(func, readerTKind)`**: Applies a function `A -> B` to the value `A` inside the `ReaderT` structure, if present and successful within the `F` context. The transformation `A -> B` happens within the `outerMonad.map` call. Result: `ReaderT(r -> F<B>)`.
-* **`readerTMonad.flatMap(func, readerTKind)`**: The core sequencing operation. Takes a function `A -> Kind<ReaderTKind.Witness<F, R>, B>` (which is effectively `A -> ReaderT<F, R, B>`). It runs the initial `ReaderT` with the environment `R` to get `Kind<F, A>`. Then, it uses `outerMonad.flatMap` to process this. If `Kind<F, A>` yields an `A`, `func` is applied to `a` to get a new `ReaderT<F, R, B>`. This new `ReaderT` is then also run with the *same original environment*`R` to yield `Kind<F, B>`. This allows composing computations that all depend on the same environment `R` while also managing the effects of `F`. Result: `ReaderT(r -> F<B>)`.
+~~~admonish note title="Type Witness and Helpers"
+**Witness Type:** `ReaderTKind<F, R, A>` extends `Kind<ReaderTKind.Witness<F, R>, A>`. The outer monad `F` and environment `R` are fixed; `A` is the variable value type.
+
+**KindHelper:** `ReaderTKindHelper` provides `READER_T.widen` and `READER_T.narrow` for safe conversion.
+
+```java
+Kind<ReaderTKind.Witness<F, R>, A> kind = READER_T.widen(readerT);
+ReaderT<F, R, A> concrete = READER_T.narrow(kind);
+```
 ~~~
+
+---
+
+## Key Operations
+
+~~~admonish info title="Key Operations with _ReaderTMonad_"
+* **`readerTMonad.of(value)`**: Lifts a pure value into `ReaderT`. The environment is ignored. Result: `ReaderT(r -> outerMonad.of(value))`.
+* **`readerTMonad.map(func, readerTKind)`**: Transforms the result value `A -> B` within the outer monad. The environment passes through unchanged. Result: `ReaderT(r -> F<B>)`.
+* **`readerTMonad.flatMap(func, readerTKind)`**: The core sequencing operation. Runs the first `ReaderT` with the environment to get `Kind<F, A>`. If it yields an `A`, applies `func` to get a new `ReaderT<F, R, B>`, which is then also run with the **same environment**. This is what makes configuration threading automatic.
+~~~
+
+---
+
+## Creating ReaderT Instances
 
 ~~~admonish title="Creating _ReaderT_ Instances"
 
-You typically create `ReaderT` instances using its static factory methods. These methods often require an instance of `Monad<F>` for the outer monad.
-
 ```java
- public void createExample(){
-  // --- Setup ---
-  // Outer Monad F = OptionalKind.Witness
-  OptionalMonad optMonad = OptionalMonad.INSTANCE;
+OptionalMonad optMonad = OptionalMonad.INSTANCE;
+record Config(String setting) {}
+Config testConfig = new Config("TestValue");
 
-  // Environment Type R
-  record Config(String setting) {
-  }
-  Config testConfig = new Config("TestValue");
+// 1. Directly from R -> F<A> function
+ReaderT<OptionalKind.Witness, Config, String> rt1 = ReaderT.of(
+    cfg -> OPTIONAL.widen(Optional.of("Data based on " + cfg.setting())));
+// Run: OPTIONAL.narrow(rt1.run().apply(testConfig))
+// → Optional.of("Data based on TestValue")
 
-  // --- Factory Methods ---
+// 2. Lifting an existing F<A> (environment ignored)
+Kind<OptionalKind.Witness, Integer> optionalValue =
+    OPTIONAL.widen(Optional.of(123));
+ReaderT<OptionalKind.Witness, Config, Integer> rt2 =
+    ReaderT.lift(optMonad, optionalValue);
+// Run: always returns Optional.of(123) regardless of config
 
-  // 1. `ReaderT.of(Function<R, Kind<F, A>> runFunction)`
-  //    Constructs directly from the R -> F<A> function.
-  Function<Config, Kind<OptionalKind.Witness, String>> runFn1 =
-      cfg -> OPTIONAL.widen(Optional.of("Data based on " + cfg.setting()));
-  ReaderT<OptionalKind.Witness, Config, String> rt1 = ReaderT.of(runFn1);
-  // To run: OPTIONAL.narrow(rt1.run().apply(testConfig)) is Optional.of("Data based on TestValue")
-  System.out.println(OPTIONAL.narrow(rt1.run().apply(testConfig)));
+// 3. From R -> A function (result lifted into F)
+ReaderT<OptionalKind.Witness, Config, String> rt3 =
+    ReaderT.reader(optMonad, cfg -> "Hello from " + cfg.setting());
+// Run: Optional.of("Hello from TestValue")
 
-  // 2. `ReaderT.lift(Monad<F> outerMonad, Kind<F, A> fa)`
-  //    Lifts an existing monadic value `Kind<F, A>` into ReaderT.
-  //    The resulting ReaderT ignores the environment R and always returns `fa`.
-  Kind<OptionalKind.Witness, Integer> optionalValue = OPTIONAL.widen(Optional.of(123));
-  ReaderT<OptionalKind.Witness, Config, Integer> rt2 = ReaderT.lift(optMonad, optionalValue);
-  // To run: OPTIONAL.narrow(rt2.run().apply(testConfig)) is Optional.of(123)
-  System.out.println(OPTIONAL.narrow(rt2.run().apply(testConfig)));
-
-  Kind<OptionalKind.Witness, Integer> emptyOptional = OPTIONAL.widen(Optional.empty());
-  ReaderT<OptionalKind.Witness, Config, Integer> rt2Empty = ReaderT.lift(optMonad, emptyOptional);
-  // To run: OPTIONAL.narrow(rt2Empty.run().apply(testConfig)) is Optional.empty()
-
-
-  // 3. `ReaderT.reader(Monad<F> outerMonad, Function<R, A> f)`
-  //    Creates a ReaderT from a function R -> A. The result A is then lifted into F using outerMonad.of(A).
-  Function<Config, String> simpleReaderFn = cfg -> "Hello from " + cfg.setting();
-  ReaderT<OptionalKind.Witness, Config, String> rt3 = ReaderT.reader(optMonad, simpleReaderFn);
-  // To run: OPTIONAL.narrow(rt3.run().apply(testConfig)) is Optional.of("Hello from TestValue")
-  System.out.println(OPTIONAL.narrow(rt3.run().apply(testConfig)));
-
-  // 4. `ReaderT.ask(Monad<F> outerMonad)`
-  //    Creates a ReaderT that, when run, provides the environment R itself as the result, lifted into F.
-  //    The function is r -> outerMonad.of(r).
-  ReaderT<OptionalKind.Witness, Config, Config> rt4 = ReaderT.ask(optMonad);
-  // To run: OPTIONAL.narrow(rt4.run().apply(testConfig)) is Optional.of(new Config("TestValue"))
-  System.out.println(OPTIONAL.narrow(rt4.run().apply(testConfig)));
-
-  // --- Using ReaderTKindHelper.READER_T to widen/narrow for Monad operations ---
-  //    Avoid a cast with var ReaderTKind<OptionalKind.Witness, Config, String> kindRt1 =
-  //        (ReaderTKind<OptionalKind.Witness, Config, String>) READER_T.widen(rt1);
-  var kindRt1 = READER_T.widen(rt1);
-  ReaderT<OptionalKind.Witness, Config, String> unwrappedRt1 = READER_T.narrow(kindRt1);
-}
+// 4. ask: provides the environment itself as the result
+ReaderT<OptionalKind.Witness, Config, Config> rt4 = ReaderT.ask(optMonad);
+// Run: Optional.of(Config("TestValue"))
 ```
 ~~~
 
-~~~admonish example title="Example: `ReaderT` for Actions Returning `Unit`"
+---
 
-Sometimes, a computation dependent on an environment `R` and involving an outer monad `F` might perform an action (e.g., logging, initializing a resource, sending a fire-and-forget message) without producing a specific data value. In such cases, the result type `A` of `ReaderT<F, R, A>` can be `org.higherkindedj.hkt.Unit`.
+## Real-World Example: Configuration-Dependent Async Services
 
-Let's extend the asynchronous example to include an action that logs a message using the `AppConfig` and completes asynchronously, returning `Unit`.
+~~~admonish Example title="Configuration-Dependent Asynchronous Service Calls"
+
+- [ReaderTAsyncExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncExample.java)
+
+**The problem:** You have async service operations that all need an `AppConfig` (API keys, URLs, executor). You want to compose them without passing config through every call.
+
+**The solution:**
+
+```java
+static final Monad<CompletableFutureKind.Witness> futureMonad =
+    CompletableFutureMonad.INSTANCE;
+static final ReaderTMonad<CompletableFutureKind.Witness, AppConfig> cfReaderTMonad =
+    new ReaderTMonad<>(futureMonad);
+
+record AppConfig(String apiKey, String serviceUrl, ExecutorService executor) {}
+record ServiceData(String rawData) {}
+record ProcessedData(String info) {}
+
+// Operation 1: fetch data (needs config for URL and API key)
+static ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData>
+    fetchServiceDataRT(String itemId) {
+  return ReaderT.of(config -> FUTURE.widen(
+      CompletableFuture.supplyAsync(() ->
+          new ServiceData("Raw data for " + itemId + " from " + config.serviceUrl()),
+          config.executor())));
+}
+
+// Operation 2: process data (needs config for API key)
+static ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData>
+    processDataRT(ServiceData data) {
+  return ReaderT.reader(futureMonad,
+      config -> new ProcessedData("Processed: " + data.rawData().toUpperCase()));
+}
+
+// Compose: fetch then process
+Kind<ReaderTKind.Witness<CompletableFutureKind.Witness, AppConfig>, ProcessedData>
+    workflowRT = cfReaderTMonad.flatMap(
+        data -> READER_T.widen(processDataRT(data)),
+        READER_T.widen(fetchServiceDataRT("item123")));
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData> composedWorkflow =
+    READER_T.narrow(workflowRT);
+
+// Run with different configs:
+AppConfig prodConfig = new AppConfig("prod_key", "https://api.prod.example.com", executor);
+AppConfig stagingConfig = new AppConfig("staging_key", "https://api.staging.example.com", executor);
+
+ProcessedData prodResult = FUTURE.join(composedWorkflow.run().apply(prodConfig));
+ProcessedData stagingResult = FUTURE.join(composedWorkflow.run().apply(stagingConfig));
+```
+
+**Why this works:** The `AppConfig` is threaded through both `fetchServiceDataRT` and `processDataRT` by `flatMap`. The same workflow runs against production and staging simply by providing different configs at the `run().apply(...)` call. The workflow definition is completely decoupled from the environment.
+~~~
+
+---
+
+## Using `ask` to Access Configuration Mid-Workflow
+
+~~~admonish Example title="Accessing Configuration with `ask`"
+
+**The problem:** Within a composed workflow, you need to read a specific config value without restructuring the computation.
+
+**The solution:**
+
+```java
+ReaderT<CompletableFutureKind.Witness, AppConfig, AppConfig> getConfigRT =
+    ReaderT.ask(futureMonad);
+
+Kind<ReaderTKind.Witness<CompletableFutureKind.Witness, AppConfig>, String>
+    getServiceUrlRT = cfReaderTMonad.map(
+        (AppConfig cfg) -> "Service URL: " + cfg.serviceUrl(),
+        READER_T.widen(getConfigRT));
+
+String stagingUrl = FUTURE.join(
+    READER_T.narrow(getServiceUrlRT).run().apply(stagingConfig));
+// → "Service URL: https://api.staging.example.com"
+```
+
+`ReaderT.ask` returns the entire environment as the result, which you can then `map` over to extract specific fields.
+~~~
+
+---
+
+## Fire-and-Forget Operations with Unit
+
+~~~admonish Example title="`ReaderT` for Actions Returning `Unit`"
 
 - [ReaderTAsyncUnitExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncUnitExample.java)
 
-```java
-    // Action: Log a message using AppConfig, complete asynchronously returning F<Unit>
-    public static Kind<CompletableFutureKind.Witness, Unit> logInitialisationAsync(AppConfig config) {
-        CompletableFuture<Unit> future = CompletableFuture.runAsync(() -> {
-            System.out.println("Thread: " + Thread.currentThread().getName() +
-                " - Initialising component with API Key: " + config.apiKey() +
-                " for Service URL: " + config.serviceUrl());
-            // Simulate some work
-            try {
-                TimeUnit.MILLISECONDS.sleep(50);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
-            System.out.println("Thread: " + Thread.currentThread().getName() +
-                " - Initialisation complete for: " + config.serviceUrl());
-        }, config.executor()).thenApply(v -> Unit.INSTANCE); // Ensure CompletableFuture<Unit>
-        return FUTURE.widen(future);
-    }
+**The problem:** Some operations (logging, initialisation, sending metrics) depend on configuration but don't produce a meaningful return value.
 
-    // Wrap the action in ReaderT: R -> F<Unit>
-    public static ReaderT<CompletableFutureKind.Witness, AppConfig, Unit> initialiseComponentRT() {
-        return ReaderT.of(ReaderTAsyncUnitExample::logInitialisationAsync);
-    }
-
-    public static void main(String[] args) {
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-        AppConfig prodConfig = new AppConfig("prod_secret_for_init", "[https://init.prod.service](https://init.prod.service)", executor);
-
-        // Get the ReaderT for the initialisation action
-        ReaderT<CompletableFutureKind.Witness, AppConfig, Unit> initAction = initialiseComponentRT();
-
-        System.out.println("--- Running Initialisation Action with Prod Config ---");
-        // Run the action by providing the prodConfig environment
-        // This returns Kind<CompletableFutureKind.Witness, Unit>
-        Kind<CompletableFutureKind.Witness, Unit> futureUnit = initAction.run().apply(prodConfig);
-
-        // Wait for completion and get the Unit result (which is just Unit.INSTANCE)
-        Unit result = FUTURE.join(futureUnit);
-        System.out.println("Initialisation Result: " + result); // Expected: Initialisation Result: ()
-
-        executor.shutdown();
-        try {
-            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
-    }
-```
-This example illustrates:
-
-- An asynchronous action (`logInitialisationAsync`) that depends on `AppConfig` but logically returns no specific data, so its result is `CompletableFuture<Unit>`.
-- This action is wrapped into a `ReaderT<CompletableFutureKind.Witness, AppConfig, Unit>`.
-- When this `ReaderT` is run with an `AppConfig`, it yields a `Kind<CompletableFutureKind.Witness, Unit>`.
-- The final result of joining such a future is `Unit.INSTANCE`, signifying successful completion of the effectful, environment-dependent action.
-
-
-~~~
-
-
-~~~admonish example title="Example: Configuration-Dependent Asynchronous Service Calls"
-
-Let's illustrate `ReaderT` by combining an environment dependency (`AppConfig`) with an asynchronous operation (`CompletableFuture`).
+**The solution:** Use `Unit` as the value type:
 
 ```java
-
-public class ReaderTAsyncExample {
-  // --- Monad Setup ---
-  // Outer Monad F = CompletableFutureKind.Witness
-  static final Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-  // ReaderTMonad for AppConfig and CompletableFutureKind
-  static final ReaderTMonad<CompletableFutureKind.Witness, AppConfig> cfReaderTMonad =
-      new ReaderTMonad<>(futureMonad);
-
-  // Simulates an async call to an external service
-  public static Kind<CompletableFutureKind.Witness, ServiceData> fetchExternalData(AppConfig config, String itemId) {
-    System.out.println("Thread: " + Thread.currentThread().getName() + " - Fetching external data for " + itemId + " using API key: " + config.apiKey() + " from " + config.serviceUrl());
-    CompletableFuture<ServiceData> future = CompletableFuture.supplyAsync(() -> {
-      try {
-        TimeUnit.MILLISECONDS.sleep(100); // Simulate network latency
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
-      }
-      return new ServiceData("Raw data for " + itemId + " from " + config.serviceUrl());
-    }, config.executor());
-    return FUTURE.widen(future);
-  }
-
-  // Operation 1: Fetch data, wrapped in ReaderT
-  // This is R -> F<A> which is the core of ReaderT
-  public static ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData> fetchServiceDataRT(String itemId) {
-    return ReaderT.of(appConfig -> fetchExternalData(appConfig, itemId));
-  }
-
-  // Operation 2: Process data (sync part, depends on AppConfig, then lifts to ReaderT)
-  // This uses ReaderT.reader: R -> A, then A is lifted to F<A>
-  public static ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData> processDataRT(ServiceData sData) {
-    return ReaderT.reader(futureMonad, // Outer monad to lift the result
-        appConfig -> { // Function R -> A (Config -> ProcessedData)
-          System.out.println("Thread: " + Thread.currentThread().getName() + " - Processing data with config: " + appConfig.apiKey());
-          return new ProcessedData("Processed: " + sData.rawData().toUpperCase() + " (API Key Suffix: " + appConfig.apiKey().substring(Math.max(0, appConfig.apiKey().length() - 3)) + ")");
-        });
-  }
-
-
-  // --- Service Logic (depends on AppConfig, returns Future<ServiceData>) ---
-
-  public static void main(String[] args) throws Exception {
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    AppConfig prodConfig = new AppConfig("prod_secret_key_xyz", "https://api.prod.example.com", executor);
-    AppConfig stagingConfig = new AppConfig("stag_test_key_123", "https://api.staging.example.com", executor);
-
-    // --- Composing with ReaderTMonad.flatMap ---
-    // Define a workflow: fetch data, then process it.
-    // The AppConfig is threaded through automatically by ReaderT.
-    Kind<ReaderTKind.Witness<CompletableFutureKind.Witness, AppConfig>, ProcessedData> workflowRTKind =
-        cfReaderTMonad.flatMap(
-            serviceData -> READER_T.widen(processDataRT(serviceData)), // ServiceData -> ReaderTKind<..., ProcessedData>
-            READER_T.widen(fetchServiceDataRT("item123")) // Initial ReaderTKind<..., ServiceData>
-        );
-
-    // Unwrap to the concrete ReaderT to run it
-    ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData> composedWorkflow =
-        READER_T.narrow(workflowRTKind);
-
-    // --- Running the workflow with different configurations ---
-
-    System.out.println("--- Running with Production Config ---");
-    // Run the workflow by providing the 'prodConfig' environment
-    // This returns Kind<CompletableFutureKind.Witness, ProcessedData>
-    Kind<CompletableFutureKind.Witness, ProcessedData> futureResultProd = composedWorkflow.run().apply(prodConfig);
-    ProcessedData resultProd = FUTURE.join(futureResultProd); // Blocks for result
-    System.out.println("Prod Result: " + resultProd);
-    // Expected output will show "prod_secret_key_xyz", "[https://api.prod.example.com](https://api.prod.example.com)" in logs
-    // and "Processed: RAW DATA FOR ITEM123 FROM [https://api.prod.example.com](https://api.prod.example.com) (API Key Suffix: xyz)"
-
-
-    System.out.println("\n--- Running with Staging Config ---");
-    // Run the same workflow with 'stagingConfig'
-    Kind<CompletableFutureKind.Witness, ProcessedData> futureResultStaging = composedWorkflow.run().apply(stagingConfig);
-    ProcessedData resultStaging = FUTURE.join(futureResultStaging); // Blocks for result
-    System.out.println("Staging Result: " + resultStaging);
-    // Expected output will show "stag_test_key_123", "[https://api.staging.example.com](https://api.staging.example.com)" in logs
-    // and "Processed: RAW DATA FOR ITEM123 FROM [https://api.staging.example.com](https://api.staging.example.com) (API Key Suffix: 123)"
-
-
-    // --- Another example: Using ReaderT.ask ---
-    ReaderT<CompletableFutureKind.Witness, AppConfig, AppConfig> getConfigSettingRT =
-        ReaderT.ask(futureMonad); // Provides the whole AppConfig
-
-    Kind<ReaderTKind.Witness<CompletableFutureKind.Witness, AppConfig>, String> getServiceUrlRT =
-        cfReaderTMonad.map(
-            (AppConfig cfg) -> "Service URL from ask: " + cfg.serviceUrl(),
-            READER_T.widen(getConfigSettingRT)
-        );
-
-    String stagingServiceUrl = FUTURE.join(
-        READER_T.narrow(getServiceUrlRT).run().apply(stagingConfig)
-    );
-    System.out.println("\nStaging Service URL via ask: " + stagingServiceUrl);
-
-
-    executor.shutdown();
-    try {
-      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-        executor.shutdownNow();
-      }
-    } catch (InterruptedException e) {
-      executor.shutdownNow();
-      Thread.currentThread().interrupt();
-    }
-  }
-
-  // --- ReaderT-based Service Operations ---
-
-  // --- Environment ---
-  record AppConfig(String apiKey, String serviceUrl, ExecutorService executor) {
-  }
-
-  // --- Service Response ---
-  record ServiceData(String rawData) {
-  }
-
-  record ProcessedData(String info) {
-  }
+static ReaderT<CompletableFutureKind.Witness, AppConfig, Unit> initialiseComponentRT() {
+    return ReaderT.of(config -> FUTURE.widen(
+        CompletableFuture.runAsync(() -> {
+            System.out.println("Initialising with API Key: " + config.apiKey());
+            // ... initialisation work ...
+        }, config.executor()).thenApply(v -> Unit.INSTANCE)));
 }
+
+// Run:
+Unit result = FUTURE.join(initialiseComponentRT().run().apply(prodConfig));
+// → () (Unit.INSTANCE, signifying successful completion)
 ```
-
-
-**This** example demonstrates:
-
-1. Defining an `AppConfig` environment.
-2. Creating service operations (`WorkspaceServiceDataRT`, `processDataRT`) that return `ReaderT<CompletableFutureKind, AppConfig, A>`. These operations implicitly depend on `AppConfig`.
-3. Using `cfReaderTMonad.flatMap` to chain these operations. The `AppConfig` is passed implicitly through the chain.
-4. Executing the composed workflow (`composedWorkflow.run().apply(config)`) by providing a specific `AppConfig`. This "injects" the dependency at the very end.
-5. The asynchronicity from `CompletableFuture` is handled by the `futureMonad` within `ReaderTMonad` and `ReaderT`'s factories.
-6. Using `ReaderT.ask` to directly access the configuration within a `ReaderT` computation.
 ~~~
 
-~~~ admonish important  title="Key Points:"
-`ReaderT` simplifies managing computations that require a shared, read-only environment while also dealing with other monadic effects, leading to cleaner, more composable, and testable code by deferring environment injection.
+---
+
+~~~admonish warning title="Common Mistakes"
+- **Forgetting to run:** A `ReaderT` is a *description* of a computation, not the computation itself. It does nothing until you call `.run().apply(config)`. If your tests pass but nothing happens, check that you are running the `ReaderT`.
+- **Mutating the environment:** `R` should be immutable. `ReaderT` passes the same `R` to every operation in a chain. Mutating it would break referential transparency and produce unpredictable results.
+- **Using ReaderT when you need state changes:** If the configuration changes between steps, you need `StateT`, not `ReaderT`. The "Reader" in `ReaderT` means *read-only*.
+~~~
+
+---
+
+~~~admonish tip title="See Also"
+- [Monad Transformers](transformers.md) - General concept and choosing the right transformer
+- [StateT](statet_transformer.md) - When your environment needs to change between steps
+- [EitherT](eithert_transformer.md) - When operations can fail with typed errors
 ~~~
 
 ---
 
 ~~~admonish tip title="Further Reading"
-Start with the **Java-focused** resources to understand dependency injection patterns, then explore **General FP concepts** for deeper understanding, and finally check **Related Libraries** to see alternative approaches.
+- [Reader Monad for Dependency Injection](https://medium.com/@johnmcclean/reader-monad-for-dependency-injection-in-java-9056d9501c75) - Practical examples without frameworks (12 min read)
+- [Functional Dependency Injection](https://www.youtube.com/watch?v=ZasXwtTRkio) - Conference talk on Reader pattern (40 min watch)
+- [ReaderT Design Pattern](https://academy.fpblock.com/blog/2017/06/readert-design-pattern/) - Michael Snoyman's production patterns (30 min read)
+- [A Fresh Perspective on Monads](https://rockthejvm.com/articles/a-fresh-perspective-on-monads) - Rock the JVM on composing monadic effects (20 min read)
 ~~~
-
-### Java-Focused Resources
-
-**Beginner Level:**
--[Dependency Injection the Functional Way](https://www.baeldung.com/java-dependency-injection-functional) - Baeldung's introduction to Reader (15 min read)
--[Reader Monad for Dependency Injection](https://medium.com/@johnmcclean/reader-monad-for-dependency-injection-in-java-9056d9501c75) - Practical examples without frameworks (12 min read)
--[Functional Dependency Injection](https://www.youtube.com/watch?v=ZasXwtTRkio) - Conference talk on Reader pattern (40 min watch)
-
-**Intermediate Level:**
--[Configuration as Code with Reader](https://blog.rockthejvm.com/reader-monad/) - Rock the JVM's practical guide (20 min read)
--[Reader vs Dependency Injection Frameworks](https://medium.com/@olxc/reader-monad-for-dependency-injection-4c5700c4c148) - When to use what (15 min read)
-
-**Advanced:**
--[ReaderT Design Pattern](https://www.fpcomplete.com/blog/readert-design-pattern/) - FP Complete's production patterns (30 min read)
-
-### General FP Concepts
-
--[Reader Monad Explained](https://wiki.haskell.org/Reader_monad) - HaskellWiki's clear explanation
--[Environment Passing Style](https://en.wikipedia.org/wiki/Environment_passing_style) - Wikipedia on the underlying concept
--[Functions as Context](https://bartoszmilewski.com/2014/01/14/functors-are-containers/) - Bartosz Milewski's blog on function contexts
-
-### Related Libraries & Comparisons
-
--[Cats Reader](https://typelevel.org/cats/datatypes/kleisli.html) - Scala's implementation (called Kleisli)
--[Haskell's ReaderT](https://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Reader.html) - Original inspiration
-
-### Community & Discussion
-
--[Reader Monad vs Constructor Injection](https://stackoverflow.com/questions/14301361/why-is-the-reader-monad-useful) - Stack Overflow debate
--[Using Reader in Production](https://www.reddit.com/r/functionalprogramming/comments/5qvzwq/reader_monad_in_production/) - Real-world experiences
--[ReaderT Pattern at Scale](https://news.ycombinator.com/item?id=16743608) - HN discussion from production teams
-
----
 
 **Previous:** [MaybeT](maybet_transformer.md)
 **Next:** [StateT](statet_transformer.md)

--- a/hkj-book/src/transformers/transformers.md
+++ b/hkj-book/src/transformers/transformers.md
@@ -1,6 +1,12 @@
 # The Transformers:
 _Combining Monadic Effects_
 
+> *"Any sufficiently complicated program contains an ad hoc, informally-specified, bug-ridden, slow implementation of half of a monad transformer."*
+>
+> – A functional programmer's lament (after Greenspun's Tenth Rule)
+
+If you've ever written a utility method that takes a `CompletableFuture<Either<E, A>>` and tries to `flatMap` across both layers, you've already started building one. Transformers formalise the pattern.
+
 ~~~admonish info title="What You'll Learn"
 - Why directly nesting monadic types like `CompletableFuture<Either<E, A>>` leads to complex, unwieldy code
 - How monad transformers wrap nested monads to provide a unified interface with familiar `map` and `flatMap` operations
@@ -10,153 +16,169 @@ _Combining Monadic Effects_
 
 ![stand_back_monad_transformers.jpg](../images/stand_back_monad_transformers.jpg)
 
-## The Problem
+---
 
-When building applications, we often encounter scenarios where we need to combine different computational contexts or effects. For example:
+## The Problem: Monads Don't Compose
 
-* An operation might be **asynchronous** (represented by `CompletableFuture`).
-* The same operation might also **fail with specific domain errors** (represented by `Either<DomainError, Result>`).
-* An operation might need **access to a configuration** (using `Reader`) and also be **asynchronous**.
-* A computation might **accumulate logs** (using `Writer`) and also **potentially fail** (using `Maybe` or `Either`).
+When building real applications, you rarely need just one effect. An operation might be **asynchronous** and also **fail with domain errors**. Another might require **configuration** and also be **async**. A third might need to **track state** while **potentially returning nothing**.
 
-### Monads Stack Poorly
+Each of these effects has a clean monadic representation in isolation. The trouble starts when you combine them.
 
-Directly nesting these monadic types, like `CompletableFuture<Either<DomainError, Result>>` or `Reader<Config, Optional<Data>>`, leads to complex, deeply nested code ("callback hell" or nested `flatMap`/`map` calls). It becomes difficult to sequence operations and handle errors or contexts uniformly.
+### What Nesting Looks Like in Practice
 
-For instance, an operation might need to be both asynchronous *and* handle potential domain-specific errors. Representing this naively leads to nested types like:
+Consider a service that fetches a user asynchronously and might fail:
 
 ```java
-// A future that, when completed, yields either a DomainError or a SuccessValue
-Kind<CompletableFutureKind.Witness, Either<DomainError, SuccessValue>> nestedResult;
+// The nested type: async + typed error
+CompletableFuture<Either<DomainError, User>> fetchUser(String userId) { ... }
+CompletableFuture<Either<DomainError, Order>> createOrder(User user) { ... }
+CompletableFuture<Either<DomainError, Receipt>> processPayment(Order order) { ... }
+
+// Composing them manually:
+CompletableFuture<Either<DomainError, Receipt>> workflow =
+    fetchUser("user-42").thenCompose(eitherUser ->
+        eitherUser.fold(
+            error -> CompletableFuture.completedFuture(Either.left(error)),
+            user -> createOrder(user).thenCompose(eitherOrder ->
+                eitherOrder.fold(
+                    error -> CompletableFuture.completedFuture(Either.left(error)),
+                    order -> processPayment(order)
+                )
+            )
+        )
+    );
 ```
 
-But now, how do we `map` or `flatMap` over this stack  without lots of boilerplate?
+Three steps. Already deeply nested. Every step requires the same boilerplate: check if the inner `Either` is `Left`, propagate the error, or unwrap the `Right` and continue. Add a fourth step and the indentation grows further. Add error recovery and it becomes genuinely difficult to read.
 
-## Monad Transformers: A _wrapper_ to simplify nested Monads
+The problem is structural: `CompletableFuture` and `Either` each have their own `flatMap`, but Java gives you no way to unify them into a single sequencing operation.
 
-**Monad Transformers** are a design pattern in functional programming used to combine the effects of two different monads into a single, new monad. They provide a standard way to "stack" monadic contexts, allowing you to work with the combined structure more easily using familiar monadic operations like `map` and `flatMap`.
+---
 
-A monad transformer `T` takes a monad `M` and produces a new monad `T<M>` that combines the effects of both `T` (conceptually) and `M`.
+## The Solution: Transformer as Wrapper
 
-#### For example:
+A monad transformer `T` takes an outer monad `F` and produces a **new monad** `T<F>` that combines both effects. The transformer handles the interleaving of contexts automatically.
 
-* `MaybeT m a` wraps a monad `m` and adds `Maybe`-like failure
-* `StateT s m a` wraps a monad `m` and adds state-handling capability
-* `ReaderT r m a` adds dependency injection (read-only environment)
+```
+    ┌───────────────────────────────────────────────────────────────┐
+    │  HOW A TRANSFORMER WORKS                                      │
+    │                                                               │
+    │                   ┌─────────────────────────┐                 │
+    │                   │   Transformer (EitherT) │                 │
+    │                   │                         │                 │
+    │   flatMap ───────▶│  1. Sequence outer F    │──────▶ result   │
+    │                   │  2. Check inner Either  │                 │
+    │                   │  3. Route: Left → skip  │                 │
+    │                   │          Right → apply  │                 │
+    │                   └─────────────────────────┘                 │
+    │                                                               │
+    │   You call one flatMap. The transformer does both.            │
+    └───────────────────────────────────────────────────────────────┘
+```
 
-They allow you to **stack** monadic behaviours.
+The same workflow with `EitherT`:
 
-Key characteristics:
+```java
+EitherTMonad<CompletableFutureKind.Witness, DomainError> eitherTMonad =
+    new EitherTMonad<>(CompletableFutureMonad.INSTANCE);
 
-1. **Stacking:** They allow "stacking" monadic effects in a standard way.
-2. **Unified Interface:** The resulting transformed monad (e.g., `EitherT<CompletableFutureKind, ...>`) itself implements the `Monad` (and often `MonadError`, etc.) interface.
-3. **Abstraction:** They hide the complexity of manually managing the nested structure. You can use standard `map`, `flatMap`, `handleErrorWith` operations on the transformed monad, and it automatically handles the logic for both underlying monads correctly.
+Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Receipt> workflow =
+    For.from(eitherTMonad, EitherT.fromKind(fetchUser("user-42")))
+        .from(user -> EitherT.fromKind(createOrder(user)))
+        .from(order -> EitherT.fromKind(processPayment(order)))
+        .yield((user, order, receipt) -> receipt);
+```
+
+One `flatMap` sequences the async operation *and* propagates errors. No manual `fold`, no repeated `Either.left` wrapping, no growing indentation. The nesting is still there (it must be), but the transformer hides it.
+
+---
+
+## Key Characteristics
+
+1. **Stacking** – Transformers allow "stacking" monadic effects in a standard way
+2. **Unified Interface** – The resulting transformed monad implements `Monad` (and often `MonadError`), so you use the same `map`, `flatMap`, `of` you already know
+3. **Abstraction** – The complexity of managing the nested structure is encapsulated; you work with a single monadic layer
+
+~~~admonish note title="Witness Type Requirement"
+All transformers require an outer monad `F` where `F extends WitnessArity<TypeArity.Unary>`. This ensures the transformer can work with any properly-typed monad in the framework.
+~~~
+
+---
 
 ## Transformers in Higher-Kinded-J
 
-> **Note:** All transformers require an outer monad `F` where `F extends WitnessArity<TypeArity.Unary>`. This ensures the transformer can work with any properly-typed monad in the framework.
-
 ![supported_transformers.svg](../images/puml/supported_transformers.svg)
 
-### 1. `EitherT<F, L, R>` (Monad Transformer)
+Higher-Kinded-J provides five transformers. Each solves a specific composition problem:
 
-![transformers.svg](../images/puml/transformers.svg)
+### EitherT: Typed Errors in Any Context
 
-* **Definition:** A monad transformer ([`EitherT`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherT.java)) that combines an outer monad `F` with an inner `Either<L, R>`. Implemented as a record wrapping `Kind<F, Either<L, R>>`.
-* **Kind Interface:** [`EitherTKind<F, L, R>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTKind.java)
-* **Witness Type `G`:** `EitherTKind.Witness<F, L>` (where `F` and `L` are fixed for a given type class instance)
-* **Helper:** `EitherTKindHelper` (`wrap`, `unwrap`). Instances are primarily created via `EitherT` static factories (`fromKind`, `right`, `left`, `fromEither`, `liftF`).
-* **Type Class Instances:**
-  * [`EitherTMonad<F, L>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherT.java) (`MonadError<EitherTKind.Witness<F, L>, L>`)
-* **Notes:** Simplifies working with nested structures like `F<Either<L, R>>`. Requires a `Monad<F>` instance for the outer monad `F` passed to its constructor. Implements `MonadError` for the *inner* `Either`'s `Left` type `L`. See the [Order Processing Example Walkthrough](../hkts/order-walkthrough.md) for practical usage with `CompletableFuture` as `F`.
-* **Usage:** [How to use the EitherT Monad Transformer](eithert_transformer.md)
+**The problem:** Your async operation can fail with a domain-specific error, and you need to sequence multiple such operations without manual error propagation.
+
+**The solution:** `EitherT<F, E, A>` wraps `Kind<F, Either<E, A>>` and provides `MonadError<..., E>`, giving you `flatMap` for sequencing, `raiseError` for failures, and `handleErrorWith` for recovery.
+
+**Usage:** [How to use the EitherT Monad Transformer](eithert_transformer.md)
 
 ---
 
+### OptionalT: When Absence Meets Other Effects
 
-### 2. `MaybeT<F, A>` (Monad Transformer)
+**The problem:** Your async data retrieval might return nothing (user not found, config missing), and you need to chain lookups without checking each `Optional` manually.
 
-* **Definition:** A monad transformer ([`MaybeT`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeT.java)) that combines an outer monad `F` with an inner `Maybe<A>`. Implemented as a record wrapping `Kind<F, Maybe<A>>`.
-* **Kind Interface:** [`MaybeTKind<F, A>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//maybe_t/MaybeTKind.java)
-* **Witness Type `G`:** `MaybeTKind.Witness<F>` (where `F` is fixed for a given type class instance)
-* **Helper:** `MaybeTKindHelper` (`wrap`, `unwrap`). Instances are primarily created via `MaybeT` static factories (`fromKind`, `just`, `nothing`, `fromMaybe`, `liftF`).
-* **Type Class Instances:**
-  * [`MaybeTMonad<F>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//maybe_t/MaybeTMonad.java) (`MonadError<MaybeTKind.Witness<F>, Void>`)
-* **Notes:** Simplifies working with nested structures like `F<Maybe<A>>`. Requires a `Monad<F>` instance for the outer monad `F`. Implements `MonadError` where the error type is `Void`, corresponding to the `Nothing` state from the inner `Maybe`.
-* **Usage:** [How to use the MaybeT Monad Transformer](./maybet_transformer.md)
+**The solution:** `OptionalT<F, A>` wraps `Kind<F, Optional<A>>` and provides `MonadError<..., Unit>`, where `Unit` represents the "empty" state. Chain lookups with `flatMap`; if any step returns empty, the rest are skipped.
+
+**Usage:** [How to use the OptionalT Monad Transformer](optionalt_transformer.md)
 
 ---
 
-### 3. `OptionalT<F, A>` (Monad Transformer)
+### MaybeT: Functional Optionality Across Monads
 
-* **Definition:** A monad transformer ([`OptionalT`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//optional_t/OptionalT.java)) that combines an outer monad `F` with an inner `java.util.Optional<A>`. Implemented as a record wrapping `Kind<F, Optional<A>>`.
-* **Kind Interface:** [`OptionalTKind<F, A>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//optional_t/OptionalTKind.java)
-* **Witness Type `G`:** `OptionalTKind.Witness<F>` (where `F` is fixed for a given type class instance)
-* **Helper:** `OptionalTKindHelper` (`wrap`, `unwrap`). Instances are primarily created via `OptionalT` static factories (`fromKind`, `some`, `none`, `fromOptional`, `liftF`).
-* **Type Class Instances:**
-  * [`OptionalTMonad<F>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//optional_t/OptionalTMonad.java) (`MonadError<OptionalTKind.Witness<F>, Void>`)
-* **Notes:** Simplifies working with nested structures like `F<Optional<A>>`. Requires a `Monad<F>` instance for the outer monad `F`. Implements `MonadError` where the error type is `Void`, corresponding to the `Optional.empty()` state from the inner `Optional`.
-* **Usage:** [How to use the OptionalT Monad Transformer](./optionalt_transformer.md)
+**The problem:** Same as OptionalT, but you're using Higher-Kinded-J's `Maybe` type rather than `java.util.Optional`.
+
+**The solution:** `MaybeT<F, A>` wraps `Kind<F, Maybe<A>>` with the same `MonadError<..., Unit>` interface. Functionally equivalent to OptionalT; choose based on which optional type your codebase uses.
+
+**Usage:** [How to use the MaybeT Monad Transformer](maybet_transformer.md)
 
 ---
 
-### 4. `ReaderT<F, R, A>` (Monad Transformer)
+### ReaderT: Threading Configuration Through Effects
 
-* **Definition:** A monad transformer ([`ReaderT`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//reader_t/ReaderT.java)) that combines an outer monad `F` with an inner `Reader<R, A>`-like behaviour (dependency on environment `R`). Implemented as a record wrapping a function `R -> Kind<F, A>`.
-* **Kind Interface:** [`ReaderTKind<F, R, A>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//reader_t/ReaderTKind.java)
-* **Witness Type `G`:** `ReaderTKind.Witness<F, R>` (where `F` and `R` are fixed for a given type class instance)
-* **Helper:** `ReaderTKindHelper` (`wrap`, `unwrap`). Instances are primarily created via `ReaderT` static factories (`of`, `lift`, `reader`, `ask`).
-* **Type Class Instances:**
-  * [`ReaderTMonad<F, R>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//reader_t/ReaderTMonad.java) (`Monad<ReaderTKind<F, R, ?>>`)
-* **Notes:** Simplifies managing computations that depend on a read-only environment `R` while also involving other monadic effects from `F`. Requires a `Monad<F>` instance for the outer monad. The `run()` method of `ReaderT` takes `R` and returns `Kind<F, A>`.
-* **Usage:** [How to use the ReaderT Monad Transformer](./readert_transformer.md)
+**The problem:** Multiple operations need access to shared configuration (database URLs, API keys, feature flags), and each is also wrapped in another effect like `CompletableFuture`. Passing the config manually through every function signature is tedious and error-prone.
 
-### 5. `StateT<S, F, A>` (Monad Transformer)
+**The solution:** `ReaderT<F, R, A>` wraps a function `R -> Kind<F, A>`. The environment `R` is provided once at the end, when you run the computation; all intermediate operations receive it implicitly through `flatMap`.
 
-* **Definition:** A monad transformer ([`StateT`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//state_t/StateT.java)) that adds stateful computation (type `S`) to an underlying monad `F`. It represents a function `S -> Kind<F, StateTuple<S, A>>`.
-* **Kind Interface:**[`StateTKind<S, F, A>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//state_t/StateTKind.java)
-* **Witness Type `G`:**`StateTKind.Witness<S, F>` (where `S` for state and `F` for the underlying monad witness are fixed for a given type class instance; `A` is the value type parameter)
-* **Helper:**`StateTKindHelper` (`narrow`, `wrap`, `runStateT`, `evalStateT`, `execStateT`, `lift`). Instances are created via `StateT.create()`, `StateTMonad.of()`, or `StateTKind.lift()`.
-* **Type Class Instances:**
-  * [`StateTMonad<S, F>`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/main/java/org/higherkindedj/hkt//state_t/StateTMonad.java) (`Monad<StateTKind.Witness<S, F>>`)
-* **Notes:** Allows combining stateful logic with other monadic effects from `F`. Requires a `Monad<F>` instance for the underlying monad. The `runStateT(initialState)` method executes the computation, returning `Kind<F, StateTuple<S, A>>`.
-* **Usage:**[How to use the StateT Monad Transformer](./statet_transformer.md)
+**Usage:** [How to use the ReaderT Monad Transformer](readert_transformer.md)
 
 ---
 
-~~~admonish tip title="Further Reading"
-Start with the **Java-focused** articles to understand why transformers matter in Java, then explore the **General FP** theory, and finally examine how other libraries implement these patterns.
+### StateT: Managing State Across Effect Boundaries
+
+**The problem:** You need to thread mutable state through a sequence of operations that are also wrapped in another effect (e.g., a stack that can fail on pop, a counter that increments across async steps).
+
+**The solution:** `StateT<S, F, A>` wraps a function `S -> Kind<F, StateTuple<S, A>>`. Each `flatMap` threads the updated state to the next operation; the outer monad's effects are handled simultaneously.
+
+**Usage:** [How to use the StateT Monad Transformer](statet_transformer.md)
+
+---
+
+## Transformer Patterns at a Glance
+
+| Pattern | Transformer | Outer Monad | What You Get |
+|---------|-------------|-------------|--------------|
+| Async + Error | `EitherT` | `CompletableFuture` | Async workflows with typed error propagation |
+| Async + Absence | `OptionalT` / `MaybeT` | `CompletableFuture` | Async lookups that may return nothing |
+| Config + Async | `ReaderT` | `CompletableFuture` | Dependency injection for async services |
+| Config + Error | `ReaderT` | `Either` | Environment-dependent computations that can fail |
+| State + Failure | `StateT` | `Optional` / `Either` | Stateful operations that can short-circuit |
+| State + Async | `StateT` | `CompletableFuture` | State threading across async boundaries |
+
+---
+
+~~~admonish warning title="Common Pitfalls"
+- **Forgetting to unwrap:** The result of a transformer computation is still wrapped. Call `.value()` on the transformer to extract the underlying `Kind<F, Either<E, A>>` (or equivalent) when you need to interact with the outer monad directly.
+- **Wrong monad order:** `EitherT<Future, E, A>` (error inside future) is different from hypothetical `FutureT<Either, E, A>` (future inside error). The *outer* monad is the one the transformer wraps around; the *inner* effect is what the transformer adds. Choose based on which semantics you need.
+- **Overusing transformers:** If you only combine effects in one or two places, manual nesting may be simpler. Transformers shine when the pattern is repeated across many operations.
 ~~~
-
-### Java-Focused Resources
-
-**Beginner Level:**
--[Monad Transformers in Java: A Practical Guide](https://medium.com/@johnmcclean/monad-transformers-in-java-e6f6b7e0f76d) - John McClean's clear explanation with Cyclops examples (15 min read)
--[Functional Programming in Java: Beyond Streams](https://www.youtube.com/watch?v=rPSL1alFIjI) - Venkat Subramaniam discusses composition patterns (45 min watch)
--[Combining CompletableFuture with Optional: The Problem](https://www.baeldung.com/java-combine-optional-completablefuture) - Baeldung's treatment of nested monads (10 min read)
-
-**Intermediate Level:**
--[Stacking Monads in Functional Java](https://medium.com/att-israel/stacking-monads-in-functional-java-c3c8a9c9c6e) - ATT Israel Engineering team's practical examples (20 min read)
-
-**Advanced:**
--[Free Monads and Monad Transformers](https://blog.rockthejvm.com/free-monad/) - Rock the JVM's Scala-based but Java-applicable deep dive (30 min read)
-
-### General FP Concepts
-
--[Monad Transformers Step by Step](https://page.mi.fu-berlin.de/scravy/realworldhaskell/materialien/monad-transformers-step-by-step.pdf) - Martin Grabmüller's classic paper, accessible even for Java developers (PDF, 40 min read)
--[Monad Transformer - HaskellWiki](https://wiki.haskell.org/Monad_Transformers_Explained) - Formal definitions with clear examples
--[What is a Monad Transformer?](https://www.fpcomplete.com/haskell/tutorial/monad-transformers/) - FP Complete's tutorial with interactive examples
-
-### Related Libraries & Comparisons
-
--[Cyclops-React Transformers](https://github.com/aol/cyclops) - AOL's comprehensive Java FP library
--[Arrow-kt Resource](https://apidocs.arrow-kt.io/arrow-fx-coroutines/arrow.fx.coroutines/-resource/index.html) - Kotlin's excellent documentation
--[Cats MTL](https://typelevel.org/cats-mtl/) - Scala's monad transformer library (advanced)
-
-### Community & Discussion
-
--[Why are Monad Transformers useful?](https://stackoverflow.com/questions/32579133/when-to-use-monad-transformers) - Stack Overflow discussion with practical examples
--[Monad Transformers in Production](https://www.reddit.com/r/java/comments/8qhxzv/monad_transformers_in_production_code/) - Real-world experiences from Java developers
 
 ---
 


### PR DESCRIPTION

Rewrite all transformer pages (ch_intro, transformers, EitherT, OptionalT, MaybeT, ReaderT, StateT) with problem-first orientation, ASCII diagrams, literary quotes, and admonishments. Fix broken external links across the chapter. Add Problem-First Structure guideline to STYLE-GUIDE.md.

Fixes #345 