### PR TITLE
Add VStream: lazy pull-based streaming on virtual threads

### DIFF
--- a/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/VStreamBenchmark.java
+++ b/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/VStreamBenchmark.java
@@ -1,0 +1,288 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.benchmarks;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * JMH benchmarks for VStream operations.
+ *
+ * <p>These benchmarks measure:
+ *
+ * <ul>
+ *   <li>Cost of VStream construction from various sources
+ *   <li>Lazy combinator construction overhead (map, filter, flatMap)
+ *   <li>Terminal operation execution (toList, foldLeft, count)
+ *   <li>Pipeline composition with chained combinators
+ *   <li>Comparison of VStream vs raw Java Stream for equivalent operations
+ * </ul>
+ *
+ * <p>Note: VStream is lazy and pull-based, executing on virtual threads. Most combinators build up
+ * a description; only terminal operations (toList, foldLeft, etc.) materialise the stream.
+ *
+ * <p>Run with: {@code ./gradlew jmh --includes=".*VStreamBenchmark.*"}
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class VStreamBenchmark {
+
+  @Param({"50"})
+  private int streamSize;
+
+  @Param({"50"})
+  private int chainDepth;
+
+  private VStream<Integer> prebuiltStream;
+  private List<Integer> sourceList;
+
+  @Setup
+  public void setup() {
+    sourceList = new java.util.ArrayList<>(streamSize);
+    for (int i = 0; i < streamSize; i++) {
+      sourceList.add(i);
+    }
+    prebuiltStream = VStream.fromList(sourceList);
+  }
+
+  // ========== Construction ==========
+
+  /** Construction cost of VStream.empty. */
+  @Benchmark
+  public VStream<Integer> constructEmpty() {
+    return VStream.empty();
+  }
+
+  /** Construction cost of VStream.of with a single value. */
+  @Benchmark
+  public VStream<Integer> constructSingle() {
+    return VStream.of(42);
+  }
+
+  /** Construction cost of VStream.fromList. */
+  @Benchmark
+  public VStream<Integer> constructFromList() {
+    return VStream.fromList(sourceList);
+  }
+
+  /** Construction cost of VStream.range. */
+  @Benchmark
+  public VStream<Integer> constructRange() {
+    return VStream.range(0, streamSize);
+  }
+
+  // ========== Combinator Construction (lazy - doesn't execute) ==========
+
+  /** Map combinator construction. */
+  @Benchmark
+  public VStream<Integer> mapConstruction() {
+    return prebuiltStream.map(x -> x + 1);
+  }
+
+  /** Filter combinator construction. */
+  @Benchmark
+  public VStream<Integer> filterConstruction() {
+    return prebuiltStream.filter(x -> x % 2 == 0);
+  }
+
+  /** FlatMap combinator construction. */
+  @Benchmark
+  public VStream<Integer> flatMapConstruction() {
+    return prebuiltStream.flatMap(x -> VStream.of(x, x * 2));
+  }
+
+  /** Take combinator construction. */
+  @Benchmark
+  public VStream<Integer> takeConstruction() {
+    return prebuiltStream.take(streamSize / 2);
+  }
+
+  /** Concat combinator construction. */
+  @Benchmark
+  public VStream<Integer> concatConstruction() {
+    return prebuiltStream.concat(prebuiltStream);
+  }
+
+  // ========== Single Combinator Execution ==========
+
+  /** Map execution - materialises the entire stream. */
+  @Benchmark
+  public List<Integer> mapExecution() {
+    return prebuiltStream.map(x -> x + 1).toList().run();
+  }
+
+  /** Filter execution - materialises with predicate evaluation. */
+  @Benchmark
+  public List<Integer> filterExecution() {
+    return prebuiltStream.filter(x -> x % 2 == 0).toList().run();
+  }
+
+  /** FlatMap execution - each element expands to two. */
+  @Benchmark
+  public List<Integer> flatMapExecution() {
+    return prebuiltStream.flatMap(x -> VStream.of(x, x * 2)).toList().run();
+  }
+
+  /** Take execution - early termination after n elements. */
+  @Benchmark
+  public List<Integer> takeExecution() {
+    return prebuiltStream.take(streamSize / 2).toList().run();
+  }
+
+  /** Concat execution - two streams merged. */
+  @Benchmark
+  public List<Integer> concatExecution() {
+    return prebuiltStream.concat(prebuiltStream).toList().run();
+  }
+
+  // ========== Terminal Operations ==========
+
+  /** toList terminal operation. */
+  @Benchmark
+  public List<Integer> toListExecution() {
+    return prebuiltStream.toList().run();
+  }
+
+  /** foldLeft terminal operation - sum all elements. */
+  @Benchmark
+  public Integer foldLeftExecution() {
+    return prebuiltStream.foldLeft(0, Integer::sum).run();
+  }
+
+  /** count terminal operation. */
+  @Benchmark
+  public Long countExecution() {
+    return prebuiltStream.count().run();
+  }
+
+  /** exists terminal operation with short-circuit (match at start). */
+  @Benchmark
+  public Boolean existsEarlyMatch() {
+    return prebuiltStream.exists(x -> x == 0).run();
+  }
+
+  /** exists terminal operation without short-circuit (no match). */
+  @Benchmark
+  public Boolean existsNoMatch() {
+    return prebuiltStream.exists(x -> x < 0).run();
+  }
+
+  /** find terminal operation with early match. */
+  @Benchmark
+  public Object findEarlyMatch() {
+    return prebuiltStream.find(x -> x == 0).run();
+  }
+
+  // ========== Pipeline Composition ==========
+
+  /** Multi-stage pipeline: filter then map. */
+  @Benchmark
+  public List<Integer> pipelineFilterMap() {
+    return prebuiltStream.filter(x -> x % 2 == 0).map(x -> x * 3).toList().run();
+  }
+
+  /** Multi-stage pipeline: map, filter, take. */
+  @Benchmark
+  public List<Integer> pipelineMapFilterTake() {
+    return prebuiltStream.map(x -> x * 2).filter(x -> x % 3 == 0).take(10).toList().run();
+  }
+
+  /** Deep map chain construction (lazy). */
+  @Benchmark
+  public VStream<Integer> deepMapChainConstruction() {
+    VStream<Integer> result = prebuiltStream;
+    for (int i = 0; i < chainDepth; i++) {
+      result = result.map(x -> x + 1);
+    }
+    return result;
+  }
+
+  /** Deep map chain execution. */
+  @Benchmark
+  public List<Integer> deepMapChainExecution() {
+    VStream<Integer> result = prebuiltStream;
+    for (int i = 0; i < chainDepth; i++) {
+      result = result.map(x -> x + 1);
+    }
+    return result.toList().run();
+  }
+
+  /** Deep flatMap chain for stack safety validation. */
+  @Benchmark
+  public List<Integer> deepFlatMapChainExecution() {
+    VStream<Integer> result = VStream.of(0);
+    for (int i = 0; i < chainDepth; i++) {
+      result = result.flatMap(x -> VStream.of(x + 1));
+    }
+    return result.toList().run();
+  }
+
+  // ========== Comparison Baselines (Raw Java Stream) ==========
+
+  /** Baseline: raw Java Stream map + collect. */
+  @Benchmark
+  public List<Integer> baselineJavaStreamMap() {
+    return sourceList.stream().map(x -> x + 1).toList();
+  }
+
+  /** Baseline: raw Java Stream filter + collect. */
+  @Benchmark
+  public List<Integer> baselineJavaStreamFilter() {
+    return sourceList.stream().filter(x -> x % 2 == 0).toList();
+  }
+
+  /** Baseline: raw Java Stream pipeline (filter, map, limit). */
+  @Benchmark
+  public List<Integer> baselineJavaStreamPipeline() {
+    return sourceList.stream().map(x -> x * 2).filter(x -> x % 3 == 0).limit(10).toList();
+  }
+
+  /** Baseline: raw Java Stream fold (reduce). */
+  @Benchmark
+  public Integer baselineJavaStreamFold() {
+    return sourceList.stream().reduce(0, Integer::sum);
+  }
+
+  // ========== Real-World Patterns ==========
+
+  /**
+   * Real-world pattern: data transformation pipeline.
+   *
+   * <p>Simulates a typical ETL-style pipeline: generate, transform, filter, collect.
+   */
+  @Benchmark
+  public List<String> realWorldTransformPipeline(Blackhole blackhole) {
+    return VStream.range(0, streamSize)
+        .map(x -> x * x)
+        .filter(x -> x % 2 == 0)
+        .map(x -> "item-" + x)
+        .take(20)
+        .toList()
+        .run();
+  }
+
+  /**
+   * Real-world pattern: flatMap expansion with filtering.
+   *
+   * <p>Simulates expanding each item into sub-items and selecting relevant ones.
+   */
+  @Benchmark
+  public List<Integer> realWorldFlatMapFilter() {
+    return VStream.range(0, streamSize / 5)
+        .flatMap(x -> VStream.of(x, x * 10, x * 100))
+        .filter(x -> x > 0 && x < 500)
+        .toList()
+        .run();
+  }
+}

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -180,6 +180,7 @@
 
 - [Glossary](glossary.md)
 - [Release History](release-history.md)
+- [Benchmarks & Performance](benchmarks.md)
 
 # Project Info
 - [Contributing](./CONTRIBUTING.md)

--- a/hkj-book/src/benchmarks.md
+++ b/hkj-book/src/benchmarks.md
@@ -1,0 +1,216 @@
+# Benchmarks & Performance
+
+Higher-Kinded-J ships with a comprehensive JMH benchmark suite in the `hkj-benchmarks` module. These benchmarks measure the real cost of the library's abstractions so you can make informed decisions about where and when to use them.
+
+~~~admonish info title="What You'll Learn"
+- What the benchmark suite covers and how it is organised
+- How to run benchmarks: all, per-type, with GC profiling
+- How to interpret results and spot regressions
+- What performance characteristics to expect from each type
+~~~
+
+> *"Measure. Don't guess."*
+> — **Kirk Pepperdine**, Java performance expert
+
+---
+
+## Why Benchmarks Matter
+
+Functional abstractions wrap values. Wrapping has a cost. The question is never "is there overhead?" — there always is — but "does the overhead matter for my workload?" The benchmark suite answers that question with data rather than intuition.
+
+The suite is designed around three principles:
+
+1. **Honesty** — measure real abstraction costs, not contrived best cases
+2. **Comparability** — include raw Java baselines alongside library operations
+3. **Actionability** — organise results so regressions are immediately visible
+
+---
+
+## What Is Measured
+
+The `hkj-benchmarks` module contains 18 benchmark classes covering every major type in the library:
+
+### Core Types
+
+| Benchmark | Type | What It Tells You |
+|-----------|------|-------------------|
+| `EitherBenchmark` | `Either<L,R>` | Instance reuse on the Left track, short-circuit efficiency |
+| `MaybeBenchmark` | `Maybe<A>` | Instance reuse on Nothing, nullable interop cost |
+| `TrampolineBenchmark` | `Trampoline<A>` | Stack-safe recursion overhead vs naive recursion |
+| `FreeBenchmark` | `Free<F,A>` | Free monad interpretation cost |
+
+### Effect Types
+
+| Benchmark | Type | What It Tells You |
+|-----------|------|-------------------|
+| `IOBenchmark` | `IO<A>` | Lazy construction and platform thread execution |
+| `VTaskBenchmark` | `VTask<A>` | Virtual thread execution, map/flatMap chains |
+| `VStreamBenchmark` | `VStream<A>` | Pull-based stream construction, combinator pipelines, Java Stream comparison |
+| `VTaskParBenchmark` | `Par` combinators | Parallel zip, all, race, traverse via StructuredTaskScope |
+
+### Effect Path Wrappers
+
+| Benchmark | Type | What It Tells You |
+|-----------|------|-------------------|
+| `VTaskPathBenchmark` | `VTaskPath<A>` | Wrapper overhead on top of VTask |
+| `IOPathBenchmark` | `IOPath<A>` | Wrapper overhead on top of IO |
+| `ForPathVTaskBenchmark` | ForPath with VTask | For-comprehension tuple allocation cost |
+
+### Comparisons
+
+| Benchmark | What It Compares |
+|-----------|-----------------|
+| `VTaskVsIOBenchmark` | Virtual threads vs platform threads |
+| `VTaskVsPlatformThreadsBenchmark` | VTask vs ExecutorService at scale |
+| `VTaskPathVsIOPathBenchmark` | Path wrapper costs across effect types |
+| `AbstractionOverheadBenchmark` | HKJ abstractions vs raw Java |
+| `ConcurrencyScalingBenchmark` | Thread scaling under concurrent load |
+| `MemoryFootprintBenchmark` | Allocation rates for VTask, IO, CompletableFuture |
+
+---
+
+## Running Benchmarks
+
+### All Benchmarks
+
+```bash
+./gradlew :hkj-benchmarks:jmh
+```
+
+### A Single Benchmark Class
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*VStreamBenchmark.*"
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskBenchmark.*"
+./gradlew :hkj-benchmarks:jmh --includes=".*EitherBenchmark.*"
+```
+
+### A Single Benchmark Method
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskBenchmark.runSucceed.*"
+```
+
+### With GC Profiling
+
+This reveals allocation rates and GC pressure — essential for understanding memory behaviour:
+
+```bash
+./gradlew :hkj-benchmarks:jmh -Pjmh.profilers=gc
+```
+
+### Long / Stress Mode
+
+Runs with `chainDepth=10000` and `recursionDepth=10000` for thorough stack-safety validation:
+
+```bash
+./gradlew :hkj-benchmarks:longBenchmark
+```
+
+### Formatted Report
+
+```bash
+./gradlew :hkj-benchmarks:benchmarkReport
+```
+
+---
+
+## Reading the Output
+
+JMH reports throughput in operations per microsecond. Higher is better.
+
+```
+Benchmark                                    Mode  Cnt   Score   Error   Units
+EitherBenchmark.rightMap                   thrpt   20  15.234 ± 0.512  ops/us
+EitherBenchmark.leftMap                    thrpt   20  89.123 ± 1.234  ops/us
+```
+
+**Score** is the measured throughput. **Error** is the 99.9% confidence interval. If the error is larger than ~30% of the score, the result is noisy — increase warmup or measurement iterations.
+
+### What to Look For
+
+| Signal | Meaning |
+|--------|---------|
+| Left/Nothing operations 5-10x faster than Right/Just | Instance reuse is working |
+| VTask ~10-30% slower than IO for simple ops | Expected virtual thread overhead |
+| Deep chain (50+ steps) completes without error | Stack safety is intact |
+| VStream slower than Java Stream | Expected; virtual thread + pull overhead |
+| Wrapper overhead < 15% | Acceptable Path wrapper cost |
+
+### Warning Signs
+
+| Signal | Possible Cause |
+|--------|---------------|
+| Left/Nothing same speed as Right/Just | Instance reuse broken |
+| Error margin > 50% of score | Noisy environment, insufficient warmup |
+| Deep chain throws StackOverflowError | Stack safety regression |
+| VStream > 100x slower than Java Stream | Excessive allocation in pull loop |
+| Wrapper overhead > 30% | Unnecessary allocation in Path wrapper |
+
+---
+
+## Expected Performance by Type
+
+### Either and Maybe
+
+These types use **instance reuse**: `Left` and `Nothing` operations return the same object without allocating, making short-circuit paths essentially free.
+
+| Comparison | Expected Ratio |
+|------------|---------------|
+| `leftMap` vs `rightMap` | Left 5-10x faster |
+| `nothingMap` vs `justMap` | Nothing 5-10x faster |
+| `leftLongChain` vs `rightLongChain` | Left 10-50x faster |
+
+### VTask
+
+Virtual thread overhead is the dominant cost for simple operations. For real workloads involving I/O, this overhead is negligible.
+
+| Comparison | Expected |
+|------------|----------|
+| Construction (succeed, delay) | Very fast (~100+ ops/us) |
+| VTask vs IO (simple execution) | VTask ~10-30% slower |
+| Deep chains (50+) | Completes without error |
+| High concurrency (1000+ tasks) | VTask scales better than platform threads |
+
+### VStream
+
+VStream's pull-based model adds overhead per element compared to Java Stream's push model, but provides laziness, virtual thread execution, and error recovery that Java Stream cannot.
+
+| Comparison | Expected |
+|------------|----------|
+| Construction (empty, of, range) | Very fast (~100+ ops/us) |
+| VStream map vs Java Stream map | VStream slower |
+| Deep map chain (50) | Completes without error |
+| Deep flatMap chain (50) | Completes without error |
+| `existsEarlyMatch` vs `existsNoMatch` | Early match much faster (short-circuit) |
+
+### Effect Path Wrappers
+
+| Comparison | Expected Overhead |
+|------------|-------------------|
+| VTaskPath vs raw VTask | 5-15% |
+| IOPath vs raw IO | 5-15% |
+| ForPath vs direct chaining | 10-25% |
+
+---
+
+## When Overhead Matters (and When It Doesn't)
+
+The benchmarks consistently show that abstraction overhead is measured in **nanoseconds**. Real-world operations — database queries, HTTP calls, file reads — are measured in **milliseconds**. The overhead is three to four orders of magnitude smaller than any I/O operation.
+
+Abstraction overhead matters in exactly two scenarios:
+
+1. **Tight computational loops** processing millions of items per second with no I/O — use primitives directly
+2. **Very long chains** (hundreds of steps) creating GC pressure — break into named submethods
+
+For everything else, the type safety, composability, and testability benefits far outweigh the cost.
+
+~~~admonish tip title="See Also"
+- [Production Readiness](effect/production_readiness.md) — stack traces, allocation analysis, and stack safety for Effect Path types
+- [hkj-benchmarks README](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/README.md) — full method reference for all 18 benchmark classes
+- [Performance Testing Guide](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/docs/PERFORMANCE-TESTING-GUIDE.md) — benchmark categories and CI integration
+~~~
+
+---
+
+**Previous:** [Release History](release-history.md)

