### PR TITLE
Add maven-compiler-plugin configuration for annotation processing

### DIFF
--- a/hkj-book/src/quickstart.md
+++ b/hkj-book/src/quickstart.md
@@ -80,6 +80,21 @@ repositories {
 
 <build>
     <plugins>
+        <!-- Optional: generates Focus paths and Effect paths for your records -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.14.1</version>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>io.github.higher-kinded-j</groupId>
+                        <artifactId>hkj-processor-plugins</artifactId>
+                        <version>LATEST_VERSION</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
         <!-- Required: enable preview features for tests -->
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description

This change adds optional Maven compiler plugin configuration to the quickstart guide to enable annotation processing for the HKJ processor plugins. This allows users to automatically generate Focus paths and Effect paths for their records during the build process.

The configuration includes the `hkj-processor-plugins` artifact as an annotation processor path, enabling the code generation features provided by the Higher-Kinded Java library.

Relates to documentation and developer experience improvements.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Documentation reviewed for accuracy and clarity
- [x] Maven configuration syntax validated

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (quickstart.md)
- [x] My changes generate no new warnings

## Additional Comments

This is an optional configuration that enhances the developer experience by providing automatic code generation capabilities. The configuration is clearly marked as "Optional" in the documentation to indicate it's not required for basic usage but recommended for users who want to leverage the annotation processing features.
