### PR TITLE
Phase 0: Quickstart, cheat sheet, and developer onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,10 @@ Traversal<League, Player> activePlayers =
 
 ## Requirements
 
-* **Java Development Kit (JDK): Version 25** or later.
+* **Java Development Kit (JDK): Version 25** or later, with `--enable-preview` enabled.
 * Gradle (the project includes a Gradle wrapper).
+
+Higher-Kinded-J uses Java preview features. See the [Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart.html) for full Gradle and Maven configuration including preview flags.
 
 ### Version Compatibility
 
@@ -260,9 +262,24 @@ dependencies {
     implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
     annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
 }
+
+// Required: enable Java preview features
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("--enable-preview")
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("--enable-preview")
+}
+
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs("--enable-preview")
+}
 ```
 
 The annotation processor generates Focus paths and Effect paths for your records, enabling seamless integration between effects and data navigation.
+
+See the **[Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart.html)** for full setup including Maven configuration.
 
 **For SNAPSHOTS:**
 

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -1,6 +1,9 @@
 # Summary
 [Introduction to Higher-Kinded-J](home.md)
 
+- [Quickstart](quickstart.md)
+- [Cheat Sheet](cheatsheet.md)
+
 - [Effect Path API](effect/ch_intro.md)
   - [Effect Path Overview](effect/effect_path_overview.md)
   - [Capability Interfaces](effect/capabilities.md)

--- a/hkj-book/src/cheatsheet.md
+++ b/hkj-book/src/cheatsheet.md
@@ -1,0 +1,137 @@
+# Cheat Sheet
+
+~~~admonish info title="What You'll Learn"
+- Quick reference for all Path types, creation, and extraction
+- Common operators at a glance
+- How to get back to standard Java from any Path
+- Type conversion routes between Path types
+~~~
+
+---
+
+## Path Types
+
+| Path Type | For | Create | Extract |
+|-----------|-----|--------|---------|
+| `MaybePath<A>` | Absence | `Path.maybe(v)`, `Path.just(v)`, `Path.nothing()` | `.run()` → `Maybe<A>` |
+| `EitherPath<E, A>` | Typed errors | `Path.right(v)`, `Path.left(e)`, `Path.either(e)` | `.run()` → `Either<E, A>` |
+| `TryPath<A>` | Exceptions | `Path.tryOf(() -> ...)`, `Path.success(v)`, `Path.failure(ex)` | `.run()` → `Try<A>` |
+| `ValidationPath<E, A>` | Accumulating errors | `Path.valid(v, sg)`, `Path.invalid(e, sg)` | `.run()` → `Validated<E, A>` |
+| `IOPath<A>` | Deferred side effects | `Path.io(() -> ...)`, `Path.ioPure(v)` | `.unsafeRun()` → `A` |
+| `VTaskPath<A>` | Virtual threads | `Path.vtask(() -> ...)`, `Path.vtaskPure(v)` | `.unsafeRun()` → `A` |
+| `ReaderPath<R, A>` | Dependency injection | `Path.reader(r)`, `Path.ask()`, `Path.asks(fn)` | `.run(env)` → `A` |
+| `WriterPath<W, A>` | Logging, audit | `Path.writer(w, m)`, `Path.tell(log, m)` | `.run()` → `Writer<W, A>` |
+| `WithStatePath<S, A>` | Stateful computation | `Path.state(s)`, `Path.getState()` | `.run(initial)` → `(S, A)` |
+| `TrampolinePath<A>` | Stack-safe recursion | `Path.trampolineDone(v)`, `Path.trampolineDefer(s)` | `.run()` → `A` |
+| `LazyPath<A>` | Deferred, memoised | `Path.lazyDefer(() -> ...)`, `Path.lazyNow(v)` | `.run()` → `A` |
+| `CompletableFuturePath<A>` | Async | `Path.future(cf)`, `Path.futureAsync(() -> ...)` | `.run()` → `CompletableFuture<A>` |
+| `ListPath<A>` | Batch processing with positional zipping | `Path.listPath(list)` | `.run()` → `List<A>` |
+| `StreamPath<A>` | Lazy sequences | `Path.stream(stream)` | `.run()` → `Stream<A>` |
+| `NonDetPath<A>` | Non-deterministic search, combinations | `Path.list(list)` | `.run()` → `List<A>` |
+| `IdPath<A>` | Pure values | `Path.id(v)` | `.run()` → `Id<A>` |
+| `OptionalPath<A>` | java.util.Optional bridge | `Path.optional(opt)`, `Path.present(v)` | `.run()` → `Optional<A>` |
+| `FreePath<F, A>` | DSL building | `Path.freePure(v, f)`, `Path.freeLift(fa, f)` | `.foldMap(nat, m)` |
+| `GenericPath<F, A>` | Custom monads | `Path.generic(kind, monad)` | `.run()` → `Kind<F, A>` |
+
+---
+
+## Operators
+
+### Transformation
+
+| Operator | What It Does | Available On |
+|----------|-------------|--------------|
+| `.map(fn)` | Transform the success value | All paths |
+| `.peek(fn)` | Observe the value without changing it | All paths |
+| `.focus(lens)` | Navigate into a nested field via optics | MaybePath, EitherPath, TryPath, IOPath, ValidationPath |
+
+### Chaining
+
+| Operator | What It Does | Available On |
+|----------|-------------|--------------|
+| `.via(fn)` | Chain to another path (monadic bind) | All chainable paths |
+| `.flatMap(fn)` | Alias for `via` | All chainable paths |
+| `.then(supplier)` | Sequence, ignoring previous value | All chainable paths |
+
+### Combination
+
+| Operator | What It Does | Available On |
+|----------|-------------|--------------|
+| `.zipWith(other, fn)` | Combine two paths (fail-fast) | All combinable paths |
+| `.zipWith3(b, c, fn)` | Combine three paths (fail-fast) | Most paths |
+| `.zipWithAccum(other, fn)` | Combine, accumulating errors | ValidationPath |
+| `.zipWith3Accum(b, c, fn)` | Combine three, accumulating errors | ValidationPath |
+| `.andAlso(other)` | Accumulate errors, keep left value | ValidationPath |
+
+### Error Handling
+
+| Operator | What It Does | Available On |
+|----------|-------------|--------------|
+| `.recover(fn)` | Error → success value | MaybePath, EitherPath, TryPath, ValidationPath |
+| `.recoverWith(fn)` | Error → new path | MaybePath, EitherPath, TryPath, ValidationPath |
+| `.orElse(supplier)` | Try an alternative path | MaybePath, EitherPath, TryPath, ValidationPath |
+| `.mapError(fn)` | Transform the error type | EitherPath, TryPath, ValidationPath |
+| `.peekLeft(fn)` | Observe the error without changing it | EitherPath |
+| `.peekFailure(fn)` | Observe the exception without changing it | TryPath |
+
+### Extraction
+
+| Operator | What It Does | Available On |
+|----------|-------------|--------------|
+| `.run()` | Extract the underlying value | All paths |
+| `.unsafeRun()` | Execute a deferred effect (may throw) | IOPath, VTaskPath |
+| `.runSafe()` | Execute safely, returning `Try` | IOPath, VTaskPath |
+| `.fold(onErr, onOk)` | Handle both tracks | EitherPath, TryPath, ValidationPath |
+| `.getOrElse(default)` | Extract or use default | MaybePath, EitherPath, TryPath, ValidationPath |
+| `.getOrElseGet(supplier)` | Extract or compute default | MaybePath, EitherPath, TryPath, ValidationPath |
+
+---
+
+## Escape Hatches
+
+Getting back to standard Java from any Path:
+
+| From | To | How |
+|------|----|-----|
+| `MaybePath<A>` | `Maybe<A>` | `.run()` |
+| `MaybePath<A>` | `Optional<A>` | `.run().toOptional()` |
+| `MaybePath<A>` | `A` (or default) | `.getOrElse(defaultValue)` |
+| `EitherPath<E, A>` | `Either<E, A>` | `.run()` |
+| `EitherPath<E, A>` | `A` (or default) | `.getOrElse(defaultValue)` |
+| `EitherPath<E, A>` | `B` | `.run().fold(onErr, onOk)` |
+| `TryPath<A>` | `Try<A>` | `.run()` |
+| `TryPath<A>` | `A` (or default) | `.getOrElse(defaultValue)` |
+| `ValidationPath<E, A>` | `Validated<E, A>` | `.run()` |
+| `ValidationPath<E, A>` | `B` | `.fold(onInvalid, onValid)` |
+| `IOPath<A>` | `A` | `.unsafeRun()` |
+| `IOPath<A>` | `Try<A>` | `.runSafe()` |
+| `VTaskPath<A>` | `A` | `.unsafeRun()` |
+| `VTaskPath<A>` | `Try<A>` | `.runSafe()` |
+
+---
+
+## Type Conversions
+
+| From | To | Method |
+|------|----|--------|
+| `MaybePath<A>` | `EitherPath<E, A>` | `.toEitherPath(error)` |
+| `MaybePath<A>` | `TryPath<A>` | `.toTryPath(exceptionSupplier)` |
+| `MaybePath<A>` | `ValidationPath<E, A>` | `.toValidationPath(error, semigroup)` |
+| `MaybePath<A>` | `OptionalPath<A>` | `.toOptionalPath()` |
+| `EitherPath<E, A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `EitherPath<E, A>` | `TryPath<A>` | `.toTryPath(errorToException)` |
+| `EitherPath<E, A>` | `ValidationPath<E, A>` | `.toValidationPath(semigroup)` |
+| `EitherPath<E, A>` | `OptionalPath<A>` | `.toOptionalPath()` |
+| `TryPath<A>` | `EitherPath<E, A>` | `.toEitherPath(exceptionToError)` |
+| `TryPath<A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `ValidationPath<E, A>` | `EitherPath<E, A>` | `.toEitherPath()` |
+| `ValidationPath<E, A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `FocusPath<S, A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `FocusPath<S, A>` | `EitherPath<E, A>` | `.toEitherPath(errorFn)` |
+| `AffinePath<S, A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `AffinePath<S, A>` | `EitherPath<E, A>` | `.toEitherPath(errorFn)` |
+
+---
+
+**Previous:** [Quickstart](quickstart.md)
+**Next:** [Effect Path API](effect/ch_intro.md)

