### PR TITLE
Document v0.3.5 release and add release history to book

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -178,6 +178,7 @@
 - [More Functional Thinking](reading.md)
 
 - [Glossary](glossary.md)
+- [Release History](release-history.md)
 
 # Project Info
 - [Contributing](./CONTRIBUTING.md)

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -12,6 +12,27 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ## Recent Releases
 
+### [v0.3.5](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.3.5) -- 15 February 2026
+
+**Extended For-Comprehensions, VTask API Refinement, and Documentation Restructure**
+
+This release extends for-comprehension arity to 12, simplifies the VTask API, adds Maybe-to-Either conversions, upgrades to JUnit 6, and delivers a comprehensive documentation restructure with quickstart guides, cheat sheets, migration cookbooks, and railway diagrams.
+
+- [For-Comprehension Arity 12](functional/for_comprehension.md) -- `For` and `ForPath` now support up to 12 monadic bindings (previously 5), with generated `Tuple9`–`Tuple12` and `Function9`–`Function12`
+- [VTask API](monads/vtask_monad.md) -- `VTask.run()` no longer declares `throws Throwable`; checked exceptions are wrapped in `VTaskExecutionException`
+- [Maybe.toEither](monads/maybe_monad.md) -- New `toEither(L)` and `toEither(Supplier<L>)` conversion methods for seamless `Maybe` → `Either` transitions
+- [Quickstart](quickstart.md) -- New getting-started guide with Gradle and Maven setup including `--enable-preview` configuration
+- [Cheat Sheet](cheatsheet.md) -- Quick-reference for Path types, operators, escape hatches, and type conversions
+- [Stack Archetypes](transformers/archetypes.md) -- 7 named transformer stack archetypes with colour-coded railway diagrams
+- [Migration Cookbook](migration_cookbook.md) -- 6 recipes for migrating from try/catch, Optional chains, null checks, CompletableFuture, validation, and nested records
+- [Compiler Error Guide](compiler_errors.md) -- Solutions for the 5 most common Effect Path compiler errors
+- [Effects-Optics Capstone](capstone_focus_effect.md) -- Combined effects and optics pipeline example
+- Railway operator diagrams for all 8 Effect Path operators and for EitherT, MaybeT, OptionalT transformers
+- JUnit 6.0.2 upgrade (from 5.14.1) across all test modules
+- Golden file test infrastructure with automated sync verification and pitest mutation coverage improvements
+
+---
+
 ### [v0.3.4](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.3.4) -- 31 January 2026
 
 **External Type Optics and Examples Gallery**


### PR DESCRIPTION
## Description

This PR adds documentation for the v0.3.5 release of Higher-Kinded-J and integrates the release history page into the book's navigation structure.

The changes include:
- Added comprehensive v0.3.5 release notes documenting major features: extended for-comprehension arity (up to 12), VTask API refinement, Maybe-to-Either conversions, JUnit 6 upgrade, and extensive documentation improvements (quickstart guides, cheat sheets, migration cookbook, compiler error guide, and railway diagrams)
- Added "Release History" link to the book's SUMMARY.md table of contents for improved discoverability

Relates to the v0.3.5 release cycle.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

N/A - Documentation-only changes. The release notes are informational content documenting completed work.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (release-history.md and SUMMARY.md)
- [x] My changes generate no new warnings

## Additional Comments

This is a documentation-only PR that captures the v0.3.5 release information and improves navigation to the release history within the book structure.

https://claude.ai/code/session_0135yhxJcddMrcGcKaJWWW3k