--- a/hkj-book/src/effect/forpath_comprehension.md
+++ b/hkj-book/src/effect/forpath_comprehension.md
@@ -347,6 +347,19 @@ as it works directly with the transformer's `Kind` representation.
 * **Type safety is preserved** throughout the comprehension
 ~~~
 
+~~~admonish example title="Benchmarks"
+ForPath has dedicated JMH benchmarks measuring for-comprehension overhead compared to direct chaining. Key expectations:
+
+- **ForPath vs direct chaining:** 10-25% overhead — primarily from tuple allocation
+- **`let()` vs `from()`:** `let()` is ~20% faster as it avoids Path wrapping
+- ForPath overhead > 50% is a warning sign indicating tuple handling inefficiency
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*ForPathVTaskBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details and how to interpret results.
+~~~
+
 ~~~admonish tip title="See Also"
 - [For Comprehension](../functional/for_comprehension.md) - The underlying For class for raw `Kind` values
 - [Effect Path Overview](effect_path_overview.md) - Introduction to the Effect Path API

--- a/hkj-book/src/effect/path_io.md
+++ b/hkj-book/src/effect/path_io.md
@@ -188,6 +188,20 @@ Integer length = transformed.unsafeRun();  // Prints "Side effect!"
 - You want immediate execution → use [TryPath](path_try.md)
 - There are no side effects → use [EitherPath](path_either.md) or [MaybePath](path_maybe.md)
 
+~~~admonish example title="Benchmarks"
+IOPath has dedicated JMH benchmarks measuring wrapper overhead on top of raw IO. Key expectations:
+
+- **IOPath vs raw IO:** 5-15% overhead — wrapper allocation plus delegation cost
+- Wrapper overhead > 30% is a warning sign suggesting unnecessary allocation
+- Comparison benchmarks against VTaskPath are available for choosing between effect types
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*IOPathBenchmark.*"
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskPathVsIOPathBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, comparison benchmarks, and how to interpret results.
+~~~
+
 ~~~admonish tip title="See Also"
 - [IO Monad](../monads/io_monad.md) - Underlying type for IOPath
 - [VTaskPath](path_vtask.md) - Virtual thread-based alternative for concurrent workloads

--- a/hkj-book/src/effect/path_vtask.md
+++ b/hkj-book/src/effect/path_vtask.md
@@ -370,6 +370,21 @@ Try<Dashboard> dashboard = loadDashboard(userId).runSafe();
 Practice VTaskPath composition in [TutorialVTaskPath.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTaskPath.java) (8 exercises, ~20 minutes).
 ~~~
 
+~~~admonish example title="Benchmarks"
+VTaskPath has dedicated JMH benchmarks measuring wrapper overhead on top of raw VTask. Key expectations:
+
+- **VTaskPath vs raw VTask:** 5-15% overhead — wrapper allocation plus delegation cost
+- **`let()` vs `from()`:** `let()` is ~20% faster as it avoids VTaskPath wrapping
+- Wrapper overhead > 30% is a warning sign suggesting unnecessary allocation
+- Comparison benchmarks against IOPath are also available
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskPathBenchmark.*"
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskPathVsIOPathBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, comparison benchmarks, and how to interpret results.
+~~~
+
 ~~~admonish tip title="See Also"
 - [VTask Monad](../monads/vtask_monad.md) - Underlying type with full API details
 - [Structured Concurrency](../monads/vtask_scope.md) - Scope and ScopeJoiner for task coordination

--- a/hkj-book/src/effect/production_readiness.md
+++ b/hkj-book/src/effect/production_readiness.md
@@ -112,7 +112,7 @@ For the vast majority of applications, particularly those performing any I/O, **
 
 ### Measuring It Yourself
 
-The project includes JMH benchmarks that measure construction, execution, and composition overhead for all Path types. To run them:
+The project includes JMH benchmarks that measure construction, execution, and composition overhead for all Path types. To run the most relevant ones:
 
 ```bash
 ./gradlew jmh --includes=".*IOPathBenchmark.*"
@@ -125,6 +125,10 @@ The project includes JMH benchmarks that measure construction, execution, and co
 - [AbstractionOverheadBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/AbstractionOverheadBenchmark.java) - Raw Java vs IO vs VTask comparison
 - [MemoryFootprintBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/MemoryFootprintBenchmark.java) - Allocation rates under GC profiling
 - [TrampolineBenchmark.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/TrampolineBenchmark.java) - Stack-safe recursion performance
+~~~
+
+~~~admonish tip title="Full Benchmark Suite"
+The `hkj-benchmarks` module contains 18 benchmark classes covering every major type in the library — not just Effect Path types. For the full picture including VTask, VStream, Either, Maybe, concurrency scaling, and Java baseline comparisons, see [Benchmarks & Performance](../benchmarks.md).
 ~~~
 
 ---

--- a/hkj-book/src/monads/either_monad.md
+++ b/hkj-book/src/monads/either_monad.md
@@ -260,6 +260,19 @@ EitherPath<Error, Order> order = Path.either(findUser(id))
 See [Effect Path Overview](../effect/effect_path_overview.md) for the complete guide.
 ~~~
 
+~~~admonish example title="Benchmarks"
+Either has dedicated JMH benchmarks measuring instance reuse, short-circuit efficiency, and chain composition. Key expectations:
+
+- **`leftMap` is 5-10x faster than `rightMap`** — Left reuses the same instance with zero allocation
+- **`leftLongChain` is 10-50x faster than `rightLongChain`** — sustained reuse benefit over 50-deep chains
+- If Left/Nothing operations allocate memory, instance reuse is broken
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*EitherBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, expected ratios, and how to interpret results.
+~~~
+
 ---
 
 **Previous:** [CompletableFuture](cf_monad.md)

--- a/hkj-book/src/monads/free_monad.md
+++ b/hkj-book/src/monads/free_monad.md
@@ -1000,6 +1000,19 @@ For deeper exploration of Free monads and their applications:
 - [Coyoneda](coyoneda.md) - Automatic Functor instances and map fusion
 ~~~
 
+~~~admonish example title="Benchmarks"
+Free has dedicated JMH benchmarks measuring interpretation cost and stack safety. Key expectations:
+
+- **Deep recursion (10,000+)** completes without `StackOverflowError` — Free monad interpretation is stack-safe via trampolining
+- **Performance scaling is linear with depth** — interpretation cost grows proportionally, not exponentially
+- Abstraction overhead of 50-200x vs raw Java is expected and acceptable — real workloads involve I/O that dominates compute time
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*FreeBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details and how to interpret results.
+~~~
+
 ---
 
 **Previous:** [Trampoline](trampoline_monad.md)

--- a/hkj-book/src/monads/io_monad.md
+++ b/hkj-book/src/monads/io_monad.md
@@ -143,9 +143,11 @@ String result = IOKindHelper.unsafeRunSync(potentiallyFailingIO);
    System.out.println("\nRunning printHello again:");
 IOKindHelper.unsafeRunSync(printHello); // Prints "Hello from IO!" again
 ```
+
 ~~~~
 
-~~~admonish title="Example 3: Composing IO Actions with `map` and `flatMap`"
+
+~~~admonish example title="Example 3: Composing IO Actions with _map_ and _flatMap_"
 
 
 - [IOExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/io/IOExample.java)
@@ -216,9 +218,13 @@ System.out.println("\nComplete IO Program defined. Executing...");
 // IOKindHelper.unsafeRunSync(program); // Uncomment to run the full program
 ```
 
+
 _Notes:_
-* `map` transforms the *result* of an `IO` action without changing the effect itself (though the transformation happens *after* the effect runs).
-* `flatMap` sequences `IO` actions, ensuring the effect of the first action completes before the second action (which might depend on the first action's result) begins.
+
+- `map` transforms the *result* of an `IO` action without changing the effect itself (though the transformation happens *after* the effect runs).
+- `flatMap` sequences `IO` actions, ensuring the effect of the first action completes before the second action (which might depend on the first action's result) begins.
+
+~~~
 
 ---
 
@@ -241,6 +247,21 @@ IOPath<String> value = Path.io(() -> loadConfig())
 ```
 
 See [Effect Path Overview](../effect/effect_path_overview.md) for the complete guide.
+~~~
+
+~~~admonish example title="Benchmarks"
+IO has dedicated JMH benchmarks measuring lazy construction, platform thread execution, and map/flatMap chains. Key expectations:
+
+- **Construction** (delay, pure) is very fast (~100+ ops/us) — IO is a lazy wrapper with no immediate execution
+- **IO vs VTask:** IO is ~10-30% faster for simple operations due to no virtual thread spawn overhead
+- **Deep chains (50+)** complete without error — composition overhead dominates at depth
+- At high concurrency (1000+ tasks), VTask scales better than IO due to virtual threads
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*IOBenchmark.*"
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskVsIOBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, comparison benchmarks against VTask, and how to interpret results.
 ~~~
 
 ---

--- a/hkj-book/src/monads/maybe_monad.md
+++ b/hkj-book/src/monads/maybe_monad.md
@@ -349,6 +349,20 @@ MaybePath<String> name = Path.maybe(findUser(id))
 See [Effect Path Overview](../effect/effect_path_overview.md) for the complete guide.
 ~~~
 
+~~~admonish example title="Benchmarks"
+Maybe has dedicated JMH benchmarks measuring instance reuse, short-circuit efficiency, filtering, and nullable interop. Key expectations:
+
+- **`nothingMap` is 5-10x faster than `justMap`** — Nothing reuses the same instance with zero allocation
+- **`nothingLongChain` is 10-50x faster than `justLongChain`** — sustained reuse benefit over 50-deep chains
+- `nothingFilter` and `nothingFlatMap` should show similar reuse benefits
+- If Nothing operations allocate memory, instance reuse is broken
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*MaybeBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, expected ratios, and how to interpret results.
+~~~
+
 ---
 
 **Previous:** [List](list_monad.md)

