### PR TITLE
Add VStreamPath: fluent API for lazy virtual-thread streams

### DIFF
--- a/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/VStreamBenchmark.java
+++ b/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/VStreamBenchmark.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.benchmarks;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.higherkindedj.hkt.vstream.VStream;
@@ -49,7 +50,7 @@ public class VStreamBenchmark {
 
   @Setup
   public void setup() {
-    sourceList = new java.util.ArrayList<>(streamSize);
+    sourceList = new ArrayList<>(streamSize);
     for (int i = 0; i < streamSize; i++) {
       sourceList.add(i);
     }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/DefaultVStreamPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/DefaultVStreamPath.java
@@ -1,0 +1,294 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.effect;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.effect.capability.Chainable;
+import org.higherkindedj.hkt.effect.capability.Combinable;
+import org.higherkindedj.hkt.function.Function3;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vtask.VTask;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.indexed.Pair;
+
+/**
+ * Default implementation of {@link VStreamPath}.
+ *
+ * <p>This class wraps a {@link VStream} and delegates all operations to it, providing the fluent
+ * Effect Path API. All stream operations remain lazy; terminal operations bridge to {@link
+ * VTaskPath} via {@link Path#vtaskPath(VTask)}.
+ *
+ * @param stream the underlying VStream; must not be null
+ * @param <A> the type of elements in the stream
+ */
+record DefaultVStreamPath<A>(VStream<A> stream) implements VStreamPath<A> {
+
+  DefaultVStreamPath {
+    Objects.requireNonNull(stream, "stream must not be null");
+  }
+
+  @Override
+  public VStream<A> run() {
+    return stream;
+  }
+
+  // ===== Composable implementation =====
+
+  @Override
+  public <B> VStreamPath<B> map(Function<? super A, ? extends B> mapper) {
+    Objects.requireNonNull(mapper, "mapper must not be null");
+    return new DefaultVStreamPath<>(stream.map(mapper));
+  }
+
+  @Override
+  public VStreamPath<A> peek(Consumer<? super A> consumer) {
+    Objects.requireNonNull(consumer, "consumer must not be null");
+    return new DefaultVStreamPath<>(stream.peek(consumer));
+  }
+
+  @Override
+  public VStreamPath<Unit> asUnit() {
+    return new DefaultVStreamPath<>(stream.asUnit());
+  }
+
+  // ===== Chainable implementation =====
+
+  @Override
+  public <B> VStreamPath<B> via(Function<? super A, ? extends Chainable<B>> mapper) {
+    Objects.requireNonNull(mapper, "mapper must not be null");
+    return new DefaultVStreamPath<>(
+        stream.flatMap(
+            a -> {
+              Chainable<B> chainable = mapper.apply(a);
+              Objects.requireNonNull(chainable, "mapper must not return null");
+
+              if (!(chainable instanceof VStreamPath<?> vsp)) {
+                throw new IllegalArgumentException(
+                    "via mapper must return VStreamPath, got: " + chainable.getClass());
+              }
+
+              @SuppressWarnings("unchecked")
+              VStreamPath<B> typedResult = (VStreamPath<B>) vsp;
+              return typedResult.run();
+            }));
+  }
+
+  @Override
+  public <B> VStreamPath<B> then(Supplier<? extends Chainable<B>> supplier) {
+    Objects.requireNonNull(supplier, "supplier must not be null");
+    return via(ignored -> supplier.get());
+  }
+
+  // ===== Combinable implementation =====
+
+  @Override
+  public <B, C> VStreamPath<C> zipWith(
+      Combinable<B> other, BiFunction<? super A, ? super B, ? extends C> combiner) {
+    Objects.requireNonNull(other, "other must not be null");
+    Objects.requireNonNull(combiner, "combiner must not be null");
+
+    if (!(other instanceof VStreamPath<?> otherVStream)) {
+      throw new IllegalArgumentException("Cannot zipWith non-VStreamPath: " + other.getClass());
+    }
+
+    @SuppressWarnings("unchecked")
+    VStreamPath<B> typedOther = (VStreamPath<B>) otherVStream;
+
+    return new DefaultVStreamPath<>(stream.zipWith(typedOther.run(), combiner::apply));
+  }
+
+  @Override
+  public <B, C, D> VStreamPath<D> zipWith3(
+      VStreamPath<B> second,
+      VStreamPath<C> third,
+      Function3<? super A, ? super B, ? super C, ? extends D> combiner) {
+    Objects.requireNonNull(second, "second must not be null");
+    Objects.requireNonNull(third, "third must not be null");
+    Objects.requireNonNull(combiner, "combiner must not be null");
+
+    // Zip this with second, then zip the result with third
+    VStream<D> zipped =
+        stream
+            .zipWith(second.run(), Pair::new)
+            .zipWith(third.run(), (pair, c) -> combiner.apply(pair.first(), pair.second(), c));
+
+    return new DefaultVStreamPath<>(zipped);
+  }
+
+  // ===== Stream-specific operations =====
+
+  @Override
+  public VStreamPath<A> filter(Predicate<? super A> predicate) {
+    Objects.requireNonNull(predicate, "predicate must not be null");
+    return new DefaultVStreamPath<>(stream.filter(predicate));
+  }
+
+  @Override
+  public VStreamPath<A> take(long n) {
+    return new DefaultVStreamPath<>(stream.take(n));
+  }
+
+  @Override
+  public VStreamPath<A> drop(long n) {
+    return new DefaultVStreamPath<>(stream.drop(n));
+  }
+
+  @Override
+  public VStreamPath<A> takeWhile(Predicate<? super A> predicate) {
+    Objects.requireNonNull(predicate, "predicate must not be null");
+    return new DefaultVStreamPath<>(stream.takeWhile(predicate));
+  }
+
+  @Override
+  public VStreamPath<A> dropWhile(Predicate<? super A> predicate) {
+    Objects.requireNonNull(predicate, "predicate must not be null");
+    return new DefaultVStreamPath<>(stream.dropWhile(predicate));
+  }
+
+  @Override
+  public VStreamPath<A> distinct() {
+    return new DefaultVStreamPath<>(stream.distinct());
+  }
+
+  @Override
+  public VStreamPath<A> concat(VStreamPath<A> other) {
+    Objects.requireNonNull(other, "other must not be null");
+    return new DefaultVStreamPath<>(stream.concat(other.run()));
+  }
+
+  // ===== Terminal operations (bridge to VTaskPath) =====
+
+  @Override
+  public VTaskPath<List<A>> toList() {
+    return new DefaultVTaskPath<>(stream.toList());
+  }
+
+  @Override
+  public VTaskPath<A> fold(A identity, BinaryOperator<A> op) {
+    Objects.requireNonNull(op, "op must not be null");
+    return new DefaultVTaskPath<>(stream.fold(identity, op));
+  }
+
+  @Override
+  public <B> VTaskPath<B> foldLeft(B identity, BiFunction<B, A, B> f) {
+    Objects.requireNonNull(f, "f must not be null");
+    return new DefaultVTaskPath<>(stream.foldLeft(identity, f));
+  }
+
+  @Override
+  public <M> VTaskPath<M> foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f) {
+    Objects.requireNonNull(monoid, "monoid must not be null");
+    Objects.requireNonNull(f, "f must not be null");
+    return new DefaultVTaskPath<>(
+        stream.foldLeft(monoid.empty(), (acc, a) -> monoid.combine(acc, f.apply(a))));
+  }
+
+  @Override
+  public VTaskPath<Optional<A>> headOption() {
+    return new DefaultVTaskPath<>(stream.headOption());
+  }
+
+  @Override
+  public VTaskPath<Optional<A>> lastOption() {
+    return new DefaultVTaskPath<>(stream.lastOption());
+  }
+
+  @Override
+  public VTaskPath<Long> count() {
+    return new DefaultVTaskPath<>(stream.count());
+  }
+
+  @Override
+  public VTaskPath<Boolean> exists(Predicate<? super A> predicate) {
+    Objects.requireNonNull(predicate, "predicate must not be null");
+    return new DefaultVTaskPath<>(stream.exists(predicate));
+  }
+
+  @Override
+  public VTaskPath<Boolean> forAll(Predicate<? super A> predicate) {
+    Objects.requireNonNull(predicate, "predicate must not be null");
+    return new DefaultVTaskPath<>(stream.forAll(predicate));
+  }
+
+  @Override
+  public VTaskPath<Optional<A>> find(Predicate<? super A> predicate) {
+    Objects.requireNonNull(predicate, "predicate must not be null");
+    return new DefaultVTaskPath<>(stream.find(predicate));
+  }
+
+  @Override
+  public VTaskPath<Unit> forEach(Consumer<? super A> consumer) {
+    Objects.requireNonNull(consumer, "consumer must not be null");
+    return new DefaultVTaskPath<>(stream.forEach(consumer));
+  }
+
+  // ===== Focus bridge =====
+
+  @Override
+  public <B> VStreamPath<B> focus(FocusPath<A, B> path) {
+    Objects.requireNonNull(path, "path must not be null");
+    return map(path::get);
+  }
+
+  @Override
+  public <B> VStreamPath<B> focus(AffinePath<A, B> path) {
+    Objects.requireNonNull(path, "path must not be null");
+    return new DefaultVStreamPath<>(
+        stream.map(a -> path.getOptional(a)).filter(Optional::isPresent).map(Optional::get));
+  }
+
+  // ===== Conversions =====
+
+  @Override
+  public VTaskPath<A> first() {
+    return new DefaultVTaskPath<>(
+        stream
+            .headOption()
+            .map(opt -> opt.orElseThrow(() -> new NoSuchElementException("VStreamPath is empty"))));
+  }
+
+  @Override
+  public VTaskPath<A> last() {
+    return new DefaultVTaskPath<>(
+        stream
+            .lastOption()
+            .map(opt -> opt.orElseThrow(() -> new NoSuchElementException("VStreamPath is empty"))));
+  }
+
+  @Override
+  public StreamPath<A> toStreamPath() {
+    List<A> elements = stream.toList().run();
+    return StreamPath.fromList(elements);
+  }
+
+  @Override
+  public ListPath<A> toListPath() {
+    List<A> elements = stream.toList().run();
+    return ListPath.of(elements);
+  }
+
+  @Override
+  public NonDetPath<A> toNonDetPath() {
+    List<A> elements = stream.toList().run();
+    return NonDetPath.of(elements);
+  }
+
+  // ===== Object methods =====
+
+  @Override
+  public String toString() {
+    return "VStreamPath(<stream>)";
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/DefaultVTaskPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/DefaultVTaskPath.java
@@ -16,7 +16,6 @@ import org.higherkindedj.hkt.function.Function3;
 import org.higherkindedj.hkt.io.IO;
 import org.higherkindedj.hkt.vtask.Par;
 import org.higherkindedj.hkt.vtask.VTask;
-import org.higherkindedj.hkt.vtask.VTaskExecutionException;
 import org.higherkindedj.optics.focus.AffinePath;
 import org.higherkindedj.optics.focus.FocusPath;
 
@@ -48,13 +47,9 @@ final class DefaultVTaskPath<A> implements VTaskPath<A> {
 
   @Override
   public A unsafeRun() {
-    try {
-      return value.run();
-    } catch (RuntimeException | Error e) {
-      throw e;
-    } catch (Throwable t) {
-      throw new VTaskExecutionException(t);
-    }
+    // VTask.run() already wraps checked exceptions in VTaskExecutionException,
+    // so it can only throw RuntimeException or Error — no additional wrapping needed.
+    return value.run();
   }
 
   @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/Path.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/Path.java
@@ -33,6 +33,7 @@ import org.higherkindedj.hkt.state.State;
 import org.higherkindedj.hkt.trampoline.Trampoline;
 import org.higherkindedj.hkt.trymonad.Try;
 import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.vstream.VStream;
 import org.higherkindedj.hkt.vtask.VTask;
 import org.higherkindedj.hkt.writer.Writer;
 import org.jspecify.annotations.Nullable;
@@ -134,6 +135,7 @@ import org.jspecify.annotations.Nullable;
  * @see CompletableFuturePath
  * @see NonDetPath
  * @see StreamPath
+ * @see VStreamPath
  * @see TrampolinePath
  * @see FreePath
  * @see FreeApPath
@@ -984,6 +986,131 @@ public final class Path {
    */
   public static <A> StreamPath<A> streamIterate(A seed, UnaryOperator<A> f) {
     return StreamPath.iterate(seed, f);
+  }
+
+  // ===== VStreamPath factory methods =====
+
+  /**
+   * Creates a VStreamPath from an existing VStream.
+   *
+   * <p>The VStream is wrapped directly; no materialisation occurs.
+   *
+   * @param stream the VStream to wrap; must not be null
+   * @param <A> the element type
+   * @return a VStreamPath wrapping the VStream
+   * @throws NullPointerException if stream is null
+   */
+  public static <A> VStreamPath<A> vstream(VStream<A> stream) {
+    Objects.requireNonNull(stream, "stream must not be null");
+    return new DefaultVStreamPath<>(stream);
+  }
+
+  /**
+   * Creates a VStreamPath from the given elements.
+   *
+   * @param elements the elements to include; must not be null
+   * @param <A> the element type
+   * @return a VStreamPath containing the elements
+   * @throws NullPointerException if elements is null
+   */
+  @SafeVarargs
+  public static <A> VStreamPath<A> vstreamOf(A... elements) {
+    Objects.requireNonNull(elements, "elements must not be null");
+    return new DefaultVStreamPath<>(VStream.of(elements));
+  }
+
+  /**
+   * Creates a VStreamPath from a list.
+   *
+   * <p>The list is iterated lazily; it is not copied.
+   *
+   * @param list the list to stream; must not be null
+   * @param <A> the element type
+   * @return a VStreamPath streaming the list
+   * @throws NullPointerException if list is null
+   */
+  public static <A> VStreamPath<A> vstreamFromList(List<A> list) {
+    Objects.requireNonNull(list, "list must not be null");
+    return new DefaultVStreamPath<>(VStream.fromList(list));
+  }
+
+  /**
+   * Creates a VStreamPath with a single element.
+   *
+   * @param value the single element
+   * @param <A> the element type
+   * @return a VStreamPath containing one element
+   */
+  public static <A> VStreamPath<A> vstreamPure(A value) {
+    return new DefaultVStreamPath<>(VStream.of(value));
+  }
+
+  /**
+   * Creates an empty VStreamPath.
+   *
+   * @param <A> the element type
+   * @return an empty VStreamPath
+   */
+  public static <A> VStreamPath<A> vstreamEmpty() {
+    return new DefaultVStreamPath<>(VStream.empty());
+  }
+
+  /**
+   * Creates an infinite VStreamPath by iteration.
+   *
+   * <p><b>Warning:</b> Use {@code take()} to limit infinite streams.
+   *
+   * @param seed the initial value
+   * @param f the iteration function; must not be null
+   * @param <A> the element type
+   * @return an infinite VStreamPath
+   * @throws NullPointerException if f is null
+   */
+  public static <A> VStreamPath<A> vstreamIterate(A seed, UnaryOperator<A> f) {
+    Objects.requireNonNull(f, "f must not be null");
+    return new DefaultVStreamPath<>(VStream.iterate(seed, f));
+  }
+
+  /**
+   * Creates an infinite VStreamPath from a supplier.
+   *
+   * <p><b>Warning:</b> Use {@code take()} to limit infinite streams.
+   *
+   * @param supplier the element supplier; must not be null
+   * @param <A> the element type
+   * @return an infinite VStreamPath
+   * @throws NullPointerException if supplier is null
+   */
+  public static <A> VStreamPath<A> vstreamGenerate(Supplier<A> supplier) {
+    Objects.requireNonNull(supplier, "supplier must not be null");
+    return new DefaultVStreamPath<>(VStream.generate(supplier));
+  }
+
+  /**
+   * Creates a VStreamPath of integers in the range {@code [start, end)}.
+   *
+   * @param startInclusive the inclusive start of the range
+   * @param endExclusive the exclusive end of the range
+   * @return a VStreamPath of integers
+   */
+  public static VStreamPath<Integer> vstreamRange(int startInclusive, int endExclusive) {
+    return new DefaultVStreamPath<>(VStream.range(startInclusive, endExclusive));
+  }
+
+  /**
+   * Creates a VStreamPath by effectful unfolding from an initial state.
+   *
+   * @param seed the initial state
+   * @param f a function producing the next value and state, or empty to complete; must not be null
+   * @param <S> the state type
+   * @param <A> the element type
+   * @return a VStreamPath produced by unfolding
+   * @throws NullPointerException if f is null
+   */
+  public static <S, A> VStreamPath<A> vstreamUnfold(
+      S seed, Function<S, VTask<Optional<VStream.Seed<A, S>>>> f) {
+    Objects.requireNonNull(f, "f must not be null");
+    return new DefaultVStreamPath<>(VStream.unfold(seed, f));
   }
 
   // ===== PathRegistry integration =====

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/VStreamPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/VStreamPath.java
@@ -1,0 +1,394 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.effect;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.effect.capability.Chainable;
+import org.higherkindedj.hkt.effect.capability.Combinable;
+import org.higherkindedj.hkt.function.Function3;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+
+/**
+ * A fluent path wrapper for {@link VStream} values.
+ *
+ * <p>{@code VStreamPath} provides a chainable API for composing lazy, pull-based streaming
+ * computations that execute on virtual threads. It implements {@link Chainable} to support monadic
+ * composition within the Effect Path ecosystem.
+ *
+ * <h2>Relationship to VStream</h2>
+ *
+ * <p>VStreamPath wraps a {@link VStream} and provides:
+ *
+ * <ul>
+ *   <li>Fluent API consistent with other Effect Path types
+ *   <li>Stream-specific operations (filter, take, drop, distinct, concat)
+ *   <li>Terminal operations that bridge to {@link VTaskPath} for single-value results
+ *   <li>Optics focus bridge for navigating into stream elements
+ *   <li>Conversions to other path types (StreamPath, ListPath, NonDetPath)
+ * </ul>
+ *
+ * <h2>Creating VStreamPath instances</h2>
+ *
+ * <p>Use the {@link Path} factory class:
+ *
+ * <pre>{@code
+ * VStreamPath<Integer> numbers = Path.vstream(VStream.fromList(List.of(1, 2, 3)));
+ * VStreamPath<String> names = Path.vstreamOf("Alice", "Bob", "Charlie");
+ * VStreamPath<Integer> range = Path.vstreamRange(1, 100);
+ * VStreamPath<Integer> infinite = Path.vstreamIterate(1, n -> n + 1);
+ * }</pre>
+ *
+ * <h2>Composing operations</h2>
+ *
+ * <p>Operations are lazy; nothing executes until a terminal operation is called:
+ *
+ * <pre>{@code
+ * VStreamPath<String> pipeline = Path.vstreamRange(1, 100)
+ *     .filter(n -> n % 2 == 0)
+ *     .map(n -> "Even: " + n)
+ *     .take(5);
+ *
+ * // Terminal operation triggers execution, returning VTaskPath
+ * List<String> result = pipeline.toList().unsafeRun();
+ * }</pre>
+ *
+ * <h2>Terminal operations</h2>
+ *
+ * <p>Terminal operations return {@link VTaskPath}, bridging from stream to single-value effect:
+ *
+ * <pre>{@code
+ * VTaskPath<List<String>> collected = pipeline.toList();
+ * VTaskPath<Long> counted = pipeline.count();
+ * VTaskPath<Boolean> hasEven = pipeline.exists(s -> s.contains("Even"));
+ * }</pre>
+ *
+ * <h2>Comparison with StreamPath</h2>
+ *
+ * <ul>
+ *   <li>{@code VStreamPath} - Lazy, pull-based, virtual thread execution, effectful elements
+ *   <li>{@code StreamPath} - Materialises internally, no virtual thread integration
+ * </ul>
+ *
+ * @param <A> the type of elements in the stream
+ * @see VStream
+ * @see VTaskPath
+ * @see StreamPath
+ */
+public sealed interface VStreamPath<A> extends Chainable<A> permits DefaultVStreamPath {
+
+  // ===== Core access =====
+
+  /**
+   * Returns the underlying {@link VStream}.
+   *
+   * @return the wrapped VStream; never null
+   */
+  VStream<A> run();
+
+  // ===== Composable operations (Functor) =====
+
+  @Override
+  <B> VStreamPath<B> map(Function<? super A, ? extends B> mapper);
+
+  /**
+   * Performs a side effect on each element without modifying it.
+   *
+   * @param consumer the action to perform on each element; must not be null
+   * @return a new VStreamPath that performs the action
+   * @throws NullPointerException if consumer is null
+   */
+  VStreamPath<A> peek(Consumer<? super A> consumer);
+
+  /**
+   * Maps all elements to {@link Unit}, discarding values but preserving stream structure.
+   *
+   * @return a VStreamPath that produces Unit for each element
+   */
+  VStreamPath<Unit> asUnit();
+
+  // ===== Chainable operations (Monad) =====
+
+  @Override
+  <B> VStreamPath<B> via(Function<? super A, ? extends Chainable<B>> mapper);
+
+  @Override
+  default <B> VStreamPath<B> flatMap(Function<? super A, ? extends Chainable<B>> mapper) {
+    return via(mapper);
+  }
+
+  @Override
+  <B> VStreamPath<B> then(Supplier<? extends Chainable<B>> supplier);
+
+  // ===== Combinable operations (Applicative) =====
+
+  @Override
+  <B, C> VStreamPath<C> zipWith(
+      Combinable<B> other, BiFunction<? super A, ? super B, ? extends C> combiner);
+
+  /**
+   * Combines this path with two others using a ternary function. Elements are paired positionally;
+   * the result has length equal to the shortest input.
+   *
+   * @param second the second path; must not be null
+   * @param third the third path; must not be null
+   * @param combiner the function to combine the values; must not be null
+   * @param <B> the type of the second path's value
+   * @param <C> the type of the third path's value
+   * @param <D> the type of the combined result
+   * @return a new VStreamPath containing the combined results
+   */
+  <B, C, D> VStreamPath<D> zipWith3(
+      VStreamPath<B> second,
+      VStreamPath<C> third,
+      Function3<? super A, ? super B, ? super C, ? extends D> combiner);
+
+  // ===== Stream-specific operations =====
+
+  /**
+   * Filters elements using the given predicate. Non-matching elements are skipped lazily.
+   *
+   * @param predicate the predicate to test elements against; must not be null
+   * @return a new VStreamPath with only matching elements
+   * @throws NullPointerException if predicate is null
+   */
+  VStreamPath<A> filter(Predicate<? super A> predicate);
+
+  /**
+   * Takes at most the first {@code n} elements.
+   *
+   * @param n the maximum number of elements to take
+   * @return a new VStreamPath limited to n elements
+   */
+  VStreamPath<A> take(long n);
+
+  /**
+   * Drops the first {@code n} elements.
+   *
+   * @param n the number of elements to drop
+   * @return a new VStreamPath without the first n elements
+   */
+  VStreamPath<A> drop(long n);
+
+  /**
+   * Takes elements while the predicate holds, then completes.
+   *
+   * @param predicate the predicate to test elements against; must not be null
+   * @return a new VStreamPath that completes when the predicate fails
+   * @throws NullPointerException if predicate is null
+   */
+  VStreamPath<A> takeWhile(Predicate<? super A> predicate);
+
+  /**
+   * Drops elements while the predicate holds, then emits all remaining.
+   *
+   * @param predicate the predicate to test elements against; must not be null
+   * @return a new VStreamPath that skips initial matching elements
+   * @throws NullPointerException if predicate is null
+   */
+  VStreamPath<A> dropWhile(Predicate<? super A> predicate);
+
+  /**
+   * Removes duplicate elements. Elements are compared using {@link Object#equals(Object)}.
+   *
+   * <p><b>Warning:</b> For infinite streams, the internal set grows without bound.
+   *
+   * @return a new VStreamPath with duplicates removed
+   */
+  VStreamPath<A> distinct();
+
+  /**
+   * Appends another VStreamPath after this one.
+   *
+   * @param other the VStreamPath to append; must not be null
+   * @return a new VStreamPath containing elements from both
+   * @throws NullPointerException if other is null
+   */
+  VStreamPath<A> concat(VStreamPath<A> other);
+
+  // ===== Materialisation to VTaskPath (terminal operations) =====
+
+  /**
+   * Collects all elements into a list. This is a terminal operation.
+   *
+   * <p><b>Warning:</b> For infinite streams, this will not terminate. Use {@link #take(long)}
+   * first.
+   *
+   * @return a VTaskPath that produces the list of all elements
+   */
+  VTaskPath<List<A>> toList();
+
+  /**
+   * Left-folds all elements with the given identity and operator.
+   *
+   * @param identity the initial accumulator value
+   * @param op the binary operator; must not be null
+   * @return a VTaskPath that produces the fold result
+   * @throws NullPointerException if op is null
+   */
+  VTaskPath<A> fold(A identity, BinaryOperator<A> op);
+
+  /**
+   * Left-folds all elements with the given initial value and accumulator function.
+   *
+   * @param identity the initial accumulator value
+   * @param f the accumulator function; must not be null
+   * @param <B> the type of the accumulator
+   * @return a VTaskPath that produces the fold result
+   * @throws NullPointerException if f is null
+   */
+  <B> VTaskPath<B> foldLeft(B identity, BiFunction<B, A, B> f);
+
+  /**
+   * Folds all elements using a monoid, mapping each element first.
+   *
+   * @param monoid the Monoid for combining values; must not be null
+   * @param f the mapping function; must not be null
+   * @param <M> the monoid type
+   * @return a VTaskPath that produces the fold result
+   * @throws NullPointerException if monoid or f is null
+   */
+  <M> VTaskPath<M> foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f);
+
+  /**
+   * Returns the first element, or empty if the stream is empty.
+   *
+   * @return a VTaskPath producing the first element as an Optional
+   */
+  VTaskPath<Optional<A>> headOption();
+
+  /**
+   * Returns the last element, or empty if the stream is empty.
+   *
+   * <p><b>Warning:</b> For infinite streams, this will not terminate.
+   *
+   * @return a VTaskPath producing the last element as an Optional
+   */
+  VTaskPath<Optional<A>> lastOption();
+
+  /**
+   * Counts the number of elements.
+   *
+   * <p><b>Warning:</b> For infinite streams, this will not terminate.
+   *
+   * @return a VTaskPath producing the element count
+   */
+  VTaskPath<Long> count();
+
+  /**
+   * Checks whether any element matches the given predicate. Short-circuits on the first match.
+   *
+   * @param predicate the predicate to test; must not be null
+   * @return a VTaskPath producing true if any element matches
+   * @throws NullPointerException if predicate is null
+   */
+  VTaskPath<Boolean> exists(Predicate<? super A> predicate);
+
+  /**
+   * Checks whether all elements match the given predicate. Short-circuits on the first non-match.
+   *
+   * @param predicate the predicate to test; must not be null
+   * @return a VTaskPath producing true if all elements match
+   * @throws NullPointerException if predicate is null
+   */
+  VTaskPath<Boolean> forAll(Predicate<? super A> predicate);
+
+  /**
+   * Finds the first element matching the given predicate.
+   *
+   * @param predicate the predicate to test; must not be null
+   * @return a VTaskPath producing the first match as an Optional
+   * @throws NullPointerException if predicate is null
+   */
+  VTaskPath<Optional<A>> find(Predicate<? super A> predicate);
+
+  /**
+   * Executes a side effect for each element.
+   *
+   * @param consumer the action to perform on each element; must not be null
+   * @return a VTaskPath that completes when all elements are processed
+   * @throws NullPointerException if consumer is null
+   */
+  VTaskPath<Unit> forEach(Consumer<? super A> consumer);
+
+  // ===== Optics focus bridge =====
+
+  /**
+   * Applies a {@link FocusPath} to each element, extracting a focused value. Since FocusPath always
+   * succeeds, every element produces a result.
+   *
+   * @param path the FocusPath to apply; must not be null
+   * @param <B> the focused type
+   * @return a new VStreamPath with focused values
+   * @throws NullPointerException if path is null
+   */
+  <B> VStreamPath<B> focus(FocusPath<A, B> path);
+
+  /**
+   * Applies an {@link AffinePath} to each element, keeping only elements where the affine matches.
+   * Elements where the affine does not match are excluded from the result stream.
+   *
+   * @param path the AffinePath to apply; must not be null
+   * @param <B> the focused type
+   * @return a new VStreamPath with focused values (non-matching elements filtered out)
+   * @throws NullPointerException if path is null
+   */
+  <B> VStreamPath<B> focus(AffinePath<A, B> path);
+
+  // ===== Conversions =====
+
+  /**
+   * Returns the first element as a VTaskPath. Fails with {@link java.util.NoSuchElementException}
+   * if the stream is empty.
+   *
+   * @return a VTaskPath producing the first element
+   */
+  VTaskPath<A> first();
+
+  /**
+   * Returns the last element as a VTaskPath. Fails with {@link java.util.NoSuchElementException} if
+   * the stream is empty.
+   *
+   * <p><b>Warning:</b> For infinite streams, this will not terminate.
+   *
+   * @return a VTaskPath producing the last element
+   */
+  VTaskPath<A> last();
+
+  /**
+   * Converts to a StreamPath by materialising all elements.
+   *
+   * <p><b>Note:</b> This executes the VStream, collecting all elements into memory.
+   *
+   * @return a StreamPath containing the materialised elements
+   */
+  StreamPath<A> toStreamPath();
+
+  /**
+   * Converts to a ListPath by materialising all elements.
+   *
+   * <p><b>Note:</b> This executes the VStream, collecting all elements into memory.
+   *
+   * @return a ListPath containing the materialised elements
+   */
+  ListPath<A> toListPath();
+
+  /**
+   * Converts to a NonDetPath by materialising all elements.
+   *
+   * <p><b>Note:</b> This executes the VStream, collecting all elements into memory.
+   *
+   * @return a NonDetPath containing the materialised elements
+   */
+  NonDetPath<A> toNonDetPath();
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/capability/Chainable.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/capability/Chainable.java
@@ -14,6 +14,7 @@ import org.higherkindedj.hkt.effect.OptionalPath;
 import org.higherkindedj.hkt.effect.ReaderPath;
 import org.higherkindedj.hkt.effect.StreamPath;
 import org.higherkindedj.hkt.effect.TrampolinePath;
+import org.higherkindedj.hkt.effect.VStreamPath;
 import org.higherkindedj.hkt.effect.ValidationPath;
 import org.higherkindedj.hkt.effect.WithStatePath;
 import org.higherkindedj.hkt.effect.WriterPath;
@@ -66,6 +67,7 @@ public sealed interface Chainable<A> extends Combinable<A>
         ListPath,
         NonDetPath,
         StreamPath,
+        VStreamPath,
         TrampolinePath,
         FreePath {
 

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/EffectPathTestingRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/EffectPathTestingRules.java
@@ -65,6 +65,7 @@ class EffectPathTestingRules {
           "CompletableFuturePath",
           "ListPath",
           "StreamPath",
+          "VStreamPath",
           "NonDetPath");
 
   @BeforeAll

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathLawsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathLawsTest.java
@@ -1,0 +1,233 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.effect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ * Law verification tests for VStreamPath.
+ *
+ * <p>Verifies that VStreamPath satisfies Functor and Monad laws. VStreamPath uses lazy pull-based
+ * stream evaluation with virtual thread execution.
+ */
+@DisplayName("VStreamPath Law Verification Tests")
+class VStreamPathLawsTest {
+
+  private static final int TEST_VALUE = 42;
+  private static final Function<Integer, Integer> ADD_ONE = x -> x + 1;
+  private static final Function<Integer, Integer> DOUBLE = x -> x * 2;
+  private static final Function<Integer, String> INT_TO_STRING = x -> "value:" + x;
+  private static final Function<String, Integer> STRING_LENGTH = String::length;
+
+  private static List<Integer> materialise(VStreamPath<Integer> path) {
+    return path.toList().unsafeRun();
+  }
+
+  private static List<String> materialiseStr(VStreamPath<String> path) {
+    return path.toList().unsafeRun();
+  }
+
+  @Nested
+  @DisplayName("Functor Laws")
+  class FunctorLawsTests {
+
+    @TestFactory
+    @DisplayName("Functor Identity Law: path.map(id) == path")
+    Stream<DynamicTest> functorIdentityLaw() {
+      return Stream.of(
+          DynamicTest.dynamicTest(
+              "Identity law holds for single element",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamPure(TEST_VALUE);
+                VStreamPath<Integer> result = path.map(Function.identity());
+                assertThat(materialise(result)).isEqualTo(materialise(path));
+              }),
+          DynamicTest.dynamicTest(
+              "Identity law holds for multiple elements",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3, 4, 5));
+                VStreamPath<Integer> result = path.map(Function.identity());
+                assertThat(materialise(result)).isEqualTo(materialise(path));
+              }),
+          DynamicTest.dynamicTest(
+              "Identity law holds for empty stream",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamEmpty();
+                VStreamPath<Integer> result = path.map(Function.identity());
+                assertThat(materialise(result)).isEqualTo(materialise(path));
+              }));
+    }
+
+    @TestFactory
+    @DisplayName("Functor Composition Law: path.map(f).map(g) == path.map(g.compose(f))")
+    Stream<DynamicTest> functorCompositionLaw() {
+      return Stream.of(
+          DynamicTest.dynamicTest(
+              "Composition law holds for single element",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamPure(TEST_VALUE);
+                VStreamPath<Integer> leftSide = path.map(ADD_ONE).map(DOUBLE);
+                VStreamPath<Integer> rightSide = path.map(ADD_ONE.andThen(DOUBLE));
+                assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+              }),
+          DynamicTest.dynamicTest(
+              "Composition law holds for multiple elements",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3));
+                VStreamPath<Integer> leftSide = path.map(ADD_ONE).map(DOUBLE);
+                VStreamPath<Integer> rightSide = path.map(ADD_ONE.andThen(DOUBLE));
+                assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+              }),
+          DynamicTest.dynamicTest(
+              "Composition with type-changing functions",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamPure(TEST_VALUE);
+                VStreamPath<Integer> leftSide = path.map(INT_TO_STRING).map(STRING_LENGTH);
+                VStreamPath<Integer> rightSide = path.map(INT_TO_STRING.andThen(STRING_LENGTH));
+                assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+              }));
+    }
+  }
+
+  @Nested
+  @DisplayName("Monad Laws")
+  class MonadLawsTests {
+
+    private final Function<Integer, VStreamPath<String>> intToVStreamString =
+        x -> Path.vstreamOf("a:" + x, "b:" + x);
+
+    private final Function<String, VStreamPath<Integer>> stringToVStreamInt =
+        s -> Path.vstreamPure(s.length());
+
+    @TestFactory
+    @DisplayName("Left Identity Law: VStreamPath.pure(a).via(f) == f(a)")
+    Stream<DynamicTest> leftIdentityLaw() {
+      return Stream.of(
+          DynamicTest.dynamicTest(
+              "Left identity with stream-returning function",
+              () -> {
+                int value = 10;
+                VStreamPath<String> leftSide = Path.vstreamPure(value).via(intToVStreamString);
+                VStreamPath<String> rightSide = intToVStreamString.apply(value);
+                assertThat(materialiseStr(leftSide)).isEqualTo(materialiseStr(rightSide));
+              }),
+          DynamicTest.dynamicTest(
+              "Left identity with single-element function",
+              () -> {
+                int value = 10;
+                Function<Integer, VStreamPath<Integer>> doubleIt = x -> Path.vstreamPure(x * 2);
+                VStreamPath<Integer> leftSide = Path.vstreamPure(value).via(doubleIt);
+                VStreamPath<Integer> rightSide = doubleIt.apply(value);
+                assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+              }));
+    }
+
+    @TestFactory
+    @DisplayName("Right Identity Law: path.via(x -> VStreamPath.pure(x)) == path")
+    Stream<DynamicTest> rightIdentityLaw() {
+      return Stream.of(
+          DynamicTest.dynamicTest(
+              "Right identity holds for single element",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamPure(TEST_VALUE);
+                VStreamPath<Integer> result = path.via(x -> Path.vstreamPure(x));
+                assertThat(materialise(result)).isEqualTo(materialise(path));
+              }),
+          DynamicTest.dynamicTest(
+              "Right identity holds for multiple elements",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3));
+                VStreamPath<Integer> result = path.via(x -> Path.vstreamPure(x));
+                assertThat(materialise(result)).isEqualTo(materialise(path));
+              }),
+          DynamicTest.dynamicTest(
+              "Right identity holds for empty stream",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamEmpty();
+                VStreamPath<Integer> result = path.via(x -> Path.vstreamPure(x));
+                assertThat(materialise(result)).isEqualTo(materialise(path));
+              }));
+    }
+
+    @TestFactory
+    @DisplayName("Associativity Law: path.via(f).via(g) == path.via(x -> f(x).via(g))")
+    Stream<DynamicTest> associativityLaw() {
+      return Stream.of(
+          DynamicTest.dynamicTest(
+              "Associativity holds for single element",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamPure(10);
+                VStreamPath<Integer> leftSide =
+                    path.via(intToVStreamString).via(stringToVStreamInt);
+                VStreamPath<Integer> rightSide =
+                    path.via(x -> intToVStreamString.apply(x).via(stringToVStreamInt));
+                assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+              }),
+          DynamicTest.dynamicTest(
+              "Associativity holds for multiple elements",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3));
+                VStreamPath<Integer> leftSide =
+                    path.via(intToVStreamString).via(stringToVStreamInt);
+                VStreamPath<Integer> rightSide =
+                    path.via(x -> intToVStreamString.apply(x).via(stringToVStreamInt));
+                assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+              }));
+    }
+  }
+
+  @Nested
+  @DisplayName("Additional Invariants")
+  class AdditionalInvariantsTests {
+
+    @TestFactory
+    @DisplayName("Stream operations preserve expected semantics")
+    Stream<DynamicTest> streamOperationsWorkCorrectly() {
+      return Stream.of(
+          DynamicTest.dynamicTest(
+              "filter removes non-matching elements",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3, 4, 5));
+                VStreamPath<Integer> result = path.filter(x -> x % 2 == 0);
+                assertThat(materialise(result)).containsExactly(2, 4);
+              }),
+          DynamicTest.dynamicTest(
+              "take limits elements",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3, 4, 5));
+                VStreamPath<Integer> result = path.take(3);
+                assertThat(materialise(result)).containsExactly(1, 2, 3);
+              }),
+          DynamicTest.dynamicTest(
+              "distinct removes duplicates preserving order",
+              () -> {
+                VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 2, 3, 1));
+                VStreamPath<Integer> result = path.distinct();
+                assertThat(materialise(result)).containsExactly(1, 2, 3);
+              }),
+          DynamicTest.dynamicTest(
+              "concat preserves element order",
+              () -> {
+                VStreamPath<Integer> a = Path.vstreamOf(1, 2);
+                VStreamPath<Integer> b = Path.vstreamOf(3, 4);
+                assertThat(materialise(a.concat(b))).containsExactly(1, 2, 3, 4);
+              }),
+          DynamicTest.dynamicTest(
+              "zipWith pairs elements positionally",
+              () -> {
+                VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+                VStreamPath<String> strs = Path.vstreamOf("a", "b", "c");
+                VStreamPath<String> result = nums.zipWith(strs, (n, s) -> n + s);
+                assertThat(materialiseStr(result)).containsExactly("1a", "2b", "3c");
+              }));
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathOpsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathOpsTest.java
@@ -1,0 +1,148 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.effect;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.test.assertions.VStreamPathAssert.assertThatVStreamPath;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for VStreamPath operations in PathOps.
+ *
+ * <p>Tests cover concatVStream, traverseVStream, and flattenVStream.
+ */
+@DisplayName("PathOps VStreamPath Operations")
+class VStreamPathOpsTest {
+
+  @Nested
+  @DisplayName("concatVStream")
+  class ConcatVStreamTests {
+
+    @Test
+    @DisplayName("concatenates multiple VStreamPaths")
+    void concatenatesMultiple() {
+      List<VStreamPath<Integer>> paths =
+          List.of(Path.vstreamOf(1, 2), Path.vstreamOf(3, 4), Path.vstreamOf(5));
+
+      VStreamPath<Integer> result = PathOps.concatVStream(paths);
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("returns empty for empty list of paths")
+    void returnsEmptyForEmptyList() {
+      VStreamPath<Integer> result = PathOps.concatVStream(List.of());
+
+      assertThatVStreamPath(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("single path is returned as-is")
+    void singlePathReturnedAsIs() {
+      VStreamPath<Integer> single = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Integer> result = PathOps.concatVStream(List.of(single));
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("concatenates with empty paths")
+    void concatenatesWithEmptyPaths() {
+      List<VStreamPath<Integer>> paths =
+          List.of(Path.vstreamEmpty(), Path.vstreamOf(1, 2), Path.vstreamEmpty());
+
+      VStreamPath<Integer> result = PathOps.concatVStream(paths);
+
+      assertThatVStreamPath(result).producesElements(1, 2);
+    }
+
+    @Test
+    @DisplayName("validates non-null paths")
+    void validatesNonNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> PathOps.concatVStream(null))
+          .withMessageContaining("paths must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("traverseVStream")
+  class TraverseVStreamTests {
+
+    @Test
+    @DisplayName("maps and concatenates results")
+    void mapsAndConcatenates() {
+      List<Integer> items = List.of(1, 2, 3);
+
+      VStreamPath<String> result =
+          PathOps.traverseVStream(items, n -> Path.vstreamOf("a:" + n, "b:" + n));
+
+      assertThatVStreamPath(result).producesElements("a:1", "b:1", "a:2", "b:2", "a:3", "b:3");
+    }
+
+    @Test
+    @DisplayName("returns empty for empty input")
+    void returnsEmptyForEmptyInput() {
+      VStreamPath<String> result = PathOps.traverseVStream(List.of(), n -> Path.vstreamPure("x"));
+
+      assertThatVStreamPath(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("validates non-null items")
+    void validatesNonNullItems() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> PathOps.traverseVStream(null, n -> Path.vstreamPure(n)))
+          .withMessageContaining("items must not be null");
+    }
+
+    @Test
+    @DisplayName("validates non-null function")
+    void validatesNonNullFunction() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> PathOps.traverseVStream(List.of(1), null))
+          .withMessageContaining("f must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("flattenVStream")
+  class FlattenVStreamTests {
+
+    @Test
+    @DisplayName("flattens nested VStreamPaths")
+    void flattensNested() {
+      VStreamPath<VStreamPath<Integer>> nested =
+          Path.vstreamOf(Path.vstreamOf(1, 2), Path.vstreamOf(3, 4), Path.vstreamOf(5));
+
+      VStreamPath<Integer> result = PathOps.flattenVStream(nested);
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("flattens with empty inner streams")
+    void flattensWithEmptyInner() {
+      VStreamPath<VStreamPath<Integer>> nested =
+          Path.vstreamOf(Path.vstreamOf(1), Path.vstreamEmpty(), Path.vstreamOf(2));
+
+      VStreamPath<Integer> result = PathOps.flattenVStream(nested);
+
+      assertThatVStreamPath(result).producesElements(1, 2);
+    }
+
+    @Test
+    @DisplayName("validates non-null nested")
+    void validatesNonNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> PathOps.flattenVStream(null))
+          .withMessageContaining("nested must not be null");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathPropertyTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathPropertyTest.java
@@ -1,0 +1,242 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.effect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+import net.jqwik.api.*;
+import net.jqwik.api.constraints.IntRange;
+
+/**
+ * Property-based tests for VStreamPath using jQwik.
+ *
+ * <p>Verifies Functor and Monad laws hold across a wide range of inputs. VStreamPath represents
+ * lazy, pull-based streams that execute on virtual threads.
+ */
+@Label("VStreamPath Property-Based Tests")
+class VStreamPathPropertyTest {
+
+  private static List<Integer> materialise(VStreamPath<Integer> path) {
+    return path.toList().unsafeRun();
+  }
+
+  private static List<String> materialiseStr(VStreamPath<String> path) {
+    return path.toList().unsafeRun();
+  }
+
+  @Provide
+  Arbitrary<VStreamPath<Integer>> vstreamPaths() {
+    return Arbitraries.oneOf(
+        // Empty stream
+        Arbitraries.just(Path.vstreamEmpty()),
+        // Single element
+        Arbitraries.integers().between(-100, 100).map(Path::vstreamPure),
+        // From list
+        Arbitraries.integers()
+            .between(-100, 100)
+            .list()
+            .ofMinSize(1)
+            .ofMaxSize(10)
+            .map(Path::vstreamFromList));
+  }
+
+  @Provide
+  Arbitrary<Function<Integer, String>> intToStringFunctions() {
+    return Arbitraries.of(
+        i -> "value:" + i, i -> String.valueOf(i * 2), i -> "n" + i, Object::toString);
+  }
+
+  @Provide
+  Arbitrary<Function<String, Integer>> stringToIntFunctions() {
+    return Arbitraries.of(String::length, String::hashCode, s -> s.isEmpty() ? 0 : 1);
+  }
+
+  @Provide
+  Arbitrary<Function<Integer, VStreamPath<String>>> intToVStreamStringFunctions() {
+    return Arbitraries.of(
+        i -> Path.vstreamPure("value:" + i),
+        i -> Path.vstreamOf("a:" + i, "b:" + i),
+        i -> i % 2 == 0 ? Path.vstreamOf("even") : Path.vstreamEmpty());
+  }
+
+  @Provide
+  Arbitrary<Function<String, VStreamPath<String>>> stringToVStreamStringFunctions() {
+    return Arbitraries.of(
+        s -> Path.vstreamPure(s.toUpperCase()),
+        s -> Path.vstreamOf(s + "!", s + "?"),
+        s -> s.isEmpty() ? Path.vstreamEmpty() : Path.vstreamPure("non-empty:" + s));
+  }
+
+  // ===== Functor Laws =====
+
+  @Property
+  @Label("Functor Identity Law: path.map(id) == path")
+  void functorIdentityLaw(@ForAll("vstreamPaths") VStreamPath<Integer> path) {
+    VStreamPath<Integer> result = path.map(Function.identity());
+    assertThat(materialise(result)).isEqualTo(materialise(path));
+  }
+
+  @Property
+  @Label("Functor Composition Law: path.map(f).map(g) == path.map(g.compose(f))")
+  void functorCompositionLaw(
+      @ForAll("vstreamPaths") VStreamPath<Integer> path,
+      @ForAll("intToStringFunctions") Function<Integer, String> f,
+      @ForAll("stringToIntFunctions") Function<String, Integer> g) {
+
+    VStreamPath<Integer> leftSide = path.map(f).map(g);
+    VStreamPath<Integer> rightSide = path.map(f.andThen(g));
+
+    assertThat(materialise(leftSide)).isEqualTo(materialise(rightSide));
+  }
+
+  // ===== Monad Laws =====
+
+  @Property
+  @Label("Monad Left Identity Law: pure(a).via(f) == f(a)")
+  void leftIdentityLaw(
+      @ForAll @IntRange(min = -100, max = 100) int value,
+      @ForAll("intToVStreamStringFunctions") Function<Integer, VStreamPath<String>> f) {
+
+    VStreamPath<String> leftSide = Path.vstreamPure(value).via(f);
+    VStreamPath<String> rightSide = f.apply(value);
+
+    assertThat(materialiseStr(leftSide)).isEqualTo(materialiseStr(rightSide));
+  }
+
+  @Property
+  @Label("Monad Right Identity Law: path.via(pure) == path")
+  void rightIdentityLaw(@ForAll("vstreamPaths") VStreamPath<Integer> path) {
+    VStreamPath<Integer> result = path.via(x -> Path.vstreamPure(x));
+    assertThat(materialise(result)).isEqualTo(materialise(path));
+  }
+
+  @Property
+  @Label("Monad Associativity Law: path.via(f).via(g) == path.via(x -> f(x).via(g))")
+  void associativityLaw(
+      @ForAll("vstreamPaths") VStreamPath<Integer> path,
+      @ForAll("intToVStreamStringFunctions") Function<Integer, VStreamPath<String>> f,
+      @ForAll("stringToVStreamStringFunctions") Function<String, VStreamPath<String>> g) {
+
+    VStreamPath<String> leftSide = path.via(f).via(g);
+    VStreamPath<String> rightSide = path.via(x -> f.apply(x).via(g));
+
+    assertThat(materialiseStr(leftSide)).isEqualTo(materialiseStr(rightSide));
+  }
+
+  // ===== Derived Properties =====
+
+  @Property
+  @Label("empty returns empty stream")
+  void emptyReturnsEmptyStream() {
+    VStreamPath<Integer> path = Path.vstreamEmpty();
+    assertThat(materialise(path)).isEmpty();
+    assertThat(path.count().unsafeRun()).isEqualTo(0L);
+  }
+
+  @Property
+  @Label("pure creates single-element stream")
+  void pureCreatesSingleElementStream(@ForAll @IntRange(min = -100, max = 100) int value) {
+    VStreamPath<Integer> path = Path.vstreamPure(value);
+    assertThat(materialise(path)).containsExactly(value);
+    assertThat(path.count().unsafeRun()).isEqualTo(1L);
+  }
+
+  @Property
+  @Label("map over empty returns empty")
+  void mapOverEmptyReturnsEmpty(@ForAll("intToStringFunctions") Function<Integer, String> f) {
+    VStreamPath<Integer> empty = Path.vstreamEmpty();
+    VStreamPath<String> result = empty.map(f);
+    assertThat(materialiseStr(result)).isEmpty();
+  }
+
+  @Property
+  @Label("via over empty returns empty")
+  void viaOverEmptyReturnsEmpty(
+      @ForAll("intToVStreamStringFunctions") Function<Integer, VStreamPath<String>> f) {
+    VStreamPath<Integer> empty = Path.vstreamEmpty();
+    VStreamPath<String> result = empty.via(f);
+    assertThat(materialiseStr(result)).isEmpty();
+  }
+
+  @Property
+  @Label("filter removes non-matching elements")
+  void filterRemovesNonMatching() {
+    VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3, 4, 5));
+    VStreamPath<Integer> result = path.filter(i -> i % 2 == 0);
+    assertThat(materialise(result)).containsExactly(2, 4);
+  }
+
+  @Property
+  @Label("take limits stream size")
+  void takeLimitsSize() {
+    VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3, 4, 5));
+    VStreamPath<Integer> result = path.take(3);
+    assertThat(materialise(result)).containsExactly(1, 2, 3);
+  }
+
+  @Property
+  @Label("zipWith pairs elements positionally")
+  void zipWithPairsElements() {
+    VStreamPath<Integer> a = Path.vstreamOf(1, 2, 3);
+    VStreamPath<String> b = Path.vstreamOf("a", "b", "c");
+
+    VStreamPath<String> result = a.zipWith(b, (i, s) -> i + s);
+
+    // VStreamPath uses positional zipping (shortest length)
+    assertThat(materialiseStr(result)).containsExactly("1a", "2b", "3c");
+  }
+
+  @Property(tries = 50)
+  @Label("Multiple maps compose correctly")
+  void multipleMapsCompose(@ForAll("vstreamPaths") VStreamPath<Integer> path) {
+    Function<Integer, Integer> addOne = x -> x + 1;
+    Function<Integer, Integer> doubleIt = x -> x * 2;
+    Function<Integer, Integer> subtract3 = x -> x - 3;
+
+    VStreamPath<Integer> stepByStep = path.map(addOne).map(doubleIt).map(subtract3);
+    VStreamPath<Integer> composed = path.map(x -> subtract3.apply(doubleIt.apply(addOne.apply(x))));
+
+    assertThat(materialise(stepByStep)).isEqualTo(materialise(composed));
+  }
+
+  @Property
+  @Label("headOption returns first element or empty")
+  void headOptionReturnsFirstOrEmpty(@ForAll("vstreamPaths") VStreamPath<Integer> path) {
+    var head = path.headOption().unsafeRun();
+    var list = materialise(path);
+
+    if (list.isEmpty()) {
+      assertThat(head.isEmpty()).isTrue();
+    } else {
+      assertThat(head.isPresent()).isTrue();
+      assertThat(head.orElse(-999)).isEqualTo(list.get(0));
+    }
+  }
+
+  @Property
+  @Label("count matches list size")
+  void countMatchesListSize(@ForAll("vstreamPaths") VStreamPath<Integer> path) {
+    long count = path.count().unsafeRun();
+    int listSize = materialise(path).size();
+
+    assertThat(count).isEqualTo(listSize);
+  }
+
+  @Property
+  @Label("concat preserves all elements")
+  void concatPreservesElements(
+      @ForAll("vstreamPaths") VStreamPath<Integer> a,
+      @ForAll("vstreamPaths") VStreamPath<Integer> b) {
+    List<Integer> listA = materialise(a);
+    List<Integer> listB = materialise(b);
+
+    VStreamPath<Integer> concatenated = a.concat(b);
+    List<Integer> resultList = materialise(concatenated);
+
+    assertThat(resultList.size()).isEqualTo(listA.size() + listB.size());
+    assertThat(resultList.subList(0, listA.size())).isEqualTo(listA);
+    assertThat(resultList.subList(listA.size(), resultList.size())).isEqualTo(listB);
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/effect/VStreamPathTest.java
@@ -1,0 +1,996 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.effect;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.test.assertions.VStreamPathAssert.assertThatVStreamPath;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vtask.VTask;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.AffinePath;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Comprehensive test suite for VStreamPath.
+ *
+ * <p>Tests cover factory methods, Composable/Combinable/Chainable operations, stream-specific
+ * operations, terminal operations, focus bridge, conversions, and null validation.
+ */
+@DisplayName("VStreamPath<A> Complete Test Suite")
+class VStreamPathTest {
+
+  private static final String TEST_VALUE = "test";
+  private static final Integer TEST_INT = 42;
+
+  @Nested
+  @DisplayName("Factory Methods via Path")
+  class FactoryMethodsTests {
+
+    @Test
+    @DisplayName("Path.vstream() creates VStreamPath from VStream")
+    void vstreamCreatesPathFromVStream() {
+      VStreamPath<Integer> path = Path.vstream(VStream.fromList(List.of(1, 2, 3)));
+
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamOf() creates VStreamPath from varargs")
+    void vstreamOfCreatesPath() {
+      VStreamPath<String> path = Path.vstreamOf("a", "b", "c");
+
+      assertThatVStreamPath(path).producesElements("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("Path.vstreamFromList() creates VStreamPath from list")
+    void vstreamFromListCreatesPath() {
+      VStreamPath<Integer> path = Path.vstreamFromList(List.of(1, 2, 3));
+
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamPure() creates single-element VStreamPath")
+    void vstreamPureCreatesSingleElement() {
+      VStreamPath<Integer> path = Path.vstreamPure(TEST_INT);
+
+      assertThatVStreamPath(path).producesElements(TEST_INT);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamEmpty() creates empty VStreamPath")
+    void vstreamEmptyCreatesEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      assertThatVStreamPath(path).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Path.vstreamIterate() creates infinite stream")
+    void vstreamIterateCreatesInfinite() {
+      VStreamPath<Integer> path = Path.vstreamIterate(1, n -> n + 1).take(5);
+
+      assertThatVStreamPath(path).producesElements(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamGenerate() creates from supplier")
+    void vstreamGenerateCreatesFromSupplier() {
+      AtomicInteger counter = new AtomicInteger(0);
+      VStreamPath<Integer> path = Path.vstreamGenerate(counter::incrementAndGet).take(3);
+
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamRange() creates integer range")
+    void vstreamRangeCreatesRange() {
+      VStreamPath<Integer> path = Path.vstreamRange(1, 6);
+
+      assertThatVStreamPath(path).producesElements(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamRange() with empty range creates empty stream")
+    void vstreamRangeEmptyRange() {
+      VStreamPath<Integer> path = Path.vstreamRange(5, 5);
+
+      assertThatVStreamPath(path).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Path.vstreamUnfold() creates stream by unfolding from seed")
+    void vstreamUnfoldCreatesStreamFromSeed() {
+      // Unfold from 1, producing values 1,2,3 and stopping when state > 3
+      VStreamPath<Integer> path =
+          Path.vstreamUnfold(
+              1,
+              state ->
+                  VTask.succeed(
+                      state > 3
+                          ? Optional.empty()
+                          : Optional.of(new VStream.Seed<>(state, state + 1))));
+
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("Path.vstreamUnfold() validates non-null function")
+    void vstreamUnfoldValidatesNonNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Path.vstreamUnfold(0, null))
+          .withMessageContaining("f must not be null");
+    }
+
+    @Test
+    @DisplayName("Path.vstream() validates non-null stream")
+    void vstreamValidatesNonNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Path.vstream(null))
+          .withMessageContaining("stream must not be null");
+    }
+
+    @Test
+    @DisplayName("Path.vstreamOf() validates non-null elements")
+    void vstreamOfValidatesNonNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Path.vstreamOf((Object[]) null))
+          .withMessageContaining("elements must not be null");
+    }
+
+    @Test
+    @DisplayName("Path.vstreamFromList() validates non-null list")
+    void vstreamFromListValidatesNonNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Path.vstreamFromList(null))
+          .withMessageContaining("list must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("run()")
+  class RunTests {
+
+    @Test
+    @DisplayName("run() returns the underlying VStream")
+    void runReturnsUnderlying() {
+      VStream<Integer> vs = VStream.of(1, 2, 3);
+      VStreamPath<Integer> path = Path.vstream(vs);
+
+      assertThat(path.run()).isSameAs(vs);
+    }
+  }
+
+  @Nested
+  @DisplayName("Composable Operations (Functor)")
+  class ComposableTests {
+
+    @Test
+    @DisplayName("map() transforms elements")
+    void mapTransformsElements() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<String> result = path.map(n -> "v:" + n);
+
+      assertThatVStreamPath(result).producesElements("v:1", "v:2", "v:3");
+    }
+
+    @Test
+    @DisplayName("map() with identity returns equivalent stream")
+    void mapIdentity() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Integer> result = path.map(x -> x);
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("map() validates non-null mapper")
+    void mapValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.map(null))
+          .withMessageContaining("mapper must not be null");
+    }
+
+    @Test
+    @DisplayName("peek() observes elements without modifying")
+    void peekObservesElements() {
+      AtomicInteger sum = new AtomicInteger(0);
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Integer> peeked = path.peek(sum::addAndGet);
+      // Not materialised yet
+      assertThat(sum.get()).isZero();
+
+      assertThatVStreamPath(peeked).producesElements(1, 2, 3);
+      assertThat(sum.get()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("peek() validates non-null consumer")
+    void peekValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.peek(null))
+          .withMessageContaining("consumer must not be null");
+    }
+
+    @Test
+    @DisplayName("asUnit() maps all elements to Unit")
+    void asUnitMapsToUnit() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Unit> result = path.asUnit();
+
+      assertThatVStreamPath(result).hasCount(3);
+      List<Unit> elements = result.toList().unsafeRun();
+      assertThat(elements).containsExactly(Unit.INSTANCE, Unit.INSTANCE, Unit.INSTANCE);
+    }
+  }
+
+  @Nested
+  @DisplayName("Chainable Operations (Monad)")
+  class ChainableTests {
+
+    @Test
+    @DisplayName("via() flatMaps to sub-streams")
+    void viaFlatMapsToSubStreams() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Integer> result = path.via(n -> Path.vstreamOf(n, n * 10));
+
+      assertThatVStreamPath(result).producesElements(1, 10, 2, 20, 3, 30);
+    }
+
+    @Test
+    @DisplayName("via() with empty sub-stream skips element")
+    void viaWithEmptySubStream() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Integer> result =
+          path.via(n -> n == 2 ? Path.vstreamEmpty() : Path.vstreamPure(n));
+
+      assertThatVStreamPath(result).producesElements(1, 3);
+    }
+
+    @Test
+    @DisplayName("flatMap() is alias for via()")
+    void flatMapIsAliasForVia() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2);
+
+      VStreamPath<String> result = path.flatMap(n -> Path.vstreamOf("a:" + n, "b:" + n));
+
+      assertThatVStreamPath(result).producesElements("a:1", "b:1", "a:2", "b:2");
+    }
+
+    @Test
+    @DisplayName("via() validates non-null mapper")
+    void viaValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.via(null))
+          .withMessageContaining("mapper must not be null");
+    }
+
+    @Test
+    @DisplayName("via() rejects non-VStreamPath return")
+    void viaRejectsNonVStreamPath() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      VStreamPath<Integer> result = path.via(n -> Path.listPath(n));
+
+      assertThatThrownBy(() -> result.toList().unsafeRun())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("via mapper must return VStreamPath");
+    }
+
+    @Test
+    @DisplayName("then() ignores value and chains next stream")
+    void thenChainsNextStream() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2);
+      VStreamPath<String> next = Path.vstreamOf("a", "b");
+
+      VStreamPath<String> result = path.then(() -> next);
+
+      // then() flatMaps each element to the next stream
+      assertThatVStreamPath(result).producesElements("a", "b", "a", "b");
+    }
+
+    @Test
+    @DisplayName("then() validates non-null supplier")
+    void thenValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.then(null))
+          .withMessageContaining("supplier must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Combinable Operations (Applicative)")
+  class CombinableTests {
+
+    @Test
+    @DisplayName("zipWith() pairs elements positionally")
+    void zipWithPairsPositionally() {
+      VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+      VStreamPath<String> strs = Path.vstreamOf("a", "b", "c");
+
+      VStreamPath<String> result = nums.zipWith(strs, (n, s) -> n + s);
+
+      assertThatVStreamPath(result).producesElements("1a", "2b", "3c");
+    }
+
+    @Test
+    @DisplayName("zipWith() stops at shorter stream")
+    void zipWithStopsAtShorter() {
+      VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3, 4, 5);
+      VStreamPath<String> strs = Path.vstreamOf("a", "b");
+
+      VStreamPath<String> result = nums.zipWith(strs, (n, s) -> n + s);
+
+      assertThatVStreamPath(result).producesElements("1a", "2b");
+    }
+
+    @Test
+    @DisplayName("zipWith() validates non-null other")
+    void zipWithValidatesNonNullOther() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.zipWith(null, (a, b) -> a))
+          .withMessageContaining("other must not be null");
+    }
+
+    @Test
+    @DisplayName("zipWith() validates non-null combiner")
+    void zipWithValidatesNonNullCombiner() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+      VStreamPath<Integer> other = Path.vstreamPure(2);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.zipWith(other, null))
+          .withMessageContaining("combiner must not be null");
+    }
+
+    @Test
+    @DisplayName("zipWith() rejects non-VStreamPath other")
+    void zipWithRejectsNonVStreamPath() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+      StreamPath<Integer> other = StreamPath.pure(2);
+
+      assertThatThrownBy(() -> path.zipWith(other, (a, b) -> a + b))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cannot zipWith non-VStreamPath");
+    }
+
+    @Test
+    @DisplayName("zipWith3() combines three streams")
+    void zipWith3CombinesThreeStreams() {
+      VStreamPath<Integer> a = Path.vstreamOf(1, 2);
+      VStreamPath<String> b = Path.vstreamOf("x", "y");
+      VStreamPath<Boolean> c = Path.vstreamOf(true, false);
+
+      VStreamPath<String> result = a.zipWith3(b, c, (i, s, bool) -> i + s + bool);
+
+      assertThatVStreamPath(result).producesElements("1xtrue", "2yfalse");
+    }
+
+    @Test
+    @DisplayName("zipWith3() validates non-null arguments")
+    void zipWith3ValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+      VStreamPath<Integer> other = Path.vstreamPure(2);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.zipWith3(null, other, (a, b, c) -> a))
+          .withMessageContaining("second must not be null");
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.zipWith3(other, null, (a, b, c) -> a))
+          .withMessageContaining("third must not be null");
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.zipWith3(other, other, null))
+          .withMessageContaining("combiner must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Stream-Specific Operations")
+  class StreamSpecificTests {
+
+    @Test
+    @DisplayName("filter() keeps matching elements")
+    void filterKeepsMatchingElements() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> result = path.filter(n -> n % 2 == 0);
+
+      assertThatVStreamPath(result).producesElements(2, 4);
+    }
+
+    @Test
+    @DisplayName("filter() validates non-null predicate")
+    void filterValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.filter(null))
+          .withMessageContaining("predicate must not be null");
+    }
+
+    @Test
+    @DisplayName("take() limits elements")
+    void takeLimitsElements() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> result = path.take(3);
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("take(0) produces empty")
+    void takeZeroProducesEmpty() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      VStreamPath<Integer> result = path.take(0);
+
+      assertThatVStreamPath(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("drop() skips elements")
+    void dropSkipsElements() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> result = path.drop(2);
+
+      assertThatVStreamPath(result).producesElements(3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("takeWhile() takes while predicate holds")
+    void takeWhileTakesWhilePredicateHolds() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> result = path.takeWhile(n -> n < 4);
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("takeWhile() validates non-null predicate")
+    void takeWhileValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.takeWhile(null))
+          .withMessageContaining("predicate must not be null");
+    }
+
+    @Test
+    @DisplayName("dropWhile() drops while predicate holds")
+    void dropWhileDropsWhilePredicateHolds() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> result = path.dropWhile(n -> n < 3);
+
+      assertThatVStreamPath(result).producesElements(3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("dropWhile() validates non-null predicate")
+    void dropWhileValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.dropWhile(null))
+          .withMessageContaining("predicate must not be null");
+    }
+
+    @Test
+    @DisplayName("distinct() removes duplicates")
+    void distinctRemovesDuplicates() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 2, 3, 1, 3, 4);
+
+      VStreamPath<Integer> result = path.distinct();
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("concat() appends another stream")
+    void concatAppendsStream() {
+      VStreamPath<Integer> first = Path.vstreamOf(1, 2);
+      VStreamPath<Integer> second = Path.vstreamOf(3, 4);
+
+      VStreamPath<Integer> result = first.concat(second);
+
+      assertThatVStreamPath(result).producesElements(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("concat() validates non-null other")
+    void concatValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.concat(null))
+          .withMessageContaining("other must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Terminal Operations (bridge to VTaskPath)")
+  class TerminalOperationsTests {
+
+    @Test
+    @DisplayName("toList() collects all elements")
+    void toListCollectsAll() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      List<Integer> result = path.toList().unsafeRun();
+
+      assertThat(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("toList() returns empty list for empty stream")
+    void toListReturnsEmptyForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      List<Integer> result = path.toList().unsafeRun();
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("fold() reduces elements")
+    void foldReducesElements() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      Integer result = path.fold(0, Integer::sum).unsafeRun();
+
+      assertThat(result).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("foldLeft() with accumulator")
+    void foldLeftWithAccumulator() {
+      VStreamPath<String> path = Path.vstreamOf("a", "b", "c");
+
+      String result = path.foldLeft("", (acc, s) -> acc + s).unsafeRun();
+
+      assertThat(result).isEqualTo("abc");
+    }
+
+    @Test
+    @DisplayName("foldMap() with monoid")
+    void foldMapWithMonoid() {
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      VStreamPath<String> path = Path.vstreamOf("a", "bb", "ccc");
+
+      Integer result = path.foldMap(sumMonoid, String::length).unsafeRun();
+
+      assertThat(result).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("headOption() returns first element")
+    void headOptionReturnsFirst() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      Optional<Integer> result = path.headOption().unsafeRun();
+
+      assertThat(result).contains(1);
+    }
+
+    @Test
+    @DisplayName("headOption() returns empty for empty stream")
+    void headOptionEmptyForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      Optional<Integer> result = path.headOption().unsafeRun();
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("lastOption() returns last element")
+    void lastOptionReturnsLast() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      Optional<Integer> result = path.lastOption().unsafeRun();
+
+      assertThat(result).contains(3);
+    }
+
+    @Test
+    @DisplayName("lastOption() returns empty for empty stream")
+    void lastOptionEmptyForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      Optional<Integer> result = path.lastOption().unsafeRun();
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("count() counts elements")
+    void countCountsElements() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      Long result = path.count().unsafeRun();
+
+      assertThat(result).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("count() returns 0 for empty stream")
+    void countZeroForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      Long result = path.count().unsafeRun();
+
+      assertThat(result).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("exists() finds matching element")
+    void existsFindsMatch() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      Boolean result = path.exists(n -> n == 3).unsafeRun();
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("exists() returns false when no match")
+    void existsFalseWhenNoMatch() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      Boolean result = path.exists(n -> n > 10).unsafeRun();
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("forAll() returns true when all match")
+    void forAllTrueWhenAllMatch() {
+      VStreamPath<Integer> path = Path.vstreamOf(2, 4, 6);
+
+      Boolean result = path.forAll(n -> n % 2 == 0).unsafeRun();
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("forAll() returns false when any doesn't match")
+    void forAllFalseWhenAnyDoesntMatch() {
+      VStreamPath<Integer> path = Path.vstreamOf(2, 3, 4);
+
+      Boolean result = path.forAll(n -> n % 2 == 0).unsafeRun();
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("forAll() returns true for empty stream")
+    void forAllTrueForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      Boolean result = path.forAll(n -> n > 100).unsafeRun();
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("find() finds first matching element")
+    void findFindsFirstMatch() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      Optional<Integer> result = path.find(n -> n > 3).unsafeRun();
+
+      assertThat(result).contains(4);
+    }
+
+    @Test
+    @DisplayName("find() returns empty when no match")
+    void findEmptyWhenNoMatch() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      Optional<Integer> result = path.find(n -> n > 10).unsafeRun();
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("forEach() executes action on each element")
+    void forEachExecutesAction() {
+      AtomicInteger sum = new AtomicInteger(0);
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      path.forEach(sum::addAndGet).unsafeRun();
+
+      assertThat(sum.get()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("forEach() validates non-null consumer")
+    void forEachValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.forEach(null))
+          .withMessageContaining("consumer must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Focus Bridge")
+  class FocusBridgeTests {
+
+    record Pair(String name, int value) {}
+
+    @Test
+    @DisplayName("focus(FocusPath) extracts focused values")
+    void focusPathExtractsValues() {
+      Lens<Pair, String> nameLens = Lens.of(Pair::name, (p, n) -> new Pair(n, p.value));
+      FocusPath<Pair, String> focusPath = FocusPath.of(nameLens);
+
+      VStreamPath<Pair> path = Path.vstreamOf(new Pair("Alice", 1), new Pair("Bob", 2));
+
+      VStreamPath<String> result = path.focus(focusPath);
+
+      assertThatVStreamPath(result).producesElements("Alice", "Bob");
+    }
+
+    @Test
+    @DisplayName("focus(FocusPath) validates non-null path")
+    void focusPathValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.focus((FocusPath<Integer, ?>) null))
+          .withMessageContaining("path must not be null");
+    }
+
+    @Test
+    @DisplayName("focus(AffinePath) filters and extracts matching values")
+    void affinePathFiltersAndExtracts() {
+      Affine<String, Integer> parseIntAffine =
+          Affine.of(
+              s -> {
+                try {
+                  return Optional.of(Integer.parseInt(s));
+                } catch (NumberFormatException e) {
+                  return Optional.empty();
+                }
+              },
+              (s, i) -> String.valueOf(i));
+
+      AffinePath<String, Integer> affinePath = AffinePath.of(parseIntAffine);
+
+      VStreamPath<String> path = Path.vstreamOf("1", "hello", "42", "world", "3");
+
+      VStreamPath<Integer> result = path.focus(affinePath);
+
+      assertThatVStreamPath(result).producesElements(1, 42, 3);
+    }
+
+    @Test
+    @DisplayName("focus(AffinePath) validates non-null path")
+    void affinePathValidatesNonNull() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> path.focus((AffinePath<Integer, ?>) null))
+          .withMessageContaining("path must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Conversions")
+  class ConversionTests {
+
+    @Test
+    @DisplayName("first() returns first element as VTaskPath")
+    void firstReturnsFirstElement() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      Integer result = path.first().unsafeRun();
+
+      assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("first() throws for empty stream")
+    void firstThrowsForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      assertThatThrownBy(() -> path.first().unsafeRun())
+          .isInstanceOf(NoSuchElementException.class)
+          .hasMessageContaining("VStreamPath is empty");
+    }
+
+    @Test
+    @DisplayName("last() returns last element as VTaskPath")
+    void lastReturnsLastElement() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      Integer result = path.last().unsafeRun();
+
+      assertThat(result).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("last() throws for empty stream")
+    void lastThrowsForEmpty() {
+      VStreamPath<Integer> path = Path.vstreamEmpty();
+
+      assertThatThrownBy(() -> path.last().unsafeRun())
+          .isInstanceOf(NoSuchElementException.class)
+          .hasMessageContaining("VStreamPath is empty");
+    }
+
+    @Test
+    @DisplayName("toStreamPath() materialises to StreamPath")
+    void toStreamPathMaterialises() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      StreamPath<Integer> streamPath = path.toStreamPath();
+
+      assertThat(streamPath.toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("toListPath() materialises to ListPath")
+    void toListPathMaterialises() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      ListPath<Integer> listPath = path.toListPath();
+
+      assertThat(listPath.run()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("toNonDetPath() materialises to NonDetPath")
+    void toNonDetPathMaterialises() {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      NonDetPath<Integer> nonDetPath = path.toNonDetPath();
+
+      assertThat(nonDetPath.run()).containsExactly(1, 2, 3);
+    }
+  }
+
+  @Nested
+  @DisplayName("Laziness")
+  class LazinessTests {
+
+    @Test
+    @DisplayName("Stream operations are lazy - no execution until terminal")
+    void operationsAreLazy() {
+      AtomicBoolean executed = new AtomicBoolean(false);
+
+      VStreamPath<Integer> path =
+          Path.vstreamOf(1, 2, 3)
+              .map(
+                  n -> {
+                    executed.set(true);
+                    return n * 2;
+                  })
+              .filter(n -> n > 2)
+              .take(1);
+
+      // No execution yet
+      assertThat(executed).isFalse();
+
+      // Now materialise
+      path.toList().unsafeRun();
+      assertThat(executed).isTrue();
+    }
+
+    @Test
+    @DisplayName("take() limits execution of infinite stream")
+    void takeLimitsInfiniteStream() {
+      VStreamPath<Integer> infinite = Path.vstreamIterate(1, n -> n + 1);
+
+      VStreamPath<Integer> limited = infinite.take(5);
+
+      assertThatVStreamPath(limited).producesElements(1, 2, 3, 4, 5);
+    }
+  }
+
+  @Nested
+  @DisplayName("Object Methods")
+  class ObjectMethodsTests {
+
+    @Test
+    @DisplayName("toString() returns descriptive string")
+    void toStringReturnsDescriptive() {
+      VStreamPath<Integer> path = Path.vstreamPure(1);
+
+      assertThat(path.toString()).isEqualTo("VStreamPath(<stream>)");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composition Chains")
+  class CompositionChainTests {
+
+    @Test
+    @DisplayName("Complex pipeline with map, filter, take")
+    void complexPipeline() {
+      VStreamPath<String> result =
+          Path.vstreamRange(1, 100).filter(n -> n % 2 == 0).map(n -> "Even: " + n).take(3);
+
+      assertThatVStreamPath(result).producesElements("Even: 2", "Even: 4", "Even: 6");
+    }
+
+    @Test
+    @DisplayName("Pipeline with flatMap and terminal")
+    void pipelineWithFlatMap() {
+      VStreamPath<Integer> result =
+          Path.vstreamOf(1, 2, 3).via(n -> Path.vstreamOf(n, n * 10)).filter(n -> n > 5);
+
+      assertThatVStreamPath(result).producesElements(10, 20, 30);
+    }
+
+    @Test
+    @DisplayName("Pipeline folds with monoid")
+    void pipelineFoldWithMonoid() {
+      Monoid<String> stringMonoid =
+          new Monoid<>() {
+            @Override
+            public String empty() {
+              return "";
+            }
+
+            @Override
+            public String combine(String a, String b) {
+              return a.isEmpty() ? b : a + ", " + b;
+            }
+          };
+
+      String result =
+          Path.vstreamOf(1, 2, 3).map(n -> "item" + n).foldMap(stringMonoid, s -> s).unsafeRun();
+
+      assertThat(result).isEqualTo("item1, item2, item3");
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/test/assertions/VStreamPathAssert.java
+++ b/hkj-core/src/test/java/org/higherkindedj/test/assertions/VStreamPathAssert.java
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.test.assertions;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+import org.higherkindedj.hkt.effect.VStreamPath;
+
+/**
+ * Custom AssertJ assertions for {@link VStreamPath} instances.
+ *
+ * <p>Provides fluent assertion methods specifically designed for testing {@code VStreamPath}
+ * instances. Since VStreamPath wraps a lazy pull-based VStream, assertions handle materialisation
+ * (collecting to a list via VTask execution) for verification.
+ *
+ * <h2>Usage Examples:</h2>
+ *
+ * <pre>{@code
+ * import static org.higherkindedj.test.assertions.VStreamPathAssert.assertThatVStreamPath;
+ *
+ * VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+ * assertThatVStreamPath(path).producesElements(1, 2, 3);
+ *
+ * VStreamPath<String> empty = Path.vstreamEmpty();
+ * assertThatVStreamPath(empty).isEmpty();
+ * }</pre>
+ *
+ * @param <A> The type of elements produced by the VStreamPath
+ */
+public class VStreamPathAssert<A> extends AbstractAssert<VStreamPathAssert<A>, VStreamPath<A>> {
+
+  /**
+   * Creates a new {@code VStreamPathAssert} instance.
+   *
+   * @param <A> The type of elements produced by the VStreamPath
+   * @param actual The VStreamPath instance to make assertions on
+   * @return A new VStreamPathAssert instance
+   */
+  public static <A> VStreamPathAssert<A> assertThatVStreamPath(VStreamPath<A> actual) {
+    return new VStreamPathAssert<>(actual);
+  }
+
+  private List<A> materialisedElements;
+  private Throwable materialisedException;
+  private boolean hasMaterialised = false;
+
+  protected VStreamPathAssert(VStreamPath<A> actual) {
+    super(actual, VStreamPathAssert.class);
+  }
+
+  private void materialise() {
+    if (!hasMaterialised) {
+      isNotNull();
+      try {
+        materialisedElements = actual.toList().unsafeRun();
+        materialisedException = null;
+      } catch (Throwable t) {
+        materialisedElements = null;
+        materialisedException = t;
+      }
+      hasMaterialised = true;
+    }
+  }
+
+  /**
+   * Verifies that the VStreamPath produces the expected elements in order.
+   *
+   * @param expected The expected elements
+   * @return This assertion object for method chaining
+   */
+  @SafeVarargs
+  public final VStreamPathAssert<A> producesElements(A... expected) {
+    materialise();
+    if (materialisedException != null) {
+      failWithMessage(
+          "Expected VStreamPath to produce elements but it threw: %s",
+          materialisedException.getClass().getName() + ": " + materialisedException.getMessage());
+    }
+    if (!Objects.equals(materialisedElements, List.of(expected))) {
+      failWithMessage(
+          "Expected VStreamPath to produce %s but produced %s",
+          List.of(expected), materialisedElements);
+    }
+    return this;
+  }
+
+  /**
+   * Verifies that the VStreamPath produces elements matching the expected list.
+   *
+   * @param expected The expected element list
+   * @return This assertion object for method chaining
+   */
+  public VStreamPathAssert<A> producesElementsInOrder(List<A> expected) {
+    materialise();
+    if (materialisedException != null) {
+      failWithMessage(
+          "Expected VStreamPath to produce elements but it threw: %s",
+          materialisedException.getClass().getName() + ": " + materialisedException.getMessage());
+    }
+    if (!Objects.equals(materialisedElements, expected)) {
+      failWithMessage(
+          "Expected VStreamPath to produce %s but produced %s", expected, materialisedElements);
+    }
+    return this;
+  }
+
+  /**
+   * Verifies that the VStreamPath is empty (produces no elements).
+   *
+   * @return This assertion object for method chaining
+   */
+  public VStreamPathAssert<A> isEmpty() {
+    materialise();
+    if (materialisedException != null) {
+      failWithMessage(
+          "Expected VStreamPath to be empty but it threw: %s",
+          materialisedException.getClass().getName() + ": " + materialisedException.getMessage());
+    }
+    if (materialisedElements != null && !materialisedElements.isEmpty()) {
+      failWithMessage(
+          "Expected VStreamPath to be empty but it produced %d elements: %s",
+          materialisedElements.size(), materialisedElements);
+    }
+    return this;
+  }
+
+  /**
+   * Verifies that the VStreamPath produces the expected number of elements.
+   *
+   * @param expected The expected element count
+   * @return This assertion object for method chaining
+   */
+  public VStreamPathAssert<A> hasCount(long expected) {
+    materialise();
+    if (materialisedException != null) {
+      failWithMessage(
+          "Expected VStreamPath to have %d elements but it threw: %s",
+          expected,
+          materialisedException.getClass().getName() + ": " + materialisedException.getMessage());
+    }
+    long actual = materialisedElements != null ? materialisedElements.size() : 0;
+    if (actual != expected) {
+      failWithMessage("Expected VStreamPath to have %d elements but had %d", expected, actual);
+    }
+    return this;
+  }
+
+  /**
+   * Verifies that the VStreamPath produces elements satisfying the given requirements.
+   *
+   * @param requirements the requirements for the element list
+   * @return This assertion object for method chaining
+   */
+  public VStreamPathAssert<A> satisfies(Consumer<List<A>> requirements) {
+    materialise();
+    if (materialisedException != null) {
+      failWithMessage(
+          "Expected VStreamPath to produce elements but it threw: %s",
+          materialisedException.getClass().getName() + ": " + materialisedException.getMessage());
+    }
+    requirements.accept(materialisedElements);
+    return this;
+  }
+
+  /**
+   * Verifies that the VStreamPath fails when materialised.
+   *
+   * @return This assertion object for method chaining
+   */
+  public VStreamPathAssert<A> failsOnMaterialise() {
+    materialise();
+    if (materialisedException == null) {
+      failWithMessage(
+          "Expected VStreamPath to fail but it succeeded with: %s", materialisedElements);
+    }
+    return this;
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/effect/VStreamPathExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/effect/VStreamPathExample.java
@@ -1,0 +1,379 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.effect;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.effect.ListPath;
+import org.higherkindedj.hkt.effect.NonDetPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.PathOps;
+import org.higherkindedj.hkt.effect.StreamPath;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vtask.VTask;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.FocusPath;
+
+/**
+ * Examples demonstrating VStreamPath for lazy, pull-based streaming on virtual threads.
+ *
+ * <p>VStreamPath wraps VStream to provide a fluent Effect Path API for composing lazy stream
+ * pipelines. All intermediate operations are lazy; execution is deferred until a terminal operation
+ * (toList, fold, count, etc.) is called.
+ *
+ * <p>This example demonstrates:
+ *
+ * <ul>
+ *   <li>Creating VStreamPath instances via Path factory methods
+ *   <li>Composing lazy pipelines with map, filter, flatMap, take, drop
+ *   <li>Terminal operations that bridge to VTaskPath for single-value results
+ *   <li>Zipping multiple streams positionally
+ *   <li>Optics focus bridge for navigating into stream elements
+ *   <li>Converting to other path types (StreamPath, ListPath, NonDetPath)
+ *   <li>Sequence and traverse operations via PathOps
+ * </ul>
+ *
+ * <p>Run with: {@code ./gradlew :hkj-examples:run
+ * -PmainClass=org.higherkindedj.example.effect.VStreamPathExample}
+ *
+ * @see org.higherkindedj.hkt.effect.VStreamPath
+ * @see org.higherkindedj.hkt.vstream.VStream
+ */
+public class VStreamPathExample {
+
+  public static void main(String[] args) {
+    System.out.println("=== VStreamPath: Lazy Streaming on Virtual Threads ===\n");
+
+    factoryMethods();
+    lazyComposition();
+    terminalOperations();
+    zippingStreams();
+    focusBridge();
+    conversions();
+    sequenceAndTraverse();
+    realWorldPipeline();
+  }
+
+  // ============================================================
+  // Factory Methods
+  // ============================================================
+
+  private static void factoryMethods() {
+    System.out.println("--- Factory Methods ---\n");
+
+    // From varargs
+    VStreamPath<String> names = Path.vstreamOf("Alice", "Bob", "Charlie");
+    System.out.println("vstreamOf: " + names.toList().unsafeRun());
+
+    // From a list
+    VStreamPath<Integer> fromList = Path.vstreamFromList(List.of(10, 20, 30));
+    System.out.println("vstreamFromList: " + fromList.toList().unsafeRun());
+
+    // Single element
+    VStreamPath<Integer> single = Path.vstreamPure(42);
+    System.out.println("vstreamPure: " + single.toList().unsafeRun());
+
+    // Empty stream
+    VStreamPath<Integer> empty = Path.vstreamEmpty();
+    System.out.println("vstreamEmpty: " + empty.toList().unsafeRun());
+
+    // Integer range [1, 6)
+    VStreamPath<Integer> range = Path.vstreamRange(1, 6);
+    System.out.println("vstreamRange(1, 6): " + range.toList().unsafeRun());
+
+    // Infinite stream, take first 5
+    VStreamPath<Integer> naturals = Path.vstreamIterate(1, n -> n + 1).take(5);
+    System.out.println("vstreamIterate (first 5): " + naturals.toList().unsafeRun());
+
+    // Effectful unfold
+    VStreamPath<Integer> unfolded =
+        Path.vstreamUnfold(
+            1,
+            state ->
+                VTask.succeed(
+                    state > 3
+                        ? Optional.empty()
+                        : Optional.of(new VStream.Seed<>(state, state + 1))));
+    System.out.println("vstreamUnfold (1..3): " + unfolded.toList().unsafeRun());
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Lazy Composition
+  // ============================================================
+
+  private static void lazyComposition() {
+    System.out.println("--- Lazy Composition ---\n");
+
+    // Map: transform elements
+    VStreamPath<String> upper = Path.vstreamOf("hello", "world").map(String::toUpperCase);
+    System.out.println("map: " + upper.toList().unsafeRun());
+
+    // Filter: keep matching elements
+    VStreamPath<Integer> evens = Path.vstreamRange(1, 11).filter(n -> n % 2 == 0);
+    System.out.println("filter (evens): " + evens.toList().unsafeRun());
+
+    // FlatMap: expand each element into a sub-stream
+    VStreamPath<Integer> expanded = Path.vstreamOf(1, 2, 3).flatMap(n -> Path.vstreamOf(n, n * 10));
+    System.out.println("flatMap: " + expanded.toList().unsafeRun());
+
+    // Take, drop, takeWhile, dropWhile
+    VStreamPath<Integer> base = Path.vstreamRange(1, 11);
+    System.out.println("take(3): " + base.take(3).toList().unsafeRun());
+    System.out.println("drop(7): " + base.drop(7).toList().unsafeRun());
+    System.out.println("takeWhile(<5): " + base.takeWhile(n -> n < 5).toList().unsafeRun());
+    System.out.println("dropWhile(<5): " + base.dropWhile(n -> n < 5).toList().unsafeRun());
+
+    // Distinct
+    VStreamPath<Integer> distinct = Path.vstreamOf(1, 2, 2, 3, 1, 3, 4).distinct();
+    System.out.println("distinct: " + distinct.toList().unsafeRun());
+
+    // Concat
+    VStreamPath<Integer> combined = Path.vstreamOf(1, 2).concat(Path.vstreamOf(3, 4));
+    System.out.println("concat: " + combined.toList().unsafeRun());
+
+    // Complex pipeline: all operations are lazy until toList() triggers execution
+    List<String> pipeline =
+        Path.vstreamRange(1, 100)
+            .filter(n -> n % 2 == 0)
+            .map(n -> "Even: " + n)
+            .take(5)
+            .toList()
+            .unsafeRun();
+    System.out.println("pipeline: " + pipeline);
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Terminal Operations
+  // ============================================================
+
+  private static void terminalOperations() {
+    System.out.println("--- Terminal Operations ---\n");
+
+    VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3, 4, 5);
+
+    // Fold with identity and operator
+    Integer sum = stream.fold(0, Integer::sum).unsafeRun();
+    System.out.println("fold (sum): " + sum);
+
+    // FoldLeft with accumulator
+    String csv =
+        stream
+            .foldLeft("", (acc, n) -> acc.isEmpty() ? String.valueOf(n) : acc + "," + n)
+            .unsafeRun();
+    System.out.println("foldLeft (csv): " + csv);
+
+    // FoldMap with monoid
+    Monoid<Integer> sumMonoid =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+    Integer doubleSum =
+        Path.vstreamOf("ab", "cde", "f").foldMap(sumMonoid, String::length).unsafeRun();
+    System.out.println("foldMap (string lengths): " + doubleSum);
+
+    // Count
+    Long count = stream.count().unsafeRun();
+    System.out.println("count: " + count);
+
+    // Exists and forAll
+    Boolean hasEven = stream.exists(n -> n % 2 == 0).unsafeRun();
+    Boolean allPositive = stream.forAll(n -> n > 0).unsafeRun();
+    System.out.println("exists (even): " + hasEven);
+    System.out.println("forAll (positive): " + allPositive);
+
+    // Find
+    Optional<Integer> firstBig = stream.find(n -> n > 3).unsafeRun();
+    System.out.println("find (>3): " + firstBig);
+
+    // Head and last
+    Optional<Integer> head = stream.headOption().unsafeRun();
+    Optional<Integer> last = stream.lastOption().unsafeRun();
+    System.out.println("headOption: " + head);
+    System.out.println("lastOption: " + last);
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Zipping Streams
+  // ============================================================
+
+  private static void zippingStreams() {
+    System.out.println("--- Zipping Streams ---\n");
+
+    VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+    VStreamPath<String> labels = Path.vstreamOf("a", "b", "c");
+
+    // zipWith: pairs positionally
+    VStreamPath<String> zipped = nums.zipWith(labels, (n, s) -> n + s);
+    System.out.println("zipWith: " + zipped.toList().unsafeRun());
+
+    // zipWith3: three-way zip
+    VStreamPath<Boolean> flags = Path.vstreamOf(true, false, true);
+    VStreamPath<String> zipped3 = nums.zipWith3(labels, flags, (n, s, b) -> n + s + "(" + b + ")");
+    System.out.println("zipWith3: " + zipped3.toList().unsafeRun());
+
+    // Stops at shortest
+    VStreamPath<Integer> long_ = Path.vstreamRange(1, 100);
+    VStreamPath<String> short_ = Path.vstreamOf("x", "y");
+    VStreamPath<String> shortened = long_.zipWith(short_, (n, s) -> n + s);
+    System.out.println("zipWith (stops at shortest): " + shortened.toList().unsafeRun());
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Focus Bridge (Optics Integration)
+  // ============================================================
+
+  record Person(String name, int age) {}
+
+  private static void focusBridge() {
+    System.out.println("--- Focus Bridge ---\n");
+
+    Lens<Person, String> nameLens = Lens.of(Person::name, (p, n) -> new Person(n, p.age));
+    Lens<Person, Integer> ageLens = Lens.of(Person::age, (p, a) -> new Person(p.name, a));
+    FocusPath<Person, String> nameFocus = FocusPath.of(nameLens);
+    FocusPath<Person, Integer> ageFocus = FocusPath.of(ageLens);
+
+    VStreamPath<Person> people =
+        Path.vstreamOf(new Person("Alice", 30), new Person("Bob", 25), new Person("Charlie", 35));
+
+    // FocusPath: extract field from every element
+    List<String> names = people.focus(nameFocus).toList().unsafeRun();
+    System.out.println("focus (names): " + names);
+
+    // Combine focus with stream operations
+    List<Integer> adultAges = people.focus(ageFocus).filter(age -> age >= 30).toList().unsafeRun();
+    System.out.println("focus + filter (ages >= 30): " + adultAges);
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Conversions
+  // ============================================================
+
+  private static void conversions() {
+    System.out.println("--- Conversions ---\n");
+
+    VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3);
+
+    // To single elements via VTaskPath
+    Integer first = stream.first().unsafeRun();
+    Integer last = stream.last().unsafeRun();
+    System.out.println("first: " + first);
+    System.out.println("last: " + last);
+
+    // To other path types (materialises the stream)
+    StreamPath<Integer> streamPath = stream.toStreamPath();
+    System.out.println("toStreamPath: " + streamPath.toList());
+
+    ListPath<Integer> listPath = stream.toListPath();
+    System.out.println("toListPath: " + listPath.run());
+
+    NonDetPath<Integer> nonDetPath = stream.toNonDetPath();
+    System.out.println("toNonDetPath: " + nonDetPath.run());
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Concat, Traverse, and Flatten (PathOps)
+  // ============================================================
+
+  private static void sequenceAndTraverse() {
+    System.out.println("--- Concat, Traverse, and Flatten (PathOps) ---\n");
+
+    // Concat: List<VStreamPath<A>> -> VStreamPath<A> (sequential concatenation)
+    List<VStreamPath<Integer>> streams =
+        List.of(Path.vstreamOf(1, 2), Path.vstreamOf(10, 20), Path.vstreamOf(100, 200));
+    VStreamPath<Integer> concatenated = PathOps.concatVStream(streams);
+    System.out.println("concatVStream: " + concatenated.toList().unsafeRun());
+
+    // Traverse: List<A> -> (A -> VStreamPath<B>) -> VStreamPath<B> (map + concat)
+    List<Integer> inputs = List.of(1, 2, 3);
+    VStreamPath<String> traversed =
+        PathOps.traverseVStream(inputs, n -> Path.vstreamOf("v" + n, "w" + n));
+    System.out.println("traverseVStream: " + traversed.toList().unsafeRun());
+
+    // Flatten: VStreamPath<VStreamPath<A>> -> VStreamPath<A>
+    VStreamPath<VStreamPath<Integer>> nested =
+        Path.vstreamOf(Path.vstreamOf(10, 20), Path.vstreamOf(30));
+    VStreamPath<Integer> flattened = PathOps.flattenVStream(nested);
+    System.out.println("flattenVStream: " + flattened.toList().unsafeRun());
+
+    System.out.println();
+  }
+
+  // ============================================================
+  // Real-World Pipeline
+  // ============================================================
+
+  record LogEntry(String level, String message, long timestamp) {}
+
+  private static void realWorldPipeline() {
+    System.out.println("--- Real-World Pipeline: Log Processing ---\n");
+
+    // Simulate a stream of log entries
+    VStreamPath<LogEntry> logs =
+        Path.vstreamOf(
+            new LogEntry("INFO", "Application started", 1000),
+            new LogEntry("DEBUG", "Connecting to database", 1001),
+            new LogEntry("INFO", "User login: alice", 1002),
+            new LogEntry("WARN", "Slow query detected", 1003),
+            new LogEntry("ERROR", "Connection timeout", 1004),
+            new LogEntry("INFO", "User login: bob", 1005),
+            new LogEntry("DEBUG", "Cache hit ratio: 0.85", 1006),
+            new LogEntry("ERROR", "Disk space low", 1007),
+            new LogEntry("INFO", "Batch job completed", 1008));
+
+    // Pipeline: extract error messages
+    List<String> errorMessages =
+        logs.filter(log -> "ERROR".equals(log.level())).map(LogEntry::message).toList().unsafeRun();
+    System.out.println("Errors: " + errorMessages);
+
+    // Pipeline: count entries by level
+    Long warnAndAbove =
+        logs.filter(log -> "WARN".equals(log.level()) || "ERROR".equals(log.level()))
+            .count()
+            .unsafeRun();
+    System.out.println("Warnings and errors: " + warnAndAbove);
+
+    // Pipeline: check if any errors exist
+    Boolean hasErrors = logs.exists(log -> "ERROR".equals(log.level())).unsafeRun();
+    System.out.println("Has errors: " + hasErrors);
+
+    // Pipeline: find first error
+    Optional<String> firstError =
+        logs.filter(log -> "ERROR".equals(log.level()))
+            .map(LogEntry::message)
+            .headOption()
+            .unsafeRun();
+    System.out.println("First error: " + firstError);
+
+    // Pipeline: build summary using fold
+    String summary =
+        logs.filter(log -> "INFO".equals(log.level()))
+            .map(LogEntry::message)
+            .foldLeft("", (acc, msg) -> acc.isEmpty() ? msg : acc + "; " + msg)
+            .unsafeRun();
+    System.out.println("Info summary: " + summary);
+
+    System.out.println();
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamPath.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamPath.java
@@ -1,0 +1,312 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial: VStreamPath - Fluent Streaming with Effect Path API
+ *
+ * <p>VStreamPath wraps VStream to provide a fluent, chainable API for lazy streaming computations
+ * on virtual threads. All intermediate operations are lazy; execution is deferred until a terminal
+ * operation is called.
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>Path factory methods create VStreamPath instances
+ *   <li>map, filter, flatMap compose lazy pipelines
+ *   <li>Terminal operations (toList, fold, count) return VTaskPath
+ *   <li>zipWith pairs streams positionally
+ *   <li>Focus bridge navigates into stream elements with optics
+ *   <li>Conversions bridge to StreamPath, ListPath, NonDetPath
+ * </ul>
+ *
+ * <p>Prerequisites: Complete VStream Basics and VStream HKT tutorials first.
+ *
+ * <p>Estimated time: 15 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial: VStreamPath")
+public class TutorialVStreamPath {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  // ===========================================================================
+  // Part 1: Creating VStreamPath Instances
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Creating VStreamPath Instances")
+  class CreatingInstances {
+
+    /**
+     * Exercise 1: Create a VStreamPath from varargs
+     *
+     * <p>The Path factory class provides methods for creating VStreamPath instances. The simplest
+     * is Path.vstreamOf() which takes varargs.
+     *
+     * <p>Task: Create a VStreamPath containing the numbers 1, 2, 3 and collect to a list
+     */
+    @Test
+    @DisplayName("Exercise 1: Create from varargs")
+    void exercise1_createFromVarargs() {
+      // TODO: Replace answerRequired() with Path.vstreamOf(1, 2, 3)
+      VStreamPath<Integer> path = answerRequired();
+
+      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+    }
+
+    /**
+     * Exercise 2: Create a VStreamPath from a range
+     *
+     * <p>Path.vstreamRange(start, end) creates an integer range [start, end).
+     *
+     * <p>Task: Create a VStreamPath for the range [1, 6) and collect to a list
+     */
+    @Test
+    @DisplayName("Exercise 2: Create from range")
+    void exercise2_createFromRange() {
+      // TODO: Replace answerRequired() with Path.vstreamRange(1, 6)
+      VStreamPath<Integer> path = answerRequired();
+
+      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    /**
+     * Exercise 3: Create an infinite stream and take elements
+     *
+     * <p>Path.vstreamIterate(seed, f) creates an infinite stream. Use take(n) to limit it.
+     *
+     * <p>Task: Create an infinite stream starting at 10, adding 10 each step, and take the first 4
+     */
+    @Test
+    @DisplayName("Exercise 3: Infinite stream with take")
+    void exercise3_infiniteStreamWithTake() {
+      // TODO: Replace answerRequired() with Path.vstreamIterate(10, n -> n + 10).take(4)
+      VStreamPath<Integer> path = answerRequired();
+
+      assertThat(path.toList().unsafeRun()).containsExactly(10, 20, 30, 40);
+    }
+
+    /**
+     * Exercise 4: Effectful unfold
+     *
+     * <p>Path.vstreamUnfold(seed, f) creates a stream by repeatedly applying an effectful function
+     * to a state. The function returns Optional.empty() to signal completion.
+     *
+     * <p>Task: Unfold from seed 1, emitting state and incrementing, stopping when state > 3
+     */
+    @Test
+    @DisplayName("Exercise 4: Effectful unfold")
+    void exercise4_effectfulUnfold() {
+      // TODO: Replace answerRequired() with Path.vstreamUnfold(1, state -> ...)
+      // Hint: Return VTask.succeed(state > 3 ? Optional.empty()
+      //         : Optional.of(new VStream.Seed<>(state, state + 1)))
+      VStreamPath<Integer> path = answerRequired();
+
+      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Composing Operations
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Composing Operations")
+  class ComposingOperations {
+
+    /**
+     * Exercise 5: Map elements
+     *
+     * <p>map() transforms each element lazily. Nothing executes until a terminal operation.
+     *
+     * <p>Task: Map the stream of names to uppercase
+     */
+    @Test
+    @DisplayName("Exercise 5: Map elements")
+    void exercise5_mapElements() {
+      VStreamPath<String> names = Path.vstreamOf("alice", "bob");
+
+      // TODO: Replace answerRequired() with names.map(String::toUpperCase)
+      VStreamPath<String> upper = answerRequired();
+
+      assertThat(upper.toList().unsafeRun()).containsExactly("ALICE", "BOB");
+    }
+
+    /**
+     * Exercise 6: Filter elements
+     *
+     * <p>filter() keeps only elements matching the predicate.
+     *
+     * <p>Task: Filter the range to keep only even numbers
+     */
+    @Test
+    @DisplayName("Exercise 6: Filter elements")
+    void exercise6_filterElements() {
+      VStreamPath<Integer> range = Path.vstreamRange(1, 11);
+
+      // TODO: Replace answerRequired() with range.filter(n -> n % 2 == 0)
+      VStreamPath<Integer> evens = answerRequired();
+
+      assertThat(evens.toList().unsafeRun()).containsExactly(2, 4, 6, 8, 10);
+    }
+
+    /**
+     * Exercise 7: FlatMap to sub-streams
+     *
+     * <p>flatMap() (or via()) expands each element into a sub-stream, then flattens the results.
+     *
+     * <p>Task: Expand each number into a pair [n, n*10]
+     */
+    @Test
+    @DisplayName("Exercise 7: FlatMap to sub-streams")
+    void exercise7_flatMapToSubStreams() {
+      VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+
+      // TODO: Replace answerRequired() with nums.flatMap(n -> Path.vstreamOf(n, n * 10))
+      VStreamPath<Integer> expanded = answerRequired();
+
+      assertThat(expanded.toList().unsafeRun()).containsExactly(1, 10, 2, 20, 3, 30);
+    }
+
+    /**
+     * Exercise 8: Compose a pipeline
+     *
+     * <p>Chain multiple operations together. All are lazy until the terminal toList().
+     *
+     * <p>Task: From range [1,100), keep evens, map to strings, take 3
+     */
+    @Test
+    @DisplayName("Exercise 8: Compose a pipeline")
+    void exercise8_composePipeline() {
+      // TODO: Replace answerRequired() with a pipeline:
+      //   Path.vstreamRange(1, 100).filter(n -> n % 2 == 0).map(n -> "Even:" + n).take(3)
+      VStreamPath<String> pipeline = answerRequired();
+
+      assertThat(pipeline.toList().unsafeRun()).containsExactly("Even:2", "Even:4", "Even:6");
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: Terminal Operations and Zipping
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: Terminal Operations and Zipping")
+  class TerminalAndZipping {
+
+    /**
+     * Exercise 9: Fold to a sum
+     *
+     * <p>Terminal operations return VTaskPath. fold() reduces elements with a seed and operator.
+     *
+     * <p>Task: Fold the stream to compute the sum
+     */
+    @Test
+    @DisplayName("Exercise 9: Fold to sum")
+    void exercise9_foldToSum() {
+      VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      // TODO: Replace answerRequired() with stream.fold(0, Integer::sum).unsafeRun()
+      Integer sum = answerRequired();
+
+      assertThat(sum).isEqualTo(15);
+    }
+
+    /**
+     * Exercise 10: Check existence
+     *
+     * <p>exists() short-circuits; it returns true as soon as one element matches.
+     *
+     * <p>Task: Check if any element is greater than 4
+     */
+    @Test
+    @DisplayName("Exercise 10: Check existence")
+    void exercise10_checkExistence() {
+      VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      // TODO: Replace answerRequired() with stream.exists(n -> n > 4).unsafeRun()
+      Boolean found = answerRequired();
+
+      assertThat(found).isTrue();
+    }
+
+    /**
+     * Exercise 11: Zip two streams
+     *
+     * <p>zipWith() pairs elements from two streams positionally, stopping at the shortest.
+     *
+     * <p>Task: Zip numbers with labels using (n, s) -> n + s
+     */
+    @Test
+    @DisplayName("Exercise 11: Zip two streams")
+    void exercise11_zipTwoStreams() {
+      VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+      VStreamPath<String> labels = Path.vstreamOf("a", "b", "c");
+
+      // TODO: Replace answerRequired() with nums.zipWith(labels, (n, s) -> n + s)
+      VStreamPath<String> zipped = answerRequired();
+
+      assertThat(zipped.toList().unsafeRun()).containsExactly("1a", "2b", "3c");
+    }
+
+    /**
+     * Exercise 12: Focus bridge with lens
+     *
+     * <p>focus(FocusPath) extracts a field from every element using a lens.
+     *
+     * <p>Task: Extract names from a stream of Person records
+     */
+    @Test
+    @DisplayName("Exercise 12: Focus bridge with lens")
+    void exercise12_focusBridge() {
+      record Person(String name, int age) {}
+
+      Lens<Person, String> nameLens = Lens.of(Person::name, (p, n) -> new Person(n, p.age));
+      FocusPath<Person, String> nameFocus = FocusPath.of(nameLens);
+
+      VStreamPath<Person> people = Path.vstreamOf(new Person("Alice", 30), new Person("Bob", 25));
+
+      // TODO: Replace answerRequired() with people.focus(nameFocus)
+      VStreamPath<String> names = answerRequired();
+
+      assertThat(names.toList().unsafeRun()).containsExactly("Alice", "Bob");
+    }
+  }
+
+  /**
+   * Congratulations! You've completed the VStreamPath tutorial.
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How to create VStreamPath instances via Path factory methods
+   *   <li>Composing lazy pipelines with map, filter, flatMap, take
+   *   <li>Terminal operations that bridge to VTaskPath (toList, fold, exists)
+   *   <li>Zipping streams positionally with zipWith
+   *   <li>Using the optics focus bridge to navigate into stream elements
+   * </ul>
+   *
+   * <p>Key Takeaways:
+   *
+   * <ul>
+   *   <li>VStreamPath operations are lazy; nothing runs until a terminal operation
+   *   <li>Terminal operations return VTaskPath, bridging stream to single-value effect
+   *   <li>VStreamPath implements Chainable, fitting into the Effect Path hierarchy
+   * </ul>
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamPath_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamPath_Solution.java
@@ -1,0 +1,188 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vtask.VTask;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial: VStreamPath - Fluent Streaming with Effect Path API
+ *
+ * <p>Each exercise solution replaces the answerRequired() placeholder with the correct code.
+ */
+@DisplayName("Tutorial Solution: VStreamPath")
+public class TutorialVStreamPath_Solution {
+
+  // ===========================================================================
+  // Part 1: Creating VStreamPath Instances
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Creating VStreamPath Instances")
+  class CreatingInstances {
+
+    @Test
+    @DisplayName("Exercise 1: Create from varargs")
+    void exercise1_createFromVarargs() {
+      // SOLUTION: Use Path.vstreamOf() to create from varargs
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("Exercise 2: Create from range")
+    void exercise2_createFromRange() {
+      // SOLUTION: Use Path.vstreamRange() to create an integer range
+      VStreamPath<Integer> path = Path.vstreamRange(1, 6);
+
+      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("Exercise 3: Infinite stream with take")
+    void exercise3_infiniteStreamWithTake() {
+      // SOLUTION: Use Path.vstreamIterate() for an infinite stream and take(4)
+      VStreamPath<Integer> path = Path.vstreamIterate(10, n -> n + 10).take(4);
+
+      assertThat(path.toList().unsafeRun()).containsExactly(10, 20, 30, 40);
+    }
+
+    @Test
+    @DisplayName("Exercise 4: Effectful unfold")
+    void exercise4_effectfulUnfold() {
+      // SOLUTION: Use Path.vstreamUnfold() with a function that stops when state > 3
+      VStreamPath<Integer> path =
+          Path.vstreamUnfold(
+              1,
+              state ->
+                  VTask.succeed(
+                      state > 3
+                          ? Optional.empty()
+                          : Optional.of(new VStream.Seed<>(state, state + 1))));
+
+      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Composing Operations
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Composing Operations")
+  class ComposingOperations {
+
+    @Test
+    @DisplayName("Exercise 5: Map elements")
+    void exercise5_mapElements() {
+      VStreamPath<String> names = Path.vstreamOf("alice", "bob");
+
+      // SOLUTION: Use map to transform each element to uppercase
+      VStreamPath<String> upper = names.map(String::toUpperCase);
+
+      assertThat(upper.toList().unsafeRun()).containsExactly("ALICE", "BOB");
+    }
+
+    @Test
+    @DisplayName("Exercise 6: Filter elements")
+    void exercise6_filterElements() {
+      VStreamPath<Integer> range = Path.vstreamRange(1, 11);
+
+      // SOLUTION: Use filter to keep only even numbers
+      VStreamPath<Integer> evens = range.filter(n -> n % 2 == 0);
+
+      assertThat(evens.toList().unsafeRun()).containsExactly(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    @DisplayName("Exercise 7: FlatMap to sub-streams")
+    void exercise7_flatMapToSubStreams() {
+      VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+
+      // SOLUTION: Use flatMap to expand each element into [n, n*10]
+      VStreamPath<Integer> expanded = nums.flatMap(n -> Path.vstreamOf(n, n * 10));
+
+      assertThat(expanded.toList().unsafeRun()).containsExactly(1, 10, 2, 20, 3, 30);
+    }
+
+    @Test
+    @DisplayName("Exercise 8: Compose a pipeline")
+    void exercise8_composePipeline() {
+      // SOLUTION: Chain filter, map, and take in a lazy pipeline
+      VStreamPath<String> pipeline =
+          Path.vstreamRange(1, 100).filter(n -> n % 2 == 0).map(n -> "Even:" + n).take(3);
+
+      assertThat(pipeline.toList().unsafeRun()).containsExactly("Even:2", "Even:4", "Even:6");
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: Terminal Operations and Zipping
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: Terminal Operations and Zipping")
+  class TerminalAndZipping {
+
+    @Test
+    @DisplayName("Exercise 9: Fold to sum")
+    void exercise9_foldToSum() {
+      VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      // SOLUTION: Use fold with seed 0 and Integer::sum
+      Integer sum = stream.fold(0, Integer::sum).unsafeRun();
+
+      assertThat(sum).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("Exercise 10: Check existence")
+    void exercise10_checkExistence() {
+      VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3, 4, 5);
+
+      // SOLUTION: Use exists to check if any element is greater than 4
+      Boolean found = stream.exists(n -> n > 4).unsafeRun();
+
+      assertThat(found).isTrue();
+    }
+
+    @Test
+    @DisplayName("Exercise 11: Zip two streams")
+    void exercise11_zipTwoStreams() {
+      VStreamPath<Integer> nums = Path.vstreamOf(1, 2, 3);
+      VStreamPath<String> labels = Path.vstreamOf("a", "b", "c");
+
+      // SOLUTION: Use zipWith to pair elements positionally
+      VStreamPath<String> zipped = nums.zipWith(labels, (n, s) -> n + s);
+
+      assertThat(zipped.toList().unsafeRun()).containsExactly("1a", "2b", "3c");
+    }
+
+    @Test
+    @DisplayName("Exercise 12: Focus bridge with lens")
+    void exercise12_focusBridge() {
+      record Person(String name, int age) {}
+
+      Lens<Person, String> nameLens = Lens.of(Person::name, (p, n) -> new Person(n, p.age));
+      FocusPath<Person, String> nameFocus = FocusPath.of(nameLens);
+
+      VStreamPath<Person> people = Path.vstreamOf(new Person("Alice", 30), new Person("Bob", 25));
+
+      // SOLUTION: Use focus() to extract names from each Person
+      VStreamPath<String> names = people.focus(nameFocus);
+
+      assertThat(names.toList().unsafeRun()).containsExactly("Alice", "Bob");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Introduces `VStreamPath<A>`, a new Effect Path type that wraps `VStream` to provide a fluent, chainable API for composing lazy, pull-based streaming computations that execute on virtual threads.

VStreamPath implements the `Chainable` and `Combinable` interfaces, enabling monadic and applicative composition within the Effect Path ecosystem. All intermediate operations remain lazy; execution is deferred until a terminal operation (toList, fold, count, etc.) is called, which bridges to `VTaskPath`.

### Key Features

- **Factory methods** via `Path` class: `vstreamOf()`, `vstreamRange()`, `vstreamIterate()`, `vstreamUnfold()`, etc.
- **Composable operations**: `map()`, `peek()`, `asUnit()`
- **Chainable operations**: `via()` / `flatMap()`, `then()`
- **Combinable operations**: `zipWith()`, `zipWith3()`
- **Stream-specific operations**: `filter()`, `take()`, `drop()`, `takeWhile()`, `dropWhile()`, `distinct()`, `concat()`
- **Terminal operations**: `toList()`, `fold()`, `count()`, `exists()`, `forAll()`, `findFirst()`, `reduce()`
- **Optics focus bridge**: Navigate into stream elements with `focus()`
- **Conversions**: Bridge to `StreamPath`, `ListPath`, `NonDetPath`
- **PathOps support**: `concatVStream()`, `traverseVStream()`, `flattenVStream()`

### Implementation Details

- `VStreamPath` is a sealed interface with `DefaultVStreamPath` as the sole implementation
- All operations delegate to the underlying `VStream`, preserving laziness
- Null validation on all public methods
- Type-safe composition with runtime checks for operation compatibility

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/update

## How Has This Been Tested?

- **Comprehensive unit tests** (`VStreamPathTest.java`): 996 lines covering factory methods, composable/chainable/combinable operations, stream-specific operations, terminal operations, focus bridge, conversions, and null validation
- **Property-based tests** (`VStreamPathPropertyTest.java`): jQwik tests verifying Functor and Monad laws across a wide range of inputs
- **Law verification tests** (`VStreamPathLawsTest.java`): Explicit verification of Functor and Monad laws
- **PathOps tests** (`VStreamPathOpsTest.java`): Tests for `concatVStream()`, `traverseVStream()`, and `flattenVStream()`
- **Custom assertions** (`VStreamPathAssert.java`): Fluent AssertJ assertions for testing VStreamPath instances
- **Tutorial and examples**: `TutorialVStreamPath.java` with exercises and `VStreamPathExample.java` demonstrating real-world usage patterns

All tests pass with `./gradlew test`.

## Checklist:

- [x] My code follows the style guidelines of this project (Google Java Conventions)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Javadoc, examples)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] GitHub Actions CI build passes with my changes

## Additional Comments

This addition completes the Effect Path ecosystem's support for streaming abstractions, providing a virtual-thread-aware alternative to `StreamPath` for lazy, pull-based computations. The implementation maintains consistency with existing Path types while leveraging VStream's efficient virtual thread execution model.

fixes #378 