### PR TITLE
Restructure Phase 5 & 7: Production Readiness & Migration Cookbook and Compiler Error Guide

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -25,6 +25,8 @@
   - [Type Conversions](effect/conversions.md)
   - [Focus-Effect Integration](effect/focus_integration.md)
   - [Patterns and Recipes](effect/patterns.md)
+  - [Migration Cookbook](effect/migration_cookbook.md)
+  - [Common Compiler Errors](effect/compiler_errors.md)
   - [Advanced Effects](effect/advanced_effects.md)
   - [Effect Contexts](effect/effect_contexts.md)
     - [ErrorContext](effect/effect_contexts_error.md)
@@ -32,6 +34,7 @@
     - [ConfigContext](effect/effect_contexts_config.md)
     - [MutableContext](effect/effect_contexts_mutable.md)
   - [Advanced Topics](effect/advanced_topics.md)
+  - [Production Readiness](effect/production_readiness.md)
 
 - [Advanced Topics](transformers/ch_intro.md)
   - [Stack Archetypes](transformers/archetypes.md)

--- a/hkj-book/src/effect/advanced_effects.md
+++ b/hkj-book/src/effect/advanced_effects.md
@@ -485,5 +485,5 @@ The systems remain subtle and pervasive, but no longer tyrannical.
 
 ---
 
-**Previous:** [Patterns and Recipes](patterns.md)
+**Previous:** [Common Compiler Errors](compiler_errors.md)
 **Next:** [Effect Contexts](effect_contexts.md)

--- a/hkj-book/src/effect/advanced_topics.md
+++ b/hkj-book/src/effect/advanced_topics.md
@@ -742,3 +742,4 @@ systems that handle the full spectrum of real-world complexity.
 ---
 
 **Previous:** [MutableContext](effect_contexts_mutable.md)
+**Next:** [Production Readiness](production_readiness.md)

--- a/hkj-book/src/effect/ch_intro.md
+++ b/hkj-book/src/effect/ch_intro.md
@@ -34,9 +34,15 @@ If you've used the Focus DSL from the optics chapters, the patterns will feel fa
 
 - **[Patterns and Recipes](patterns.md)** – Real-world patterns distilled from production code: validation pipelines, service orchestration, fallback chains, resilience with retry, and the pitfalls that await the unwary.
 
+- **[Migration Cookbook](migration_cookbook.md)** – Pattern-by-pattern translations from imperative Java to Effect Path. Six recipes covering try/catch, Optional chains, null checks, CompletableFuture, validation, and nested record updates.
+
+- **[Common Compiler Errors](compiler_errors.md)** – The five most common compiler errors when using the Effect Path API, with full error messages, minimal triggers, and fixes.
+
 - **[Advanced Effects](advanced_effects.md)** – Reader, State, and Writer paths for environment access, stateful computation, and logging accumulation.
 
 - **[Advanced Topics](advanced_topics.md)** – Stack-safe recursion, DSL building with Free structures, resource management, parallel execution, and resilience patterns.
+
+- **[Production Readiness](production_readiness.md)** – Stack traces, allocation overhead, and stack safety. The honest answers to the questions senior engineers ask before adopting a library.
 ~~~
 
 ~~~admonish example title="See Example Code"
@@ -69,8 +75,11 @@ If you've used the Focus DSL from the optics chapters, the patterns will feel fa
 5. [Type Conversions](conversions.md) - Moving between different Path types
 6. [Focus-Effect Integration](focus_integration.md) - Bridging optics and effects
 7. [Patterns and Recipes](patterns.md) - Real-world patterns, resilience, and hard-won wisdom
-8. [Advanced Effects](advanced_effects.md) - Reader, State, and Writer patterns
-9. [Advanced Topics](advanced_topics.md) - Stack-safety, DSLs, resources, parallelism, resilience
+8. [Migration Cookbook](migration_cookbook.md) - Imperative Java to Effect Path, recipe by recipe
+9. [Common Compiler Errors](compiler_errors.md) - Fixing type inference and Path type mismatches
+10. [Advanced Effects](advanced_effects.md) - Reader, State, and Writer patterns
+11. [Advanced Topics](advanced_topics.md) - Stack-safety, DSLs, resources, parallelism, resilience
+12. [Production Readiness](production_readiness.md) - Stack traces, allocation overhead, and stack safety
 
 ---
 