--- a/hkj-book/src/monads/trampoline_monad.md
+++ b/hkj-book/src/monads/trampoline_monad.md
@@ -324,6 +324,20 @@ For detailed implementation examples and more advanced use cases, see the [Tramp
 For a comprehensive exploration of recursion, thunks, and trampolines in Java and Scala, see Scott Logic's blog post: [Recursion, Thunks and Trampolines with Java and Scala](https://blog.scottlogic.com/2025/05/02/recursion-thunks-trampolines-with-java-and-scala.html).
 ~~~
 
+~~~admonish example title="Benchmarks"
+Trampoline has dedicated JMH benchmarks measuring stack-safe recursion overhead and scaling behaviour. Key expectations:
+
+- **Deep recursion (10,000+)** completes without `StackOverflowError` — stack-safe trampolining is working
+- **Performance scaling is linear with depth** — no exponential blowup or quadratic complexity
+- **`factorialTrampoline` vs `factorialNaive`** show similar performance at depth 100 — trampoline overhead is minimal for moderate depths
+- Non-linear scaling is a warning sign suggesting memory leak or quadratic complexity
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*TrampolineBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details and how to interpret results.
+~~~
+
 ---
 
 **Previous:** [Stream](stream_monad.md)

--- a/hkj-book/src/monads/vstream.md
+++ b/hkj-book/src/monads/vstream.md
@@ -476,6 +476,15 @@ virtual thread integration or error recovery.
 Practice VStream basics in [TutorialVStream](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStream.java) (11 exercises, ~12-15 minutes).
 ~~~
 
+~~~admonish example title="Benchmarks"
+VStream has a dedicated JMH benchmark suite measuring construction, combinator pipelines, terminal operations, and comparison with raw Java Streams. Run it with:
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*VStreamBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details and how to interpret results.
+~~~
+
+
 ~~~admonish tip title="See Also"
 - [VTask](vtask_monad.md) - The single-value effect type that powers VStream pulls
 - [VTaskPath](../effect/path_vtask.md) - Fluent Path API wrapper for VTask

--- a/hkj-book/src/monads/vtask_monad.md
+++ b/hkj-book/src/monads/vtask_monad.md
@@ -398,6 +398,15 @@ Choose `IO` when:
 Practice VTask fundamentals in [Tutorial: VTask](../tutorials/concurrency/vtask_journey.md) (8 exercises, ~25 minutes).
 ~~~
 
+~~~admonish example title="Benchmarks"
+VTask has dedicated JMH benchmarks measuring construction, execution, map/flatMap chains, deep recursion, and parallel combinators. Run them with:
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskBenchmark.*"
+./gradlew :hkj-benchmarks:jmh --includes=".*VTaskParBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, comparison benchmarks against IO, and how to interpret results.
+~~~
+
 ~~~admonish tip title="See Also"
 - [Structured Concurrency](vtask_scope.md) - Scope and ScopeJoiner for advanced task coordination
 - [Resource Management](vtask_resource.md) - Bracket pattern for safe resource handling

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamAlternative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamAlternative.java
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Kind;
+
+/**
+ * Implements the {@link Alternative} type class for {@link VStream}, using {@link
+ * VStreamKind.Witness} as the higher-kinded type witness.
+ *
+ * <p>This implementation uses <b>concatenation semantics</b> for the {@link #orElse} operation,
+ * consistent with list-like types. Given two streams, {@code orElse} produces a stream that emits
+ * all elements from the first stream followed by all elements from the second stream.
+ *
+ * <p><b>Alternative Laws:</b>
+ *
+ * <ul>
+ *   <li><b>Left Identity:</b> {@code orElse(empty(), () -> fa) == fa}
+ *   <li><b>Right Identity:</b> {@code orElse(fa, () -> empty()) == fa}
+ *   <li><b>Associativity:</b> {@code orElse(fa, () -> orElse(fb, () -> fc)) == orElse(orElse(fa, ()
+ *       -> fb), () -> fc)}
+ * </ul>
+ *
+ * @see Alternative
+ * @see VStreamMonad
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamKind.Witness
+ */
+public class VStreamAlternative extends VStreamMonad implements Alternative<VStreamKind.Witness> {
+
+  /** Singleton instance of {@code VStreamAlternative}. */
+  public static final VStreamAlternative INSTANCE = new VStreamAlternative();
+
+  /** Protected constructor to enforce the singleton pattern. */
+  protected VStreamAlternative() {
+    super();
+  }
+
+  /**
+   * Returns an empty VStream, representing the identity element for the {@link #orElse} operation.
+   *
+   * @param <A> The phantom type parameter of the empty stream.
+   * @return A {@code Kind<VStreamKind.Witness, A>} representing an empty VStream. Never null.
+   */
+  @Override
+  public <A> Kind<VStreamKind.Witness, A> empty() {
+    return VSTREAM.widen(VStream.empty());
+  }
+
+  /**
+   * Concatenates two VStreams. The resulting stream emits all elements from {@code fa} followed by
+   * all elements from the stream provided by {@code fb}.
+   *
+   * <p>The second argument is lazy (provided via {@link Supplier}) to avoid unnecessary computation
+   * when only elements from the first stream are needed.
+   *
+   * @param <A> The type of elements in both streams.
+   * @param fa The first non-null VStream.
+   * @param fb A non-null {@link Supplier} providing the second VStream (evaluated lazily).
+   * @return A {@code Kind<VStreamKind.Witness, A>} representing the concatenated stream. Never
+   *     null.
+   * @throws NullPointerException if {@code fa} or {@code fb} is null.
+   */
+  @Override
+  public <A> Kind<VStreamKind.Witness, A> orElse(
+      Kind<VStreamKind.Witness, A> fa, Supplier<Kind<VStreamKind.Witness, A>> fb) {
+    Objects.requireNonNull(fa, "First alternative (fa) must not be null");
+    Objects.requireNonNull(fb, "Second alternative supplier (fb) must not be null");
+
+    VStream<A> streamA = VSTREAM.narrow(fa);
+    // Defer evaluation of second stream until first is exhausted
+    VStream<A> combined = streamA.concat(VStream.defer(() -> VSTREAM.narrow(fb.get())));
+    return VSTREAM.widen(combined);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamApplicative.java
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.util.validation.Validation;
+
+/**
+ * Implements the {@link Applicative} type class for {@link VStream}, using {@link
+ * VStreamKind.Witness} as the higher-kinded type witness.
+ *
+ * <p>This implementation provides the ability to lift pure values into single-element VStreams and
+ * to apply streams of functions to streams of values using Cartesian product semantics.
+ *
+ * <p><b>Applicative Semantics:</b> The {@link #ap} operation uses Cartesian product semantics,
+ * consistent with list-like monads. Given a stream of functions {@code [f1, f2]} and a stream of
+ * values {@code [a1, a2, a3]}, the result is {@code [f1(a1), f1(a2), f1(a3), f2(a1), f2(a2),
+ * f2(a3)]}.
+ *
+ * <p><b>Applicative Laws:</b>
+ *
+ * <ul>
+ *   <li><b>Identity:</b> {@code ap(of(id), fa) == fa}
+ *   <li><b>Homomorphism:</b> {@code ap(of(f), of(x)) == of(f(x))}
+ *   <li><b>Interchange:</b> {@code ap(ff, of(y)) == ap(of(f -> f(y)), ff)}
+ * </ul>
+ *
+ * @see Applicative
+ * @see VStreamFunctor
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamKind.Witness
+ * @see VStreamKindHelper
+ */
+public class VStreamApplicative extends VStreamFunctor implements Applicative<VStreamKind.Witness> {
+
+  private static final Class<VStreamApplicative> VSTREAM_APPLICATIVE_CLASS =
+      VStreamApplicative.class;
+
+  /** Singleton instance of {@code VStreamApplicative}. */
+  public static final VStreamApplicative INSTANCE = new VStreamApplicative();
+
+  /** Protected constructor to enforce the singleton pattern while allowing subclassing. */
+  protected VStreamApplicative() {
+    super();
+  }
+
+  /**
+   * Lifts a pure value into a single-element VStream.
+   *
+   * <p>The resulting stream produces the given value on the first pull, then completes.
+   *
+   * @param <A> The type of the value.
+   * @param value The value to lift into the VStream context. Can be {@code null}.
+   * @return A {@code Kind<VStreamKind.Witness, A>} representing a single-element VStream. Never
+   *     null.
+   */
+  @Override
+  public <A> Kind<VStreamKind.Witness, A> of(A value) {
+    return VSTREAM.widen(VStream.of(value));
+  }
+
+  /**
+   * Applies a VStream of functions to a VStream of values using Cartesian product semantics.
+   *
+   * <p>Each function in the function stream is applied to every value in the value stream. This
+   * produces a result stream containing all combinations of function applications. The operation
+   * remains lazy; no elements are produced until a terminal operation is invoked.
+   *
+   * @param <A> The input type of the functions.
+   * @param <B> The output type of the functions.
+   * @param ff The {@code Kind<VStreamKind.Witness, Function<A, B>>} containing the functions. Must
+   *     not be null.
+   * @param fa The {@code Kind<VStreamKind.Witness, A>} containing the argument values. Must not be
+   *     null.
+   * @return A {@code Kind<VStreamKind.Witness, B>} representing the Cartesian product of function
+   *     applications. Never null.
+   * @throws NullPointerException if {@code ff} or {@code fa} is null.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code ff} or {@code fa} cannot
+   *     be unwrapped.
+   */
+  @Override
+  public <A, B> Kind<VStreamKind.Witness, B> ap(
+      Kind<VStreamKind.Witness, ? extends Function<A, B>> ff, Kind<VStreamKind.Witness, A> fa) {
+
+    Validation.kind().validateAp(ff, fa, VSTREAM_APPLICATIVE_CLASS);
+
+    VStream<? extends Function<A, B>> fStream = VSTREAM.narrow(ff);
+    VStream<A> aStream = VSTREAM.narrow(fa);
+
+    // Cartesian product: each function applied to each value
+    VStream<B> result = fStream.flatMap(f -> aStream.map(f));
+    return VSTREAM.widen(result);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamConverterOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamConverterOps.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.exception.KindUnwrapException;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Defines conversion operations (widen and narrow) specific to VStream types and their Kind
+ * representations. The methods are generic to handle the element type (A).
+ *
+ * <p>This interface is intended to be implemented by a service provider, such as an enum, offering
+ * these operations as instance methods.
+ *
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamKindHelper
+ */
+public interface VStreamConverterOps {
+
+  /**
+   * Widens a concrete {@link VStream} instance into its higher-kinded representation, {@code
+   * Kind<VStreamKind.Witness, A>}.
+   *
+   * @param <A> The element type of the {@code VStream}.
+   * @param vstream The non-null, concrete {@link VStream} instance to widen.
+   * @return A non-null {@link Kind} representing the wrapped {@code VStream}.
+   * @throws NullPointerException if {@code vstream} is {@code null}.
+   */
+  <A> Kind<VStreamKind.Witness, A> widen(VStream<A> vstream);
+
+  /**
+   * Narrows a {@code Kind<VStreamKind.Witness, A>} back to its concrete {@link VStream} type.
+   *
+   * @param <A> The element type of the {@code VStream}.
+   * @param kind The {@code Kind<VStreamKind.Witness, A>} instance to narrow. May be {@code null}.
+   * @return The underlying, non-null {@link VStream} instance.
+   * @throws KindUnwrapException if the input {@code kind} is {@code null}, or not an instance of
+   *     the expected underlying holder type for VStream.
+   */
+  <A> VStream<A> narrow(@Nullable Kind<VStreamKind.Witness, A> kind);
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamFunctor.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.higherkindedj.hkt.util.validation.Operation.MAP;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.util.validation.Validation;
+
+/**
+ * Implements the {@link Functor} type class for {@link VStream}, using {@link VStreamKind.Witness}
+ * as the higher-kinded type witness.
+ *
+ * <p>This implementation provides the ability to transform elements of a VStream using a pure
+ * function, while maintaining the lazy, pull-based evaluation semantics. No elements are produced
+ * until a terminal operation is invoked on the resulting stream.
+ *
+ * <p><b>Functor Laws:</b>
+ *
+ * <ul>
+ *   <li><b>Identity:</b> {@code map(id, fa) == fa}
+ *   <li><b>Composition:</b> {@code map(g.compose(f), fa) == map(g, map(f, fa))}
+ * </ul>
+ *
+ * @see Functor
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamKind.Witness
+ * @see VStreamKindHelper
+ */
+public class VStreamFunctor implements Functor<VStreamKind.Witness> {
+
+  private static final Class<VStreamFunctor> VSTREAM_FUNCTOR_CLASS = VStreamFunctor.class;
+
+  /** Singleton instance of {@code VStreamFunctor}. */
+  public static final VStreamFunctor INSTANCE = new VStreamFunctor();
+
+  /** Protected constructor to enforce the singleton pattern while allowing subclassing. */
+  protected VStreamFunctor() {}
+
+  /**
+   * Applies a function to each element of a VStream, creating a new lazy VStream.
+   *
+   * <p>This operation maintains the lazy evaluation semantics of VStream. The function is not
+   * applied until elements are pulled from the resulting stream via a terminal operation.
+   *
+   * @param <A> The type of elements in the input VStream.
+   * @param <B> The type of elements in the output VStream after applying the function.
+   * @param f The function to apply to each element. Must not be null.
+   * @param fa The {@code Kind<VStreamKind.Witness, A>} representing the VStream to transform. Must
+   *     not be null.
+   * @return A {@code Kind<VStreamKind.Witness, B>} representing the transformed VStream. Never
+   *     null.
+   * @throws NullPointerException if {@code f} or {@code fa} is null.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code fa} cannot be unwrapped.
+   */
+  @Override
+  public <A, B> Kind<VStreamKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<VStreamKind.Witness, A> fa) {
+
+    Validation.function().requireMapper(f, "f", VSTREAM_FUNCTOR_CLASS, MAP);
+    Validation.kind().requireNonNull(fa, VSTREAM_FUNCTOR_CLASS, MAP);
+
+    VStream<A> stream = VSTREAM.narrow(fa);
+    VStream<B> mapped = stream.map(f);
+    return VSTREAM.widen(mapped);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamKind.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamKind.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+
+/**
+ * Kind interface marker for the VStream type in Higher-Kinded-J. Represents VStream as a type
+ * constructor 'F' in {@code Kind<F, A>}. The witness type F is VStreamKind.Witness.
+ *
+ * <p>{@code VStream} is a lazy, pull-based streaming abstraction that executes element production
+ * on virtual threads via {@link org.higherkindedj.hkt.vtask.VTask}. This HKT encoding enables
+ * VStream to participate in polymorphic, type-class-based programming alongside VTask, Maybe,
+ * Either, and other HKT-encoded types.
+ *
+ * @param <A> The type of elements produced by the VStream.
+ * @see org.higherkindedj.hkt.Kind
+ * @see VStream
+ * @see VStreamKindHelper
+ */
+public interface VStreamKind<A> extends Kind<VStreamKind.Witness, A> {
+  /**
+   * The phantom type marker for the VStream type constructor. This is used as the 'F' in {@code
+   * Kind<F, A>}.
+   */
+  final class Witness implements WitnessArity<TypeArity.Unary> {
+    private Witness() {} // Private constructor to prevent instantiation
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamKindHelper.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.util.validation.Validation;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Enum implementing {@link VStreamConverterOps} for widen/narrow operations on {@link VStream}
+ * types.
+ *
+ * <p>Access these operations via the singleton {@code VSTREAM}. For example: {@code
+ * VStreamKindHelper.VSTREAM.widen(myVStream);} Or, with static import: {@code import static
+ * org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM; VSTREAM.widen(...);}
+ *
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamConverterOps
+ */
+public enum VStreamKindHelper implements VStreamConverterOps {
+  /** The singleton instance for VStream operations. */
+  VSTREAM;
+
+  private static final Class<VStream> VSTREAM_CLASS = VStream.class;
+
+  /**
+   * Widens a concrete {@link VStream} instance into its higher-kinded representation, {@code
+   * Kind<VStreamKind.Witness, A>}. Implements {@link VStreamConverterOps#widen}.
+   *
+   * <p>Since {@code VStream} extends {@code VStreamKind}, this method performs a simple type-safe
+   * cast without requiring a wrapper object.
+   *
+   * @param <A> The element type of the {@code VStream}.
+   * @param vstream The non-null, concrete {@link VStream} instance to widen.
+   * @return A non-null {@link Kind} representing the {@code VStream}.
+   * @throws NullPointerException if {@code vstream} is {@code null}.
+   */
+  @Override
+  public <A> Kind<VStreamKind.Witness, A> widen(VStream<A> vstream) {
+    Validation.kind().requireForWiden(vstream, VSTREAM_CLASS);
+    return vstream;
+  }
+
+  /**
+   * Narrows a {@code Kind<VStreamKind.Witness, A>} back to its concrete {@link VStream} type.
+   * Implements {@link VStreamConverterOps#narrow}.
+   *
+   * <p>Since {@code VStream} extends {@code VStreamKind}, this method performs a direct type check
+   * and cast without needing to unwrap from a holder.
+   *
+   * @param <A> The element type of the {@code VStream}.
+   * @param kind The {@code Kind<VStreamKind.Witness, A>} instance to narrow. May be {@code null}.
+   * @return The underlying, non-null {@link VStream} instance.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if the input {@code kind} is {@code
+   *     null}, or not an instance of {@code VStream}.
+   */
+  @Override
+  public <A> VStream<A> narrow(@Nullable Kind<VStreamKind.Witness, A> kind) {
+    return Validation.kind().narrowWithTypeCheck(kind, VSTREAM_CLASS);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamMonad.java
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.higherkindedj.hkt.util.validation.Operation.FLAT_MAP;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.util.validation.Validation;
+
+/**
+ * Implements the {@link Monad} type class for {@link VStream}, using {@link VStreamKind.Witness} as
+ * the higher-kinded type witness.
+ *
+ * <p>This implementation provides the ability to sequence VStream computations where each element
+ * can be substituted with a sub-stream that is then flattened into the result. This is the standard
+ * monadic bind (flatMap) operation for streams.
+ *
+ * <p><b>Monad Laws:</b>
+ *
+ * <ul>
+ *   <li><b>Left Identity:</b> {@code flatMap(of(a), f) == f(a)}
+ *   <li><b>Right Identity:</b> {@code flatMap(m, of) == m}
+ *   <li><b>Associativity:</b> {@code flatMap(flatMap(m, f), g) == flatMap(m, x -> flatMap(f(x),
+ *       g))}
+ * </ul>
+ *
+ * <p>This class is a stateless singleton, accessible via {@link #INSTANCE}.
+ *
+ * @see Monad
+ * @see VStreamApplicative
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamKind.Witness
+ * @see VStreamKindHelper
+ */
+public class VStreamMonad extends VStreamApplicative implements Monad<VStreamKind.Witness> {
+
+  private static final Class<VStreamMonad> VSTREAM_MONAD_CLASS = VStreamMonad.class;
+
+  /** Singleton instance of {@code VStreamMonad}. */
+  public static final VStreamMonad INSTANCE = new VStreamMonad();
+
+  /** Protected constructor to enforce the singleton pattern while allowing subclassing. */
+  protected VStreamMonad() {
+    super();
+  }
+
+  /**
+   * Sequentially composes VStream computations. Each element from the input stream is passed to
+   * function {@code f}, which produces a sub-stream. All sub-streams are flattened into the result
+   * stream.
+   *
+   * <p>This operation maintains lazy evaluation. No elements are produced until a terminal
+   * operation is invoked on the resulting stream. The flatMap implementation is stack-safe for deep
+   * chains.
+   *
+   * @param <A> The type of elements in the input stream {@code ma}.
+   * @param <B> The type of elements in the sub-streams produced by {@code f}.
+   * @param f A function that takes an element and returns a {@code Kind<VStreamKind.Witness, B>}
+   *     representing the sub-stream. Must not be null.
+   * @param ma A {@code Kind<VStreamKind.Witness, A>} representing the input stream. Must not be
+   *     null.
+   * @return A {@code Kind<VStreamKind.Witness, B>} representing the flattened result stream. Never
+   *     null.
+   * @throws NullPointerException if {@code f} or {@code ma} is null.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code ma} or the {@code Kind}
+   *     returned by {@code f} cannot be unwrapped.
+   */
+  @Override
+  public <A, B> Kind<VStreamKind.Witness, B> flatMap(
+      Function<? super A, ? extends Kind<VStreamKind.Witness, B>> f,
+      Kind<VStreamKind.Witness, A> ma) {
+
+    Validation.function().validateFlatMap(f, ma, VSTREAM_MONAD_CLASS);
+
+    VStream<A> stream = VSTREAM.narrow(ma);
+    VStream<B> result =
+        stream.flatMap(
+            a -> {
+              var kindB = f.apply(a);
+              Validation.function()
+                  .requireNonNullResult(kindB, "f", VSTREAM_MONAD_CLASS, FLAT_MAP, Kind.class);
+              return VSTREAM.narrow(kindB);
+            });
+    return VSTREAM.widen(result);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamTraverse.java
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.higherkindedj.hkt.util.validation.Operation.*;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Traverse;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.util.validation.Validation;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Implements the {@link Traverse} and {@link org.higherkindedj.hkt.Foldable} type classes for
+ * {@link VStream}, using {@link VStreamKind.Witness} as the higher-kinded type witness.
+ *
+ * <p><b>Important: Stream Materialisation</b>
+ *
+ * <p>Unlike the lazy operations in {@link VStreamFunctor} and {@link VStreamMonad}, the operations
+ * provided by {@code Traverse} and {@code Foldable} necessarily force evaluation of the stream:
+ *
+ * <ul>
+ *   <li>{@link #traverse} - Must consume the entire stream to collect results and sequence effects
+ *   <li>{@link #foldMap} - Must consume the stream to compute the folded result
+ * </ul>
+ *
+ * <p><b>Warning:</b> These operations are only safe for finite streams. Using them on infinite
+ * streams will not terminate.
+ *
+ * <p>The {@link #traverse} operation materialises the stream to a list first, then uses an
+ * iterative loop with {@code applicative.map2()} for stack-safe processing.
+ *
+ * @see Traverse
+ * @see VStream
+ * @see VStreamKind
+ * @see VStreamMonad
+ * @see VStreamFunctor
+ */
+@NullMarked
+public enum VStreamTraverse implements Traverse<VStreamKind.Witness> {
+  /** Singleton instance of {@code VStreamTraverse}. */
+  INSTANCE;
+
+  private static final Class<VStreamTraverse> VSTREAM_TRAVERSE_CLASS = VStreamTraverse.class;
+
+  /**
+   * Maps a function over a VStream in a higher-kinded context.
+   *
+   * <p>This operation delegates to {@link VStreamFunctor} and maintains lazy evaluation. It does
+   * NOT force evaluation of the stream.
+   *
+   * @param <A> The type of elements in the input stream.
+   * @param <B> The type of elements in the output stream.
+   * @param f The non-null function to apply to each element.
+   * @param fa The non-null {@code Kind<VStreamKind.Witness, A>} representing the input stream.
+   * @return A new non-null {@code Kind<VStreamKind.Witness, B>} with the function applied lazily.
+   * @throws NullPointerException if {@code f} or {@code fa} is null.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code fa} cannot be unwrapped.
+   */
+  @Override
+  public <A, B> Kind<VStreamKind.Witness, B> map(
+      Function<? super A, ? extends B> f, Kind<VStreamKind.Witness, A> fa) {
+
+    Validation.function().requireMapper(f, "f", VSTREAM_TRAVERSE_CLASS, MAP);
+    Validation.kind().requireNonNull(fa, VSTREAM_TRAVERSE_CLASS, MAP);
+
+    return VStreamFunctor.INSTANCE.map(f, fa);
+  }
+
+  /**
+   * Traverses a VStream from left to right, applying an effectful function {@code f} to each
+   * element and collecting the results within the context of the {@link Applicative} {@code G}.
+   *
+   * <p><b>Stream Materialisation Warning:</b> This operation forces evaluation of the entire
+   * stream. The stream is materialised to a list during traversal. This operation is only safe for
+   * finite streams.
+   *
+   * <p>The traversal proceeds as follows:
+   *
+   * <ol>
+   *   <li>Materialise the VStream to a list by running all VTasks
+   *   <li>Start with an empty list wrapped in the applicative context
+   *   <li>For each element, apply the effectful function and combine with the accumulator
+   *   <li>Convert the result list back to a VStream
+   * </ol>
+   *
+   * @param <G> The higher-kinded type witness for the {@link Applicative} context.
+   * @param <A> The type of elements in the input stream.
+   * @param <B> The type of elements in the resulting stream.
+   * @param applicative The non-null {@link Applicative} instance for the context {@code G}.
+   * @param f A non-null function from {@code A} to {@code Kind<G, ? extends B>}.
+   * @param ta The non-null {@code Kind<VStreamKind.Witness, A>} to traverse. This stream will be
+   *     materialised.
+   * @return A {@code Kind<G, Kind<VStreamKind.Witness, B>>} representing the traversed result.
+   *     Never null.
+   * @throws NullPointerException if {@code applicative}, {@code f}, or {@code ta} is null.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code ta} cannot be unwrapped.
+   */
+  @Override
+  public <G extends WitnessArity<TypeArity.Unary>, A, B>
+      Kind<G, Kind<VStreamKind.Witness, B>> traverse(
+          Applicative<G> applicative,
+          Function<? super A, ? extends Kind<G, ? extends B>> f,
+          Kind<VStreamKind.Witness, A> ta) {
+
+    Validation.function().validateTraverse(applicative, f, ta, VSTREAM_TRAVERSE_CLASS);
+
+    VStream<A> stream = VSTREAM.narrow(ta);
+
+    // Materialise the stream to a list
+    List<A> elements = stream.toList().run();
+
+    // Start with empty list in applicative context
+    Kind<G, List<B>> result = applicative.of(new ArrayList<>());
+
+    // Process each element, accumulating in applicative context
+    for (A a : elements) {
+      Kind<G, ? extends B> effectOfB = f.apply(a);
+      result =
+          applicative.map2(
+              result,
+              effectOfB,
+              (list, b) -> {
+                @SuppressWarnings("unchecked")
+                B bValue = (B) b;
+                list.add(bValue);
+                return list;
+              });
+    }
+
+    // Convert list to VStream and wrap
+    return applicative.map(list -> VSTREAM.widen(VStream.fromList(list)), result);
+  }
+
+  /**
+   * Maps each element of the VStream to a {@link Monoid} and combines the results.
+   *
+   * <p><b>Stream Materialisation Warning:</b> This operation forces evaluation of the entire
+   * stream. It is a terminal operation that runs all VTasks. This operation is only safe for finite
+   * streams.
+   *
+   * @param <A> The type of elements in the stream.
+   * @param <M> The Monoidal type to which elements are mapped and combined.
+   * @param monoid The {@code Monoid} used to combine the results. Must not be null.
+   * @param f A function to map each element to the Monoidal type. Must not be null.
+   * @param fa The {@code Kind<VStreamKind.Witness, A>} representing the stream to fold. Must not be
+   *     null.
+   * @return The aggregated result of type {@code M}. Never null.
+   * @throws NullPointerException if {@code monoid}, {@code f}, or {@code fa} is null.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code fa} cannot be unwrapped.
+   */
+  @Override
+  public <A, M> M foldMap(
+      Monoid<M> monoid, Function<? super A, ? extends M> f, Kind<VStreamKind.Witness, A> fa) {
+
+    Validation.function().validateFoldMap(monoid, f, fa, VSTREAM_TRAVERSE_CLASS);
+
+    VStream<A> stream = VSTREAM.narrow(fa);
+
+    // Materialise and fold using iterative consumption for stack safety
+    return stream
+        .foldLeft(
+            monoid.empty(),
+            (acc, a) -> {
+              M mapped = f.apply(a);
+              return monoid.combine(acc, mapped);
+            })
+        .run();
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/NamingConventionRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/NamingConventionRules.java
@@ -6,6 +6,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static org.higherkindedj.architecture.ArchitectureTestBase.getProductionClasses;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
+import org.higherkindedj.hkt.Alternative;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Foldable;
 import org.higherkindedj.hkt.Functor;
@@ -69,7 +70,8 @@ class NamingConventionRules {
    * <p>Examples: MaybeMonad, EitherMonad, ListMonad
    *
    * <p>Note: Selective implementations (which extend Monad) follow the "Selective" naming
-   * convention.
+   * convention. Alternative implementations (which extend Applicative, and may extend Monad) follow
+   * the "Alternative" naming convention.
    */
   @Test
   @DisplayName("Monad implementations should be named <Type>Monad")
@@ -81,6 +83,8 @@ class NamingConventionRules {
         .areNotInterfaces()
         .and()
         .doNotImplement(Selective.class) // Selective implementations use Selective suffix
+        .and()
+        .doNotImplement(Alternative.class) // Alternative implementations use Alternative suffix
         .should()
         .haveSimpleNameEndingWith("Monad")
         .allowEmptyShould(true)
@@ -93,8 +97,8 @@ class NamingConventionRules {
    * <p>Examples: MaybeApplicative, EitherApplicative
    *
    * <p>Note: Classes that implement Monad (which extends Applicative) are excluded as they follow
-   * the Monad naming convention. Selective implementations are also excluded. Anonymous and inner
-   * classes are also excluded.
+   * the Monad naming convention. Selective and Alternative implementations are also excluded.
+   * Anonymous and inner classes are also excluded.
    */
   @Test
   @DisplayName("Applicative implementations should be named <Type>Applicative")
@@ -112,8 +116,38 @@ class NamingConventionRules {
         .doNotImplement(Monad.class) // Monads are named with Monad suffix
         .and()
         .doNotImplement(Selective.class) // Selective implementations use Selective suffix
+        .and()
+        .doNotImplement(Alternative.class) // Alternative implementations use Alternative suffix
         .should()
         .haveSimpleNameEndingWith("Applicative")
+        .allowEmptyShould(true)
+        .check(productionClasses);
+  }
+
+  /**
+   * Alternative implementations must be named with "Alternative" suffix.
+   *
+   * <p>Examples: VStreamAlternative
+   *
+   * <p>Note: Classes that implement Alternative via MonadZero (which bundles Monad + Alternative
+   * into a single class named with "Monad" suffix) are excluded since they follow the Monad naming
+   * convention. Selective implementations that inherit Alternative transitively (via extending a
+   * MonadZero class) are also excluded since they follow the Selective naming convention.
+   */
+  @Test
+  @DisplayName("Alternative implementations should be named <Type>Alternative")
+  void alternative_implementations_should_end_with_alternative() {
+    classes()
+        .that()
+        .implement(Alternative.class)
+        .and()
+        .areNotInterfaces()
+        .and()
+        .haveSimpleNameNotEndingWith("Monad") // MonadZero classes use Monad suffix
+        .and()
+        .doNotImplement(Selective.class) // Selective implementations use Selective suffix
+        .should()
+        .haveSimpleNameEndingWith("Alternative")
         .allowEmptyShould(true)
         .check(productionClasses);
   }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/AlternativeLawsTestFactory.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/AlternativeLawsTestFactory.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +22,9 @@ import org.higherkindedj.hkt.maybe.MaybeKind;
 import org.higherkindedj.hkt.maybe.MaybeMonad;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vstream.VStreamAlternative;
+import org.higherkindedj.hkt.vstream.VStreamKind;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -39,7 +43,7 @@ import org.junit.jupiter.api.TestFactory;
  *       -> fb), () -> fc)}
  * </ul>
  *
- * <p>Implementations tested: Maybe, Optional, List
+ * <p>Implementations tested: Maybe, Optional, List, VStream
  *
  * <p>Note: Stream is excluded because Java Streams can only be consumed once, making them
  * unsuitable for reuse across multiple test methods. List provides equivalent coverage for
@@ -155,6 +159,19 @@ class AlternativeLawsTestFactory {
               public <A> boolean areEqual(
                   Kind<ListKind.Witness, A> a, Kind<ListKind.Witness, A> b) {
                 return LIST.narrow(a).equals(LIST.narrow(b));
+              }
+            }),
+        AlternativeTestData.of(
+            "VStream",
+            VStreamAlternative.INSTANCE,
+            AlternativeSemantics.CONCATENATION,
+            VSTREAM.widen(VStream.of(42)),
+            VSTREAM.widen(VStream.of(100)),
+            new EqualityChecker<VStreamKind.Witness>() {
+              @Override
+              public <A> boolean areEqual(
+                  Kind<VStreamKind.Witness, A> a, Kind<VStreamKind.Witness, A> b) {
+                return VSTREAM.narrow(a).toList().run().equals(VSTREAM.narrow(b).toList().run());
               }
             }));
   }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamKindHelperTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamKindHelperTest.java
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.exception.KindUnwrapException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("VStreamKindHelper Test Suite")
+class VStreamKindHelperTest {
+
+  @Nested
+  @DisplayName("widen() Operations")
+  class WidenOperations {
+
+    @Test
+    @DisplayName("widen() returns same VStream instance")
+    void widenReturnsSameVStreamInstance() {
+      VStream<Integer> original = VStream.of(1, 2, 3);
+
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(original);
+
+      assertThat(kind).isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("widen() throws for null input")
+    void widenThrowsForNullInput() {
+      assertThatThrownBy(() -> VSTREAM.widen(null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("VStream cannot be null");
+    }
+
+    @Test
+    @DisplayName("widen() preserves VStream laziness")
+    void widenPreservesVStreamLaziness() {
+      AtomicInteger counter = new AtomicInteger(0);
+      VStream<Integer> stream =
+          VStream.generate(
+              () -> {
+                counter.incrementAndGet();
+                return 42;
+              });
+
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(stream);
+
+      // Should not execute during widening
+      assertThat(counter.get()).isZero();
+
+      // Execute take(1) and verify laziness
+      List<Integer> result = VSTREAM.narrow(kind).take(1).toList().run();
+      assertThat(result).containsExactly(42);
+      assertThat(counter.get()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("narrow() Operations")
+  class NarrowOperations {
+
+    @Test
+    @DisplayName("narrow() returns original VStream")
+    void narrowReturnsOriginalVStream() {
+      VStream<Integer> original = VStream.of(1, 2, 3);
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(original);
+
+      VStream<Integer> narrowed = VSTREAM.narrow(kind);
+
+      assertThat(narrowed).isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("narrow() throws for null input")
+    void narrowThrowsForNullInput() {
+      assertThatThrownBy(() -> VSTREAM.narrow(null))
+          .isInstanceOf(KindUnwrapException.class)
+          .hasMessageContaining("Cannot narrow null Kind for VStream");
+    }
+
+    @Test
+    @DisplayName("narrow() throws for unknown Kind type")
+    void narrowThrowsForUnknownKindType() {
+      // Create a dummy VStreamKind that is not a VStream
+      VStreamKind<String> unknownKind = new VStreamKind<String>() {};
+
+      assertThatThrownBy(() -> VSTREAM.narrow(unknownKind))
+          .isInstanceOf(KindUnwrapException.class)
+          .hasMessageContaining("Kind instance cannot be narrowed to VStream");
+    }
+
+    @Test
+    @DisplayName("narrow() preserves VStream identity")
+    void narrowPreservesVStreamIdentity() {
+      VStream<String> original = VStream.of("hello", "world");
+      Kind<VStreamKind.Witness, String> widened = VSTREAM.widen(original);
+      VStream<String> narrowed = VSTREAM.narrow(widened);
+
+      assertThat(narrowed).isSameAs(original);
+      assertThat(narrowed.toList().run()).containsExactly("hello", "world");
+    }
+  }
+
+  @Nested
+  @DisplayName("Round-trip Tests")
+  class RoundTripTests {
+
+    @Test
+    @DisplayName("widen then narrow preserves identity")
+    void widenThenNarrowPreservesIdentity() {
+      VStream<Integer> original = VStream.of(1, 2, 3);
+
+      Kind<VStreamKind.Witness, Integer> widened = VSTREAM.widen(original);
+      VStream<Integer> narrowed = VSTREAM.narrow(widened);
+
+      assertThat(narrowed).isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("multiple widen/narrow cycles preserve identity")
+    void multipleWidenNarrowCyclesPreserveIdentity() {
+      VStream<Integer> original = VStream.of(42);
+
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(original);
+      for (int i = 0; i < 5; i++) {
+        VStream<Integer> narrowed = VSTREAM.narrow(kind);
+        kind = VSTREAM.widen(narrowed);
+      }
+
+      assertThat(VSTREAM.narrow(kind)).isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("round-trip preserves stream content")
+    void roundTripPreservesStreamContent() {
+      VStream<String> original = VStream.fromList(List.of("a", "b", "c"));
+
+      Kind<VStreamKind.Witness, String> widened = VSTREAM.widen(original);
+      VStream<String> narrowed = VSTREAM.narrow(widened);
+
+      assertThat(narrowed.toList().run()).containsExactly("a", "b", "c");
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases")
+  class EdgeCases {
+
+    @Test
+    @DisplayName("handles empty VStream")
+    void handlesEmptyVStream() {
+      VStream<Integer> empty = VStream.empty();
+
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(empty);
+      VStream<Integer> narrowed = VSTREAM.narrow(kind);
+
+      assertThat(narrowed.toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("handles single-element VStream")
+    void handlesSingleElementVStream() {
+      VStream<Integer> single = VStream.of(42);
+
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(single);
+      VStream<Integer> narrowed = VSTREAM.narrow(kind);
+
+      assertThat(narrowed.toList().run()).containsExactly(42);
+    }
+
+    @Test
+    @DisplayName("handles generic types")
+    void handlesGenericTypes() {
+      VStream<List<Integer>> stream = VStream.of(List.of(1, 2), List.of(3, 4));
+
+      Kind<VStreamKind.Witness, List<Integer>> kind = VSTREAM.widen(stream);
+      VStream<List<Integer>> narrowed = VSTREAM.narrow(kind);
+
+      assertThat(narrowed.toList().run()).containsExactly(List.of(1, 2), List.of(3, 4));
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamLawsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamLawsTest.java
@@ -1,0 +1,397 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.Kind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ * Explicit law verification tests for VStream using JUnit 6's @TestFactory.
+ *
+ * <p>This test class verifies that VStream satisfies all required type class laws:
+ *
+ * <ul>
+ *   <li><b>Functor Laws:</b> Identity and Composition
+ *   <li><b>Applicative Laws:</b> Identity, Homomorphism
+ *   <li><b>Monad Laws:</b> Left Identity, Right Identity, Associativity
+ *   <li><b>Alternative Laws:</b> Left Identity, Right Identity, Associativity
+ * </ul>
+ *
+ * <p>Each law is tested with multiple test values to ensure comprehensive coverage. VStream
+ * equality is determined by materialising both streams and comparing the resulting lists.
+ */
+@DisplayName("VStream Laws - Dynamic Test Factory")
+class VStreamLawsTest {
+
+  private final VStreamFunctor functor = VStreamFunctor.INSTANCE;
+  private final VStreamApplicative applicative = VStreamApplicative.INSTANCE;
+  private final VStreamMonad monad = VStreamMonad.INSTANCE;
+  private final VStreamAlternative alternative = VStreamAlternative.INSTANCE;
+
+  // ==================== Test Values ====================
+
+  private static final Integer[] TEST_VALUES = {0, 1, -1, 42, -100, 100};
+
+  /** Compares two VStream results by materialising and comparing lists. */
+  private <A> boolean vstreamsEqual(VStream<A> a, VStream<A> b) {
+    List<A> listA = a.toList().run();
+    List<A> listB = b.toList().run();
+    return Objects.equals(listA, listB);
+  }
+
+  // ==================== Functor Laws ====================
+
+  /**
+   * Functor Identity Law: map(id, fa) = fa
+   *
+   * <p>Mapping the identity function over a functor should return the original functor unchanged.
+   */
+  @TestFactory
+  @DisplayName("Functor Identity Law: map(id, fa) = fa")
+  Stream<DynamicTest> functorIdentityLaw() {
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Identity law holds for value " + value,
+                    () -> {
+                      VStream<Integer> original = VStream.of(value);
+                      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(original);
+
+                      Kind<VStreamKind.Witness, Integer> result =
+                          functor.map(Function.identity(), fa);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(result), original)).isTrue();
+                    }));
+  }
+
+  /**
+   * Functor Composition Law: map(g.f, fa) = map(g, map(f, fa))
+   *
+   * <p>Mapping a composed function should be equivalent to mapping each function in sequence.
+   */
+  @TestFactory
+  @DisplayName("Functor Composition Law: map(g.f, fa) = map(g, map(f, fa))")
+  Stream<DynamicTest> functorCompositionLaw() {
+    Function<Integer, String> f = i -> "value:" + i;
+    Function<String, Integer> g = String::length;
+
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Composition law holds for value " + value,
+                    () -> {
+                      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(VStream.of(value));
+
+                      // Left side: map(g.f, fa)
+                      Function<Integer, Integer> composed = f.andThen(g);
+                      Kind<VStreamKind.Witness, Integer> leftSide = functor.map(composed, fa);
+
+                      // Right side: map(g, map(f, fa))
+                      Kind<VStreamKind.Witness, String> intermediate = functor.map(f, fa);
+                      Kind<VStreamKind.Witness, Integer> rightSide = functor.map(g, intermediate);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(leftSide), VSTREAM.narrow(rightSide)))
+                          .isTrue();
+                    }));
+  }
+
+  /**
+   * Functor Identity Law with multi-element stream.
+   *
+   * <p>Verifies identity on streams with multiple elements.
+   */
+  @TestFactory
+  @DisplayName("Functor Identity Law (multi-element): map(id, fa) = fa")
+  Stream<DynamicTest> functorIdentityLawMultiElement() {
+    return Stream.<List<Integer>>of(
+            List.of(1, 2, 3), List.of(), List.of(42), List.of(10, 20, 30, 40, 50))
+        .map(
+            values ->
+                DynamicTest.dynamicTest(
+                    "Identity law holds for stream " + values,
+                    () -> {
+                      VStream<Integer> original = VStream.fromList(values);
+                      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(original);
+
+                      Kind<VStreamKind.Witness, Integer> result =
+                          functor.map(Function.identity(), fa);
+
+                      assertThat(VSTREAM.narrow(result).toList().run()).isEqualTo(values);
+                    }));
+  }
+
+  // ==================== Applicative Laws ====================
+
+  /**
+   * Applicative Identity Law: ap(of(id), fa) = fa
+   *
+   * <p>Applying the identity function wrapped in the applicative should return the original value.
+   */
+  @TestFactory
+  @DisplayName("Applicative Identity Law: ap(of(id), fa) = fa")
+  Stream<DynamicTest> applicativeIdentityLaw() {
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Applicative identity law holds for value " + value,
+                    () -> {
+                      VStream<Integer> original = VStream.of(value);
+                      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(original);
+                      Kind<VStreamKind.Witness, Function<Integer, Integer>> identity =
+                          applicative.of(Function.identity());
+
+                      Kind<VStreamKind.Witness, Integer> result = applicative.ap(identity, fa);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(result), original)).isTrue();
+                    }));
+  }
+
+  /**
+   * Applicative Homomorphism Law: ap(of(f), of(x)) = of(f(x))
+   *
+   * <p>Applying a wrapped function to a wrapped value equals wrapping the result of application.
+   */
+  @TestFactory
+  @DisplayName("Applicative Homomorphism Law: ap(of(f), of(x)) = of(f(x))")
+  Stream<DynamicTest> applicativeHomomorphismLaw() {
+    Function<Integer, String> f = i -> "result:" + i;
+
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Applicative homomorphism law holds for value " + value,
+                    () -> {
+                      Kind<VStreamKind.Witness, Function<Integer, String>> ff = applicative.of(f);
+                      Kind<VStreamKind.Witness, Integer> fx = applicative.of(value);
+
+                      // Left side: ap(of(f), of(x))
+                      Kind<VStreamKind.Witness, String> leftSide = applicative.ap(ff, fx);
+
+                      // Right side: of(f(x))
+                      Kind<VStreamKind.Witness, String> rightSide = applicative.of(f.apply(value));
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(leftSide), VSTREAM.narrow(rightSide)))
+                          .isTrue();
+                    }));
+  }
+
+  // ==================== Monad Laws ====================
+
+  /**
+   * Monad Left Identity Law: flatMap(of(a), f) = f(a)
+   *
+   * <p>Wrapping a value with of and then flatMapping is equivalent to just applying the function.
+   */
+  @TestFactory
+  @DisplayName("Monad Left Identity Law: flatMap(of(a), f) = f(a)")
+  Stream<DynamicTest> monadLeftIdentityLaw() {
+    Function<Integer, Kind<VStreamKind.Witness, String>> f =
+        i -> VSTREAM.widen(VStream.of("result:" + i));
+
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Left identity law holds for value " + value,
+                    () -> {
+                      // Left side: flatMap(of(a), f)
+                      Kind<VStreamKind.Witness, Integer> ofValue = monad.of(value);
+                      Kind<VStreamKind.Witness, String> leftSide = monad.flatMap(f, ofValue);
+
+                      // Right side: f(a)
+                      Kind<VStreamKind.Witness, String> rightSide = f.apply(value);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(leftSide), VSTREAM.narrow(rightSide)))
+                          .isTrue();
+                    }));
+  }
+
+  /**
+   * Monad Right Identity Law: flatMap(m, of) = m
+   *
+   * <p>FlatMapping with of should return the original monadic value unchanged.
+   */
+  @TestFactory
+  @DisplayName("Monad Right Identity Law: flatMap(m, of) = m")
+  Stream<DynamicTest> monadRightIdentityLaw() {
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Right identity law holds for value " + value,
+                    () -> {
+                      VStream<Integer> original = VStream.of(value);
+                      Kind<VStreamKind.Witness, Integer> m = VSTREAM.widen(original);
+
+                      Kind<VStreamKind.Witness, Integer> result = monad.flatMap(monad::of, m);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(result), original)).isTrue();
+                    }));
+  }
+
+  /**
+   * Monad Right Identity Law with multi-element stream.
+   *
+   * <p>Verifies right identity holds for streams with multiple elements.
+   */
+  @TestFactory
+  @DisplayName("Monad Right Identity Law (multi-element): flatMap(m, of) = m")
+  Stream<DynamicTest> monadRightIdentityLawMultiElement() {
+    return Stream.<List<Integer>>of(List.of(1, 2, 3), List.of(), List.of(10, 20))
+        .map(
+            values ->
+                DynamicTest.dynamicTest(
+                    "Right identity law holds for stream " + values,
+                    () -> {
+                      VStream<Integer> original = VStream.fromList(values);
+                      Kind<VStreamKind.Witness, Integer> m = VSTREAM.widen(original);
+
+                      Kind<VStreamKind.Witness, Integer> result = monad.flatMap(monad::of, m);
+
+                      assertThat(VSTREAM.narrow(result).toList().run()).isEqualTo(values);
+                    }));
+  }
+
+  /**
+   * Monad Associativity Law: flatMap(flatMap(m, f), g) = flatMap(m, x -> flatMap(f(x), g))
+   *
+   * <p>The order of nested flatMaps doesn't matter.
+   */
+  @TestFactory
+  @DisplayName(
+      "Monad Associativity Law: flatMap(flatMap(m, f), g) = flatMap(m, x -> flatMap(f(x), g))")
+  Stream<DynamicTest> monadAssociativityLaw() {
+    Function<Integer, Kind<VStreamKind.Witness, String>> f =
+        i -> VSTREAM.widen(VStream.of("step1:" + i));
+    Function<String, Kind<VStreamKind.Witness, Integer>> g =
+        s -> VSTREAM.widen(VStream.of(s.length()));
+
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Associativity law holds for value " + value,
+                    () -> {
+                      Kind<VStreamKind.Witness, Integer> m = VSTREAM.widen(VStream.of(value));
+
+                      // Left side: flatMap(flatMap(m, f), g)
+                      Kind<VStreamKind.Witness, String> innerFlatMap = monad.flatMap(f, m);
+                      Kind<VStreamKind.Witness, Integer> leftSide = monad.flatMap(g, innerFlatMap);
+
+                      // Right side: flatMap(m, x -> flatMap(f(x), g))
+                      Function<Integer, Kind<VStreamKind.Witness, Integer>> composed =
+                          x -> monad.flatMap(g, f.apply(x));
+                      Kind<VStreamKind.Witness, Integer> rightSide = monad.flatMap(composed, m);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(leftSide), VSTREAM.narrow(rightSide)))
+                          .isTrue();
+                    }));
+  }
+
+  // ==================== Alternative Laws ====================
+
+  /**
+   * Alternative Left Identity Law: orElse(empty(), () -> fa) = fa
+   *
+   * <p>Combining empty with any value using orElse should return that value.
+   */
+  @TestFactory
+  @DisplayName("Alternative Left Identity Law: orElse(empty(), () -> fa) = fa")
+  Stream<DynamicTest> alternativeLeftIdentityLaw() {
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Left identity law holds for value " + value,
+                    () -> {
+                      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(VStream.of(value));
+                      Kind<VStreamKind.Witness, Integer> empty = alternative.empty();
+
+                      Kind<VStreamKind.Witness, Integer> result =
+                          alternative.orElse(empty, () -> fa);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(result), VSTREAM.narrow(fa)))
+                          .isTrue();
+                    }));
+  }
+
+  /**
+   * Alternative Right Identity Law: orElse(fa, () -> empty()) = fa
+   *
+   * <p>Combining any value with empty using orElse should return that value.
+   */
+  @TestFactory
+  @DisplayName("Alternative Right Identity Law: orElse(fa, () -> empty()) = fa")
+  Stream<DynamicTest> alternativeRightIdentityLaw() {
+    return Arrays.stream(TEST_VALUES)
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    "Right identity law holds for value " + value,
+                    () -> {
+                      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(VStream.of(value));
+
+                      Kind<VStreamKind.Witness, Integer> result =
+                          alternative.orElse(fa, alternative::empty);
+
+                      assertThat(vstreamsEqual(VSTREAM.narrow(result), VSTREAM.narrow(fa)))
+                          .isTrue();
+                    }));
+  }
+
+  /**
+   * Alternative Associativity Law for concatenation semantics.
+   *
+   * <p>{@code orElse(fa, () -> orElse(fb, () -> fc)) == orElse(orElse(fa, () -> fb), () -> fc)}
+   */
+  @TestFactory
+  @DisplayName("Alternative Associativity Law (concatenation semantics)")
+  Stream<DynamicTest> alternativeAssociativityLaw() {
+    return Stream.of(
+            new Object[] {List.of(1), List.of(2), List.of(3)},
+            new Object[] {List.of(1, 2), List.of(3), List.of(4, 5)},
+            new Object[] {List.of(), List.of(1), List.of(2)})
+        .map(
+            args -> {
+              @SuppressWarnings("unchecked")
+              List<Integer> aList = (List<Integer>) args[0];
+              @SuppressWarnings("unchecked")
+              List<Integer> bList = (List<Integer>) args[1];
+              @SuppressWarnings("unchecked")
+              List<Integer> cList = (List<Integer>) args[2];
+
+              return DynamicTest.dynamicTest(
+                  "Associativity law holds for " + aList + ", " + bList + ", " + cList,
+                  () -> {
+                    Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(VStream.fromList(aList));
+                    Kind<VStreamKind.Witness, Integer> fb = VSTREAM.widen(VStream.fromList(bList));
+                    Kind<VStreamKind.Witness, Integer> fc = VSTREAM.widen(VStream.fromList(cList));
+
+                    // Left side: orElse(fa, () -> orElse(fb, () -> fc))
+                    Kind<VStreamKind.Witness, Integer> leftSide =
+                        alternative.orElse(fa, () -> alternative.orElse(fb, () -> fc));
+
+                    // Right side: orElse(orElse(fa, () -> fb), () -> fc)
+                    Kind<VStreamKind.Witness, Integer> rightSide =
+                        alternative.orElse(alternative.orElse(fa, () -> fb), () -> fc);
+
+                    assertThat(vstreamsEqual(VSTREAM.narrow(leftSide), VSTREAM.narrow(rightSide)))
+                        .isTrue();
+                  });
+            });
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamTest.java
@@ -8,6 +8,7 @@ import static org.higherkindedj.hkt.vstream.VStreamAssert.assertThatVStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.vtask.VTask;
 import org.junit.jupiter.api.DisplayName;
@@ -80,7 +81,7 @@ class VStreamTest {
     @Test
     @DisplayName("fromStream() consumes Java stream lazily")
     void fromStreamConsumesLazily() {
-      java.util.stream.Stream<Integer> javaStream = java.util.stream.Stream.of(1, 2, 3);
+      Stream<Integer> javaStream = Stream.of(1, 2, 3);
       assertThatVStream(VStream.fromStream(javaStream)).producesElements(1, 2, 3);
     }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamTypeClassTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamTypeClassTest.java
@@ -1,0 +1,451 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.vstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Operational tests for each VStream type class instance. These tests verify concrete behaviour
+ * beyond the algebraic laws tested in VStreamLawsTest.
+ */
+@DisplayName("VStream Type Class Operational Tests")
+class VStreamTypeClassTest {
+
+  // ==================== VStreamFunctor ====================
+
+  @Nested
+  @DisplayName("VStreamFunctor")
+  class VStreamFunctorTests {
+
+    private final VStreamFunctor functor = VStreamFunctor.INSTANCE;
+
+    @Test
+    @DisplayName("map transforms each element")
+    void mapTransformsEachElement() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Kind<VStreamKind.Witness, String> result = functor.map(i -> "v" + i, stream);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("v1", "v2", "v3");
+    }
+
+    @Test
+    @DisplayName("map on empty stream returns empty")
+    void mapOnEmptyStreamReturnsEmpty() {
+      Kind<VStreamKind.Witness, Integer> empty = VSTREAM.widen(VStream.empty());
+
+      Kind<VStreamKind.Witness, String> result = functor.map(Object::toString, empty);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("map preserves stream length")
+    void mapPreservesStreamLength() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3, 4, 5));
+
+      Kind<VStreamKind.Witness, Integer> result = functor.map(x -> x * 2, stream);
+
+      assertThat(VSTREAM.narrow(result).count().run()).isEqualTo(5);
+    }
+  }
+
+  // ==================== VStreamApplicative ====================
+
+  @Nested
+  @DisplayName("VStreamApplicative")
+  class VStreamApplicativeTests {
+
+    private final VStreamApplicative applicative = VStreamApplicative.INSTANCE;
+
+    @Test
+    @DisplayName("of creates single-element stream")
+    void ofCreatesSingleElementStream() {
+      Kind<VStreamKind.Witness, Integer> result = applicative.of(42);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(42);
+    }
+
+    @Test
+    @DisplayName("ap applies function stream to value stream (Cartesian product)")
+    void apAppliesFunctionStreamToValueStream() {
+      Kind<VStreamKind.Witness, Function<Integer, String>> fns =
+          VSTREAM.widen(VStream.of(i -> "a" + i, i -> "b" + i));
+      Kind<VStreamKind.Witness, Integer> values = VSTREAM.widen(VStream.of(1, 2));
+
+      Kind<VStreamKind.Witness, String> result = applicative.ap(fns, values);
+
+      // Cartesian product: [a1, a2, b1, b2]
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("a1", "a2", "b1", "b2");
+    }
+
+    @Test
+    @DisplayName("ap with empty function stream returns empty")
+    void apWithEmptyFunctionStreamReturnsEmpty() {
+      Kind<VStreamKind.Witness, Function<Integer, String>> fns = VSTREAM.widen(VStream.empty());
+      Kind<VStreamKind.Witness, Integer> values = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Kind<VStreamKind.Witness, String> result = applicative.ap(fns, values);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ap with empty value stream returns empty")
+    void apWithEmptyValueStreamReturnsEmpty() {
+      Kind<VStreamKind.Witness, Function<Integer, String>> fns =
+          VSTREAM.widen(VStream.of(i -> "v" + i));
+      Kind<VStreamKind.Witness, Integer> values = VSTREAM.widen(VStream.empty());
+
+      Kind<VStreamKind.Witness, String> result = applicative.ap(fns, values);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("map2 combines two streams")
+    void map2CombinesTwoStreams() {
+      Kind<VStreamKind.Witness, Integer> s1 = VSTREAM.widen(VStream.of(1, 2));
+      Kind<VStreamKind.Witness, String> s2 = VSTREAM.widen(VStream.of("a", "b"));
+
+      Kind<VStreamKind.Witness, String> result = applicative.map2(s1, s2, (i, s) -> i + s);
+
+      // Cartesian product via Applicative default map2
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("1a", "1b", "2a", "2b");
+    }
+  }
+
+  // ==================== VStreamMonad ====================
+
+  @Nested
+  @DisplayName("VStreamMonad")
+  class VStreamMonadTests {
+
+    private final VStreamMonad monad = VStreamMonad.INSTANCE;
+
+    @Test
+    @DisplayName("flatMap with expansion (each element produces multiple)")
+    void flatMapWithExpansion() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Kind<VStreamKind.Witness, Integer> result =
+          monad.flatMap(i -> VSTREAM.widen(VStream.of(i, i * 10)), stream);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 10, 2, 20, 3, 30);
+    }
+
+    @Test
+    @DisplayName("flatMap with contraction (some elements produce empty)")
+    void flatMapWithContraction() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3, 4, 5));
+
+      Kind<VStreamKind.Witness, Integer> result =
+          monad.flatMap(
+              i -> i % 2 == 0 ? VSTREAM.widen(VStream.of(i)) : VSTREAM.widen(VStream.empty()),
+              stream);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(2, 4);
+    }
+
+    @Test
+    @DisplayName("flatMap preserves order")
+    void flatMapPreservesOrder() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(3, 1, 2));
+
+      Kind<VStreamKind.Witness, String> result =
+          monad.flatMap(i -> VSTREAM.widen(VStream.of(i + "a", i + "b")), stream);
+
+      assertThat(VSTREAM.narrow(result).toList().run())
+          .containsExactly("3a", "3b", "1a", "1b", "2a", "2b");
+    }
+
+    @Test
+    @DisplayName("flatMap on empty stream returns empty")
+    void flatMapOnEmptyStreamReturnsEmpty() {
+      Kind<VStreamKind.Witness, Integer> empty = VSTREAM.widen(VStream.empty());
+
+      Kind<VStreamKind.Witness, String> result =
+          monad.flatMap(i -> VSTREAM.widen(VStream.of("v" + i)), empty);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+  }
+
+  // ==================== VStreamTraverse (Foldable) ====================
+
+  @Nested
+  @DisplayName("VStreamFoldable (via VStreamTraverse)")
+  class VStreamFoldableTests {
+
+    private final VStreamTraverse foldable = VStreamTraverse.INSTANCE;
+
+    private final Monoid<Integer> sumMonoid =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    private final Monoid<String> stringMonoid =
+        new Monoid<>() {
+          @Override
+          public String empty() {
+            return "";
+          }
+
+          @Override
+          public String combine(String a, String b) {
+            return a + b;
+          }
+        };
+
+    @Test
+    @DisplayName("foldMap with integer sum")
+    void foldMapWithIntegerSum() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3, 4, 5));
+
+      Integer result = foldable.foldMap(sumMonoid, Function.identity(), stream);
+
+      assertThat(result).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("foldMap with string concatenation")
+    void foldMapWithStringConcatenation() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      String result = foldable.foldMap(stringMonoid, i -> "[" + i + "]", stream);
+
+      assertThat(result).isEqualTo("[1][2][3]");
+    }
+
+    @Test
+    @DisplayName("foldMap on empty stream returns monoid identity")
+    void foldMapOnEmptyStreamReturnsMonoidIdentity() {
+      Kind<VStreamKind.Witness, Integer> empty = VSTREAM.widen(VStream.empty());
+
+      Integer result = foldable.foldMap(sumMonoid, Function.identity(), empty);
+
+      assertThat(result).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("foldMap is consistent with manual fold")
+    void foldMapIsConsistentWithManualFold() {
+      List<Integer> values = List.of(10, 20, 30, 40);
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.fromList(values));
+
+      Integer foldMapResult = foldable.foldMap(sumMonoid, Function.identity(), stream);
+      Integer manualResult = values.stream().reduce(0, Integer::sum);
+
+      assertThat(foldMapResult).isEqualTo(manualResult);
+    }
+  }
+
+  // ==================== VStreamTraverse (Traverse) ====================
+
+  @Nested
+  @DisplayName("VStreamTraverse")
+  class VStreamTraverseTests {
+
+    private final VStreamTraverse traverse = VStreamTraverse.INSTANCE;
+    private final OptionalMonad optionalApplicative = OptionalMonad.INSTANCE;
+
+    @Test
+    @DisplayName("map transforms each element")
+    void mapTransformsEachElement() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Kind<VStreamKind.Witness, String> result = traverse.map(i -> "v" + i, stream);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("v1", "v2", "v3");
+    }
+
+    @Test
+    @DisplayName("map on empty stream returns empty")
+    void mapOnEmptyStreamReturnsEmpty() {
+      Kind<VStreamKind.Witness, Integer> empty = VSTREAM.widen(VStream.empty());
+
+      Kind<VStreamKind.Witness, String> result = traverse.map(Object::toString, empty);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("map validates mapper is non-null")
+    void mapValidatesMapperIsNonNull() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1));
+
+      assertThatThrownBy(() -> traverse.map(null, stream))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("f")
+          .hasMessageContaining("VStreamTraverse")
+          .hasMessageContaining("map");
+    }
+
+    @Test
+    @DisplayName("map validates Kind is non-null")
+    void mapValidatesKindIsNonNull() {
+      assertThatThrownBy(() -> traverse.map(Object::toString, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("Kind")
+          .hasMessageContaining("VStreamTraverse")
+          .hasMessageContaining("map");
+    }
+
+    @Test
+    @DisplayName("traverse with Optional applicative (all present)")
+    void traverseWithOptionalAllPresent() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Function<Integer, Kind<OptionalKind.Witness, String>> f =
+          i -> OptionalKindHelper.OPTIONAL.widen(Optional.of("v" + i));
+
+      Kind<OptionalKind.Witness, Kind<VStreamKind.Witness, String>> result =
+          traverse.traverse(optionalApplicative, f, stream);
+
+      Optional<Kind<VStreamKind.Witness, String>> optResult =
+          OptionalKindHelper.OPTIONAL.narrow(result);
+
+      assertThat(optResult).isPresent();
+      assertThat(VSTREAM.narrow(optResult.get()).toList().run()).containsExactly("v1", "v2", "v3");
+    }
+
+    @Test
+    @DisplayName("traverse with Optional applicative (one empty, entire result empty)")
+    void traverseWithOptionalOneEmpty() {
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Function<Integer, Kind<OptionalKind.Witness, String>> f =
+          i ->
+              i == 2
+                  ? OptionalKindHelper.OPTIONAL.widen(Optional.empty())
+                  : OptionalKindHelper.OPTIONAL.widen(Optional.of("v" + i));
+
+      Kind<OptionalKind.Witness, Kind<VStreamKind.Witness, String>> result =
+          traverse.traverse(optionalApplicative, f, stream);
+
+      Optional<Kind<VStreamKind.Witness, String>> optResult =
+          OptionalKindHelper.OPTIONAL.narrow(result);
+
+      assertThat(optResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName("traverse on empty stream returns applicative of empty stream")
+    void traverseOnEmptyStreamReturnsApplicativeOfEmptyStream() {
+      Kind<VStreamKind.Witness, Integer> empty = VSTREAM.widen(VStream.empty());
+
+      Function<Integer, Kind<OptionalKind.Witness, String>> f =
+          i -> OptionalKindHelper.OPTIONAL.widen(Optional.of("v" + i));
+
+      Kind<OptionalKind.Witness, Kind<VStreamKind.Witness, String>> result =
+          traverse.traverse(optionalApplicative, f, empty);
+
+      Optional<Kind<VStreamKind.Witness, String>> optResult =
+          OptionalKindHelper.OPTIONAL.narrow(result);
+
+      assertThat(optResult).isPresent();
+      assertThat(VSTREAM.narrow(optResult.get()).toList().run()).isEmpty();
+    }
+  }
+
+  // ==================== VStreamAlternative ====================
+
+  @Nested
+  @DisplayName("VStreamAlternative")
+  class VStreamAlternativeTests {
+
+    private final VStreamAlternative alternative = VStreamAlternative.INSTANCE;
+
+    @Test
+    @DisplayName("empty produces empty stream")
+    void emptyProducesEmptyStream() {
+      Kind<VStreamKind.Witness, Integer> result = alternative.empty();
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElse concatenates streams")
+    void orElseConcatenatesStreams() {
+      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(VStream.of(1, 2));
+      Kind<VStreamKind.Witness, Integer> fb = VSTREAM.widen(VStream.of(3, 4));
+
+      Kind<VStreamKind.Witness, Integer> result = alternative.orElse(fa, () -> fb);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("orElse with empty first returns second")
+    void orElseWithEmptyFirstReturnsSecond() {
+      Kind<VStreamKind.Witness, Integer> fa = alternative.empty();
+      Kind<VStreamKind.Witness, Integer> fb = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Kind<VStreamKind.Witness, Integer> result = alternative.orElse(fa, () -> fb);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("orElse with empty second returns first")
+    void orElseWithEmptySecondReturnsFirst() {
+      Kind<VStreamKind.Witness, Integer> fa = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Kind<VStreamKind.Witness, Integer> result = alternative.orElse(fa, alternative::empty);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("guard(true) produces Unit")
+    void guardTrueProducesUnit() {
+      Kind<VStreamKind.Witness, Unit> result = alternative.guard(true);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(Unit.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("guard(false) produces empty stream")
+    void guardFalseProducesEmptyStream() {
+      Kind<VStreamKind.Witness, Unit> result = alternative.guard(false);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElse chains multiple streams")
+    void orElseChainsMultipleStreams() {
+      Kind<VStreamKind.Witness, Integer> a = VSTREAM.widen(VStream.of(1));
+      Kind<VStreamKind.Witness, Integer> b = VSTREAM.widen(VStream.of(2));
+      Kind<VStreamKind.Witness, Integer> c = VSTREAM.widen(VStream.of(3));
+
+      Kind<VStreamKind.Witness, Integer> result =
+          alternative.orElse(a, () -> alternative.orElse(b, () -> c));
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/vstream/VStreamHKTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/vstream/VStreamHKTExample.java
@@ -1,0 +1,142 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.basic.vstream;
+
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vstream.VStreamAlternative;
+import org.higherkindedj.hkt.vstream.VStreamKind;
+import org.higherkindedj.hkt.vstream.VStreamMonad;
+import org.higherkindedj.hkt.vstream.VStreamTraverse;
+
+/**
+ * Demonstrates VStream's HKT integration: type class instances, polymorphic programming, Foldable,
+ * Traverse, and Alternative operations.
+ *
+ * <p>See <a href="https://higher-kinded-j.github.io/usage-guide.html">Usage Guide</a>
+ */
+public class VStreamHKTExample {
+
+  public static void main(String[] args) {
+    VStreamHKTExample example = new VStreamHKTExample();
+
+    System.out.println("=== VStream Monad (flatMap via HKT) ===");
+    example.monadFlatMap();
+
+    System.out.println("\n=== Foldable (foldMap with Monoids) ===");
+    example.foldableExample();
+
+    System.out.println("\n=== Alternative (stream concatenation and guard) ===");
+    example.alternativeExample();
+
+    System.out.println("\n=== Polymorphic Function ===");
+    example.polymorphicFunction();
+  }
+
+  /** Demonstrates VStreamMonad flatMap via the HKT interface. */
+  void monadFlatMap() {
+    VStreamMonad monad = VStreamMonad.INSTANCE;
+
+    Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+    // Each element is expanded into a sub-stream
+    Kind<VStreamKind.Witness, Integer> result =
+        monad.flatMap(i -> VSTREAM.widen(VStream.of(i, i * 10)), stream);
+
+    List<Integer> collected = VSTREAM.narrow(result).toList().run();
+    System.out.println("flatMap expansion: " + collected);
+    // Output: [1, 10, 2, 20, 3, 30]
+  }
+
+  /** Demonstrates VStreamTraverse (Foldable) with monoid-based aggregation. */
+  void foldableExample() {
+    VStreamTraverse foldable = VStreamTraverse.INSTANCE;
+
+    Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3, 4, 5));
+
+    // Sum using integer addition monoid
+    Monoid<Integer> sumMonoid =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    Integer sum = foldable.foldMap(sumMonoid, Function.identity(), stream);
+    System.out.println("Sum of 1..5: " + sum);
+    // Output: 15
+
+    // String concatenation monoid
+    Kind<VStreamKind.Witness, String> words = VSTREAM.widen(VStream.of("Hello", " ", "World"));
+
+    Monoid<String> stringMonoid =
+        new Monoid<>() {
+          @Override
+          public String empty() {
+            return "";
+          }
+
+          @Override
+          public String combine(String a, String b) {
+            return a + b;
+          }
+        };
+
+    String joined = foldable.foldMap(stringMonoid, Function.identity(), words);
+    System.out.println("Joined: " + joined);
+    // Output: Hello World
+  }
+
+  /** Demonstrates VStreamAlternative for stream concatenation and guard filtering. */
+  void alternativeExample() {
+    VStreamAlternative alt = VStreamAlternative.INSTANCE;
+
+    // Concatenation via orElse
+    Kind<VStreamKind.Witness, Integer> a = VSTREAM.widen(VStream.of(1, 2));
+    Kind<VStreamKind.Witness, Integer> b = VSTREAM.widen(VStream.of(3, 4));
+    Kind<VStreamKind.Witness, Integer> combined = alt.orElse(a, () -> b);
+
+    System.out.println("orElse concatenation: " + VSTREAM.narrow(combined).toList().run());
+    // Output: [1, 2, 3, 4]
+
+    // guard filtering
+    Kind<VStreamKind.Witness, Unit> trueGuard = alt.guard(true);
+    Kind<VStreamKind.Witness, Unit> falseGuard = alt.guard(false);
+
+    System.out.println("guard(true): " + VSTREAM.narrow(trueGuard).toList().run());
+    // Output: [Unit.INSTANCE]
+    System.out.println("guard(false): " + VSTREAM.narrow(falseGuard).toList().run());
+    // Output: []
+  }
+
+  /** Demonstrates writing a generic function parameterised by Monad that works with VStream. */
+  void polymorphicFunction() {
+    // A generic function that works with ANY Monad
+    Kind<VStreamKind.Witness, String> result =
+        greetAll(VStreamMonad.INSTANCE, VSTREAM.widen(VStream.of("Alice", "Bob", "Charlie")));
+
+    System.out.println("Polymorphic greetAll: " + VSTREAM.narrow(result).toList().run());
+    // Output: [Hello, Alice!, Hello, Bob!, Hello, Charlie!]
+  }
+
+  /** Generic function parameterised by Monad, usable with any monad type. */
+  static <M extends WitnessArity<TypeArity.Unary>> Kind<M, String> greetAll(
+      Monad<M> monad, Kind<M, String> names) {
+    return monad.flatMap(name -> monad.of("Hello, " + name + "!"), names);
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamHKT.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamHKT.java
@@ -1,0 +1,347 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vstream.VStreamAlternative;
+import org.higherkindedj.hkt.vstream.VStreamApplicative;
+import org.higherkindedj.hkt.vstream.VStreamFunctor;
+import org.higherkindedj.hkt.vstream.VStreamKind;
+import org.higherkindedj.hkt.vstream.VStreamMonad;
+import org.higherkindedj.hkt.vstream.VStreamTraverse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial: VStream HKT - Type Class Integration for VStream
+ *
+ * <p>This tutorial covers VStream's integration into Higher-Kinded-J's type-safe HKT simulation.
+ * You will learn to widen/narrow VStreams, use type class instances (Functor, Applicative, Monad,
+ * Foldable, Alternative), and write polymorphic functions.
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>VStreamKind.Witness: phantom type marker for VStream in the Kind system
+ *   <li>VStreamKindHelper.VSTREAM: enum singleton for widen/narrow operations
+ *   <li>VStreamFunctor: lazy element-wise map via Kind interface
+ *   <li>VStreamApplicative: of and Cartesian product ap
+ *   <li>VStreamMonad: flatMap with stream substitution and flattening
+ *   <li>VStreamTraverse: foldMap (Foldable) and traverse (Traverse)
+ *   <li>VStreamAlternative: empty and orElse (concatenation semantics)
+ * </ul>
+ *
+ * <p>Prerequisites: Complete the VStream Basics tutorial first.
+ *
+ * <p>Estimated time: 12-15 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial: VStream HKT")
+public class TutorialVStreamHKT {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  // ===========================================================================
+  // Part 1: Widen and Narrow
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Widen and Narrow")
+  class WidenAndNarrow {
+
+    /**
+     * Exercise 1: Widen a VStream to Kind
+     *
+     * <p>Use VSTREAM.widen() to convert a concrete VStream into its higher-kinded representation.
+     * This allows VStream to be used with polymorphic type class functions.
+     *
+     * <p>Task: Widen the VStream to a Kind
+     */
+    @Test
+    @DisplayName("Exercise 1: Widen a VStream to Kind")
+    void exercise1_widenVStreamToKind() {
+      VStream<Integer> stream = VStream.of(1, 2, 3);
+
+      // TODO: Replace answerRequired() with VSTREAM.widen(stream)
+      Kind<VStreamKind.Witness, Integer> kind = answerRequired();
+
+      assertThat(kind).isSameAs(stream);
+    }
+
+    /**
+     * Exercise 2: Narrow a Kind back to VStream
+     *
+     * <p>Use VSTREAM.narrow() to convert from the Kind representation back to a concrete VStream.
+     *
+     * <p>Task: Narrow the Kind back to a VStream and collect elements
+     */
+    @Test
+    @DisplayName("Exercise 2: Narrow a Kind back to VStream")
+    void exercise2_narrowKindToVStream() {
+      Kind<VStreamKind.Witness, String> kind = VSTREAM.widen(VStream.of("hello", "world"));
+
+      // TODO: Replace answerRequired() with VSTREAM.narrow(kind)
+      VStream<String> stream = answerRequired();
+
+      assertThat(stream.toList().run()).containsExactly("hello", "world");
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Functor and Applicative
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Functor and Applicative")
+  class FunctorAndApplicative {
+
+    /**
+     * Exercise 3: Use VStreamFunctor.map via the HKT interface
+     *
+     * <p>VStreamFunctor.INSTANCE provides a map operation that works through the Kind interface.
+     * The operation remains lazy.
+     *
+     * <p>Task: Map a function over the stream using the functor instance
+     */
+    @Test
+    @DisplayName("Exercise 3: Functor map via HKT")
+    void exercise3_functorMapViaHKT() {
+      VStreamFunctor functor = VStreamFunctor.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      // TODO: Replace answerRequired() with functor.map(i -> i * 2, stream)
+      Kind<VStreamKind.Witness, Integer> doubled = answerRequired();
+
+      assertThat(VSTREAM.narrow(doubled).toList().run()).containsExactly(2, 4, 6);
+    }
+
+    /**
+     * Exercise 4: Use VStreamApplicative.of to create a singleton stream
+     *
+     * <p>Applicative.of lifts a pure value into the stream context.
+     *
+     * <p>Task: Create a single-element Kind using the applicative
+     */
+    @Test
+    @DisplayName("Exercise 4: Applicative of creates singleton stream")
+    void exercise4_applicativeOf() {
+      VStreamApplicative applicative = VStreamApplicative.INSTANCE;
+
+      // TODO: Replace answerRequired() with applicative.of(42)
+      Kind<VStreamKind.Witness, Integer> result = answerRequired();
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(42);
+    }
+
+    /**
+     * Exercise 5: Use VStreamApplicative.ap for Cartesian product
+     *
+     * <p>The ap operation applies each function in the function stream to each value in the value
+     * stream, producing a Cartesian product.
+     *
+     * <p>Task: Apply the function stream to the value stream
+     *
+     * <p>Hint: applicative.ap(fns, values)
+     */
+    @Test
+    @DisplayName("Exercise 5: Applicative ap (Cartesian product)")
+    void exercise5_applicativeAp() {
+      VStreamApplicative applicative = VStreamApplicative.INSTANCE;
+
+      Kind<VStreamKind.Witness, Function<Integer, String>> fns =
+          VSTREAM.widen(VStream.of(i -> "x" + i, i -> "y" + i));
+      Kind<VStreamKind.Witness, Integer> values = VSTREAM.widen(VStream.of(1, 2));
+
+      // TODO: Replace answerRequired() with applicative.ap(fns, values)
+      Kind<VStreamKind.Witness, String> result = answerRequired();
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("x1", "x2", "y1", "y2");
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: Monad
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: Monad")
+  class MonadTests {
+
+    /**
+     * Exercise 6: Use VStreamMonad.flatMap for HKT-level composition
+     *
+     * <p>Monadic flatMap substitutes each element with a sub-stream and flattens the result.
+     *
+     * <p>Task: Use monad.flatMap to expand each number into a pair [n, n*10]
+     *
+     * <p>Hint: monad.flatMap(i -> VSTREAM.widen(VStream.of(i, i * 10)), stream)
+     */
+    @Test
+    @DisplayName("Exercise 6: Monad flatMap via HKT")
+    void exercise6_monadFlatMap() {
+      VStreamMonad monad = VStreamMonad.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      // TODO: Replace answerRequired() with monad.flatMap(...)
+      Kind<VStreamKind.Witness, Integer> result = answerRequired();
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 10, 2, 20, 3, 30);
+    }
+  }
+
+  // ===========================================================================
+  // Part 4: Foldable and Alternative
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 4: Foldable and Alternative")
+  class FoldableAndAlternative {
+
+    /**
+     * Exercise 7: Use VStreamTraverse.foldMap with a sum monoid
+     *
+     * <p>Foldable.foldMap maps each element to a Monoid and combines the results.
+     *
+     * <p>Task: Fold the stream to compute the sum of all elements
+     *
+     * <p>Hint: foldable.foldMap(sumMonoid, Function.identity(), stream)
+     */
+    @Test
+    @DisplayName("Exercise 7: Foldable foldMap with sum monoid")
+    void exercise7_foldableFoldMap() {
+      VStreamTraverse foldable = VStreamTraverse.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(10, 20, 30));
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      // TODO: Replace answerRequired() with foldable.foldMap(sumMonoid, Function.identity(),
+      // stream)
+      Integer sum = answerRequired();
+
+      assertThat(sum).isEqualTo(60);
+    }
+
+    /**
+     * Exercise 8: Use VStreamAlternative.orElse for stream concatenation
+     *
+     * <p>Alternative.orElse concatenates two VStreams (concatenation semantics).
+     *
+     * <p>Task: Concatenate the two streams using orElse
+     *
+     * <p>Hint: alt.orElse(first, () -> second)
+     */
+    @Test
+    @DisplayName("Exercise 8: Alternative orElse for concatenation")
+    void exercise8_alternativeOrElse() {
+      VStreamAlternative alt = VStreamAlternative.INSTANCE;
+
+      Kind<VStreamKind.Witness, Integer> first = VSTREAM.widen(VStream.of(1, 2));
+      Kind<VStreamKind.Witness, Integer> second = VSTREAM.widen(VStream.of(3, 4));
+
+      // TODO: Replace answerRequired() with alt.orElse(first, () -> second)
+      Kind<VStreamKind.Witness, Integer> combined = answerRequired();
+
+      assertThat(VSTREAM.narrow(combined).toList().run()).containsExactly(1, 2, 3, 4);
+    }
+
+    /**
+     * Exercise 9: Use Alternative.guard for conditional filtering
+     *
+     * <p>guard(true) produces a single Unit element; guard(false) produces an empty stream.
+     *
+     * <p>Task: Use guard to conditionally produce a value
+     */
+    @Test
+    @DisplayName("Exercise 9: Alternative guard")
+    void exercise9_alternativeGuard() {
+      VStreamAlternative alt = VStreamAlternative.INSTANCE;
+
+      // TODO: Replace answerRequired() with alt.guard(true)
+      Kind<VStreamKind.Witness, Unit> trueResult = answerRequired();
+
+      // TODO: Replace answerRequired() with alt.guard(false)
+      Kind<VStreamKind.Witness, Unit> falseResult = answerRequired();
+
+      assertThat(VSTREAM.narrow(trueResult).toList().run()).containsExactly(Unit.INSTANCE);
+      assertThat(VSTREAM.narrow(falseResult).toList().run()).isEmpty();
+    }
+
+    /**
+     * Exercise 10: Combine Monad and Foldable in a pipeline
+     *
+     * <p>Use flatMap to expand elements, then foldMap to aggregate the result.
+     *
+     * <p>Task: First expand each number into [n, n+1], then sum all the results
+     *
+     * <p>Hint: First use monad.flatMap, then use foldable.foldMap on the result
+     */
+    @Test
+    @DisplayName("Exercise 10: Combine Monad and Foldable")
+    void exercise10_combineMonadAndFoldable() {
+      VStreamMonad monad = VStreamMonad.INSTANCE;
+      VStreamTraverse foldable = VStreamTraverse.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      // TODO: First expand with flatMap: each i -> [i, i+1]
+      // Then fold the result with foldMap using sumMonoid
+      // Expected: [1, 2, 2, 3, 3, 4] -> sum = 15
+      Integer sum = answerRequired();
+
+      assertThat(sum).isEqualTo(15);
+    }
+  }
+
+  /**
+   * Congratulations! You've completed the VStream HKT Tutorial.
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How to widen and narrow VStreams using VStreamKindHelper
+   *   <li>Using VStreamFunctor.map via the HKT interface
+   *   <li>Using VStreamApplicative.of and ap (Cartesian product)
+   *   <li>Using VStreamMonad.flatMap for stream composition
+   *   <li>Using VStreamTraverse.foldMap for monoid-based aggregation
+   *   <li>Using VStreamAlternative for concatenation and guard
+   *   <li>Combining type class operations in pipelines
+   * </ul>
+   *
+   * <p>Next: VStreamPath and Effect Path API (Stage 3)
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamHKT_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamHKT_Solution.java
@@ -1,0 +1,219 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vstream.VStreamAlternative;
+import org.higherkindedj.hkt.vstream.VStreamApplicative;
+import org.higherkindedj.hkt.vstream.VStreamFunctor;
+import org.higherkindedj.hkt.vstream.VStreamKind;
+import org.higherkindedj.hkt.vstream.VStreamMonad;
+import org.higherkindedj.hkt.vstream.VStreamTraverse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial: VStream HKT - Type Class Integration for VStream
+ *
+ * <p>Each exercise solution replaces the answerRequired() placeholder with the correct code.
+ */
+@DisplayName("Tutorial Solution: VStream HKT")
+public class TutorialVStreamHKT_Solution {
+
+  // ===========================================================================
+  // Part 1: Widen and Narrow
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Widen and Narrow")
+  class WidenAndNarrow {
+
+    @Test
+    @DisplayName("Exercise 1: Widen a VStream to Kind")
+    void exercise1_widenVStreamToKind() {
+      VStream<Integer> stream = VStream.of(1, 2, 3);
+
+      // SOLUTION: Use VSTREAM.widen() to convert to Kind
+      Kind<VStreamKind.Witness, Integer> kind = VSTREAM.widen(stream);
+
+      assertThat(kind).isSameAs(stream);
+    }
+
+    @Test
+    @DisplayName("Exercise 2: Narrow a Kind back to VStream")
+    void exercise2_narrowKindToVStream() {
+      Kind<VStreamKind.Witness, String> kind = VSTREAM.widen(VStream.of("hello", "world"));
+
+      // SOLUTION: Use VSTREAM.narrow() to convert back to VStream
+      VStream<String> stream = VSTREAM.narrow(kind);
+
+      assertThat(stream.toList().run()).containsExactly("hello", "world");
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Functor and Applicative
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Functor and Applicative")
+  class FunctorAndApplicative {
+
+    @Test
+    @DisplayName("Exercise 3: Functor map via HKT")
+    void exercise3_functorMapViaHKT() {
+      VStreamFunctor functor = VStreamFunctor.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      // SOLUTION: Use functor.map to double each element
+      Kind<VStreamKind.Witness, Integer> doubled = functor.map(i -> i * 2, stream);
+
+      assertThat(VSTREAM.narrow(doubled).toList().run()).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("Exercise 4: Applicative of creates singleton stream")
+    void exercise4_applicativeOf() {
+      VStreamApplicative applicative = VStreamApplicative.INSTANCE;
+
+      // SOLUTION: Use applicative.of to lift a value into VStream
+      Kind<VStreamKind.Witness, Integer> result = applicative.of(42);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(42);
+    }
+
+    @Test
+    @DisplayName("Exercise 5: Applicative ap (Cartesian product)")
+    void exercise5_applicativeAp() {
+      VStreamApplicative applicative = VStreamApplicative.INSTANCE;
+
+      Kind<VStreamKind.Witness, Function<Integer, String>> fns =
+          VSTREAM.widen(VStream.of(i -> "x" + i, i -> "y" + i));
+      Kind<VStreamKind.Witness, Integer> values = VSTREAM.widen(VStream.of(1, 2));
+
+      // SOLUTION: Use applicative.ap for Cartesian product
+      Kind<VStreamKind.Witness, String> result = applicative.ap(fns, values);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("x1", "x2", "y1", "y2");
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: Monad
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: Monad")
+  class MonadTests {
+
+    @Test
+    @DisplayName("Exercise 6: Monad flatMap via HKT")
+    void exercise6_monadFlatMap() {
+      VStreamMonad monad = VStreamMonad.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      // SOLUTION: Use monad.flatMap to expand each element
+      Kind<VStreamKind.Witness, Integer> result =
+          monad.flatMap(i -> VSTREAM.widen(VStream.of(i, i * 10)), stream);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 10, 2, 20, 3, 30);
+    }
+  }
+
+  // ===========================================================================
+  // Part 4: Foldable and Alternative
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 4: Foldable and Alternative")
+  class FoldableAndAlternative {
+
+    @Test
+    @DisplayName("Exercise 7: Foldable foldMap with sum monoid")
+    void exercise7_foldableFoldMap() {
+      VStreamTraverse foldable = VStreamTraverse.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(10, 20, 30));
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      // SOLUTION: Use foldable.foldMap with sum monoid
+      Integer sum = foldable.foldMap(sumMonoid, Function.identity(), stream);
+
+      assertThat(sum).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("Exercise 8: Alternative orElse for concatenation")
+    void exercise8_alternativeOrElse() {
+      VStreamAlternative alt = VStreamAlternative.INSTANCE;
+
+      Kind<VStreamKind.Witness, Integer> first = VSTREAM.widen(VStream.of(1, 2));
+      Kind<VStreamKind.Witness, Integer> second = VSTREAM.widen(VStream.of(3, 4));
+
+      // SOLUTION: Use alt.orElse for concatenation
+      Kind<VStreamKind.Witness, Integer> combined = alt.orElse(first, () -> second);
+
+      assertThat(VSTREAM.narrow(combined).toList().run()).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("Exercise 9: Alternative guard")
+    void exercise9_alternativeGuard() {
+      VStreamAlternative alt = VStreamAlternative.INSTANCE;
+
+      // SOLUTION: Use alt.guard(true) and alt.guard(false)
+      Kind<VStreamKind.Witness, Unit> trueResult = alt.guard(true);
+      Kind<VStreamKind.Witness, Unit> falseResult = alt.guard(false);
+
+      assertThat(VSTREAM.narrow(trueResult).toList().run()).containsExactly(Unit.INSTANCE);
+      assertThat(VSTREAM.narrow(falseResult).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Exercise 10: Combine Monad and Foldable")
+    void exercise10_combineMonadAndFoldable() {
+      VStreamMonad monad = VStreamMonad.INSTANCE;
+      VStreamTraverse foldable = VStreamTraverse.INSTANCE;
+      Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      // SOLUTION: First expand with flatMap, then fold with foldMap
+      Kind<VStreamKind.Witness, Integer> expanded =
+          monad.flatMap(i -> VSTREAM.widen(VStream.of(i, i + 1)), stream);
+      Integer sum = foldable.foldMap(sumMonoid, Function.identity(), expanded);
+
+      assertThat(sum).isEqualTo(15);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces **VStream**, a lazy, pull-based streaming abstraction that executes element production on virtual threads via VTask. VStream fills the gap between VTask (single-value effect) and Java's Stream (single-use, no virtual thread integration), enabling composable, effectful streaming pipelines.

### Key Features

- **Lazy evaluation**: Elements are produced on demand only when pulled
- **Pull-based model**: Consumer drives evaluation via `pull()`, returning `VTask<Step<A>>`
- **Virtual thread integration**: Each pull executes on a virtual thread for scalable concurrent processing
- **Rich combinators**: map, flatMap, filter, take, fold, exists, find, and many more
- **Reusable streams**: Unlike Java streams, VStream can be pulled multiple times
- **Type class integration**: Full HKT encoding with Functor, Applicative, Monad, Foldable, Traverse, and Alternative instances

### Implementation Details

**Core abstractions:**
- `VStream<A>` interface with `pull(): VTask<Step<A>>` as the fundamental operation
- `Step<A>` sealed type with three cases: `Emit` (element + continuation), `Done` (exhausted), `Skip` (no element, continue)
- `Seed<A, S>` record for unfold operations

**Factory methods:**
- `empty()`, `of()`, `fromList()`, `fromStream()`, `succeed()`, `fail()`
- `iterate()`, `unfold()`, `generate()`, `range()`, `repeat()`, `defer()`, `concat()`

**Transformation combinators:**
- `map()`, `flatMap()`, `filter()`, `filterNot()`, `take()`, `takeWhile()`, `drop()`, `dropWhile()`
- `zip()`, `zipWith()`, `intersperse()`, `scan()`, `scanLeft()`

**Terminal operations:**
- `toList()`, `fold()`, `foldLeft()`, `count()`, `exists()`, `find()`, `findIndex()`, `any()`, `all()`
- `forEach()`, `run()` (for side effects)

**Error handling:**
- `recover()`, `recoverWith()`, `attempt()` for error recovery and transformation

**Type class instances:**
- `VStreamFunctor`, `VStreamApplicative`, `VStreamMonad`, `VStreamAlternative`
- `VStreamTraverse` (Foldable + Traverse)
- `VStreamKindHelper` for widen/narrow operations in the Kind system

### Testing

- **1299 lines** of comprehensive unit tests in `VStreamTest.java` covering all factory methods, combinators, and terminal operations
- **451 lines** of type class operational tests in `VStreamTypeClassTest.java`
- **397 lines** of algebraic law verification in `VStreamLawsTest.java` (Functor, Applicative, Monad, Alternative laws)
- **189 lines** of HKT integration tests in `VStreamKindHelperTest.java`
- Custom AssertJ assertions in `VStreamAssert.java` for fluent stream testing

### Documentation

- **496 lines** of comprehensive guide in `hkj-book/src/monads/vstream.md` with examples and comparisons
- **227 lines** of HKT encoding documentation in `docs/vstream/vstream_hkt.md`
- **202 lines** of basic example code in `VStreamBasicExample.java`
- **142 lines** of HKT example code in `VStreamHKTExample.java`
- **301 lines** of tutorial exercises in `TutorialVStream.java` with solutions
- **219 lines** of HKT tutorial exercises in `TutorialVStreamHKT.java` with solutions

### Benchmarks

- **297 lines** of JMH benchmarks in `VStreamBenchmark.java` measuring construction, combinator overhead, and terminal operations

### Supporting Changes

- Added `ContextException` class to wrap checked exceptions in Context computations
- Updated `Context.java` to use `ContextException` for checked exception

fixes #377 
