### PR TITLE
Restructure Phase 2: Stack Archetypes documentation and examples

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -34,6 +34,7 @@
   - [Advanced Topics](effect/advanced_topics.md)
 
 - [Advanced Topics](transformers/ch_intro.md)
+  - [Stack Archetypes](transformers/archetypes.md)
   - [Monad Transformers](transformers/transformers.md)
   - [EitherT](transformers/eithert_transformer.md)
   - [OptionalT](transformers/optionalt_transformer.md)

--- a/hkj-book/src/transformers/archetypes.md
+++ b/hkj-book/src/transformers/archetypes.md
@@ -1,0 +1,536 @@
+# Stack Archetypes: Named Patterns for Common Problems
+
+Every enterprise application juggles multiple concerns: typed errors, optional lookups, validation, shared context, audit trails, stateful workflows, and safe recursion. Rather than designing a composition strategy from scratch each time, these **named archetypes** give you a ready-made pattern for the most common situations.
+
+~~~admonish info title="What You'll Learn"
+- Seven named stack archetypes that cover the vast majority of enterprise use cases
+- Which Path type to reach for when you recognise a familiar problem
+- How each archetype maps to its underlying monad transformer (for when you need the raw machinery)
+- How archetypes compose together in real-world workflows
+~~~
+
+~~~admonish example title="See Example Code"
+[ArchetypeExamples.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/effect/ArchetypeExamples.java)
+~~~
+
+---
+
+## Archetypes at a Glance
+
+| Archetype | Path Type | Underlying Type | Enterprise Use Case |
+|-----------|-----------|-----------------|---------------------|
+| [Service Stack](#the-service-stack) | `EitherPath<E, A>` | `Either<E, A>` | Typed domain errors with short-circuit |
+| [Lookup Stack](#the-lookup-stack) | `MaybePath<A>` | `Maybe<A>` | Optional lookups with fallback chains |
+| [Validation Stack](#the-validation-stack) | `ValidationPath<E, A>` | `Validated<E, A>` | Collecting all errors, not just the first |
+| [Context Stack](#the-context-stack) | `ReaderPath<R, A>` | `Reader<R, A>` | Dependency injection; multi-tenant context |
+| [Audit Stack](#the-audit-stack) | `WriterPath<W, A>` | `Writer<W, A>` | Compliance audit trails; structured logging |
+| [Workflow Stack](#the-workflow-stack) | `WithStatePath<S, A>` | `State<S, A>` | State machine transitions; stateful pipelines |
+| [Safe Recursion Stack](#the-safe-recursion-stack) | `TrampolinePath<A>` | `Trampoline<A>` | Stack-safe recursion; paginated aggregation |
+
+---
+
+## The Service Stack
+
+**Path type:** `EitherPath<E, A>`
+**Underlying type:** `Either<E, A>`
+**Raw transformer:** `EitherT<F, E, A>`
+
+### The problem
+
+Your service method can fail in multiple, domain-specific ways: insufficient funds, account suspended, gateway timeout. Traditional Java forces a choice between checked exceptions (verbose, uncompilable in lambdas) and unchecked exceptions (invisible, unsafe). Neither option composes cleanly across a multi-step pipeline.
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Success</b> ═══●══════════●══════════●══════════●═══▶  Confirmation</span>
+    <span style="color:#4CAF50">          right      via        via       map</span>
+    <span style="color:#4CAF50">        (account)  (validate)  (charge)</span>
+                        ╲            ╲
+                         ╲            ╲  error: switch tracks
+                          ╲            ╲
+    <span style="color:#F44336"><b>Failure</b> ────────────●────────────●──────────────▶  PaymentError</span>
+    <span style="color:#F44336">              InsufficientFunds  GatewayTimeout</span>
+                                        │
+                                   <span style="color:#4CAF50">recoverWith</span>    circuit-breaker: retry once
+                                        │
+    <span style="color:#4CAF50">                                    ●═══▶  retried Confirmation</span>
+</pre>
+
+### The solution
+
+```java
+// Domain error hierarchy
+sealed interface PaymentError {
+    record InsufficientFunds(String accountId, double shortfall) implements PaymentError {}
+    record AccountNotFound(String accountId) implements PaymentError {}
+    record AccountSuspended(String accountId) implements PaymentError {}
+    record GatewayTimeout(String provider) implements PaymentError {}
+}
+
+// Service method returning a typed error channel
+EitherPath<PaymentError, PaymentConfirmation> processPayment(PaymentRequest request) {
+    return Path.<PaymentError, Account>right(lookupAccount(request.accountId()))
+        .via(account -> validateBalance(account, request.amount()))
+        .via(account -> chargeAccount(account, request.amount()))
+        .map(charge -> new PaymentConfirmation(charge.transactionId()));
+}
+
+// Circuit-breaker with retry: recover from transient failures
+EitherPath<PaymentError, PaymentConfirmation> resilientPayment(PaymentRequest request) {
+    return processPayment(request)
+        .recoverWith(error -> switch (error) {
+            case PaymentError.GatewayTimeout t -> processPayment(request);  // retry once
+            default -> Path.left(error);                                    // propagate
+        });
+}
+```
+
+### When to use
+
+This is the default archetype. Most service-layer methods that can fail with domain-specific errors should start here. The typed error channel makes every failure mode visible in the method signature, and `recoverWith` gives you a natural place for circuit-breaker and retry logic.
+
+### The imperative alternative
+
+```java
+// Without EitherPath: scattered try/catch, invisible error modes
+try {
+    Account account = lookupAccount(request.accountId());
+    if (account.balance() < request.amount()) {
+        throw new InsufficientFundsException(account.id(), ...);
+    }
+    Charge charge = chargeAccount(account, request.amount());
+    return new PaymentConfirmation(charge.transactionId());
+} catch (GatewayTimeoutException e) {
+    // Retry logic mixed with business logic
+    return processPayment(request);  // but what about the other exceptions?
+}
+```
+
+---
+
+## The Lookup Stack
+
+**Path type:** `MaybePath<A>`
+**Underlying type:** `Maybe<A>`
+**Raw transformer:** `MaybeT<F, A>`
+
+### The problem
+
+You need to resolve a value from multiple sources with a defined priority: first check the database, then the environment, then fall back to defaults. Each source might return nothing. With `Optional`, you end up with nested `flatMap` chains that obscure the fallback logic.
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Present</b>  ═══●═══════════════════════════════════════▶  Config</span>
+    <span style="color:#4CAF50">         database</span>
+                ╲
+                 ╲  nothing: try next source
+                  ╲
+    <span style="color:#F44336"><b>Absent</b></span>   ──────●
+                  │ <span style="color:#4CAF50">orElse</span>
+    <span style="color:#4CAF50"><b>Present</b>  ═════●═════════════════════════════════════▶  Config</span>
+    <span style="color:#4CAF50">         environment</span>
+                  ╲
+                   ╲  nothing: try next source
+                    ╲
+    <span style="color:#F44336"><b>Absent</b></span>   ────────●
+                    │ <span style="color:#4CAF50">orElse</span>
+    <span style="color:#4CAF50"><b>Present</b>  ═══════●═══════════════════════════════════▶  Config</span>
+    <span style="color:#4CAF50">          defaults (guaranteed)</span>
+</pre>
+
+### The solution
+
+```java
+MaybePath<Config> resolveConfig(String key) {
+    return lookupFromDatabase(key)                          // MaybePath<Config>
+        .orElse(() -> lookupFromEnvironment(key))           // try next source
+        .orElse(() -> Path.just(Config.defaultFor(key)));   // guaranteed fallback
+}
+
+// Each lookup returns MaybePath
+MaybePath<Config> lookupFromDatabase(String key) {
+    return Path.maybe(database.find(key));   // Nothing if absent
+}
+```
+
+### When to use
+
+Whenever absence is normal and expected, not an error. Cache lookups, configuration resolution, optional user preferences, feature flag checks. If the caller needs to know *why* the value is missing, use the Service Stack instead.
+
+### The imperative alternative
+
+```java
+// Without MaybePath: null-check chains
+Config config = database.find(key);
+if (config == null) {
+    config = System.getenv(key) != null ? Config.parse(System.getenv(key)) : null;
+}
+if (config == null) {
+    config = Config.defaultFor(key);
+}
+```
+
+---
+
+## The Validation Stack
+
+**Path type:** `ValidationPath<E, A>`
+**Underlying type:** `Validated<E, A>`
+**No direct transformer equivalent**
+
+### The problem
+
+A REST API receives a request body with multiple fields. Each field has its own validation rules. The caller expects *all* validation failures in a single response, not one at a time. The Service Stack's short-circuit behaviour is wrong here; you need error accumulation.
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50">validateName ════●═══╗</span>
+                        ║
+    <span style="color:#4CAF50">validateEmail ═══●═══╬═══ zipWith3Accum ═══●═══▶  Registration</span>
+                        ║
+    <span style="color:#4CAF50">validateAge ════●════╝</span>
+
+    If any fail, errors <b>accumulate</b> (not short-circuit):
+
+    <span style="color:#F44336">validateName ────●───╗</span>
+    <span style="color:#F44336">  "Name too short"   ║</span>
+                        <span style="color:#F44336">╠═══ zipWith3Accum ═══●═══▶  List[err1, err2]</span>
+    <span style="color:#F44336">validateEmail ───●───╝</span>
+    <span style="color:#F44336">  "Invalid email"</span>
+                        ║
+    <span style="color:#4CAF50">validateAge ════●════╝</span>
+    <span style="color:#4CAF50">  (valid, but still</span>
+    <span style="color:#4CAF50">   collected with errors)</span>
+</pre>
+
+### The solution
+
+```java
+Semigroup<List<String>> errors = Semigroups.list();
+
+ValidationPath<List<String>, String> validateName(String name) {
+    return name != null && name.length() >= 2
+        ? Path.valid(name, errors)
+        : Path.invalid(List.of("Name must be at least 2 characters"), errors);
+}
+
+ValidationPath<List<String>, String> validateEmail(String email) {
+    return email != null && email.contains("@")
+        ? Path.valid(email, errors)
+        : Path.invalid(List.of("Invalid email format"), errors);
+}
+
+// Accumulate ALL errors, not just the first
+ValidationPath<List<String>, Registration> validateRequest(RegistrationRequest req) {
+    return validateName(req.name())
+        .zipWith3Accum(
+            validateEmail(req.email()),
+            validateAge(req.age()),
+            Registration::new
+        );
+}
+// Invalid case returns: List["Name must be at least 2 characters", "Invalid email format"]
+```
+
+### When to use
+
+API request validation, form input checking, configuration file parsing; anywhere the user benefits from seeing all problems at once. If you only need the first error, the Service Stack is simpler.
+
+### The imperative alternative
+
+```java
+// Without ValidationPath: manual error list accumulation
+List<String> errors = new ArrayList<>();
+if (name == null || name.length() < 2) errors.add("Name must be at least 2 characters");
+if (email == null || !email.contains("@")) errors.add("Invalid email format");
+if (age < 0 || age > 150) errors.add("Age must be between 0 and 150");
+if (!errors.isEmpty()) return ResponseEntity.badRequest().body(errors);
+// ... proceed with validated data (but the types don't prove it's valid)
+```
+
+---
+
+## The Context Stack
+
+**Path type:** `ReaderPath<R, A>`
+**Underlying type:** `Reader<R, A>`
+**Raw transformer:** `ReaderT<F, R, A>`
+
+### The problem
+
+In a multi-tenant SaaS application, every service call needs access to tenant context: the tenant ID, feature flags, rate limits, and the current user's permissions. Passing this context through every method parameter is tedious, error-prone, and clutters every signature. Spring's `@Autowired` solves this for singletons, but not for request-scoped data.
+
+### The solution
+
+```java
+record TenantContext(String tenantId, Set<String> featureFlags) {}
+
+// Service methods declare their dependency on context without receiving it yet
+ReaderPath<TenantContext, PricingPlan> resolvePricing() {
+    return Path.<TenantContext>ask()
+        .map(ctx -> ctx.featureFlags().contains("premium")
+            ? PricingPlan.PREMIUM
+            : PricingPlan.STANDARD);
+}
+
+ReaderPath<TenantContext, List<Product>> listProducts() {
+    return Path.<TenantContext>ask()
+        .map(ctx -> catalog.findByTenant(ctx.tenantId()));
+}
+
+// Compose without mentioning context at intermediate steps
+ReaderPath<TenantContext, ProductPage> buildProductPage() {
+    return resolvePricing()
+        .zipWith(listProducts(), ProductPage::new);
+}
+
+// Provide context once, at the edge
+ProductPage page = buildProductPage().run(currentTenantContext);
+```
+
+### When to use
+
+Multi-tenant systems, distributed tracing (threading trace IDs), security contexts (current user, permissions), or any situation where multiple service methods need shared request-scoped data. Particularly valuable in non-Spring contexts or when you need explicit, testable context management.
+
+### The imperative alternative
+
+```java
+// Without ReaderPath: context pollutes every signature
+PricingPlan resolvePricing(TenantContext ctx) { ... }
+List<Product> listProducts(TenantContext ctx) { ... }
+ProductPage buildProductPage(TenantContext ctx) {
+    return new ProductPage(resolvePricing(ctx), listProducts(ctx));
+}
+```
+
+---
+
+## The Audit Stack
+
+**Path type:** `WriterPath<W, A>`
+**Underlying type:** `Writer<W, A>`
+**No direct transformer in Higher-Kinded-J** (use `WriterPath` directly)
+
+### The problem
+
+Financial regulations require every step in a transaction to produce an audit entry. The audit log must be accumulated alongside the computation, not scattered across side-effecting logger calls that are invisible in the type system and easily forgotten.
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Value</b>   ═══●══════════════●══════════════●═══▶  TransferResult</span>
+    <span style="color:#4CAF50">         debit          credit         map</span>
+              │                │
+              ▼ <i>siding</i>        ▼ <i>siding</i>
+    <span style="color:#FFB300"><b>Log</b>     ──●──────────────●──────────────────▶  [DEBIT, CREDIT]</span>
+    <span style="color:#FFB300">       [DEBIT ...]    [CREDIT ...]</span>
+    <span style="color:#FFB300">                 accumulated via Monoid</span>
+</pre>
+
+### The solution
+
+```java
+Monoid<List<AuditEntry>> auditMonoid = Monoids.list();
+
+WriterPath<List<AuditEntry>, Account> debitAccount(Account account, double amount) {
+    Account updated = account.withBalance(account.balance() - amount);
+    return WriterPath.writer(
+        updated,
+        List.of(new AuditEntry("DEBIT", amount + " from " + account.id())),
+        auditMonoid
+    );
+}
+
+WriterPath<List<AuditEntry>, TransferResult> transfer(Account from, Account to, double amount) {
+    return debitAccount(from, amount)
+        .via(debited -> creditAccount(to, amount))
+        .map(credited -> new TransferResult(from.id(), to.id(), amount));
+}
+
+// Extract both result and accumulated audit trail
+Writer<List<AuditEntry>, TransferResult> result = transfer(from, to, 500.0).run();
+TransferResult outcome = result.value();
+List<AuditEntry> auditTrail = result.log();      // every step's audit entries, in order
+```
+
+### When to use
+
+Compliance-sensitive operations (financial transactions, healthcare record access, permission changes), structured logging where the log must travel with the computation, or any pipeline where you need a provable record of every step.
+
+### The imperative alternative
+
+```java
+// Without WriterPath: side-effecting logger calls, easy to forget
+Account debitAccount(Account account, double amount) {
+    logger.info("DEBIT {} from {}", amount, account.id());  // easy to forget this line
+    return account.withBalance(account.balance() - amount);
+}
+// The audit trail is scattered across log files, not attached to the result
+```
+
+---
+
+## The Workflow Stack
+
+**Path type:** `WithStatePath<S, A>`
+**Underlying type:** `State<S, A>`
+**Raw transformer:** `StateT<S, F, A>`
+
+### The problem
+
+An order fulfilment pipeline must track its current state as it progresses through stages: `Pending`, `Validated`, `Paid`, `Shipped`. Each step can inspect and update the state. With mutable fields, the state transitions are implicit and hard to test. With immutable records, you end up threading the state through every method return value manually.
+
+### The solution
+
+```java
+enum OrderStage { PENDING, VALIDATED, PAID, SHIPPED }
+
+record OrderState(OrderStage stage, List<String> events) {
+    OrderState advance(OrderStage next, String event) {
+        var updated = new java.util.ArrayList<>(events);
+        updated.add(event);
+        return new OrderState(next, List.copyOf(updated));
+    }
+}
+
+WithStatePath<OrderState, Unit> validateOrder() {
+    return WithStatePath.<OrderState>modify(
+        s -> s.advance(OrderStage.VALIDATED, "Order validated")
+    );
+}
+
+WithStatePath<OrderState, Unit> processPayment() {
+    return WithStatePath.<OrderState>modify(
+        s -> s.advance(OrderStage.PAID, "Payment processed")
+    );
+}
+
+// Compose steps; state threads through automatically
+WithStatePath<OrderState, OrderState> fulfil() {
+    return validateOrder()
+        .then(() -> processPayment())
+        .then(() -> shipOrder())
+        .then(WithStatePath::get);  // return final state
+}
+
+// Run with initial state
+OrderState initial = new OrderState(OrderStage.PENDING, List.of());
+OrderState finalState = fulfil().evalState(initial);
+// OrderState[stage=SHIPPED, events=[Order validated, Payment processed, Order shipped]]
+```
+
+### When to use
+
+Order processing pipelines, approval workflows, multi-step wizards, game state, or any computation where the state evolves through a defined sequence of transitions. Particularly powerful when combined with sealed types for the state, ensuring only valid transitions compile.
+
+### The imperative alternative
+
+```java
+// Without WithStatePath: mutable state, implicit transitions
+class OrderProcessor {
+    private OrderStage stage = OrderStage.PENDING;
+    private final List<String> events = new ArrayList<>();
+
+    void validate() { stage = OrderStage.VALIDATED; events.add("..."); }
+    void pay()      { stage = OrderStage.PAID;      events.add("..."); }
+    // State is mutable, transitions are unchecked, testing requires reset
+}
+```
+
+---
+
+## The Safe Recursion Stack
+
+**Path type:** `TrampolinePath<A>`
+**Underlying type:** `Trampoline<A>`
+**No transformer equivalent** (base effect for stack safety)
+
+### The problem
+
+You are aggregating data from a paginated external API. Each page returns a "next cursor" if more data exists. A naive recursive implementation overflows the stack after a few thousand pages. The JVM does not support tail-call optimisation.
+
+### The solution
+
+```java
+TrampolinePath<List<Record>> fetchAllPages(String cursor, List<Record> accumulated) {
+    Page page = api.fetch(cursor);
+    List<Record> all = new ArrayList<>(accumulated);
+    all.addAll(page.records());
+
+    if (page.nextCursor() == null) {
+        return TrampolinePath.done(List.copyOf(all));           // base case
+    }
+    return TrampolinePath.defer(                                // recursive case
+        () -> fetchAllPages(page.nextCursor(), all)             // no stack growth
+    );
+}
+
+// Safe even for millions of pages
+List<Record> allRecords = fetchAllPages(initialCursor, List.of()).run();
+```
+
+### When to use
+
+Paginated API aggregation, tree traversals, graph algorithms, recursive data transformations; any recursive algorithm that might exceed the JVM's stack depth. If your recursion depth is bounded to a small number (under a few hundred), plain recursion is fine.
+
+### The imperative alternative
+
+```java
+// Without TrampolinePath: manual loop (works, but less composable)
+List<Record> all = new ArrayList<>();
+String cursor = initialCursor;
+while (cursor != null) {
+    Page page = api.fetch(cursor);
+    all.addAll(page.records());
+    cursor = page.nextCursor();
+}
+```
+
+---
+
+## Combining Archetypes
+
+Real applications rarely use a single archetype in isolation. The Order Processing example in the Examples Gallery demonstrates multiple archetypes working together:
+
+- **Service Stack** (`EitherPath`) for the main workflow with typed `OrderError`
+- **Validation Stack** (`ValidationPath`) for input validation before processing
+- **Context Stack** (`ReaderPath`) for threading `WorkflowConfig` through the pipeline
+- **Audit Stack** (`WriterPath`) for compliance logging via `AuditLogWriter`
+
+The Path API's conversion methods (`toEitherPath`, `toMaybePath`, `toValidationPath`) make it straightforward to transition between archetypes at natural boundaries in your pipeline.
+
+```java
+// Validate first (accumulate all errors), then switch to service stack (short-circuit)
+EitherPath<OrderError, ValidatedOrder> validated =
+    validateRequest(request)                          // ValidationPath (accumulate)
+        .toEitherPath()                               // switch to EitherPath
+        .mapError(errors -> new OrderError.Invalid(errors));
+
+// Thread context through the validated pipeline
+ReaderPath<WorkflowConfig, EitherPath<OrderError, OrderResult>> pipeline =
+    Path.<WorkflowConfig>ask()
+        .map(config -> validated.via(order -> processOrder(order, config)));
+```
+
+---
+
+## Archetypes vs Raw Transformers
+
+Each archetype's Path type provides a fluent, concrete API. For most use cases, you never need the raw transformer. The table below shows the correspondence for when you do need to drop down:
+
+| Path Type | Corresponding Transformer | When to Use the Transformer |
+|-----------|--------------------------|----------------------------|
+| `EitherPath<E, A>` | `EitherT<F, E, A>` | Combining typed errors with a *different* outer monad (e.g. `CompletableFuture`) |
+| `MaybePath<A>` | `MaybeT<F, A>` | Combining absence with a different outer monad |
+| `OptionalPath<A>` | `OptionalT<F, A>` | Same as MaybeT, for `java.util.Optional` users |
+| `ReaderPath<R, A>` | `ReaderT<F, R, A>` | Combining environment reading with a different outer monad |
+| `WithStatePath<S, A>` | `StateT<S, F, A>` | Combining state with a different outer monad |
+| `ValidationPath<E, A>` | *(no transformer)* | Always use the Path type directly |
+| `WriterPath<W, A>` | *(no transformer)* | Always use the Path type directly |
+| `TrampolinePath<A>` | *(no transformer)* | Always use the Path type directly |
+
+~~~admonish tip title="See Also"
+- [Effect Path Overview](../effect/effect_path_overview.md) - The railway model and how Path types work
+- [Path Types](../effect/path_types.md) - Detailed reference for every Path type
+- [Order Processing Workflow](../examples/examples_order.md) - Full-scale example combining multiple archetypes
+- [Monad Transformers](transformers.md) - The raw transformer machinery underneath
+~~~
+
+---
+
+**Previous:** [Introduction](ch_intro.md)
+**Next:** [Monad Transformers](transformers.md)

--- a/hkj-book/src/transformers/ch_intro.md
+++ b/hkj-book/src/transformers/ch_intro.md
@@ -14,6 +14,12 @@ The result, `CompletableFuture<Either<DomainError, Result>>`, is technically cor
 
 Monad transformers solve this by wrapping the nested structure in a new type that provides a single, unified monadic interface. `EitherT<CompletableFutureKind.Witness, DomainError, Result>` is still `CompletableFuture<Either<DomainError, Result>>` underneath, but it offers one `flatMap` that sequences both the async and error-handling layers together. The nesting is hidden; the composition is restored.
 
+~~~admonish note title="Path First, Stack Later"
+Most users do not need to read this chapter. The [Effect Path API](../effect/ch_intro.md) wraps these transformers into a fluent interface that handles composition for you. Start there. Come here when you need to build custom transformer stacks or understand what happens under the hood.
+
+See [Stack Archetypes](archetypes.md) for named patterns that cover the most common use cases without requiring raw transformer manipulation.
+~~~
+
 Higher-Kinded-J provides five transformers, each adding a specific capability to any outer monad:
 
 ---
@@ -86,6 +92,7 @@ Same semantics. Vastly different ergonomics.
 ---
 
 ~~~admonish info title="In This Chapter"
+- **Stack Archetypes** – Seven named patterns (Service, Lookup, Validation, Context, Audit, Workflow, Safe Recursion) that cover the most common enterprise composition problems. Start here to find the right pattern for your use case.
 - **The Problem** – Monads don't compose naturally. A `CompletableFuture<Either<E, A>>` requires nested operations that become unwieldy. Transformers restore ergonomic composition.
 - **EitherT** – Adds typed error handling to any monad. Wrap your async operations with `EitherT` to get a single `flatMap` that handles both async sequencing and error propagation.
 - **OptionalT** – Lifts `java.util.Optional` into another monadic context. When your async operation might return nothing, OptionalT provides clean composition.
@@ -98,13 +105,14 @@ Same semantics. Vastly different ergonomics.
 
 ## Chapter Contents
 
-1. [Monad Transformers](transformers.md) - Why monads stack poorly and what transformers solve
-2. [EitherT](eithert_transformer.md) - Typed errors in any monadic context
-3. [OptionalT](optionalt_transformer.md) - Java Optional lifting
-4. [MaybeT](maybet_transformer.md) - Maybe lifting
-5. [ReaderT](readert_transformer.md) - Environment threading
-6. [StateT](statet_transformer.md) - State management in effectful computation
+1. [Stack Archetypes](archetypes.md) - Named patterns for the most common composition problems
+2. [Monad Transformers](transformers.md) - Why monads stack poorly and what transformers solve
+3. [EitherT](eithert_transformer.md) - Typed errors in any monadic context
+4. [OptionalT](optionalt_transformer.md) - Java Optional lifting
+5. [MaybeT](maybet_transformer.md) - Maybe lifting
+6. [ReaderT](readert_transformer.md) - Environment threading
+7. [StateT](statet_transformer.md) - State management in effectful computation
 
 ---
 
-**Next:** [Monad Transformers](transformers.md)
+**Next:** [Stack Archetypes](archetypes.md)

--- a/hkj-book/src/transformers/transformers.md
+++ b/hkj-book/src/transformers/transformers.md
@@ -14,6 +14,20 @@ If you've ever written a utility method that takes a `CompletableFuture<Either<E
 - How to choose the right transformer for your use case based on the effect you need to add
 ~~~
 
+~~~admonish note title="Prefer the Effect Path API?"
+The [Effect Path API](../effect/ch_intro.md) provides a fluent, concrete wrapper around these transformers. For most use cases you can work entirely with Path types and never touch the raw transformer machinery. See [Stack Archetypes](archetypes.md) for named patterns.
+
+| Path Type | Corresponding Transformer |
+|-----------|--------------------------|
+| `EitherPath<E, A>` | `EitherT<F, E, A>` |
+| `MaybePath<A>` | `MaybeT<F, A>` |
+| `OptionalPath<A>` | `OptionalT<F, A>` |
+| `ReaderPath<R, A>` | `ReaderT<F, R, A>` |
+| `WithStatePath<S, A>` | `StateT<S, F, A>` |
+
+Use the raw transformer when you need to combine effects with a *different* outer monad (e.g. `CompletableFuture`, `IO`, or a custom monad).
+~~~
+
 ![stand_back_monad_transformers.jpg](../images/stand_back_monad_transformers.jpg)
 
 ---
@@ -182,5 +196,5 @@ Higher-Kinded-J provides five transformers. Each solves a specific composition p
 
 ---
 
-**Previous:** [Introduction](ch_intro.md)
+**Previous:** [Stack Archetypes](archetypes.md)
 **Next:** [EitherT](eithert_transformer.md)

--- a/hkj-examples/src/main/java/org/higherkindedj/example/effect/ArchetypeExamples.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/effect/ArchetypeExamples.java
@@ -1,0 +1,468 @@
+// Copyright (c) 2025 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.effect;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.hkt.Semigroup;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.ReaderPath;
+import org.higherkindedj.hkt.effect.TrampolinePath;
+import org.higherkindedj.hkt.effect.ValidationPath;
+import org.higherkindedj.hkt.effect.WithStatePath;
+import org.higherkindedj.hkt.effect.WriterPath;
+
+/**
+ * Stack Archetype examples demonstrating the seven named patterns for common enterprise problems.
+ *
+ * <p>Each archetype demonstrates a different Effect Path type applied to a realistic enterprise
+ * scenario:
+ *
+ * <ul>
+ *   <li><b>Service Stack</b> ({@link EitherPath}) - Payment processing with typed domain errors and
+ *       circuit-breaker retry
+ *   <li><b>Lookup Stack</b> ({@link MaybePath}) - Multi-source configuration resolution with
+ *       fallback chains
+ *   <li><b>Validation Stack</b> ({@link ValidationPath}) - API request validation with error
+ *       accumulation
+ *   <li><b>Context Stack</b> ({@link ReaderPath}) - Multi-tenant SaaS with threaded tenant context
+ *   <li><b>Audit Stack</b> ({@link WriterPath}) - Financial transfer with compliance audit trail
+ *   <li><b>Workflow Stack</b> ({@link WithStatePath}) - Order fulfilment state machine
+ *   <li><b>Safe Recursion Stack</b> ({@link TrampolinePath}) - Paginated API aggregation without
+ *       stack overflow
+ * </ul>
+ *
+ * <p>Run with: {@code ./gradlew :hkj-examples:run
+ * -PmainClass=org.higherkindedj.example.effect.ArchetypeExamples}
+ *
+ * @see org.higherkindedj.hkt.effect.Path
+ */
+public class ArchetypeExamples {
+
+  public static void main(String[] args) {
+    System.out.println("=== Stack Archetype Examples ===\n");
+
+    serviceStack();
+    lookupStack();
+    validationStack();
+    contextStack();
+    auditStack();
+    workflowStack();
+    safeRecursionStack();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. THE SERVICE STACK (EitherPath)
+  //    Enterprise scenario: Payment processing with typed domain errors
+  //    and circuit-breaker retry for transient failures.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   try {
+  //       Account account = lookupAccount(id);
+  //       if (account.balance() < amount) throw new InsufficientFundsException(...);
+  //       Charge charge = chargeAccount(account, amount);
+  //       return new Confirmation(charge.txId());
+  //   } catch (GatewayTimeoutException e) { return processPayment(request); }
+
+  sealed interface PaymentError {
+    record InsufficientFunds(String accountId, double shortfall) implements PaymentError {}
+
+    record AccountNotFound(String accountId) implements PaymentError {}
+
+    record AccountSuspended(String accountId) implements PaymentError {}
+
+    record GatewayTimeout(String provider) implements PaymentError {}
+  }
+
+  record Account(String id, double balance, boolean active) {}
+
+  record PaymentConfirmation(String transactionId) {}
+
+  // Simulated account database
+  private static final Map<String, Account> ACCOUNTS =
+      Map.of(
+          "acc-1", new Account("acc-1", 1000.0, true),
+          "acc-2", new Account("acc-2", 50.0, true),
+          "acc-3", new Account("acc-3", 5000.0, false));
+
+  private static EitherPath<PaymentError, Account> lookupAccount(String accountId) {
+    Account account = ACCOUNTS.get(accountId);
+    if (account == null) {
+      return Path.left(new PaymentError.AccountNotFound(accountId));
+    }
+    return Path.right(account);
+  }
+
+  private static EitherPath<PaymentError, Account> validateBalance(Account account, double amount) {
+    if (!account.active()) {
+      return Path.left(new PaymentError.AccountSuspended(account.id()));
+    }
+    if (account.balance() < amount) {
+      return Path.left(
+          new PaymentError.InsufficientFunds(account.id(), amount - account.balance()));
+    }
+    return Path.right(account);
+  }
+
+  private static EitherPath<PaymentError, PaymentConfirmation> processPayment(
+      String accountId, double amount) {
+    return lookupAccount(accountId)
+        .via(account -> validateBalance(account, amount))
+        .map(account -> new PaymentConfirmation("tx-" + account.id() + "-" + (int) amount));
+  }
+
+  private static void serviceStack() {
+    System.out.println("--- 1. Service Stack (EitherPath): Payment Processing ---");
+
+    // Successful payment
+    var success = processPayment("acc-1", 200.0);
+    System.out.println("  Payment (acc-1, 200): " + success.run());
+
+    // Insufficient funds
+    var insufficient = processPayment("acc-2", 100.0);
+    System.out.println("  Payment (acc-2, 100): " + insufficient.run());
+
+    // Account suspended
+    var suspended = processPayment("acc-3", 10.0);
+    System.out.println("  Payment (acc-3, 10):  " + suspended.run());
+
+    // Circuit-breaker: recover from transient failures, propagate others
+    EitherPath<PaymentError, PaymentConfirmation> resilient =
+        Path.<PaymentError, PaymentConfirmation>left(new PaymentError.GatewayTimeout("stripe"))
+            .recoverWith(
+                error ->
+                    switch (error) {
+                      case PaymentError.GatewayTimeout t -> processPayment("acc-1", 200.0);
+                      default -> Path.left(error);
+                    });
+    System.out.println("  Retry after timeout:  " + resilient.run());
+    System.out.println();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. THE LOOKUP STACK (MaybePath)
+  //    Enterprise scenario: Multi-source configuration resolution.
+  //    Database -> environment -> defaults, with clean fallback.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   Config config = database.find(key);
+  //   if (config == null) config = envLookup(key);
+  //   if (config == null) config = Config.defaultFor(key);
+
+  record Config(String key, String value, String source) {}
+
+  private static final Map<String, Config> CONFIG_DB =
+      Map.of("db.url", new Config("db.url", "jdbc:postgresql://prod:5432/app", "database"));
+
+  private static MaybePath<Config> lookupFromDatabase(String key) {
+    return Path.maybe(CONFIG_DB.get(key));
+  }
+
+  private static MaybePath<Config> lookupFromEnvironment(String key) {
+    // Simulate: only "log.level" exists in environment
+    if ("log.level".equals(key)) {
+      return Path.just(new Config(key, "DEBUG", "environment"));
+    }
+    return Path.nothing();
+  }
+
+  private static MaybePath<Config> resolveConfig(String key) {
+    return lookupFromDatabase(key)
+        .orElse(() -> lookupFromEnvironment(key))
+        .orElse(() -> Path.just(new Config(key, "default", "fallback")));
+  }
+
+  private static void lookupStack() {
+    System.out.println("--- 2. Lookup Stack (MaybePath): Configuration Resolution ---");
+
+    System.out.println("  db.url:       " + resolveConfig("db.url").run());
+    System.out.println("  log.level:    " + resolveConfig("log.level").run());
+    System.out.println("  unknown.key:  " + resolveConfig("unknown.key").run());
+    System.out.println();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. THE VALIDATION STACK (ValidationPath)
+  //    Enterprise scenario: REST API request validation.
+  //    Collect ALL errors, not just the first.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   List<String> errors = new ArrayList<>();
+  //   if (name == null || name.length() < 2) errors.add("Name too short");
+  //   if (!email.contains("@")) errors.add("Invalid email");
+  //   if (!errors.isEmpty()) return badRequest(errors);
+
+  record Registration(String name, String email, int age) {}
+
+  private static final Semigroup<List<String>> LIST_SEMIGROUP = Semigroups.list();
+
+  private static ValidationPath<List<String>, String> validateName(String name) {
+    return name != null && name.length() >= 2
+        ? Path.valid(name, LIST_SEMIGROUP)
+        : Path.invalid(List.of("Name must be at least 2 characters"), LIST_SEMIGROUP);
+  }
+
+  private static ValidationPath<List<String>, String> validateEmail(String email) {
+    return email != null && email.contains("@")
+        ? Path.valid(email, LIST_SEMIGROUP)
+        : Path.invalid(List.of("Invalid email format"), LIST_SEMIGROUP);
+  }
+
+  private static ValidationPath<List<String>, Integer> validateAge(int age) {
+    return age >= 0 && age <= 150
+        ? Path.valid(age, LIST_SEMIGROUP)
+        : Path.invalid(List.of("Age must be between 0 and 150"), LIST_SEMIGROUP);
+  }
+
+  private static void validationStack() {
+    System.out.println("--- 3. Validation Stack (ValidationPath): API Request Validation ---");
+
+    // Valid request
+    var valid =
+        validateName("Alice")
+            .zipWith3Accum(validateEmail("alice@example.com"), validateAge(30), Registration::new);
+    System.out.println("  Valid:   " + valid.run());
+
+    // Multiple failures accumulated
+    var invalid =
+        validateName("A")
+            .zipWith3Accum(validateEmail("not-an-email"), validateAge(-5), Registration::new);
+    System.out.println("  Invalid: " + invalid.run());
+
+    System.out.println();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 4. THE CONTEXT STACK (ReaderPath)
+  //    Enterprise scenario: Multi-tenant SaaS with threaded context.
+  //    Tenant ID, feature flags, and rate limits flow through the pipeline.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   PricingPlan plan = resolvePricing(tenantCtx);
+  //   List<Product> products = listProducts(tenantCtx);
+  //   return new ProductPage(plan, products);
+  //   // tenantCtx pollutes every method signature
+
+  record TenantContext(String tenantId, Set<String> featureFlags) {}
+
+  record Product(String name, double price) {}
+
+  record ProductPage(String pricingTier, List<Product> products) {}
+
+  private static ReaderPath<TenantContext, String> resolvePricing() {
+    return Path.<TenantContext>ask()
+        .map(ctx -> ctx.featureFlags().contains("premium-pricing") ? "Premium" : "Standard");
+  }
+
+  private static ReaderPath<TenantContext, List<Product>> listProducts() {
+    return Path.<TenantContext>ask()
+        .map(
+            ctx -> {
+              // Simulated per-tenant product catalogue
+              if ("tenant-a".equals(ctx.tenantId())) {
+                return List.of(new Product("Widget", 9.99), new Product("Gadget", 19.99));
+              }
+              return List.of(new Product("Basic Widget", 4.99));
+            });
+  }
+
+  private static ReaderPath<TenantContext, ProductPage> buildProductPage() {
+    return resolvePricing().zipWith(listProducts(), ProductPage::new);
+  }
+
+  private static void contextStack() {
+    System.out.println("--- 4. Context Stack (ReaderPath): Multi-Tenant SaaS ---");
+
+    TenantContext premium =
+        new TenantContext("tenant-a", Set.of("premium-pricing", "beta-features"));
+    TenantContext standard = new TenantContext("tenant-b", Set.of());
+
+    System.out.println("  Premium tenant: " + buildProductPage().run(premium));
+    System.out.println("  Standard tenant: " + buildProductPage().run(standard));
+    System.out.println();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 5. THE AUDIT STACK (WriterPath)
+  //    Enterprise scenario: Financial transfer with compliance audit trail.
+  //    Every step produces an audit entry alongside its result.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   logger.info("DEBIT {} from {}", amount, from.id());  // easy to forget
+  //   Account debited = from.withBalance(from.balance() - amount);
+  //   logger.info("CREDIT {} to {}", amount, to.id());     // easy to forget
+  //   // Audit trail scattered across log files, not attached to result
+
+  record AuditEntry(String action, String detail) {
+    @Override
+    public String toString() {
+      return "[" + action + "] " + detail;
+    }
+  }
+
+  record BankAccount(String id, double balance) {
+    BankAccount withBalance(double newBalance) {
+      return new BankAccount(id, newBalance);
+    }
+  }
+
+  record TransferResult(String fromId, String toId, double amount) {}
+
+  private static final Monoid<List<AuditEntry>> AUDIT_MONOID = Monoids.list();
+
+  private static WriterPath<List<AuditEntry>, BankAccount> debitAccount(
+      BankAccount account, double amount) {
+    BankAccount updated = account.withBalance(account.balance() - amount);
+    return WriterPath.writer(
+        updated, List.of(new AuditEntry("DEBIT", amount + " from " + account.id())), AUDIT_MONOID);
+  }
+
+  private static WriterPath<List<AuditEntry>, BankAccount> creditAccount(
+      BankAccount account, double amount) {
+    BankAccount updated = account.withBalance(account.balance() + amount);
+    return WriterPath.writer(
+        updated, List.of(new AuditEntry("CREDIT", amount + " to " + account.id())), AUDIT_MONOID);
+  }
+
+  private static void auditStack() {
+    System.out.println("--- 5. Audit Stack (WriterPath): Financial Transfer ---");
+
+    BankAccount from = new BankAccount("acc-100", 1000.0);
+    BankAccount to = new BankAccount("acc-200", 500.0);
+
+    WriterPath<List<AuditEntry>, TransferResult> transfer =
+        debitAccount(from, 250.0)
+            .via(debited -> creditAccount(to, 250.0))
+            .map(credited -> new TransferResult(from.id(), to.id(), 250.0));
+
+    var result = transfer.run();
+    System.out.println("  Result: " + result.value());
+    System.out.println("  Audit trail:");
+    for (AuditEntry entry : result.log()) {
+      System.out.println("    " + entry);
+    }
+    System.out.println();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 6. THE WORKFLOW STACK (WithStatePath)
+  //    Enterprise scenario: Order fulfilment state machine.
+  //    Pending -> Validated -> Paid -> Shipped, with typed transitions.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   class OrderProcessor {
+  //       private OrderStage stage = PENDING;
+  //       private List<String> events = new ArrayList<>();
+  //       void validate() { stage = VALIDATED; events.add("..."); }
+  //       void pay()      { stage = PAID;      events.add("..."); }
+  //       // Mutable state, implicit transitions, hard to test
+  //   }
+
+  enum OrderStage {
+    PENDING,
+    VALIDATED,
+    PAID,
+    SHIPPED
+  }
+
+  record OrderState(OrderStage stage, List<String> events) {
+    OrderState advance(OrderStage next, String event) {
+      var updated = new ArrayList<>(events);
+      updated.add(event);
+      return new OrderState(next, List.copyOf(updated));
+    }
+  }
+
+  private static WithStatePath<OrderState, Unit> validateOrder() {
+    return WithStatePath.modify(s -> s.advance(OrderStage.VALIDATED, "Order validated"));
+  }
+
+  private static WithStatePath<OrderState, Unit> processOrderPayment() {
+    return WithStatePath.modify(s -> s.advance(OrderStage.PAID, "Payment processed"));
+  }
+
+  private static WithStatePath<OrderState, Unit> shipOrder() {
+    return WithStatePath.modify(s -> s.advance(OrderStage.SHIPPED, "Order shipped"));
+  }
+
+  private static void workflowStack() {
+    System.out.println("--- 6. Workflow Stack (WithStatePath): Order Fulfilment ---");
+
+    WithStatePath<OrderState, OrderState> fulfilOrder =
+        validateOrder()
+            .then(ArchetypeExamples::processOrderPayment)
+            .then(ArchetypeExamples::shipOrder)
+            .then(WithStatePath::get);
+
+    OrderState initial = new OrderState(OrderStage.PENDING, List.of());
+    OrderState finalState = fulfilOrder.evalState(initial);
+
+    System.out.println("  Final stage:  " + finalState.stage());
+    System.out.println("  Event log:    " + finalState.events());
+    System.out.println();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 7. THE SAFE RECURSION STACK (TrampolinePath)
+  //    Enterprise scenario: Paginated API aggregation.
+  //    Recursively fetch all pages without stack overflow.
+  // ---------------------------------------------------------------------------
+
+  // Imperative sketch:
+  //   List<String> all = new ArrayList<>();
+  //   int cursor = 0;
+  //   while (cursor >= 0) {
+  //       Page page = api.fetch(cursor);
+  //       all.addAll(page.records());
+  //       cursor = page.nextCursor();
+  //   }
+  //   // Works, but less composable with downstream transformations
+
+  record Page(List<String> records, int nextCursor) {}
+
+  // Simulated paginated API: 5 pages of 3 records each
+  private static Page fetchPage(int cursor) {
+    List<String> records =
+        List.of(
+            "record-" + (cursor * 3 + 1),
+            "record-" + (cursor * 3 + 2),
+            "record-" + (cursor * 3 + 3));
+    int next = cursor < 4 ? cursor + 1 : -1; // -1 signals end
+    return new Page(records, next);
+  }
+
+  private static TrampolinePath<List<String>> fetchAllPages(int cursor, List<String> accumulated) {
+    Page page = fetchPage(cursor);
+    var all = new ArrayList<>(accumulated);
+    all.addAll(page.records());
+
+    if (page.nextCursor() < 0) {
+      return TrampolinePath.done(List.copyOf(all));
+    }
+    return TrampolinePath.defer(() -> fetchAllPages(page.nextCursor(), all));
+  }
+
+  private static void safeRecursionStack() {
+    System.out.println("--- 7. Safe Recursion Stack (TrampolinePath): Paginated API ---");
+
+    List<String> allRecords = fetchAllPages(0, List.of()).run();
+    System.out.println("  Total records: " + allRecords.size());
+    System.out.println("  First: " + allRecords.getFirst());
+    System.out.println("  Last:  " + allRecords.getLast());
+    System.out.println();
+  }
+}


### PR DESCRIPTION
Add seven named stack archetypes with enterprise-focused problem-solution documentation, colour-coded railway diagrams, and runnable Java examples. Add "Path First, Stack Later" bridge notes and Path-to-Transformer cross-reference tables to the transformers chapter.

New files:
- hkj-book/src/transformers/archetypes.md
- hkj-examples/.../effect/ArchetypeExamples.java

Modified:
- transformers/ch_intro.md, transformers.md (bridge notes)
- SUMMARY.md (archetypes entry added)
 
Fixes #349 