--- a/hkj-book/src/effect/compiler_errors.md
+++ b/hkj-book/src/effect/compiler_errors.md
@@ -1,0 +1,275 @@
+# Common Compiler Errors
+
+Java's type inference works well for most Effect Path usage, but generic-heavy code occasionally produces confusing compiler messages. This page documents the five most common errors, what causes them, and how to fix them.
+
+~~~admonish info title="What You'll Learn"
+- How to fix type inference failures when creating Path instances
+- How to resolve type mismatches when mixing Path types in a chain
+- How to handle `via` signature errors and lambda type issues
+- How to fix error type mismatches across chain steps
+~~~
+
+---
+
+## 1. "Cannot infer type arguments for Path.right(...)"
+
+**The error:**
+
+```
+error: cannot infer type arguments for right(A)
+    return Path.right(user);
+               ^
+  reason: cannot infer type-variable(s) E
+```
+
+**The trigger:**
+
+```java
+EitherPath<AppError, User> findUser(String id) {
+    User user = repository.findById(id);
+    return Path.right(user);  // compiler cannot infer E
+}
+```
+
+Java can infer the success type `A` from the argument, but the error type `E` has no value to infer from. The return type provides a hint, but inference sometimes fails, particularly inside lambdas or when the return type is not directly visible.
+
+**The fix:** add explicit type parameters.
+
+```java
+return Path.<AppError, User>right(user);
+```
+
+This is the most common compiler error with Effect Path. It happens any time you create a "happy path" value where the error type has no corresponding argument.
+
+~~~admonish note title="When Inference Succeeds"
+Inference works when the context is unambiguous:
+
+```java
+// Direct assignment: return type provides the hint
+EitherPath<AppError, User> path = Path.right(user);  // usually works
+
+// Inside via: previous step constrains E
+.via(id -> Path.right(lookupUser(id)))  // usually works
+
+// Inside a lambda with unclear return type
+.via(id -> {
+    if (found) return Path.right(user);     // may fail
+    return Path.left(new NotFound(id));     // E inferred here
+})
+```
+
+When in doubt, add the type witness. It costs nothing at runtime.
+~~~
+
+---
+
+## 2. "Incompatible types: MaybePath cannot be converted to EitherPath"
+
+**The error:**
+
+```
+error: incompatible types: MaybePath<User> cannot be converted to EitherPath<AppError,User>
+    .via(id -> Path.maybe(findUser(id)))
+                   ^
+```
+
+**The trigger:**
+
+```java
+EitherPath<AppError, User> result =
+    Path.<AppError, String>right(userId)
+        .via(id -> Path.maybe(findUser(id)))   // returns MaybePath, not EitherPath
+        .map(User::name);
+```
+
+`via` expects the function to return the *same* Path kind. An `EitherPath` chain requires `via` to return an `EitherPath`, not a `MaybePath`.
+
+**The fix:** convert at the boundary using `toEitherPath`.
+
+```java
+EitherPath<AppError, User> result =
+    Path.<AppError, String>right(userId)
+        .via(id -> Path.maybe(findUser(id))
+            .toEitherPath(new AppError.UserNotFound(id)))   // MaybePath -> EitherPath
+        .map(User::name);
+```
+
+The `toEitherPath` method converts `Nothing` to a `Left` with the error you provide.
+
+### Common conversions
+
+| From | To | Method |
+|------|----|--------|
+| `MaybePath<A>` | `EitherPath<E, A>` | `.toEitherPath(errorValue)` |
+| `TryPath<A>` | `EitherPath<E, A>` | `.toEitherPath(exceptionMapper)` |
+| `EitherPath<E, A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `ValidationPath<E, A>` | `EitherPath<E, A>` | `.toEitherPath()` |
+
+---
+
+## 3. "Method via is not applicable for the arguments"
+
+**The error:**
+
+```
+error: method via in class EitherPath<E,A> cannot be applied to given types;
+    .via(this::processOrder)
+         ^
+  required: Function<? super Order, ? extends Chainable<B>>
+  found: method reference this::processOrder
+```
+
+**The trigger:**
+
+```java
+// processOrder returns the wrong type
+String processOrder(Order order) {    // returns String, not a Path
+    return order.id();
+}
+
+Path.<AppError, Order>right(order)
+    .via(this::processOrder);         // via needs a Path-returning function
+```
+
+`via` (the Effect Path equivalent of `flatMap`) requires the function to return a `Chainable`, which all Path types implement. If your function returns a plain value, use `map` instead.
+
+**The fix:** use `map` for plain transformations, `via` for Path-returning functions.
+
+```java
+// For plain transformations: use map
+Path.<AppError, Order>right(order)
+    .map(this::processOrder);              // map: A -> B
+
+// For Path-returning functions: use via
+Path.<AppError, Order>right(order)
+    .via(this::validateAndProcessOrder);   // via: A -> Path<B>
+```
+
+**Rule of thumb:**
+- `map`: your function takes `A` and returns `B`
+- `via`: your function takes `A` and returns a `Path<B>` (any Path type that matches the chain)
+
+---
+
+## 4. "No suitable method found for map(...)"
+
+**The error:**
+
+```
+error: no suitable method found for map((<lambda>))
+    .map(order -> {
+         ^
+  method EitherPath.map(Function<? super Order, ? extends B>) is not applicable
+```
+
+**The trigger:**
+
+```java
+Path.<AppError, Order>right(order)
+    .map(order -> {
+        if (order.isValid()) {
+            return order.total();    // returns Double
+        }
+        // missing return: compiler cannot determine B
+    });
+```
+
+This typically happens when:
+- A lambda has branches with different return types (or a missing branch)
+- The lambda parameter type cannot be inferred in a complex chain
+
+**The fix:** ensure all branches return the same type, or add explicit parameter types.
+
+```java
+// Fix 1: ensure all branches return the same type
+.map(order -> {
+    if (order.isValid()) {
+        return order.total();
+    }
+    return 0.0;                  // all branches return Double
+})
+
+// Fix 2: add explicit types when inference fails
+.map((Order order) -> order.total())
+```
+
+In long chains where inference struggles, extracting the lambda into a named method often resolves the issue:
+
+```java
+private Double extractTotal(Order order) {
+    return order.isValid() ? order.total() : 0.0;
+}
+
+// Method reference: no inference needed
+.map(this::extractTotal)
+```
+
+---
+
+## 5. "Type argument E is not within bounds"
+
+**The error:**
+
+```
+error: incompatible types: EitherPath<String,User> cannot be converted to
+    EitherPath<AppError,User>
+    .via(id -> lookupUser(id))
+               ^
+```
+
+**The trigger:**
+
+```java
+EitherPath<AppError, String> validated = validateInput(input);
+
+// lookupUser returns EitherPath<String, User> — wrong error type
+EitherPath<String, User> lookupUser(String id) {
+    return id.isEmpty()
+        ? Path.left("User not found")     // error type is String
+        : Path.right(new User(id));
+}
+
+validated.via(id -> lookupUser(id));       // AppError vs String mismatch
+```
+
+All steps in an `EitherPath` chain must share the same error type `E`. If one step uses `String` and another uses `AppError`, the compiler rejects the chain.
+
+**The fix:** either unify the error type, or use `mapError` to convert.
+
+```java
+// Option 1: change lookupUser to use AppError
+EitherPath<AppError, User> lookupUser(String id) {
+    return id.isEmpty()
+        ? Path.left(new AppError.NotFound("User not found"))
+        : Path.right(new User(id));
+}
+
+// Option 2: convert the error type at the boundary
+validated.via(id -> lookupUser(id)
+    .mapError(msg -> new AppError.NotFound(msg)));  // String -> AppError
+```
+
+Option 1 is preferred for new code. Option 2 is useful when integrating with existing methods you cannot change.
+
+---
+
+## Quick Diagnostic Table
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| "cannot infer type arguments" | Missing error type witness | Add `Path.<E, A>right(...)` |
+| "incompatible types: XPath cannot be converted to YPath" | Mixing Path types in `via` | Use `toEitherPath()` or `toMaybePath()` |
+| "method via is not applicable" | Function returns plain value, not a Path | Use `map` instead of `via` |
+| "no suitable method found for map" | Lambda branches with different types | Ensure consistent return types |
+| "incompatible types" with error type | Error type mismatch across steps | Use `mapError` to convert |
+
+~~~admonish tip title="See Also"
+- [Type Conversions](conversions.md) - Full reference for converting between Path types
+- [Troubleshooting](../tutorials/troubleshooting.md) - Tutorial-specific issues (Kind types, annotation processors, IDE setup)
+- [Cheat Sheet](../cheatsheet.md) - Quick reference for Path types and operators
+~~~
+
+---
+
+**Previous:** [Migration Cookbook](migration_cookbook.md)
+**Next:** [Advanced Effects](advanced_effects.md)

--- a/hkj-book/src/effect/migration_cookbook.md
+++ b/hkj-book/src/effect/migration_cookbook.md
@@ -1,0 +1,348 @@
+# Migration Cookbook
+
+You have imperative Java code that works. You want to make it more composable, more testable, and more explicit about failure modes. This cookbook provides pattern-by-pattern translations from common imperative idioms to their Effect Path equivalents.
+
+Each recipe shows the imperative code you have today, the Effect Path code you could write instead, and a one-sentence explanation of what you gain.
+
+~~~admonish info title="What You'll Learn"
+- How to translate `try/catch` blocks into `TryPath`
+- How to replace `Optional` chains with `MaybePath`
+- How to eliminate nested null checks with `MaybePath`
+- How to flatten `CompletableFuture` nesting with `CompletableFuturePath`
+- How to convert manual error accumulation into `ValidationPath`
+- How to simplify deeply nested record updates with `FocusPath` and lenses
+~~~
+
+---
+
+## Recipe 1: try/catch to TryPath
+
+**The problem:** exception handling mixed into business logic, with `catch` blocks that obscure the recovery strategy.
+
+### Before
+
+```java
+String result;
+try {
+    String raw = readFile(path);
+    result = transform(raw);
+} catch (IOException e) {
+    log.warn("File read failed, using default", e);
+    result = DEFAULT_VALUE;
+}
+return result;
+```
+
+### After
+
+```java
+String result = Path.tryOf(() -> readFile(path))
+    .map(this::transform)
+    .recover(e -> {
+        log.warn("File read failed, using default", e);
+        return DEFAULT_VALUE;
+    })
+    .getOrElse(DEFAULT_VALUE);
+```
+
+**What you gain:** the happy path reads top-to-bottom without interruption. Recovery logic is clearly separated from business logic. The `TryPath` chain is composable; you can insert additional `map` or `via` steps without restructuring the error handling.
+
+---
+
+## Recipe 2: Optional Chains to MaybePath
+
+**The problem:** `Optional.flatMap` chains that grow unwieldy, particularly when each step needs its own error handling or fallback logic.
+
+### Before
+
+```java
+String city = findUser(id)
+    .flatMap(user -> findAddress(user))
+    .map(Address::city)
+    .orElse("Unknown");
+```
+
+### After
+
+```java
+String city = Path.maybe(findUser(id))
+    .via(user -> Path.maybe(findAddress(user)))
+    .map(Address::city)
+    .run()
+    .orElse("Unknown");
+```
+
+**What you gain:** at first glance the two look similar, and for simple chains they are. The difference appears when the chain grows. `MaybePath` shares the same `via`, `map`, `peek`, and `recover` vocabulary as every other Path type. If you later need to switch from "absent" to "typed error", changing `Path.maybe(...)` to `Path.right(...)` and adding `.toEitherPath(...)` is a one-line change, not a rewrite.
+
+### When the chain needs a typed error
+
+```java
+// Seamless transition from MaybePath to EitherPath
+Either<AppError, String> city =
+    Path.maybe(findUser(id))
+        .toEitherPath(new AppError.UserNotFound(id))
+        .via(user -> Path.maybe(findAddress(user))
+            .toEitherPath(new AppError.NoAddress(user.id())))
+        .map(Address::city)
+        .run();
+```
+
+With `Optional`, this transition requires restructuring the entire chain.
+
+---
+
+## Recipe 3: Nested Null Checks to MaybePath
+
+**The problem:** defensive null checking that creates deeply nested `if` blocks, obscuring the actual data access path.
+
+### Before
+
+```java
+String postcode = null;
+Order order = findOrder(id);
+if (order != null) {
+    Customer customer = order.customer();
+    if (customer != null) {
+        Address address = customer.shippingAddress();
+        if (address != null) {
+            postcode = address.postcode();
+        }
+    }
+}
+return postcode != null ? postcode : "N/A";
+```
+
+### After
+
+```java
+String postcode = Path.maybe(findOrder(id))
+    .map(Order::customer)
+    .map(Customer::shippingAddress)
+    .map(Address::postcode)
+    .run()
+    .orElse("N/A");
+```
+
+**What you gain:** the nested `if` pyramid collapses into a flat chain. If any step returns `null`, `MaybePath` short-circuits to `Nothing` and the remaining `map` calls are skipped.
+
+~~~admonish note title="When Intermediate Nulls Are Expected"
+`MaybePath.map` propagates `null` return values as `Nothing`. If `order.customer()` returns `null`, the chain stops. You do not need explicit null checks at each step.
+
+If the *initial* value might be `null`, use `Path.maybe(value)` which wraps `null` as `Nothing` and non-null as `Just`.
+~~~
+
+---
+
+## Recipe 4: CompletableFuture Nesting to CompletableFuturePath
+
+**The problem:** `CompletableFuture` chains with `thenCompose` and `thenApply` that become difficult to read, particularly when error handling is involved.
+
+### Before
+
+```java
+CompletableFuture<OrderConfirmation> result =
+    userService.findUser(userId)
+        .thenCompose(user ->
+            inventoryService.checkStock(user.cartItems())
+                .thenCompose(stock ->
+                    paymentService.charge(user, stock.total())
+                        .thenApply(receipt ->
+                            new OrderConfirmation(user, stock, receipt))));
+```
+
+Error handling requires a separate `exceptionally` or `handle` call, often chained awkwardly at the end.
+
+### After
+
+```java
+CompletableFuturePath<OrderConfirmation> result =
+    CompletableFuturePath.fromFuture(userService.findUser(userId))
+        .via(user -> CompletableFuturePath.fromFuture(
+            inventoryService.checkStock(user.cartItems()))
+            .via(stock -> CompletableFuturePath.fromFuture(
+                paymentService.charge(user, stock.total()))
+                .map(receipt -> new OrderConfirmation(user, stock, receipt))))
+        .recover(ex -> OrderConfirmation.failed(ex.getMessage()));
+```
+
+**What you gain:** `recover` integrates directly into the chain instead of dangling at the end. `peek` lets you add logging at any step. And if you need to convert the result to a synchronous `EitherPath`, `.toEitherPath()` is one call away.
+
+### Alternative: parallel independent fetches
+
+When fetches are independent, use `parZipWith` instead of nested `via`:
+
+```java
+CompletableFuturePath<Dashboard> dashboard =
+    CompletableFuturePath.fromFuture(fetchMetrics())
+        .parZipWith(
+            CompletableFuturePath.fromFuture(fetchAlerts()),
+            Dashboard::new);
+```
+
+Both fetches run concurrently; the result is available when both complete.
+
+---
+
+## Recipe 5: Accumulating Validation Errors to ValidationPath
+
+**The problem:** you need to report *all* validation failures at once, not just the first. Manual error accumulation is error-prone and mixes validation logic with error collection.
+
+### Before
+
+```java
+List<String> errors = new ArrayList<>();
+
+if (name == null || name.length() < 2) {
+    errors.add("Name must be at least 2 characters");
+}
+if (email == null || !email.contains("@")) {
+    errors.add("Invalid email format");
+}
+if (age < 0 || age > 150) {
+    errors.add("Age must be between 0 and 150");
+}
+
+if (!errors.isEmpty()) {
+    return ResponseEntity.badRequest().body(errors);
+}
+// proceed with validated data (but the types don't prove it's valid)
+Registration reg = new Registration(name, email, age);
+```
+
+### After
+
+```java
+Semigroup<List<String>> errors = Semigroups.list();
+
+ValidationPath<List<String>, String> validateName(String name) {
+    return name != null && name.length() >= 2
+        ? Path.valid(name, errors)
+        : Path.invalid(List.of("Name must be at least 2 characters"), errors);
+}
+
+ValidationPath<List<String>, String> validateEmail(String email) {
+    return email != null && email.contains("@")
+        ? Path.valid(email, errors)
+        : Path.invalid(List.of("Invalid email format"), errors);
+}
+
+ValidationPath<List<String>, Integer> validateAge(int age) {
+    return age >= 0 && age <= 150
+        ? Path.valid(age, errors)
+        : Path.invalid(List.of("Age must be between 0 and 150"), errors);
+}
+
+// All three run; errors accumulate
+ValidationPath<List<String>, Registration> result =
+    validateName(name)
+        .zipWith3Accum(
+            validateEmail(email),
+            validateAge(age),
+            Registration::new);
+```
+
+**What you gain:** each validator is independent, reusable, and testable. `zipWith3Accum` runs all three and accumulates every error, not just the first. The result is either a valid `Registration` or a complete list of all failures. The types prove that if you have a `Registration`, it passed all validations.
+
+### Switching to short-circuit after validation
+
+Once validation passes, switch to `EitherPath` for sequential processing:
+
+```java
+EitherPath<List<String>, Confirmation> pipeline =
+    result
+        .toEitherPath()
+        .via(reg -> processRegistration(reg));
+```
+
+---
+
+## Recipe 6: Deeply Nested Record Updates to FocusPath
+
+**The problem:** updating a field buried three levels deep in immutable records requires manually reconstructing every intermediate record.
+
+### Before
+
+```java
+// Update the postcode of the shipping address of an order
+Order updatePostcode(Order order, String newPostcode) {
+    Address oldAddress = order.customer().shippingAddress();
+    Address newAddress = new Address(
+        oldAddress.street(),
+        oldAddress.city(),
+        newPostcode,
+        oldAddress.country()
+    );
+    Customer newCustomer = new Customer(
+        order.customer().id(),
+        order.customer().name(),
+        newAddress
+    );
+    return new Order(
+        order.id(),
+        newCustomer,
+        order.items(),
+        order.status()
+    );
+}
+```
+
+Every intermediate record must be reconstructed. Adding a field to any record means updating every reconstruction site.
+
+### After
+
+```java
+// With generated lenses (via @GenerateLenses annotation)
+Order updatePostcode(Order order, String newPostcode) {
+    return OrderLenses.customer()
+        .andThen(CustomerLenses.shippingAddress())
+        .andThen(AddressLenses.postcode())
+        .set(order, newPostcode);
+}
+```
+
+**What you gain:** the lens composition describes the *path* to the field; the library handles the reconstruction. When you add a field to `Address`, this code needs no change. The lens is type-safe; the compiler rejects mismatched types.
+
+### Combining with Effect Path
+
+When the update is part of an effectful pipeline, `focus()` integrates lenses directly:
+
+```java
+var postcodeLens = OrderLenses.customer()
+    .andThen(CustomerLenses.shippingAddress())
+    .andThen(AddressLenses.postcode());
+
+EitherPath<AppError, Order> result =
+    Path.<AppError, Order>right(order)
+        .via(currentOrder -> {
+            String postcode = postcodeLens.get(currentOrder);
+            return validatePostcode(postcode)
+                .map(valid -> postcodeLens.set(currentOrder, valid));
+        });
+```
+
+The lens extracts and updates the postcode within the same `via` block, so the update always applies to the current order in the pipeline, not a stale outer reference.
+
+---
+
+## Quick Reference: Which Recipe Do I Need?
+
+| I have this... | I want this... | Recipe |
+|----------------|---------------|--------|
+| `try/catch` block | Composable error handling | [Recipe 1: TryPath](#recipe-1-trycatch-to-trypath) |
+| `Optional.flatMap` chain | Uniform composition vocabulary | [Recipe 2: MaybePath](#recipe-2-optional-chains-to-maybepath) |
+| Nested `if (x != null)` | Flat, null-safe chain | [Recipe 3: MaybePath](#recipe-3-nested-null-checks-to-maybepath) |
+| `CompletableFuture.thenCompose` nesting | Readable async composition | [Recipe 4: CompletableFuturePath](#recipe-4-completablefuture-nesting-to-completablefuturepath) |
+| Manual `List<String> errors` | Automatic error accumulation | [Recipe 5: ValidationPath](#recipe-5-accumulating-validation-errors-to-validationpath) |
+| Manual record reconstruction | Lens-based deep updates | [Recipe 6: FocusPath](#recipe-6-deeply-nested-record-updates-to-focuspath) |
+
+~~~admonish tip title="See Also"
+- [Cheat Sheet](../cheatsheet.md) - One-page operator reference for all Path types
+- [Path Types](path_types.md) - Detailed reference for when to use each Path type
+- [Patterns and Recipes](patterns.md) - More real-world patterns and composition strategies
+- [Stack Archetypes](../transformers/archetypes.md) - Named patterns for common enterprise problems
+~~~
+
+---
+
+**Previous:** [Patterns and Recipes](patterns.md)
+**Next:** [Common Compiler Errors](compiler_errors.md)

--- a/hkj-book/src/effect/patterns.md
+++ b/hkj-book/src/effect/patterns.md
@@ -753,4 +753,4 @@ Writer patterns.
 ---
 
 **Previous:** [Focus-Effect Integration](focus_integration.md)
-**Next:** [Advanced Effects](advanced_effects.md)
+**Next:** [Migration Cookbook](migration_cookbook.md)

--- a/hkj-book/src/effect/production_readiness.md
+++ b/hkj-book/src/effect/production_readiness.md
@@ -1,0 +1,209 @@
+# Production Readiness
+
+Senior engineers evaluating a library for production use inevitably ask three questions: "What do the stack traces look like?", "How much does the abstraction cost?", and "Will it blow the stack?" This page answers all three honestly, with data.
+
+~~~admonish info title="What You'll Learn"
+- How to read stack traces from Path chains and add debug logging
+- The allocation cost of wrapper objects and why it is negligible in practice
+- When recursive chains can overflow the JVM stack and how to prevent it
+~~~
+
+---
+
+## Reading Path Chain Stack Traces
+
+Path chains produce deeper stack traces than their imperative equivalents. Each `map`, `via`, or `recover` call adds a frame. This is the trade-off for composability; the good news is that the traces are predictable once you know what to look for.
+
+### An Annotated Example
+
+Consider a simple service pipeline:
+
+```java
+EitherPath<AppError, Invoice> result =
+    Path.<AppError, String>right(orderId)
+        .via(id -> lookupOrder(id))          // step 1
+        .via(order -> validateOrder(order))   // step 2
+        .map(order -> generateInvoice(order)) // step 3
+        .recover(error -> Invoice.empty());   // step 4
+```
+
+If `validateOrder` throws an unexpected `NullPointerException`, the stack trace might look like this:
+
+```
+java.lang.NullPointerException: Cannot invoke "Address.postcode()" on null reference
+    at com.example.OrderService.validateOrder(OrderService.java:47)    // <-- YOUR CODE: the actual failure
+    at com.example.OrderService.lambda$process$1(OrderService.java:23) // <-- YOUR CODE: the .via() lambda
+    at org.higherkindedj.hkt.either.Either.flatMap(Either.java:142)    //     library internals (skip)
+    at org.higherkindedj.hkt.effect.EitherPath.via(EitherPath.java:98) //     library internals (skip)
+    at com.example.OrderService.process(OrderService.java:23)          // <-- YOUR CODE: the chain call site
+    at com.example.OrderController.handleOrder(OrderController.java:31)
+    ...
+```
+
+### How to Read Path Stack Traces
+
+The pattern is consistent:
+
+1. **Top of the trace**: your code that threw the exception (the business logic inside the lambda)
+2. **Middle frames**: library internals (`Either.flatMap`, `EitherPath.via`); skip these
+3. **Lower frames**: the call site where you built the chain, then your normal application frames
+
+**Rule of thumb:** look for your package name in the trace. The topmost frame with your package is the failing business logic; the next one down is the chain step that invoked it.
+
+### Using peek for Debug Logging
+
+When you need to inspect intermediate values without breaking the chain, `peek` provides observation points:
+
+```java
+EitherPath<AppError, Invoice> result =
+    Path.<AppError, String>right(orderId)
+        .via(id -> lookupOrder(id))
+        .peek(order -> log.debug("Looked up order: {}", order.id()))
+        .via(order -> validateOrder(order))
+        .peek(order -> log.debug("Validated order: {}", order.id()))
+        .map(order -> generateInvoice(order));
+```
+
+`peek` runs a side effect on the success track without changing the value. If the chain has already diverted to the error track, `peek` is skipped. This makes it safe to leave debug logging in place; it only executes on the happy path and has negligible cost.
+
+~~~admonish tip title="Naming Your Lambdas"
+For clearer stack traces, extract lambdas into named methods:
+
+```java
+// Anonymous lambda: shows as lambda$process$1 in traces
+.via(id -> lookupOrder(id))
+
+// Method reference: shows as OrderService.lookupOrder in traces
+.via(this::lookupOrder)
+```
+
+Method references produce more readable stack frames than anonymous lambdas.
+~~~
+
+---
+
+## Allocation Overhead
+
+Every step in a Path chain creates a small wrapper object. A `map` call on `EitherPath` creates one new `Either` and one new `EitherPath`. This is real allocation, and it is worth understanding.
+
+### The Cost in Context
+
+| Operation | Typical Cost | Order of Magnitude |
+|-----------|-------------|-------------------|
+| Wrapper allocation (`EitherPath`, `MaybePath`) | 5-20 ns | Nanoseconds |
+| `map` or `via` step (wrapper + lambda object) | 10-50 ns | Nanoseconds |
+| HashMap lookup | 10-100 ns | Nanoseconds |
+| JSON serialisation (small object) | 1-10 us | Microseconds |
+| Database query (local) | 0.5-5 ms | Milliseconds |
+| HTTP request (same data centre) | 1-50 ms | Milliseconds |
+| HTTP request (cross-region) | 50-200 ms | Milliseconds |
+
+A typical Path chain of five steps adds roughly 50-250 nanoseconds of overhead. A single database call takes 500,000-5,000,000 nanoseconds. The wrapper overhead is three to four orders of magnitude smaller than any I/O operation your application performs.
+
+### When Overhead Matters
+
+Allocation overhead is not zero, and in two scenarios it deserves attention:
+
+1. **Tight computational loops** processing millions of items per second with no I/O. If you are writing a number-crunching inner loop, use primitive types directly. Path types are designed for orchestrating effectful operations, not replacing arithmetic.
+
+2. **Very long chains** (hundreds of steps). Each step allocates, and the objects are short-lived, which means GC pressure. In practice, chains rarely exceed 10-20 steps. If yours does, consider breaking it into named submethods that each return a Path.
+
+For the vast majority of applications, particularly those performing any I/O, **the overhead is negligible**.
+
+### Measuring It Yourself
+
+The project includes JMH benchmarks that measure construction, execution, and composition overhead for all Path types. To run them:
+
+```bash
+./gradlew jmh --includes=".*IOPathBenchmark.*"
+./gradlew jmh --includes=".*AbstractionOverheadBenchmark.*"
+./gradlew jmh --includes=".*MemoryFootprintBenchmark.*"
+```
+
+~~~admonish example title="See Benchmark Code"
+- [IOPathBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/IOPathBenchmark.java) - Construction, execution, and composition overhead
+- [AbstractionOverheadBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/AbstractionOverheadBenchmark.java) - Raw Java vs IO vs VTask comparison
+- [MemoryFootprintBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/MemoryFootprintBenchmark.java) - Allocation rates under GC profiling
+- [TrampolineBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/TrampolineBenchmark.java) - Stack-safe recursion performance
+~~~
+
+---
+
+## Stack Safety and Trampolining
+
+The JVM does not perform Tail Call Optimisation (TCO). Every method call, including every recursive call, adds a frame to the call stack. The default stack size is typically 512KB to 1MB, which allows roughly 5,000-15,000 frames depending on frame size.
+
+### When Path Chains Are Stack-Safe
+
+Most Path usage is inherently stack-safe. A chain like this:
+
+```java
+Path.right(value)
+    .via(this::step1)
+    .via(this::step2)
+    .map(this::step3)
+    .recover(this::handleError)
+```
+
+Each step executes and returns immediately. The chain does not recurse. Even a chain with 50 steps uses only a handful of stack frames at any point; the depth is constant, not proportional to chain length.
+
+### When Recursion Causes Problems
+
+The risk arises when a Path chain calls itself recursively:
+
+```java
+// DANGER: recursive Path chain, will overflow for large n
+EitherPath<Error, Integer> countdown(int n) {
+    if (n <= 0) return Path.right(0);
+    return Path.<Error, Integer>right(n)
+        .via(x -> countdown(x - 1));  // recursive call adds a stack frame
+}
+
+countdown(100_000);  // StackOverflowError
+```
+
+Each call to `countdown` adds a frame. For large inputs, this exhausts the stack.
+
+### The Solution: TrampolinePath
+
+`TrampolinePath` converts recursive calls into a loop that uses constant stack space:
+
+```java
+// SAFE: trampolined recursion, works for any depth
+TrampolinePath<Integer> countdown(int n) {
+    if (n <= 0) return TrampolinePath.done(0);
+    return TrampolinePath.defer(() -> countdown(n - 1));
+}
+
+Integer result = countdown(1_000_000).run();  // completes without overflow
+```
+
+`TrampolinePath.done(value)` signals completion. `TrampolinePath.defer(supplier)` describes the next step without executing it. The trampoline runner bounces through deferred steps in a loop, never growing the call stack.
+
+### Quick Decision Guide
+
+| Scenario | Stack-safe? | Action needed |
+|----------|------------|---------------|
+| Linear chain (`via`, `map`, `recover`) | Yes | None |
+| Bounded recursion (depth < 1,000) | Usually | None, but consider `TrampolinePath` as insurance |
+| Unbounded recursion (paginated APIs, tree traversal) | No | Use `TrampolinePath` |
+| Mutual recursion (A calls B calls A) | No | Use `TrampolinePath` |
+
+~~~admonish tip title="See Also"
+- [TrampolinePath](path_trampoline.md) - Creation, usage, and conversion
+- [Advanced Topics: Stack-Safe Recursion](advanced_topics.md#stack-safe-recursion-with-trampolinepath) - Deep dive with fibonacci, mutual recursion, and integration patterns
+- [Safe Recursion Stack archetype](../transformers/archetypes.md#the-safe-recursion-stack) - When to reach for `TrampolinePath` in enterprise applications
+~~~
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **Stack traces** from Path chains are deeper but predictable. Look for your package name; the top frame is your failing logic, the next is the chain step that invoked it.
+* **Allocation overhead** is real but negligible for any application that performs I/O. Wrapper allocation costs nanoseconds; database calls cost milliseconds.
+* **Linear Path chains are stack-safe.** Only unbounded recursion needs `TrampolinePath`, which converts recursion into constant-space iteration.
+* **Honesty builds trust.** These are the real trade-offs. For the vast majority of production workloads, they are non-issues.
+~~~
+
+---
+
+**Previous:** [Advanced Topics](advanced_topics.md)


### PR DESCRIPTION
Add migration_cookbook.md with six imperative-to-FP recipes (try/catch, Optional chains, null checks, CompletableFuture, validation, nested records) and compiler_errors.md with the five most common Effect Path compiler errors. Both placed after Patterns and Recipes, before Advanced Effects.

Restructure Phase 5: Production Readiness documentation

Add production_readiness.md covering the three questions senior engineers ask before adopting a library: stack traces, allocation overhead, and stack safety. Cross-references existing TrampolinePath and benchmark content rather than duplicating it.



Fixes #353 