--- a/hkj-book/src/effect/path_types.md
+++ b/hkj-book/src/effect/path_types.md
@@ -24,6 +24,30 @@ fleet, a more pressing question: *which one do you need?*
 
 Before diving into specifics, orient yourself by the problem you're solving:
 
+```
+                             START HERE
+                                 │
+                      Can the operation fail?
+                           /          \
+                         No            Yes
+                         │              │
+                  Is the value      Do you need ALL
+                  optional?          errors at once?
+                   /     \            /          \
+                 Yes      No        Yes           No
+                  │        │         │             │
+              MaybePath  IdPath  ValidationPath    │
+                                              Is the error a
+                                              typed domain error
+                                              or an exception?
+                                               /            \
+                                            Typed        Exception
+                                             │              │
+                                         EitherPath     TryPath
+```
+
+*For deferred side effects, see [`IOPath`](path_io.md). For virtual-thread concurrency, see [`VTaskPath`](path_vtask.md). For stack-safe recursion, see [`TrampolinePath`](path_trampoline.md).*
+
 ### _"The value might not exist"_
 
 You're dealing with absence: a lookup that returns nothing, an optional

--- a/hkj-book/src/home.md
+++ b/hkj-book/src/home.md
@@ -249,46 +249,16 @@ public class UserController {
 
 ## Getting Started
 
-> [!NOTE]
-> Before diving in, ensure you have the following:
-> **Java Development Kit (JDK): Version 25** or later. The library makes use of features available in this version.
+Ready to start? See the **[Quickstart](quickstart.md)** for Gradle and Maven setup (including required Java 25 preview flags) and your first Effect Paths in 5 minutes.
 
-Add the following dependencies to your `build.gradle.kts`:
-
-```gradle
-dependencies {
-    implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
-    annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
-}
-```
-
-The annotation processor generates Focus paths and Effect paths for your records, enabling seamless integration between effects and data navigation.
-
-**For Spring Boot Integration:**
-
-```gradle
-dependencies {
-    implementation("io.github.higher-kinded-j:hkj-spring-boot-starter:LATEST_VERSION")
-}
-```
-
-**For SNAPSHOTS:**
-
-```gradle
-repositories {
-    mavenCentral()
-    maven {
-        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-    }
-}
-```
+For a one-page operator reference, see the **[Cheat Sheet](cheatsheet.md)**.
 
 ---
 
 ## Documentation Guide
 
 ~~~admonish tip title="Recommended Starting Point"
-Start with the **Effect Path API** section below. It is the primary user-facing API of Higher-Kinded-J and provides everything most applications need.
+If you want working code immediately, start with the **[Quickstart](quickstart.md)**. For a deeper understanding, continue with the **Effect Path API** section below.
 ~~~
 
 ### Effect Path API (Start Here)

--- a/hkj-book/src/quickstart.md
+++ b/hkj-book/src/quickstart.md
@@ -1,0 +1,206 @@
+# Quickstart
+
+~~~admonish info title="What You'll Learn"
+- How to add Higher-Kinded-J to a Gradle or Maven project
+- Java 25 preview mode configuration (required)
+- Your first Effect Paths in under 5 minutes
+~~~
+
+---
+
+## Prerequisites
+
+Higher-Kinded-J requires **Java 25** or later with **preview features enabled**.
+
+The library uses Java preview features including stable values and flexible constructor bodies. Without `--enable-preview`, your project will not compile.
+
+---
+
+## Gradle Setup
+
+```gradle
+// build.gradle.kts
+plugins { java }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
+
+    // Optional: generates Focus paths and Effect paths for your records
+    annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
+}
+
+// Required: enable Java preview features
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("--enable-preview")
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("--enable-preview")
+}
+
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs("--enable-preview")
+}
+```
+
+For SNAPSHOTS, add the Sonatype snapshots repository:
+
+```gradle
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+```
+
+---
+
+## Maven Setup
+
+```xml
+<properties>
+    <maven.compiler.release>25</maven.compiler.release>
+    <maven.compiler.enablePreview>true</maven.compiler.enablePreview>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>io.github.higher-kinded-j</groupId>
+        <artifactId>hkj-core</artifactId>
+        <version>LATEST_VERSION</version>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <!-- Required: enable preview features for tests -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <argLine>--enable-preview</argLine>
+            </configuration>
+        </plugin>
+        <!-- Required: enable preview features for application execution -->
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+                <executable>java</executable>
+                <arguments>
+                    <argument>--enable-preview</argument>
+                </arguments>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+---
+
+## Handle Absence
+
+When a value might not exist, use `MaybePath`:
+
+```java
+import org.higherkindedj.hkt.effect.Path;
+
+var user = Path.maybe(repository.findById(id));   // Just(user) or Nothing
+var name = user.map(User::name);                  // transforms only if present
+var result = name.run().orElse("Anonymous");       // extract to standard Java
+```
+
+---
+
+## Handle Errors
+
+When an operation can fail with a typed error, use `EitherPath`:
+
+```java
+import org.higherkindedj.hkt.effect.Path;
+
+var user = Path.maybe(repository.findById(userId))
+    .toEitherPath(new AppError.NotFound(userId));     // Nothing becomes Left(error)
+
+var order = user
+    .via(u -> Path.either(orderService.create(u)))    // chain another operation
+    .map(Order::confirm);                             // transform the success value
+
+var result = order.run();                             // Either<AppError, Order>
+```
+
+---
+
+## Validate Input
+
+When you need *all* errors, not just the first, use `ValidationPath`:
+
+```java
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.Semigroup;
+
+Semigroup<List<String>> sg = Semigroup.listSemigroup();
+
+var name = validateName(input.name());       // ValidationPath<List<String>, String>
+var email = validateEmail(input.email());     // ValidationPath<List<String>, String>
+var age = validateAge(input.age());           // ValidationPath<List<String>, Integer>
+
+var user = name.zipWith3Accum(email, age, User::new);  // accumulates ALL errors
+var result = user.run();                                // Validated<List<String>, User>
+```
+
+---
+
+## Chain It Together
+
+Combine absence, errors, and transformation in a single pipeline:
+
+```java
+import org.higherkindedj.hkt.effect.Path;
+
+public EitherPath<AppError, Receipt> processPayment(String userId, BigDecimal amount) {
+    return Path.maybe(userRepository.findById(userId))
+        .toEitherPath(new AppError.UserNotFound(userId))
+        .via(user -> Path.either(validateAmount(user, amount)))
+        .via(validated -> Path.tryOf(() -> gateway.charge(validated))
+            .toEitherPath(AppError.PaymentFailed::new))
+        .map(charge -> new Receipt(charge.id(), amount));
+}
+```
+
+---
+
+## Getting Back to Standard Java
+
+Every Path type unwraps to a standard Java value. You are never locked in:
+
+```java
+Maybe<User> maybe = maybePath.run();                         // → Maybe
+Either<AppError, User> either = eitherPath.run();            // → Either
+Optional<User> opt = maybePath.run().toOptional();           // → java.util.Optional
+User user = eitherPath.run().getOrElse(User.anonymous());    // → raw value
+String msg = eitherPath.run().fold(
+    error -> "Failed: " + error,                             // handle error
+    value -> "Success: " + value                             // handle success
+);
+```
+
+---
+
+~~~admonish tip title="See Also"
+- [Effect Path Overview](effect/effect_path_overview.md) - The railway model explained in depth
+- [Path Types](effect/path_types.md) - Choosing the right path for your problem
+- [Cheat Sheet](cheatsheet.md) - One-page operator reference
+- [Focus-Effect Integration](effect/focus_integration.md) - Combining effects with optics
+~~~
+
+---
+
+**Next:** [Cheat Sheet](cheatsheet.md)

--- a/hkj-book/src/transformers/ch_intro.md
+++ b/hkj-book/src/transformers/ch_intro.md
@@ -20,29 +20,29 @@ Higher-Kinded-J provides five transformers, each adding a specific capability to
 
 ## The Stacking Concept
 
-```
-    ┌─────────────────────────────────────────────────────────────┐
+<pre style="line-height:1.4;font-size:0.95em">
+<span style="color:#F44336">    ┌─────────────────────────────────────────────────────────────┐
     │  WITHOUT TRANSFORMER                                        │
     │                                                             │
-    │    CompletableFuture<Either<Error, Result>>                 │
+    │    CompletableFuture&lt;Either&lt;Error, Result&gt;&gt;                 │
     │                                                             │
-    │    future.thenApply(either ->                               │
-    │        either.map(result ->                                 │
-    │            either2.map(r2 ->                                │
+    │    future.thenApply(either -&gt;                               │
+    │        either.map(result -&gt;                                 │
+    │            either2.map(r2 -&gt;                                │
     │                ...)))   // Nesting grows unboundedly        │
-    └─────────────────────────────────────────────────────────────┘
+    └─────────────────────────────────────────────────────────────┘</span>
 
-    ┌─────────────────────────────────────────────────────────────┐
+<span style="color:#4CAF50">    ┌─────────────────────────────────────────────────────────────┐
     │  WITH TRANSFORMER                                           │
     │                                                             │
-    │    EitherT<FutureWitness, Error, Result>                    │
+    │    EitherT&lt;FutureWitness, Error, Result&gt;                    │
     │                                                             │
     │    eitherT                                                  │
-    │        .flatMap(result -> operation1(result))               │
-    │        .flatMap(r1 -> operation2(r1))                       │
-    │        .map(r2 -> finalTransform(r2))  // Flat!             │
-    └─────────────────────────────────────────────────────────────┘
-```
+    │        .flatMap(result -&gt; operation1(result))               │
+    │        .flatMap(r1 -&gt; operation2(r1))                       │
+    │        .map(r2 -&gt; finalTransform(r2))  // Flat!             │
+    └─────────────────────────────────────────────────────────────┘</span>
+</pre>
 
 Same semantics. Vastly different ergonomics.
 

--- a/hkj-book/src/transformers/eithert_transformer.md
+++ b/hkj-book/src/transformers/eithert_transformer.md
@@ -67,26 +67,26 @@ Same four steps. No manual error propagation. If any step returns `Left`, subseq
 
 `EitherT<F, L, R>` wraps a value of type `Kind<F, Either<L, R>>`. It represents a computation within the context `F` that will eventually yield an `Either<L, R>`.
 
-```
+<pre style="line-height:1.4;font-size:0.95em">
     ┌──────────────────────────────────────────────────────────┐
-    │  EitherT<CompletableFutureKind.Witness, Error, Value>    │
+    │  EitherT&lt;CompletableFutureKind.Witness, Error, Value&gt;    │
     │                                                          │
     │  ┌─── CompletableFuture ──────────────────────────────┐  │
     │  │                                                    │  │
     │  │  ┌─── Either ──────────────────────────────────┐   │  │
     │  │  │                                             │   │  │
-    │  │  │   Left(error)       │     Right(value)      │   │  │
+    │  │  │   <span style="color:#F44336">Left(error)</span>       │     <span style="color:#4CAF50">Right(value)</span>      │   │  │
     │  │  │                     │                       │   │  │
     │  │  └─────────────────────────────────────────────┘   │  │
     │  │                                                    │  │
     │  └────────────────────────────────────────────────────┘  │
     │                                                          │
-    │  flatMap ──▶ sequences F, then routes on Either          │
-    │  map ──────▶ transforms Right(value) only                │
-    │  raiseError ──▶ creates Left(error) in F                 │
-    │  handleErrorWith ──▶ recovers from Left                  │
+    │  flatMap ──▶ sequences F, then routes on Either         │
+    │  map ──────▶ transforms <span style="color:#4CAF50">Right(value)</span> only               │
+    │  raiseError ──▶ creates <span style="color:#F44336">Left(error)</span> in F                │
+    │  handleErrorWith ──▶ recovers from <span style="color:#F44336">Left</span>                 │
     └──────────────────────────────────────────────────────────┘
-```
+</pre>
 
 ![eithert_transformer.svg](../images/puml/eithert_transformer.svg)
 

--- a/hkj-book/src/transformers/maybet_transformer.md
+++ b/hkj-book/src/transformers/maybet_transformer.md
@@ -59,26 +59,26 @@ If `fetchUserAsync` returns `Nothing`, the preferences lookup is skipped entirel
 
 `MaybeT<F, A>` wraps a computation yielding `Kind<F, Maybe<A>>`. It represents an effectful computation in `F` that may produce `Just(value)` or `Nothing`.
 
-```
+<pre style="line-height:1.4;font-size:0.95em">
     ┌──────────────────────────────────────────────────────────┐
-    │  MaybeT<CompletableFutureKind.Witness, Value>            │
+    │  MaybeT&lt;CompletableFutureKind.Witness, Value&gt;            │
     │                                                          │
     │  ┌─── CompletableFuture ──────────────────────────────┐  │
     │  │                                                    │  │
     │  │  ┌─── Maybe ───────────────────────────────────┐   │  │
     │  │  │                                             │   │  │
-    │  │  │   Nothing            │   Just(value)        │   │  │
+    │  │  │   <span style="color:#F44336">Nothing</span>            │   <span style="color:#4CAF50">Just(value)</span>        │   │  │
     │  │  │                      │                      │   │  │
     │  │  └─────────────────────────────────────────────┘   │  │
     │  │                                                    │  │
     │  └────────────────────────────────────────────────────┘  │
     │                                                          │
-    │  flatMap ──▶ sequences F, then routes on Maybe           │
-    │  map ──────▶ transforms Just(value) only                 │
-    │  raiseError(Unit) ──▶ creates Nothing in F               │
-    │  handleErrorWith ──▶ recovers from Nothing               │
+    │  flatMap ──▶ sequences F, then routes on Maybe          │
+    │  map ──────▶ transforms <span style="color:#4CAF50">Just(value)</span> only                │
+    │  raiseError(Unit) ──▶ creates <span style="color:#F44336">Nothing</span> in F              │
+    │  handleErrorWith ──▶ recovers from <span style="color:#F44336">Nothing</span>              │
     └──────────────────────────────────────────────────────────┘
-```
+</pre>
 
 ![maybet_transformer.svg](../images/puml/maybet_transformer.svg)
 

--- a/hkj-book/src/transformers/optionalt_transformer.md
+++ b/hkj-book/src/transformers/optionalt_transformer.md
@@ -58,26 +58,26 @@ If any step returns empty, subsequent steps are skipped. No manual `orElse` fall
 
 `OptionalT<F, A>` wraps a computation yielding `Kind<F, Optional<A>>`. It represents an effectful computation in `F` that may or may not produce a value.
 
-```
+<pre style="line-height:1.4;font-size:0.95em">
     ┌──────────────────────────────────────────────────────────┐
-    │  OptionalT<CompletableFutureKind.Witness, Value>         │
+    │  OptionalT&lt;CompletableFutureKind.Witness, Value&gt;         │
     │                                                          │
     │  ┌─── CompletableFuture ──────────────────────────────┐  │
     │  │                                                    │  │
     │  │  ┌─── Optional ────────────────────────────────┐   │  │
     │  │  │                                             │   │  │
-    │  │  │   empty()            │   of(value)          │   │  │
+    │  │  │   <span style="color:#F44336">empty()</span>            │   <span style="color:#4CAF50">of(value)</span>          │   │  │
     │  │  │                      │                      │   │  │
     │  │  └─────────────────────────────────────────────┘   │  │
     │  │                                                    │  │
     │  └────────────────────────────────────────────────────┘  │
     │                                                          │
-    │  flatMap ──▶ sequences F, then routes on Optional        │
-    │  map ──────▶ transforms present value only               │
-    │  raiseError(Unit) ──▶ creates empty() in F               │
-    │  handleErrorWith ──▶ recovers from empty                 │
+    │  flatMap ──▶ sequences F, then routes on Optional       │
+    │  map ──────▶ transforms <span style="color:#4CAF50">present value</span> only              │
+    │  raiseError(Unit) ──▶ creates <span style="color:#F44336">empty()</span> in F              │
+    │  handleErrorWith ──▶ recovers from <span style="color:#F44336">empty</span>                │
     └──────────────────────────────────────────────────────────┘
-```
+</pre>
 
 ![optional_t_transformer.svg](../images/puml/optional_t_transformer.svg)
 

--- a/plan/PEDAGOGICAL-REPORT.md
+++ b/plan/PEDAGOGICAL-REPORT.md
@@ -1,0 +1,354 @@
+# The Pedagogical Imperative: Restructuring Monad Transformer Documentation for the Java Ecosystem
+
+## 1. Introduction: The Composition Crisis in Modern Java
+
+The evolution of the Java programming language over the last decade has been characterized by a steady, albeit cautious, migration toward functional programming (FP) paradigms. With the introduction of lambda expressions in Java 8, the Stream API, and more recently, Records and Pattern Matching in Java 21, the language has adopted many of the syntactic conveniences of functional languages. However, as developers move beyond simple data transformation pipelines into complex system architecture, they encounter a fundamental limitation that syntax alone cannot resolve: the problem of effect composition.
+
+In standard Object-Oriented Programming (OOP), side effects—such as database queries, logging, or state mutation—are typically implicit. A method signature `User findUser(String id)` does not explicitly state that it might fail with a network exception or return a null value. In contrast, functional programming demands that these effects be reified into the type system. A query becomes `CompletableFuture<User>` (asynchrony), a nullable lookup becomes `Optional<User>` (optionality), and a validation becomes `Either<Error, User>` (failure).
+
+While these wrapper types (Monads) provide clarity and safety in isolation, they resist composition. A developer who needs to perform a database lookup (Asynchrony) that might not find a record (Optionality) and then validate that record (Failure) ends up with a type signature resembling `CompletableFuture<Optional<Either<Error, User>>>`. Manipulating values within this nested structure requires a sequence of unwrapping operations often derided as the "Pyramid of Doom".
+
+This report analyzes the role of **Monad Transformers**—the theoretical solution to this composition problem—within the specific context of the **Higher-Kinded-J (HKJ)** library. Unlike other functional libraries that attempt to port Scala paradigms directly to Java, HKJ introduces novel abstractions such as the **Effect Path API** and **Focus DSL**. These abstractions offer a unique pedagogical opportunity.
+
+The objective of this report is to critique the existing documentation strategies for Monad Transformers and propose a comprehensive restructuring. The central thesis is that for Java developers, the mathematical definition of a Monad Transformer is a barrier to entry, not a foundation for learning. By leveraging the **Railway Oriented Programming (ROP)** metaphor and HKJ's specific architectural innovations, documentation can be transformed from a theoretical reference into a practical playbook for enterprise engineering.
+
+---
+
+## 2. Theoretical Foundations and Pedagogical Barriers
+
+To prescribe a better way to teach Monad Transformers, one must first understand why they are notoriously difficult to learn, particularly for developers coming from an imperative background. The difficulty is not merely incidental; it is rooted in the "missing features" of the Java type system and the cognitive load associated with simulating them.
+
+### 2.1 The "Missing Link": Higher-Kinded Types (HKT)
+
+In languages like Haskell or Scala, Monad Transformers are implemented using Higher-Kinded Types (HKTs). An HKT is essentially a "generic of a generic." If `List<T>` is a type constructor that takes a type `T` and returns a List of T, an HKT allows one to abstract over the List container itself. One can write a function that accepts `M<T>`, where `M` could be `List`, `Optional`, or `CompletableFuture`.
+
+Java does not natively support HKTs. To implement a Monad Transformer like `OptionT` (which adds optionality to any other Monad), a library must simulate HKTs. HKJ achieves this through a technique known as **Defunctionalization** (or Lightweight Higher-Kinded Polymorphism).
+
+- **The Witness:** A marker class (e.g., `ListKind`) acts as a runtime representative of the generic type.
+- **The Kind Interface:** The interface `Kind<F, A>` represents `F<A>`.
+- **The Wrapper:** To treat `List<String>` as a Monad, it must be wrapped in a `ListKind<String>` adapter.
+
+**Pedagogical Implication:** Before a Java developer can even write their first Monad Transformer, they are often forced to understand "Witness Types," "Kind Interfaces," and explicit "wrapping/unwrapping" mechanics. This creates a massive implementation detail barrier that obscures the actual utility of the pattern. Documentation that leads with the implementation details of HKT simulation inevitably alienates the learner.
+
+### 2.2 The "Monad Tutorial Fallacy"
+
+The "Monad Tutorial Fallacy" suggests that because Monads are abstract mathematical structures (Monoids in the category of endofunctors), educators feel compelled to explain them via metaphors (burritos, space suits, boxes) or raw category theory.
+
+For a Java developer, a Monad Transformer is not a mathematical construct; it is a **refactoring tool**. It is the mechanism by which nested `if/else` blocks and nested `flatMap` calls are flattened into a linear chain. The research indicates that the most effective teaching method avoids the word "Monad" entirely in the early stages, focusing instead on **Railway Oriented Programming (ROP)**. ROP visualizes execution as a two-track railway: a Green track for success and a Red track for failure. Transformers are simply the mechanism that allows this railway to run through different terrains (e.g., an asynchronous terrain).
+
+### 2.3 The Cognitive Load of "Nested Contexts"
+
+The primary motivator for Monad Transformers is the cognitive load of handling nested contexts. Consider the following Java scenario without transformers:
+
+```java
+// The "Pyramid of Doom"
+public CompletableFuture<Optional<User>> findActiveUser(String id) {
+    return repo.findById(id).thenApply(maybeUser -> {
+        if (maybeUser.isPresent()) {
+            User user = maybeUser.get();
+            if (user.isActive()) {
+                return Optional.of(user);
+            }
+        }
+        return Optional.empty();
+    });
+}
+```
+
+The developer must hold three distinct contexts in their head:
+
+1. **Time:** The value hasn't arrived yet (`CompletableFuture`).
+2. **Existence:** The value might be null (`Optional`).
+3. **Domain Logic:** The user must be active (Boolean check).
+
+A Monad Transformer like `OptionT` collapses these into a single context: `OptionT<Future, User>`. The operations `map` and `flatMap` now handle the "Future" and "Optional" layers automatically, allowing the developer to focus solely on the "Domain Logic." This reduction in cognitive load is the **single most important selling point** and must be the focal point of any documentation.
+
+---
+
+## 3. Higher-Kinded-J: Architectural Analysis
+
+The higher-kinded-j library distinguishes itself from competitors like Vavr or Functional Java by providing a layered architecture that explicitly addresses the verbosity of HKT simulation.
+
+### 3.1 Layer 1: The Core Simulation
+
+At the bottom layer, HKJ provides the machinery for HKTs using the "Witness" pattern. It defines interfaces for Functor, Applicative, and Monad.
+
+- **Pros:** It is mathematically sound and allows for generic code that works across List, Option, and Future.
+- **Cons:** It is verbose. Writing a function `foo` that takes a `Monad<M>` requires passing the Monad instance explicitly (e.g., `OptionMonad.INSTANCE`), a pattern known as "Dictionary Passing Style" since Java lacks implicit resolution.
+
+### 3.2 Layer 2: The Raw Transformers
+
+Built on top of the simulation are the standard transformers:
+
+- **`EitherT<F, L, R>`:** Adds error handling (`Either<L, R>`) to an effect `F`.
+- **`StateT<F, S, A>`:** Adds state passing (`S`) to an effect `F`.
+- **`ReaderT<F, R, A>`:** Adds environment reading (`R`) to an effect `F`.
+
+In libraries like Cats (Scala), these are the primary user-facing types. In Java, however, `EitherT<CompletableFutureKind, Error, User>` is syntactically intimidating. The type signature alone occupies significant screen real estate, distracting from the business logic.
+
+### 3.3 Layer 3: The Effect Path API (The Abstraction Layer)
+
+The research identifies the **Effect Path API** as the **crown jewel of HKJ**. This layer wraps the raw Monad Transformers into fluent, concrete classes.
+
+- **`EitherPath<E, A>`:** A wrapper around `EitherT`.
+- **`MaybePath<A>`:** A wrapper around `OptionT`.
+- **`IOPath<A>`:** A wrapper around `IO` (which itself might handle stack safety).
+
+**Crucial Analysis:** The Effect Path API effectively acts as a **Domain Specific Language (DSL)** for Monad Transformers. It hides the Kind interface and the Witness types. When a user calls `Path.maybe(future)`, the library internally constructs the `OptionT` stack. This architectural decision acknowledges that Java developers prefer **Fluent Interfaces** (like Stream) over **Type Class Constraints**.
+
+**Pedagogical Opportunity:** The documentation should treat the Effect Path API as the **primary** interface, relegating the raw Transformers and HKT simulation to "Advanced" sections. The user does not need to know *how* `EitherT` is implemented to use `EitherPath`.
+
+### 3.4 The Optics Bridge (Focus DSL)
+
+HKJ provides a feature rarely seen even in Scala libraries: seamless integration of **Optics** (Lenses, Prisms) with **Effects**.
+
+- **The Problem:** Updating a deeply nested field inside a Monad Transformer usually requires mapping over the transformer, then mapping over the data structure.
+- **The Solution:** `path.focus(Lens).modify(fn)`.
+
+This integration provides a powerful narrative for documentation: "Surgical precision for your data, even when it is wrapped in Futures and Results."
+
+---
+
+## 4. Documentation Critique: Identifying the Gaps
+
+Based on the research snippets and the inferred structure of the library, the current state of documentation likely suffers from "Concept Leakage"—where advanced implementation details (HKTs) leak into introductory material—and a lack of concrete "Enterprise" use cases.
+
+### 4.1 Gap 1: The "Why" is Buried
+
+The documentation likely defines *what* a Monad Transformer is (a type constructor `T[M[_], A]`) before explaining *why* a developer needs it. For a Java developer struggling with `CompletableFuture`, this definition is irrelevant. The documentation needs to start with the "Pyramid of Doom" code smell.
+
+### 4.2 Gap 2: Disconnected Features
+
+The "Optics" chapter and the "Transformers" chapter are likely separate. This separation ignores the unique synergy of HKJ. A developer learning Transformers might not realize that Optics can simplify the `map` calls inside the transformer stack.
+
+### 4.3 Gap 3: Lack of "Railway" Visuals
+
+While the text might mention "Railway Oriented Programming," without explicit diagrams showing the "Green Track" and "Red Track," the metaphor is lost. Visual learners (a large portion of the developer population) need to see the "Switch" points where logic creates a branch in the railway.
+
+### 4.4 Gap 4: Implicit Context Management
+
+Java developers are used to Dependency Injection (Spring/CDI). The concept of using `ReaderT` for dependency injection is foreign. Documentation often fails to bridge the gap between "Field Injection" (`@Autowired`) and "Parameter Injection" (`ReaderT`).
+
+### 4.5 Gap 5: The "Scary Types" Problem
+
+Showing `EitherT<IO, AppError, User>` early in the tutorial induces anxiety. The documentation should prioritize `EitherPath<AppError, User>` and only introduce the generic type signature when discussing extension mechanisms.
+
+---
+
+## 5. Strategic Proposals for Documentation Improvement
+
+The following proposals are designed to restructure the HKJ documentation into a cohesive, narrative-driven learning path. The goal is to lower the barrier to entry while maintaining rigorous technical accuracy.
+
+### Proposal 1: Invert the Abstraction Ladder (The "Path-First" Strategy)
+
+**Current State:**
+
+1. HKT Simulation (Kind).
+2. Type Classes (Monad).
+3. Transformers (EitherT).
+4. Effect Path API (as a utility).
+
+**Proposed State:**
+
+1. **The Pain Point:** The "Pyramid of Doom" in standard Java.
+2. **The Solution:** The Effect Path API (Path).
+3. **The Mechanics:** How Path wraps EitherT (Intermediate).
+4. **The Foundation:** How EitherT uses Kind (Advanced).
+
+**Justification:** This aligns with **Progressive Disclosure**. Users get immediate value from Path without needing to understand the underlying Category Theory. It mimics the successful pedagogy of Java Streams (users learn `.map()` and `.filter()` long before they learn `Spliterator` mechanics).
+
+### Proposal 2: Adopt "Railway Oriented Programming" as the Core Metaphor
+
+**Implementation:**
+
+- Rename the introductory section from "Monad Transformers" to **"Railway Oriented Java: Handling Errors and Asynchrony."**
+- **Visual Language:** Use green/red diagrams to illustrate every operator.
+  - `map`: Transforms data on the Green track.
+  - `mapError`: Transforms data on the Red track.
+  - `recover`: Switches from Red to Green.
+  - `ensure`: Switches from Green to Red (validation).
+- **Terminology:** Explicitly map HKJ methods to ROP concepts.
+  - `via` = "Track Switch" (`flatMap`).
+  - `peek` = "Siding" (Side effects without changing tracks).
+
+**Justification:** ROP provides a shared vocabulary that abstracts away the mathematical "bind" operations. It makes the behavior of `flatMap` intuitive: "It connects two track sections that might fail".
+
+### Proposal 3: The "Focus-Effect" Unification Case Study
+
+**Implementation:**
+
+Create a central "Capstone Example" that runs through the entire documentation. This example should require both **Effects** (Async/Failure) and **Optics** (Nested Update).
+
+- **Scenario:** An E-commerce "Order Processing" system.
+- **Requirement:** Update the shipping address postcode of an order.
+  - The Order is loaded asynchronously (Async).
+  - The Order might not exist (Optional).
+  - The update must be validated (Failure).
+  - The shipping address is nested 3 levels deep (Optics).
+
+**Code Comparison (Before vs. After):**
+
+The documentation must show the side-by-side comparison.
+
+- **Before (Standard Java):** 20 lines of nested if/else and try/catch.
+- **After (HKJ):**
+
+```java
+return Path.from(repo.findOrder(id))         // MaybePath
+    .toEitherPath(OrderNotFound::new)
+    .focus(OrderFocus.shippingAddress())      // Lens
+    .focus(AddressFocus.postcode())           // Lens
+    .via(this::validatePostcode)              // Validation Logic
+    .map(Order::save);
+```
+
+**Justification:** This demonstrates the *unique* value of HKJ. No other library in the Java ecosystem (and few in Scala) allows for this level of succinctness. It proves that Transformers and Optics are force multipliers for each other.
+
+### Proposal 4: "Refactoring Recipes" for Spring Boot Developers
+
+**Implementation:**
+
+Java developers typically work within frameworks like Spring Boot. The documentation should include specific recipes for integrating HKJ types with Spring.
+
+- **Recipe: The Functional Controller.**
+  How to convert `EitherPath<Error, User>` directly into a Spring `ResponseEntity`.
+  - `Left(Error)` → `400 Bad Request` or `404 Not Found`.
+  - `Right(User)` → `200 OK` with JSON body.
+- **Recipe: The Transactional Reader.** Using `ReaderT` to pass `TransactionContext` implicitly, referencing the `hkj-spring-boot-autoconfigure` capabilities.
+
+**Justification:** Most Java developers are not writing greenfield pure FP applications. They are refactoring existing Spring applications. Meeting them where they are increases adoption frictionlessly.
+
+### Proposal 5: Explicit "Stack Archetypes"
+
+**Implementation:**
+
+Instead of teaching users how to build arbitrary transformer stacks (which is error-prone and verbose), provide pre-defined **Archetypes**.
+
+| Archetype | Stack | Use Case |
+|-----------|-------|----------|
+| The Service Stack | `IOPath<Either<AppError, A>>` | Standard business logic (Async + Failure). |
+| The Validation Stack | `ValidationPath<List<String>, A>` | Form validation (Accumulating Errors). |
+| The Context Stack | `ReaderT<IO, Context, Either<Error, A>>` | Complex systems with global context (Tracing/Auth). |
+
+**Justification:** Cognitive Load Theory suggests that learners handle "Chunks" better than raw components. "The Service Stack" is a manageable chunk; "A monad transformer stack of IO, Either, and Reader" is an overwhelming set of components.
+
+### Proposal 6: Addressing Performance and Debugging
+
+**Implementation:**
+
+Add a dedicated section on "Production Readiness."
+
+- **Stack Traces:** Acknowledge that Transformers create deep stack traces. Show how to read them.
+- **Allocation:** Explain that every step in the "Path" creates a small object. Compare this cost (nanoseconds) to the I/O cost (milliseconds) to debunk premature optimization concerns.
+- **Trampolining:** Explain `TrampolinePath` for recursion safety, addressing the lack of Tail Call Optimization (TCO) in the JVM.
+
+**Justification:** Honesty builds trust. Senior engineers will inevitably ask about performance overhead. Addressing it proactively with data (e.g., "The overhead is negligible compared to a DB call") prevents FUD (Fear, Uncertainty, Doubt).
+
+---
+
+## 6. Detailed Teaching Module: "Monad Transformers for the Java Pragmatist"
+
+This section outlines the structure and content of the proposed new documentation chapter.
+
+### 6.1 Module 1: Anatomy of a Disaster (The Problem)
+
+**Goal:** Establish emotional resonance.
+
+- Start with the "Pyramid of Doom."
+- Annotate the code with comments like `// WAIT: What if this throws an exception?` and `// TODO: We forgot to check for null here.`
+- Conclude that **Composition** is the missing feature. "We can make Futures, and we can make Optionals, but we can't make Future-Optionals."
+
+### 6.2 Module 2: The Railway Metaphor (The Mental Model)
+
+**Goal:** Establish the visual intuition.
+
+- Introduce the **Effect Path**.
+- Define the **Green Track** (Happy Path) and **Red Track** (Error Path).
+- **Interactive Diagram (Conceptual):**
+  - `map`: Function fits on the Green Track.
+  - `mapError`: Function fits on the Red Track.
+  - `via`: A switch that can divert Green to Red.
+  - `recover`: A switch that can divert Red to Green.
+
+### 6.3 Module 3: The Service Stack (EitherPath)
+
+**Goal:** Solve the 80% use case (Async + Failure).
+
+- Introduce `EitherPath` as the implementation of the Async Railway.
+- **Code Example:**
+
+```java
+// Defining the Railway
+public EitherPath<AppError, User> findUser(String id) {
+    return Path.of(repo.findById(id))         // Starts on Green
+        .toEitherPath(AppError::notFound);    // Handles Nulls
+}
+```
+
+- **Key Insight:** This looks like a standard Java Stream, but it handles *time* and *failure* implicitly.
+
+### 6.4 Module 4: Injecting Context (ReaderPath)
+
+**Goal:** Solve the "Parameter Pollution" problem.
+
+- Scenario: Passing `UserContext` through 10 layers of function calls.
+- Solution: `ReaderPath` (wrapper for `ReaderT`).
+- Show how `ReaderPath` defers the requirement of `UserContext` until the very end ("At the Edge of the World").
+- **Analogy:** "Currying on steroids."
+
+### 6.5 Module 5: Surgical Precision (Transformers + Optics)
+
+**Goal:** Demonstrate the "Power User" feature.
+
+- Revisit the "Capstone Example" (Order Processing).
+- Introduce the `focus()` method.
+- Explain that `focus()` is a "Wormhole" that bypasses the layers of the transformer stack to touch the data directly.
+- **Key takeaway:** "You don't need to unwrap the present to check the color of the toy inside."
+
+### 6.6 Module 6: Under the Hood (For the Curious)
+
+**Goal:** Satisfy the intellectual curiosity without blocking the pragmatic learner.
+
+- Now, and only now, introduce **Defunctionalization**.
+- Show the `Kind` interface.
+- Explain that `EitherPath` is backed by `EitherT`.
+- Explain that `EitherT` works by implementing `flatMap` for the inner Monad (`CompletableFuture`).
+- **Message:** "HKJ does the heavy lifting of HKT simulation so you don't have to."
+
+---
+
+## 7. Comparative Analysis: Why HKJ?
+
+To effectively teach HKJ, the documentation must position it against alternatives.
+
+| Feature | Vavr | Functional Java | Cats (Scala) | Higher-Kinded-J |
+|---------|------|-----------------|--------------|-----------------|
+| Monad Support | Good (Try, Option) | Comprehensive | Comprehensive | Comprehensive |
+| Transformers | Limited/Deprecated | Verbose | Implicit-based | Effect Path API |
+| HKT Simulation | None | Traditional | Native (Scala) | Defunctionalization |
+| Optics | Basic (Lenses) | Basic | Monocle (Separate) | Integrated (Focus DSL) |
+| Java Interaction | "Better Java" | "Haskell in Java" | N/A | "Pragmatic Functionalism" |
+
+**Analysis:**
+
+- **Vavr** is excellent for data structures but lacks the transformer machinery for complex effect composition.
+- **Functional Java** offers the machinery but exposes the raw complexity of HKT simulation, making it difficult to teach.
+- **HKJ** strikes the balance by *hiding* the HKT simulation behind the Effect Path facade. This architectural decision is the key pedagogical lever.
+
+---
+
+## 8. Conclusion and Future Outlook
+
+The difficulty in teaching Monad Transformers to Java developers is not a failing of the developers, but a failure of the tooling and documentation to adapt to the language's constraints. Traditional "Category Theory First" approaches fail because they ask developers to pay a high cognitive tax (learning HKT simulation) before receiving any value.
+
+The higher-kinded-j library offers a unique opportunity to break this cycle. Its **Effect Path API** allows for a "Railway First" pedagogical strategy, where the focus is on linearizing control flow rather than stacking types. Furthermore, its integration of **Optics** allows for a "Focus First" strategy, where data manipulation is decoupled from effect management.
+
+**Recommendations Summary:**
+
+1. **Rename and Reframe:** Move from "Monad Transformers" to "Effect Paths" and "Railways."
+2. **Invert the Ladder:** Teach the high-level API first; hide the Kind mechanics.
+3. **Visualize:** Use ROP diagrams for every operation.
+4. **Integrate:** Teach Transformers and Optics as a unified toolset for "Surgical Data/Effect Manipulation."
+5. **Pragmatism:** Provide recipes for Spring Boot and explicit guidance on performance.
+
+By adopting these strategies, HKJ can position itself not just as a library, but as the standard reference for how functional architecture should be implemented in the modern Java ecosystem.

--- a/plan/RESTRUCTURE-PLAN.md
+++ b/plan/RESTRUCTURE-PLAN.md
@@ -1,0 +1,669 @@
+# Documentation Restructure Plan: Monad Transformers for the Java Ecosystem
+
+Based on the pedagogical report analyzing how to restructure Monad Transformer documentation for Java developers, this plan maps the report's 6 strategic proposals against the current state of the HKJ book and identifies concrete, actionable work items.
+
+---
+
+## Executive Summary
+
+The HKJ documentation is already well-structured in several important ways:
+- The Effect Path API is the first chapter (Path-First ordering)
+- The Railway model is introduced with the Pyramid of Doom motivator
+- Transformers are under "Advanced Topics" (not front and centre)
+- HKT foundations are at the bottom under "Foundations"
+
+The main gaps are: no quickstart for impatient developers, missing named Stack Archetypes, no Production Readiness section, incomplete ROP terminology mapping, no Spring-specific refactoring recipes, no cheat sheet, and insufficient before/after code comparisons as a consistent pattern throughout the docs.
+
+---
+
+## Gap Analysis
+
+| Report Proposal | Current Status | Work Needed |
+|----------------|---------------|-------------|
+| 1. Path-First Strategy | **Done** - SUMMARY.md already leads with Effect Path API | Minor: add a bridging paragraph from transformers back to Paths |
+| 2. ROP Core Metaphor | **Mostly Done** - Railway diagrams with green/red colouring in overview; operator-to-ROP mapping table added | Enhance per-operator diagrams (Task 1.2) |
+| 3. Focus-Effect Capstone | **Partial** - focus_integration.md + OrderWorkflow exist separately | Create unified before/after capstone threading both chapters |
+| 4. Spring Boot Recipes | **Partial** - Spring integration docs exist | Add "Functional Controller" and "Transactional Reader" recipes |
+| 5. Stack Archetypes | **Missing** - No named archetypes | Create archetype table and per-archetype guidance |
+| 6. Performance & Debugging | **Missing** - No production readiness section | Create dedicated section on stack traces, allocation, trampolining |
+
+**Additional gaps identified beyond the report:**
+
+| Gap | Current Status | Work Needed |
+|-----|---------------|-------------|
+| Quickstart | **Done** - `quickstart.md` created with Gradle/Maven setup, preview flags, 4 examples | None |
+| Cheat Sheet | **Done** - `cheatsheet.md` created with 19 path types, operators, escape hatches, type conversions | None |
+| Decision Flowchart | **Done** - ASCII flowchart added to `path_types.md` | None |
+| Migration Cookbook | **Missing** - No imperative-to-FP pattern mapping | "I have try/catch → here's TryPath" recipes |
+| Escape Hatches | **Done** - Dedicated section in `effect_path_overview.md` + table in `cheatsheet.md` | None |
+| Compiler Error Guide | **Missing** - No help for cryptic generic errors | Top 5 compiler errors and what they mean |
+
+---
+
+## Actionable Work Items
+
+### Phase 0: Quickstart and Developer Onboarding ✓ COMPLETE
+
+> **Goal:** Give impatient developers working code in under 5 minutes, and give returning developers a one-page reference they bookmark.
+>
+> **Status:** All 7 tasks complete. Quickstart and Cheat Sheet created, SUMMARY.md updated, home.md and README.md slimmed down, decision flowchart and escape hatches added.
+
+#### Style Guide Compliance
+
+All new pages in this phase must follow `docs/STYLE-GUIDE.md`:
+- British English spelling throughout (e.g., "colour", "behaviour", "optimisation")
+- No em dashes; use commas or semicolons instead
+- No emojis
+- `# Title` as level-1 heading
+- `~~~admonish info title="What You'll Learn"` section near the top
+- Horizontal rules (`---`) between major sections
+- Navigation links (`**Previous:** / **Next:**`) at the bottom
+- Example code links via `~~~admonish example title="See Example Code"` where applicable
+- Code blocks with language specifier (` ```java `, ` ```gradle `, ` ```xml `)
+
+---
+
+#### Task 0.1: Create Quickstart Page ✓
+
+**File:** New `hkj-book/src/quickstart.md` — CREATED
+
+**Structure:**
+
+```
+# Quickstart
+
+~~~admonish info title="What You'll Learn"
+- How to add Higher-Kinded-J to a Gradle or Maven project
+- Java 25 preview mode configuration (required)
+- Your first Effect Path in under 5 minutes
+~~~
+
+---
+
+## Prerequisites
+
+> Java 25+ with preview features enabled. Higher-Kinded-J uses
+> Java preview features (stable values, flexible constructor bodies).
+
+---
+
+## Gradle Setup
+
+```gradle
+// build.gradle.kts
+plugins { java }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
+    annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
+}
+
+// Required: enable Java preview features
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("--enable-preview")
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("--enable-preview")
+}
+
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs("--enable-preview")
+}
+```
+
+## Maven Setup
+
+```xml
+<properties>
+    <maven.compiler.release>25</maven.compiler.release>
+    <maven.compiler.enablePreview>true</maven.compiler.enablePreview>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>io.github.higher-kinded-j</groupId>
+        <artifactId>hkj-core</artifactId>
+        <version>LATEST_VERSION</version>
+    </dependency>
+</dependencies>
+
+<!-- Required for test execution with preview features -->
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <argLine>--enable-preview</argLine>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+## Example 1: Handle Absence (MaybePath)
+
+(6 lines: Path.maybe → map → run → orElse)
+
+## Example 2: Handle Errors (EitherPath)
+
+(8 lines: Path.right → via → map → run → fold)
+
+## Example 3: Validate Input (ValidationPath)
+
+(10 lines: Path.valid → zipWith → map → run)
+
+## Example 4: Chain It Together
+
+(12 lines: combining MaybePath → toEitherPath → via → map)
+
+## Getting Back to Standard Java
+
+(4 lines showing .run(), .fold(), .toOptional(), .getOrElse())
+
+~~~admonish tip title="See Also"
+- [Effect Path Overview](effect/effect_path_overview.md) - The railway model explained
+- [Path Types](effect/path_types.md) - Choosing the right path for your problem
+- [Cheat Sheet](cheatsheet.md) - One-page operator reference
+~~~
+
+---
+
+**Next:** [Cheat Sheet](cheatsheet.md)
+```
+
+**Key requirements:**
+- Java 25 preview mode must be prominently flagged with both Gradle and Maven configurations
+- The Gradle config must show `--enable-preview` for compile, test, and run tasks (matching the project's own `build.gradle.kts`)
+- The Maven config must show `maven.compiler.enablePreview` property and surefire `--enable-preview` arg
+- Examples must use only `Path.*` factory methods; no raw transformers, no Kind types, no witness types
+- One-line comments only; no prose between code lines
+- The entire page should fit on two screens (aim for ~120 lines of markdown)
+
+**Why:** A large segment of developers learn by running code first and reading docs second. The current home.md is well-written but is a 300+ line narrative. The quickstart is the "show me the code" alternative. The `--enable-preview` requirement is currently absent from all user-facing docs; this is the first place to fix it.
+
+---
+
+#### Task 0.2: Create Cheat Sheet ✓
+
+**File:** New `hkj-book/src/cheatsheet.md` — CREATED
+
+**Structure:**
+
+```
+# Cheat Sheet
+
+~~~admonish info title="What You'll Learn"
+- Quick reference for all Path types, operators, and escape hatches
+- At-a-glance lookup for daily use
+~~~
+```
+
+Three reference tables (as previously specified in the plan):
+
+**Section 1: Path Types at a Glance**
+
+| Type | For | Create with | Run with |
+|------|-----|-------------|----------|
+| `MaybePath<A>` | Absence | `Path.maybe(v)` / `Path.just(v)` | `.run()` |
+| `EitherPath<E, A>` | Typed errors | `Path.right(v)` / `Path.left(e)` | `.run()` |
+| `TryPath<A>` | Exceptions | `Path.tryOf(() -> ...)` | `.run()` |
+| `ValidationPath<E, A>` | Accumulating errors | `Path.valid(v, sg)` | `.run()` |
+| `IOPath<A>` | Side effects | `Path.io(() -> ...)` | `.unsafeRun()` |
+| `VTaskPath<A>` | Concurrency | `Path.vtask(() -> ...)` | `.run()` |
+| `ReaderPath<R, A>` | Dependency injection | `Path.reader(fn)` | `.run(env)` |
+| `WriterPath<W, A>` | Logging/audit | `Path.writer(v, log)` | `.run()` |
+| `WithStatePath<S, A>` | Stateful computation | `Path.state(fn)` | `.run(initial)` |
+| `TrampolinePath<A>` | Stack-safe recursion | `Path.trampoline(...)` | `.run()` |
+| `LazyPath<A>` | Deferred + memoised | `Path.lazy(() -> ...)` | `.run()` |
+
+**Section 2: Common Operators**
+
+(as previously specified, plus `zipWith`, `zipWith3`, `parZipWith`, `fold`)
+
+**Section 3: Escape Hatches**
+
+(as previously specified, expanded with all path types)
+
+**Section 4: Type Conversions**
+
+| From | To | How |
+|------|----|-----|
+| `MaybePath` | `EitherPath` | `.toEitherPath(errorSupplier)` |
+| `TryPath` | `EitherPath` | `.toEitherPath(exMapper)` |
+| `EitherPath` | `MaybePath` | `.toMaybePath()` |
+| `FocusPath` | `MaybePath` | `.toMaybePath()` |
+| `FocusPath` | `EitherPath` | `.toEitherPath(errorFn)` |
+
+**Style guide compliance:**
+- "What You'll Learn" admonishment at top
+- Horizontal rules between sections
+- Navigation links: `**Previous:** [Quickstart](quickstart.md)` / `**Next:** [Effect Path API](effect/ch_intro.md)`
+- No em dashes; semicolons where needed
+- British English throughout
+
+**Why:** Developers bookmark cheat sheets. This becomes the page they return to daily until the API is muscle memory.
+
+---
+
+#### Task 0.3: Add "Which Path?" Visual Flowchart ✓
+
+**File:** `hkj-book/src/effect/path_types.md` — UPDATED (ASCII flowchart added above existing prose)
+
+**What:** Add an ASCII decision tree **above** the existing prose-based guide. The flowchart should cover the 6 most common path types. The existing prose sections remain below as the detailed explanation.
+
+```
+                         START HERE
+                             │
+                  Can the operation fail?
+                       /          \
+                     No            Yes
+                     │              │
+              Is the value      Do you need ALL
+              optional?          errors at once?
+               /     \            /          \
+             Yes      No        Yes           No
+              │        │         │             │
+          MaybePath  IdPath  ValidationPath    │
+                                          Is the error a
+                                          typed domain error
+                                          or an exception?
+                                           /            \
+                                        Typed        Exception
+                                         │              │
+                                     EitherPath     TryPath
+```
+
+Add a brief note below: *"For deferred side effects, see `IOPath`. For virtual-thread concurrency, see `VTaskPath`. For stack-safe recursion, see `TrampolinePath`."*
+
+**Why:** Faster to scan than prose. Developers in a hurry can follow the arrows in 5 seconds.
+
+---
+
+#### Task 0.4: Add Escape Hatches Section to Effect Path Overview ✓
+
+**File:** `hkj-book/src/effect/effect_path_overview.md` — UPDATED (escape hatches section added before Summary)
+
+**What:** Add a section titled **"Getting Back to Standard Java"** near the end of the overview, before any "What's Next" or navigation links. Include a brief intro paragraph and code block:
+
+```java
+// Every path has a clean exit
+Maybe<User> maybe = maybePath.run();                       // Maybe
+Either<AppError, User> either = eitherPath.run();          // Either
+Optional<User> opt = maybePath.run().toOptional();         // java.util.Optional
+User user = eitherPath.run().getOrElse(User.anonymous());  // raw value
+String msg = tryPath.run().fold(Throwable::getMessage, Object::toString);
+```
+
+One-sentence framing: *"You are never locked in. Every Path type unwraps to a standard Java value with `.run()`, and `.fold()` gives you full control over both tracks."*
+
+**Why:** Adoption anxiety is real. Developers worry about committing to a paradigm they cannot escape. Showing the exit reduces the perceived risk of trying the library.
+
+---
+
+#### Task 0.5: Update SUMMARY.md ✓
+
+**File:** `hkj-book/src/SUMMARY.md` — UPDATED (Quickstart and Cheat Sheet added as first entries)
+
+**What:** Add Quickstart and Cheat Sheet as the first entries after the home page:
+
+```markdown
+[Introduction to Higher-Kinded-J](home.md)
+
+- [Quickstart](quickstart.md)
+- [Cheat Sheet](cheatsheet.md)
+
+- [Effect Path API](effect/ch_intro.md)
+  ...
+```
+
+These must be top-level entries (not nested under a chapter) so they appear as the first sidebar items after the landing page.
+
+---
+
+#### Task 0.6: Slim Down home.md (Content Migration) ✓
+
+**File:** `hkj-book/src/home.md` — UPDATED (Getting Started replaced with quickstart link; Documentation Guide updated)
+
+**What to change:**
+
+1. **Replace the "Getting Started" section** (lines ~250-284 in current home.md) with a short paragraph and link:
+   > Ready to start? See the **[Quickstart](quickstart.md)** for setup instructions and your first Effect Path in 5 minutes.
+
+   The full Gradle/Maven dependency blocks and Java 25 note currently in home.md move to quickstart.md. This eliminates duplication and ensures there is a single source of truth for setup instructions (the quickstart).
+
+2. **Keep the "Path Types at a Glance" table** in home.md. It serves a different purpose here (selling the breadth of the library) than in the cheatsheet (daily reference with create/run columns). No change needed.
+
+3. **Keep the before/after code examples**. The home.md examples are narrative-driven (demonstrating the pyramid problem). The quickstart examples are copy-paste-driven (minimal, self-contained). They serve different audiences.
+
+4. **Add a link to the Cheat Sheet** in the "Documentation Guide" section, under "Effect Path API (Start Here)":
+   > 0. **[Quickstart](quickstart.md):** Setup and first examples in 5 minutes
+   > 0b. **[Cheat Sheet](cheatsheet.md):** One-page operator reference
+
+**Why:** home.md should be the "why" page (narrative, vision, selling points). quickstart.md should be the "how" page (setup, copy-paste, go). Currently home.md tries to be both.
+
+---
+
+#### Task 0.7: Slim Down README.md (Content Migration) ✓
+
+**File:** `README.md` (project root) — UPDATED (--enable-preview added to Requirements and Gradle snippet; quickstart link added)
+
+**What to change:**
+
+1. **Replace the "How to Use This Library" section** with a shorter version that links to the quickstart:
+   ```markdown
+   ## Getting Started
+
+   > **Requires Java 25** with preview features enabled.
+
+   ```gradle
+   dependencies {
+       implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
+       annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
+   }
+   ```
+
+   See the **[Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart.html)** for full setup including Maven, preview flags, and first examples.
+   ```
+
+2. **Add `--enable-preview` to the Requirements section.** The current README says "Java Development Kit (JDK): Version 25 or later" but does not mention preview features. Update to:
+   > **Java Development Kit (JDK): Version 25** or later, with `--enable-preview` enabled. Higher-Kinded-J uses Java preview features. See the [Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart.html) for Gradle and Maven configuration.
+
+3. **Keep all other content** (feature comparison table, Spring Boot section, project structure, etc.). The README serves GitHub visitors who may never visit the docs site; it needs to remain self-contained for its audience.
+
+**Why:** The README currently duplicates the dependency block without the critical `--enable-preview` flags. Linking to the quickstart creates a single source of truth and fixes the missing preview requirement.
+
+---
+
+### Phase 1: Enhance the Railway Metaphor (Effect Path Chapter) — PARTIALLY COMPLETE
+
+#### Task 1.1: Add ROP Operator Mapping Table ✓
+**File:** `hkj-book/src/effect/effect_path_overview.md` — UPDATED (operator mapping table added with green/red colour coding)
+**What:** Add a reference table mapping every Path operator to its ROP concept:
+
+| Operator | ROP Concept | Description |
+|----------|-------------|-------------|
+| `map` | Green Track transform | Transforms data on the success track |
+| `mapError` | Red Track transform | Transforms data on the error track |
+| `via` / `flatMap` | Track Switch | Chains an operation that may divert success to failure |
+| `recover` | Red-to-Green Switch | Recovers from failure back to success |
+| `ensure` | Green-to-Red Switch | Validates, diverting success to failure |
+| `peek` | Siding | Side-effect observation without changing tracks |
+| `orElse` | Fallback Junction | Tries an alternative path if the first fails |
+
+**Why:** Makes the metaphor concrete and gives developers a shared vocabulary.
+
+#### Task 1.2: Enhance Railway Diagrams Per Operator
+**File:** `hkj-book/src/effect/effect_path_overview.md`
+**What:** For each operator in the mapping table, add a small ASCII diagram showing the track behaviour. Example for `via`:
+
+```
+  Success ═══●══╗
+                ╠═══ via(fn) ═══●═══▶ continues on success
+  Failure ═══●══╝                 ╲
+                                   ╲══▶ diverts to failure
+```
+
+**Why:** Visual learners need to see the switch points.
+
+---
+
+### Phase 2: Stack Archetypes (Transformers Chapter)
+
+#### Task 2.1: Create Stack Archetypes Reference
+**File:** `hkj-book/src/transformers/ch_intro.md` (or new `transformers/archetypes.md`)
+**What:** Define 3-4 named archetype stacks that cover common use cases:
+
+| Archetype | Path Type | Raw Stack | Use Case |
+|-----------|-----------|-----------|----------|
+| **The Service Stack** | `EitherPath<AppError, A>` | `EitherT<IO, AppError, A>` | Standard business logic (async + typed failure) |
+| **The Lookup Stack** | `MaybePath<A>` | `MaybeT<IO, A>` | Optional lookups (async + absence) |
+| **The Validation Stack** | `ValidationPath<List<String>, A>` | N/A (direct) | Form/input validation (accumulating errors) |
+| **The Context Stack** | `ReaderPath<Config, A>` | `ReaderT<IO, Config, Either<E, A>>` | Systems with shared context (tracing, auth, config) |
+
+For each archetype include:
+- A 3-sentence description of when to use it
+- A minimal code example (5-10 lines)
+- The Path API equivalent (showing that users don't need the raw stack)
+
+**Why:** Reduces cognitive load by giving developers named patterns rather than requiring them to design transformer stacks from scratch. Aligns with Cognitive Load Theory (the report's "chunks" argument).
+
+#### Task 2.2: Add "Path First, Stack Later" Bridge
+**File:** `hkj-book/src/transformers/transformers.md`
+**What:** Add a prominent note at the top of the transformers chapter:
+
+> **Most users don't need to read this chapter.** The Effect Path API (Chapter 1) wraps these transformers into a fluent interface. Start there. Come here when you need to build custom transformer stacks or understand what happens under the hood.
+
+Include a cross-reference table showing which Path type wraps which transformer.
+
+**Why:** Prevents intermediate developers from diving into raw transformers when the Path API would serve them better.
+
+---
+
+### Phase 3: Capstone Example (Focus-Effect Unification)
+
+#### Task 3.1: Create Unified Before/After Capstone
+**File:** New section in `hkj-book/src/effect/focus_integration.md` or new `hkj-book/src/examples/capstone_order.md`
+**What:** A single end-to-end example that demonstrates Effects + Optics working together. The report's suggested scenario is good:
+
+**Scenario:** Update the shipping address postcode of an order.
+- Load order asynchronously (Async)
+- Order might not exist (Optional)
+- Validate the new postcode (Failure)
+- Shipping address is nested 3 levels deep (Optics)
+
+**Before (Standard Java):** 20+ lines of nested if/else, try/catch, manual field access.
+
+**After (HKJ):**
+```java
+return Path.from(repo.findOrder(id))         // MaybePath
+    .toEitherPath(OrderNotFound::new)         // → EitherPath
+    .focus(OrderFocus.shippingAddress())       // Lens into nested data
+    .focus(AddressFocus.postcode())            // Deeper lens
+    .via(this::validatePostcode)               // Validation
+    .map(Order::save);                         // Persist
+```
+
+**Why:** Demonstrates the unique value of HKJ (no other Java library combines transformers + optics this cleanly). This should be the "aha moment" in the documentation.
+
+#### Task 3.2: Link Capstone from Multiple Chapters
+**Files:** `effect/ch_intro.md`, `optics/ch5_intro.md`, `transformers/ch_intro.md`
+**What:** Add cross-references to the capstone from each relevant chapter's intro, so readers discover it from wherever they enter the documentation.
+
+---
+
+### Phase 4: Spring Boot Refactoring Recipes
+
+#### Task 4.1: "Functional Controller" Recipe
+**File:** `hkj-book/src/spring/spring_boot_integration.md` or new `spring/recipes.md`
+**What:** Show how to convert `EitherPath<AppError, T>` directly into a Spring `ResponseEntity`:
+
+```java
+@GetMapping("/users/{id}")
+public ResponseEntity<?> getUser(@PathVariable String id) {
+    return userService.findUser(id)              // EitherPath<AppError, User>
+        .run()
+        .fold(
+            error -> switch (error) {
+                case NotFound e -> ResponseEntity.notFound().build();
+                case ValidationError e -> ResponseEntity.badRequest().body(e.messages());
+                case Unauthorized e -> ResponseEntity.status(403).build();
+            },
+            user -> ResponseEntity.ok(user)
+        );
+}
+```
+
+Include an explanation of why this replaces scattered `try/catch` + `@ExceptionHandler` patterns.
+
+#### Task 4.2: "ReaderT vs @Autowired" Bridge
+**File:** `hkj-book/src/effect/advanced_effects.md` or `spring/spring_boot_integration.md`
+**What:** Add a section explicitly comparing Spring's DI with ReaderT/ReaderPath:
+
+| Concept | Spring DI | ReaderPath |
+|---------|-----------|------------|
+| Provide dependency | `@Autowired` on field | `.run(context)` at the edge |
+| Access dependency | Direct field access | `.ask()` / `Path.reader(ctx -> ...)` |
+| Scope | Container-managed (singleton/request) | Explicit, passed through composition |
+| Testing | MockBean / TestConfiguration | Just pass a test context |
+
+**Why:** Java developers think in Spring. Meeting them where they are reduces the conceptual leap.
+
+---
+
+### Phase 5: Production Readiness Section
+
+#### Task 5.1: Create Production Readiness Page
+**File:** New `hkj-book/src/effect/production_readiness.md`
+**What:** Three subsections:
+
+**Stack Traces:**
+- Acknowledge that Path chains create deeper stack traces than imperative code
+- Show an annotated example of a typical stack trace and how to read it
+- Explain that `peek` can be used to add debug logging at specific points in the chain
+
+**Allocation Overhead:**
+- Explain that each step in a Path chain creates a small wrapper object
+- Provide a cost comparison: wrapper allocation (nanoseconds) vs I/O operations (milliseconds)
+- Conclusion: "The overhead is negligible compared to any database call, HTTP request, or file operation"
+
+**Stack Safety (Trampolining):**
+- Explain that the JVM lacks Tail Call Optimization
+- Show when recursive Path chains can overflow the stack
+- Introduce `TrampolinePath` as the solution
+- Provide a simple before/after example
+
+#### Task 5.2: Link from Transformers and Effect Chapters
+**Files:** `effect/ch_intro.md`, `transformers/ch_intro.md`
+**What:** Add Production Readiness to the chapter contents and SUMMARY.md.
+
+---
+
+### Phase 6: Minor Enhancements
+
+#### Task 6.1: Consistent Before/After Pattern
+**Files:** Multiple effect and transformer docs
+**What:** Audit existing documentation and ensure that wherever a concept is introduced, there's a clear before/after comparison:
+- **Before:** The imperative Java code with the problem
+- **After:** The HKJ code solving it
+- Each pair should have brief annotations explaining what changed
+
+#### Task 6.2: Add Transformer Railway Diagrams
+**File:** `hkj-book/src/transformers/transformers.md`
+**What:** Add ROP-style diagrams to the transformer chapter showing how `EitherT`, `MaybeT`, etc. provide unified track management across two effect layers. Currently the transformer docs have good ASCII art for stacking but don't use the railway visual language established in the Effect Path chapter.
+
+#### Task 6.3: Update SUMMARY.md — PARTIALLY COMPLETE
+**File:** `hkj-book/src/SUMMARY.md`
+**What:** Add new pages created by this plan to the book's table of contents:
+- ~~Quickstart and Cheat Sheet at the top (Phase 0)~~ ✓ Done
+- Stack Archetypes under Advanced Topics (transformers)
+- Production Readiness under Effect Path API
+- Migration Cookbook and Compiler Errors under Effect Path or a new Troubleshooting section
+- Any new recipe pages under Integration Guides (Spring)
+
+---
+
+### Phase 7: Migration Cookbook and Compiler Error Guide (New)
+
+#### Task 7.1: Create Migration Cookbook
+**File:** New `hkj-book/src/effect/migration_cookbook.md`
+**What:** A pattern-by-pattern translation guide from imperative Java to HKJ. Each recipe is a two-column before/after with a one-sentence explanation:
+
+**Recipe: try/catch → TryPath**
+```java
+// Before                              // After
+try {                                  Path.tryOf(() -> riskyOperation())
+    Result r = riskyOperation();           .map(this::transform)
+    return transform(r);                   .recover(ex -> fallback())
+} catch (Exception e) {                    .run();
+    return fallback();
+}
+```
+
+**Recipe: Optional chains → MaybePath**
+```java
+// Before                              // After
+return findUser(id)                    Path.maybe(findUser(id))
+    .flatMap(u -> findAddress(u))          .via(u -> Path.maybe(findAddress(u)))
+    .map(Address::city)                    .map(Address::city)
+    .orElse("Unknown");                    .run().orElse("Unknown");
+```
+
+**Recipe: CompletableFuture nesting → EitherPath**
+**Recipe: Nested if/null checks → MaybePath**
+**Recipe: Accumulating validation errors → ValidationPath**
+**Recipe: Deeply nested record updates → FocusPath**
+
+**Why:** Developers don't think "I need a MaybePath." They think "I have this ugly Optional chain." Meeting them at their current code pattern is the fastest path to adoption.
+
+#### Task 7.2: Create Common Compiler Errors Guide
+**File:** New `hkj-book/src/effect/compiler_errors.md` or `tutorials/troubleshooting.md` (enhance existing)
+**What:** Document the 5 most common compiler errors when using the Effect Path API, with the actual error message, what it means, and how to fix it:
+
+1. **"Incompatible types: EitherPath<X, Y> cannot be converted to MaybePath<Y>"**
+   - You're mixing path types in a chain. Use `.toEitherPath()` or `.toMaybePath()` to convert.
+
+2. **"Cannot infer type arguments for Path.right(...)"**
+   - Java can't figure out the error type. Add explicit type: `Path.<AppError, User>right(user)`.
+
+3. **"Method via in type X is not applicable for the arguments"**
+   - The function passed to `via` returns the wrong path type. Check that it returns the same path kind.
+
+4. **"No suitable method found for map(...)"**
+   - Lambda type inference failed. Add explicit parameter types to the lambda.
+
+5. **"Type argument X is not within bounds of type-variable E"**
+   - Error type mismatch in a chain. All steps must use the same error type, or use `mapError` to convert.
+
+Each entry should include the full compiler message (as developers would see it), a minimal code snippet that triggers it, and the fix.
+
+**Why:** Nothing kills adoption faster than a cryptic compiler error with no Google results. This page becomes the first search result.
+
+---
+
+## Implementation Order
+
+The tasks are ordered by impact (highest value first):
+
+1. **Phase 0: Quickstart & Onboarding** ✓ COMPLETE
+2. **Phase 2: Stack Archetypes** - Highest bang for buck; gives developers named patterns
+3. **Phase 5: Production Readiness** - Builds trust with senior engineers (the decision makers)
+4. **Phase 7: Migration Cookbook** - Meets developers at their existing code
+5. **Phase 1: ROP Enhancement** - PARTIALLY COMPLETE (Task 1.1 done; Task 1.2 remaining)
+6. **Phase 3: Capstone Example** - The "aha moment" that sells the library
+7. **Phase 4: Spring Recipes** - Meets developers where they are
+8. **Phase 6: Minor Enhancements** - Polish and consistency (Task 6.3 partially done for Phase 0 items)
+
+Each phase is independent and can be worked in parallel or reordered based on priority.
+
+---
+
+## Bonus Work Completed
+
+The following enhancements were completed during Phase 0 as additional improvements:
+
+- **Green/red colour coding for railway diagrams** — Applied HTML `<span>` colour styling (green #4CAF50 for success, red #F44336 for failure) to diagrams in:
+  - `effect/effect_path_overview.md` — Main railway diagram and operator mapping table
+  - `transformers/ch_intro.md` — Before/after stacking concept (red=problem, green=solution)
+  - `transformers/eithert_transformer.md` — Left(error) red, Right(value) green
+  - `transformers/maybet_transformer.md` — Nothing red, Just(value) green
+  - `transformers/optionalt_transformer.md` — empty() red, of(value) green
+- **Operator-to-ROP mapping table** — Added to `effect_path_overview.md` (originally drafted for cheat sheet, moved to overview where the railway metaphor is introduced with visual context)
+
+---
+
+## What NOT to Change
+
+The report's analysis is thorough, but several of its recommendations are already implemented. To avoid unnecessary churn:
+
+- **Do NOT restructure SUMMARY.md ordering** - It's already Path-First
+- **Do NOT rename the transformers chapter** - "Advanced Topics" is appropriate; the report's suggestion to rename to "Railway Oriented Java" would conflict with the Effect Path chapter which already owns that metaphor
+- **Do NOT remove or downplay HKT documentation** - It's correctly placed at the bottom under "Foundations" for advanced users
+- **Do NOT add the comparative analysis table (HKJ vs Vavr vs Cats)** to the book - This belongs in the README or marketing materials, not the learning path


### PR DESCRIPTION
- Add quickstart.md with Gradle/Maven setup (including --enable-preview), 
- cheatsheet.md with path types, operators, escape hatches, and type conversions. 
- Add decision flowchart to path_types.md, escape hatches section to effect_path_overview.md, and green/red railway colour coding across effect and transformer diagrams.
-  Slim down home.md and README.md to link to quickstart as single source of truth for setup. 
- Include restructure plan and pedagogical report as planning references.

Fixes #348 