### PR TITLE
Add VStream optics integration with Each, Traversal, and FocusDSL

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [FreePath](effect/path_free.md)
     - [FreeApPath](effect/path_freeap.md)
     - [VTaskPath](effect/path_vtask.md)
+    - [VStreamPath](effect/path_vstream.md)
   - [Composition Patterns](effect/composition.md)
   - [ForPath Comprehension](effect/forpath_comprehension.md)
   - [Type Conversions](effect/conversions.md)
@@ -173,6 +174,7 @@
     - [Structured Concurrency](monads/vtask_scope.md)
     - [Resource Management](monads/vtask_resource.md)
   - [VStream](monads/vstream.md)
+    - [HKT and Type Classes](monads/vstream_hkt.md)
   - [Writer](monads/writer_monad.md)
   - [Const](monads/const_type.md)
 

--- a/hkj-book/src/effect/path_types.md
+++ b/hkj-book/src/effect/path_types.md
@@ -94,6 +94,15 @@ multiple APIs in parallel, or processing streams of events.
 simple blocking code that scales to millions of concurrent tasks without
 the complexity of reactive streams.
 
+### _"I need lazy streaming with virtual threads"_
+
+You have data arriving from paginated APIs, sensors, or infinite sequences,
+and you want to process it lazily without materialising everything in memory.
+
+**Reach for [`VStreamPath`](path_vstream.md)** for pull-based streaming on virtual
+threads. Elements are produced one at a time, the consumer controls the pace,
+and terminal operations bridge back to `VTaskPath`.
+
 ### _"I need stack-safe recursion"_
 
 Deep recursive algorithms that would blow the stack with direct recursion.
@@ -132,6 +141,7 @@ with a `Monad` instance.
 | [`TryPath<A>`](path_try.md) | `Try<A>` | `Throwable` | Immediate | Exception wrapping |
 | [`IOPath<A>`](path_io.md) | `IO<A>` | `Throwable` | **Deferred** | Side effects |
 | [`VTaskPath<A>`](path_vtask.md) | `VTask<A>` | `Throwable` | **Deferred** | Virtual thread concurrency |
+| [`VStreamPath<A>`](path_vstream.md) | `VStream<A>` | Via VTask | **Lazy pull** | Lazy streaming on virtual threads |
 | [`ValidationPath<E, A>`](path_validation.md) | `Validated<E, A>` | `E` (accumulated) | Immediate | Form validation |
 | [`IdPath<A>`](path_id.md) | `Id<A>` | None (always succeeds) | Immediate | Pure values |
 | [`OptionalPath<A>`](path_optional.md) | `Optional<A>` | None (absence) | Immediate | Java stdlib bridge |
@@ -166,6 +176,7 @@ These types describe computations without executing them:
 
 - **[IOPath](path_io.md)** - Side effects, runs when you call `unsafeRun()`
 - **[VTaskPath](path_vtask.md)** - Virtual thread concurrency, runs when you call `run()`
+- **[VStreamPath](path_vstream.md)** - Lazy pull-based streaming on virtual threads
 - **[TrampolinePath](path_trampoline.md)** - Stack-safe recursion
 
 ### DSL Building
@@ -190,6 +201,7 @@ These types support building domain-specific languages:
 | Wrapping exception-throwing code | `TryPath` | Exception → functional bridge |
 | Side effects to defer | `IOPath` | Lazy, referential transparency |
 | Concurrent operations at scale | `VTaskPath` | Virtual threads, simple blocking code |
+| Lazy streaming with virtual threads | `VStreamPath` | Pull-based, infinite-safe, backpressure |
 | Need ALL validation errors | `ValidationPath` | Error accumulation |
 | Bridging Java's Optional | `OptionalPath` | Stdlib compatibility |
 | Always succeeds, pure value | `IdPath` | Generic/testing contexts |

--- a/hkj-book/src/effect/path_vstream.md
+++ b/hkj-book/src/effect/path_vstream.md
@@ -1,0 +1,417 @@
+# VStreamPath
+
+`VStreamPath<A>` wraps `VStream<A>` for **lazy, pull-based streaming on virtual
+threads**. It brings VStream's consumer-driven evaluation model into the Effect
+Path API, letting you compose stream pipelines with the same fluent syntax used by
+VTaskPath, IOPath, and every other path type.
+
+> *"The stream of time sweeps away errors, and leaves the truth for the inheritance of posterity."*
+>
+> -- Georg Brandes
+
+VStreamPath occupies a unique position among path types: it is the only one that
+models a sequence of zero or more values produced lazily over time. Where VTaskPath
+wraps a single deferred value, VStreamPath wraps an entire pipeline of deferred
+values. Terminal operations on a VStreamPath return a `VTaskPath`, bridging the
+multi-value world back to single-value effects.
+
+~~~admonish info title="What You'll Learn"
+- Creating VStreamPath instances via the Path factory
+- Composing stream pipelines with map, via, filter, and take
+- Terminal operations that bridge to VTaskPath
+- Optics focus bridge for navigating into stream elements
+- Conversions to StreamPath, ListPath, and NonDetPath
+- When to choose VStreamPath over StreamPath or VTaskPath
+~~~
+
+~~~admonish info title="Hands-On Learning"
+[TutorialVStreamPath.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamPath.java)
+~~~
+
+~~~admonish example title="See Example Code"
+[VStreamPathExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/effect/VStreamPathExample.java)
+~~~
+
+---
+
+## Where VStreamPath Fits
+
+VStreamPath implements `Chainable<A>`, the monadic composition capability in the
+Effect Path hierarchy. It does not implement `Effectful` (no side-effect execution
+model) or `Recoverable` (error handling is on the underlying VStream).
+
+```
+                  ┌────────────────────┐
+                  │    Composable<A>   │  map, peek
+                  └─────────┬──────────┘
+                            │
+              ┌─────────────┼─────────────┐
+              │             │             │
+   ┌──────────▼──────┐  ┌──▼───────┐  ┌──▼──────────┐
+   │  Combinable<A>  │  │Chainable │  │ Effectful<A> │
+   │  zipWith        │  │ via,then │  │ run, runSafe │
+   └─────────────────┘  └──┬───────┘  └──────────────┘
+                            │
+       Implemented by:      │
+       ┌────────────────────┼────────────────────┐
+       │                    │                    │
+  VTaskPath<A>      VStreamPath<A>        IOPath<A>
+  (single value)    (lazy stream)     (single value)
+```
+
+**Package**: `org.higherkindedj.hkt.effect`
+**Module**: `hkj-core`
+
+---
+
+## Creation
+
+```java
+// From an existing VStream
+VStreamPath<String> fromStream = Path.vstream(myVStream);
+
+// From values (varargs)
+VStreamPath<Integer> numbers = Path.vstreamOf(1, 2, 3, 4, 5);
+
+// From a list (lazy; does not copy)
+VStreamPath<String> fromList = Path.vstreamFromList(List.of("a", "b", "c"));
+
+// Single element
+VStreamPath<String> single = Path.vstreamPure("hello");
+
+// Empty stream
+VStreamPath<Integer> empty = Path.vstreamEmpty();
+
+// Integer range [start, end)
+VStreamPath<Integer> range = Path.vstreamRange(1, 100);
+
+// Infinite stream from seed and step
+VStreamPath<Integer> powers = Path.vstreamIterate(1, n -> n * 2);
+
+// Infinite stream from supplier
+VStreamPath<Double> randoms = Path.vstreamGenerate(Math::random);
+
+// Effectful unfolding (e.g. paginated API)
+VStreamPath<Page> pages = Path.vstreamUnfold(1, pageNum ->
+    VTask.of(() -> {
+        if (pageNum > lastPage) return Optional.empty();
+        return Optional.of(new VStream.Seed<>(fetchPage(pageNum), pageNum + 1));
+    }));
+```
+
+Like VTaskPath, nothing runs until a terminal operation executes. Construction only
+describes the pipeline.
+
+---
+
+## Core Operations
+
+### map
+
+Transform each element lazily:
+
+```java
+VStreamPath<String> tags = Path.vstreamOf(1, 2, 3)
+    .map(n -> "#" + n);
+// Lazy: no elements produced yet
+```
+
+### via (flatMap)
+
+Replace each element with a sub-stream and flatten. This is the monadic bind,
+and the mapper must return a `VStreamPath`:
+
+```java
+VStreamPath<Integer> expanded = Path.vstreamOf(1, 2, 3)
+    .via(n -> Path.vstreamOf(n, n * 10));
+// [1, 10, 2, 20, 3, 30] when materialised
+```
+
+### then
+
+Sequence two streams, discarding the first result:
+
+```java
+VStreamPath<String> withSetup = Path.vstreamOf("setup")
+    .then(() -> Path.vstreamOf("a", "b", "c"));
+// ["a", "b", "c"] when materialised
+```
+
+### peek
+
+Observe elements without modifying them:
+
+```java
+VStreamPath<Integer> logged = Path.vstreamOf(1, 2, 3)
+    .peek(n -> System.out.println("Processing: " + n));
+```
+
+### zipWith
+
+Pair elements positionally from two streams. Stops at the shorter stream:
+
+```java
+VStreamPath<String> zipped = Path.vstreamOf("a", "b", "c")
+    .zipWith(Path.vstreamOf(1, 2, 3), (s, n) -> s + n);
+// ["a1", "b2", "c3"]
+```
+
+---
+
+## Stream-Specific Operations
+
+These operations are unique to VStreamPath and have no equivalent on VTaskPath or
+MaybePath.
+
+```java
+VStreamPath<Integer> pipeline = Path.vstreamRange(1, 100)
+    .filter(n -> n % 2 == 0)     // keep evens
+    .take(10)                     // first 10
+    .map(n -> n * 3);             // multiply by 3
+
+// Equivalent to: [6, 12, 18, 24, 30, 36, 42, 48, 54, 60]
+```
+
+| Operation | Description |
+|-----------|-------------|
+| `filter(predicate)` | Keep elements matching the predicate |
+| `take(n)` | Limit to the first n elements |
+| `drop(n)` | Skip the first n elements |
+| `takeWhile(predicate)` | Take while predicate holds |
+| `dropWhile(predicate)` | Skip while predicate holds |
+| `distinct()` | Remove duplicate elements |
+| `concat(other)` | Append another VStreamPath after this one |
+
+~~~admonish warning title="Infinite Streams"
+`distinct()` tracks seen elements in memory. On infinite streams, this grows
+without bound. Combine with `take()` or `takeWhile()` to limit memory usage.
+~~~
+
+---
+
+## Terminal Operations: Bridging to VTaskPath
+
+Every terminal operation on VStreamPath returns a `VTaskPath`, bridging the
+multi-value stream world back to a single deferred value. This means you can
+continue composing with VTaskPath operations after collecting results.
+
+```
+  VStreamPath ──── terminal operation ────▶ VTaskPath
+  (many values,                             (single value,
+   lazy)                                     deferred)
+```
+
+```java
+VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3, 4, 5);
+
+// Collect all elements
+VTaskPath<List<Integer>> all = stream.toList();
+List<Integer> result = all.unsafeRun();
+// [1, 2, 3, 4, 5]
+
+// Fold with seed
+VTaskPath<Integer> sum = stream.fold(0, Integer::sum);
+// 15
+
+// First element
+VTaskPath<Optional<Integer>> head = stream.headOption();
+// Optional.of(1)
+
+// Check if any match
+VTaskPath<Boolean> hasEven = stream.exists(n -> n % 2 == 0);
+// true (short-circuits after finding 2)
+```
+
+| Terminal Operation | Return Type | Description |
+|-------------------|-------------|-------------|
+| `toList()` | `VTaskPath<List<A>>` | Collect all elements |
+| `fold(identity, op)` | `VTaskPath<A>` | Left fold with seed |
+| `foldLeft(identity, f)` | `VTaskPath<B>` | Left fold with accumulator |
+| `foldMap(monoid, f)` | `VTaskPath<M>` | Map and combine via monoid |
+| `headOption()` | `VTaskPath<Optional<A>>` | First element or empty |
+| `lastOption()` | `VTaskPath<Optional<A>>` | Last element or empty |
+| `count()` | `VTaskPath<Long>` | Count elements |
+| `exists(predicate)` | `VTaskPath<Boolean>` | Any match (short-circuits) |
+| `forAll(predicate)` | `VTaskPath<Boolean>` | All match (short-circuits) |
+| `find(predicate)` | `VTaskPath<Optional<A>>` | First matching element |
+| `forEach(consumer)` | `VTaskPath<Unit>` | Side effect per element |
+
+### Chaining After Terminal Operations
+
+Because terminal operations return VTaskPath, you can chain further:
+
+```java
+String summary = Path.vstreamRange(1, 1001)
+    .filter(n -> n % 7 == 0)
+    .take(10)
+    .toList()                            // VTaskPath<List<Integer>>
+    .map(list -> "Found " + list.size() + " multiples of 7")
+    .unsafeRun();
+// "Found 10 multiples of 7"
+```
+
+---
+
+## Optics Focus Bridge
+
+VStreamPath provides `focus` methods that let you navigate into each element using
+optics. This bridges the streaming and optics worlds.
+
+### focus with FocusPath (Lens)
+
+Extract a field from every element using a lens:
+
+```java
+record User(String name, int age) {}
+
+FocusPath<User, String> nameLens = ...;
+
+VStreamPath<String> names = Path.vstreamOf(
+    new User("Alice", 30),
+    new User("Bob", 25)
+).focus(nameLens);
+// ["Alice", "Bob"]
+```
+
+### focus with AffinePath (Optional/Prism)
+
+Extract a field that may not exist. Elements where the affine does not match are
+silently excluded from the stream:
+
+```java
+AffinePath<Object, String> stringPrism = ...;
+
+VStreamPath<String> strings = Path.vstreamOf("hello", 42, "world")
+    .focus(stringPrism);
+// ["hello", "world"]  (42 is excluded)
+```
+
+### Composing Focus with Stream Operations
+
+```java
+VStreamPath<String> activeUserNames = Path.vstream(userStream)
+    .filter(user -> user.isActive())
+    .focus(userNameLens)
+    .map(String::toUpperCase)
+    .take(10);
+```
+
+---
+
+## Conversions
+
+VStreamPath can be converted to other path types. Conversions that produce a
+single value return a VTaskPath. Conversions that produce a collection materialise
+the stream.
+
+```java
+VStreamPath<Integer> stream = Path.vstreamOf(1, 2, 3);
+
+// First/last element as VTaskPath (fails if empty)
+VTaskPath<Integer> first = stream.first();
+VTaskPath<Integer> last = stream.last();
+
+// Materialise to eager collection paths
+StreamPath<Integer> streamPath = stream.toStreamPath();
+ListPath<Integer> listPath = stream.toListPath();
+NonDetPath<Integer> nonDetPath = stream.toNonDetPath();
+```
+
+~~~admonish note title="Materialisation"
+`toStreamPath()`, `toListPath()`, and `toNonDetPath()` all materialise the entire
+stream into memory. The resulting path types are eager (all elements are collected).
+For infinite streams, bound the stream with `take()` or `takeWhile()` first.
+~~~
+
+---
+
+## From Each Traversal
+
+VStreamPath can be created from an `Each` traversal, turning any traversable
+structure into a lazy stream of its elements:
+
+```java
+Each<List<String>, String> listEach = ...;
+List<String> data = List.of("alpha", "beta", "gamma");
+
+VStreamPath<String> elements = VStreamPath.fromEach(data, listEach);
+// Lazy stream: ["alpha", "beta", "gamma"]
+```
+
+---
+
+## Choosing the Right Path Type
+
+| Aspect | VStreamPath | StreamPath | VTaskPath |
+|--------|-------------|------------|-----------|
+| **Values** | Zero or more, lazy | Zero or more, eager | Exactly one, deferred |
+| **Evaluation** | Pull-based (lazy) | Eager (materialised list) | Deferred |
+| **Execution** | Virtual threads | Synchronous | Virtual threads |
+| **Infinite sources** | Yes | No | N/A |
+| **Terminal result** | VTaskPath | Direct access | Direct access |
+| **Backpressure** | Natural (pull model) | N/A (eager) | N/A (single value) |
+| **Reusability** | Reusable | Reusable | Reusable |
+
+**Choose VStreamPath when:**
+- You need lazy streaming with virtual thread execution
+- Elements come from effectful sources (paginated APIs, databases, sensors)
+- The data source may be infinite
+- You want natural backpressure through pull-based consumption
+
+**Choose StreamPath when:**
+- You have an already-materialised list
+- You want fluent Path API composition over a known collection
+- No I/O or effectful element production is needed
+
+**Choose VTaskPath when:**
+- You have a single deferred value (not a sequence)
+- The computation produces exactly one result
+
+---
+
+## Real-World Example
+
+```java
+// Paginated API with fluent composition, focus, and terminal bridging
+VStreamPath<String> userEmails = Path.vstreamUnfold(1, page ->
+        VTask.of(() -> {
+            Page<User> result = userService.listUsers(page);
+            if (result.isEmpty()) return Optional.empty();
+            return Optional.of(new VStream.Seed<>(result, page + 1));
+        }))
+    .via(page -> Path.vstreamFromList(page.items()))
+    .filter(User::isActive)
+    .focus(userEmailLens)
+    .take(100);
+
+// Terminal: collect and continue in VTaskPath
+VTaskPath<List<String>> task = userEmails.toList();
+Try<List<String>> result = task.runSafe();
+```
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **VStreamPath** wraps VStream for fluent, lazy stream composition in the Effect Path API
+* **Terminal operations return VTaskPath**, bridging multi-value streams to single-value effects
+* **Stream-specific operations** (filter, take, drop, distinct, concat) have no equivalent on other path types
+* **Focus bridge** lets you navigate into stream elements with lenses and prisms
+* **Conversions** materialise the stream to StreamPath, ListPath, or NonDetPath
+* **Everything is lazy**: no elements are produced until a terminal operation executes
+* **Chainable but not Effectful**: compose with via and map; execute via terminal then VTaskPath.run
+~~~
+
+~~~admonish tip title="See Also"
+- [VStream](../monads/vstream.md) - Core VStream type: Step protocol, factories, combinators
+- [VStream HKT](../monads/vstream_hkt.md) - Type class instances for generic programming
+- [VTaskPath](path_vtask.md) - Single-value virtual thread path (terminal operations return this)
+- [StreamPath](../monads/stream_monad.md) - Eager list-based streaming path
+- [Effect Path Overview](effect_path_overview.md) - How all path types fit together
+- [Focus-Effect Integration](focus_integration.md) - Optics meet Effect Path
+- [Each Typeclass](../optics/each_typeclass.md) - Canonical element-wise traversal (includes VStream)
+~~~
+
+---
+
+**Previous:** [VTaskPath](path_vtask.md)
+**Next:** [Composition Patterns](composition.md)

--- a/hkj-book/src/effect/path_vtask.md
+++ b/hkj-book/src/effect/path_vtask.md
@@ -397,4 +397,4 @@ See [Benchmarks & Performance](../benchmarks.md) for full details, comparison be
 ---
 
 **Previous:** [FreeApPath](path_freeap.md)
-**Next:** [Composition Patterns](composition.md)
+**Next:** [VStreamPath](path_vstream.md)

--- a/hkj-book/src/monads/vstream.md
+++ b/hkj-book/src/monads/vstream.md
@@ -447,7 +447,7 @@ The counter stays at zero after pipeline construction. It only advances when `to
 | Reusability | Reusable | Single-use | Reusable |
 | Infinite streams | Yes (take, takeWhile) | Yes (limit) | No |
 | Error handling | recover, recoverWith | Exceptions | Via effect type |
-| HKT integration | TBC | No | Yes |
+| HKT integration | Yes (Functor, Monad, Traverse) | No | Yes |
 | Effect composition | VTask per pull | None | Via Path API |
 
 **Use VStream when** you need lazy streaming with virtual thread execution, effectful
@@ -486,12 +486,15 @@ See [Benchmarks & Performance](../benchmarks.md) for full details and how to int
 
 
 ~~~admonish tip title="See Also"
+- [HKT and Type Classes](vstream_hkt.md) - VStream's type class instances for generic programming
+- [VStreamPath](../effect/path_vstream.md) - Fluent Effect Path wrapper for VStream
 - [VTask](vtask_monad.md) - The single-value effect type that powers VStream pulls
 - [VTaskPath](../effect/path_vtask.md) - Fluent Path API wrapper for VTask
 - [Stream](stream_monad.md) - Eager list-based streaming
+- [Each Typeclass](../optics/each_typeclass.md) - Canonical element-wise traversal (includes VStream)
 ~~~
 
 ---
 
 **Previous:** [Resource Management](vtask_resource.md)
-**Next:** [Writer](writer_monad.md)
+**Next:** [HKT and Type Classes](vstream_hkt.md)

--- a/hkj-book/src/monads/vstream_hkt.md
+++ b/hkj-book/src/monads/vstream_hkt.md
@@ -1,0 +1,400 @@
+# VStream HKT: Type Classes for Lazy Streams
+## _Making VStream a First-Class Citizen of Higher-Kinded-J_
+
+~~~admonish info title="What You'll Learn"
+- How VStream participates in the HKT simulation via `VStreamKind`
+- The widen/narrow pattern for moving between VStream and Kind
+- VStream's type class hierarchy: Functor, Applicative, Monad, Alternative
+- Foldable and Traverse instances (with finite-stream constraints)
+- Writing generic functions that work with VStream and any other monadic type
+~~~
+
+~~~admonish example title="See Example Code"
+[VStreamHKTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/vstream/VStreamHKTExample.java)
+~~~
+
+## Why Does VStream Need HKT?
+
+Without HKT encoding, every function that operates on containers must be rewritten
+for each type. A function that doubles every number inside a `Maybe` cannot also
+double every number inside a `VStream` without a second, near-identical
+implementation. HKT encoding solves this by letting VStream present itself as
+`Kind<VStreamKind.Witness, A>`, the same shape that Maybe, Either, VTask, and every
+other Higher-Kinded-J type uses. One generic function handles them all.
+
+```java
+// Generic: works with VStream, Maybe, Either, VTask, List, ...
+<F extends WitnessArity<TypeArity.Unary>> Kind<F, Integer> doubleAll(
+        Functor<F> functor, Kind<F, Integer> fa) {
+    return functor.map(n -> n * 2, fa);
+}
+
+// Using it with VStream
+Kind<VStreamKind.Witness, Integer> doubled =
+    doubleAll(VStreamFunctor.INSTANCE, VSTREAM.widen(VStream.of(1, 2, 3)));
+
+List<Integer> result = VSTREAM.narrow(doubled).toList().run();
+// [2, 4, 6]
+```
+
+**Package**: `org.higherkindedj.hkt.vstream`
+**Module**: `hkj-core`
+
+---
+
+## The HKT Encoding
+
+VStream uses the standard Higher-Kinded-J encoding pattern: a witness type, a Kind
+interface, and a helper for safe conversions.
+
+```
+                     Kind<F, A>
+                         │
+                         │ extends
+                         ▼
+               VStreamKind<A>                 (marker interface)
+                    │
+                    │ extends
+                    ▼
+              VStream<A>                      (concrete type)
+
+  VStreamKind.Witness                         (phantom type tag)
+  └── implements WitnessArity<TypeArity.Unary>
+```
+
+### VStreamKind: The Witness Type
+
+```java
+public interface VStreamKind<A> extends Kind<VStreamKind.Witness, A> {
+    final class Witness implements WitnessArity<TypeArity.Unary> {
+        private Witness() {}
+    }
+}
+```
+
+`VStream<A>` extends `VStreamKind<A>`, so every VStream is already a
+`Kind<VStreamKind.Witness, A>`. The `Witness` class is the phantom type tag that
+tells the type class machinery "this is VStream".
+
+### Widen and Narrow
+
+`VStreamKindHelper` provides safe conversions between the concrete and HKT
+representations:
+
+```java
+import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
+
+// Concrete → HKT (simple upcast, since VStream extends VStreamKind)
+Kind<VStreamKind.Witness, String> widened = VSTREAM.widen(VStream.of("a", "b"));
+
+// HKT → Concrete (validated downcast)
+VStream<String> narrowed = VSTREAM.narrow(widened);
+```
+
+Narrowing performs a type check. If you accidentally pass a Kind with the wrong
+witness type, you get a clear error rather than a silent ClassCastException.
+
+---
+
+## Type Class Hierarchy
+
+VStream implements the full standard type class tower, from Functor up to
+Alternative, plus Foldable and Traverse for finite streams.
+
+```
+                   ┌───────────────┐
+                   │   Functor     │  map
+                   └───────┬───────┘
+                           │
+                   ┌───────▼───────┐
+                   │  Applicative  │  of, ap
+                   └───────┬───────┘
+                           │
+                   ┌───────▼───────┐
+                   │    Monad      │  flatMap
+                   └───────┬───────┘
+                           │
+                   ┌───────▼───────┐
+                   │  Alternative  │  empty, orElse
+                   └───────────────┘
+
+  Also:
+                   ┌───────────────┐
+                   │   Foldable    │  foldMap  (finite streams only)
+                   └───────┬───────┘
+                           │
+                   ┌───────▼───────┐
+                   │   Traverse    │  traverse (finite streams only)
+                   └───────────────┘
+```
+
+Each level in the hierarchy extends the one above. `VStreamAlternative.INSTANCE`
+provides access to all of Functor, Applicative, Monad, and Alternative in a single
+object.
+
+| Instance | Singleton | Key Operation | Semantics |
+|----------|-----------|---------------|-----------|
+| `VStreamFunctor` | `INSTANCE` | `map(f, fa)` | Transform each element lazily |
+| `VStreamApplicative` | `INSTANCE` | `of(a)`, `ap(ff, fa)` | Lift value; Cartesian product |
+| `VStreamMonad` | `INSTANCE` | `flatMap(f, ma)` | Substitute and flatten |
+| `VStreamAlternative` | `INSTANCE` | `empty()`, `orElse(fa, fb)` | Empty stream; concatenation |
+| `VStreamTraverse` | `INSTANCE` | `foldMap`, `traverse` | Materialise and fold/traverse |
+
+---
+
+## Functor: Transforming Elements
+
+`VStreamFunctor` delegates to `VStream.map()`, preserving laziness. No elements are
+produced until a terminal operation runs.
+
+```java
+Functor<VStreamKind.Witness> functor = VStreamFunctor.INSTANCE;
+
+Kind<VStreamKind.Witness, String> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+Kind<VStreamKind.Witness, String> mapped = functor.map(n -> "#" + n, stream);
+
+List<String> result = VSTREAM.narrow(mapped).toList().run();
+// ["#1", "#2", "#3"]
+```
+
+**Functor laws satisfied**:
+- Identity: `map(x -> x, stream)` produces the same elements as `stream`
+- Composition: `map(g.compose(f), stream)` equals `map(g, map(f, stream))`
+
+---
+
+## Applicative: Lifting and Combining
+
+`VStreamApplicative` uses **Cartesian product** semantics for `ap`. When you apply a
+stream of functions to a stream of values, every function is applied to every value.
+This is the standard choice for list-like monads, consistent with StreamMonad and
+NonDetPath.
+
+```java
+Applicative<VStreamKind.Witness> applicative = VStreamApplicative.INSTANCE;
+
+// Lift a pure value into a single-element stream
+Kind<VStreamKind.Witness, String> single = applicative.of("hello");
+// VStream.of("hello")
+
+// Cartesian product: 2 functions x 3 values = 6 results
+Kind<VStreamKind.Witness, Function<Integer, String>> fns =
+    VSTREAM.widen(VStream.of(n -> "x" + n, n -> "y" + n));
+
+Kind<VStreamKind.Witness, Integer> vals =
+    VSTREAM.widen(VStream.of(1, 2, 3));
+
+Kind<VStreamKind.Witness, String> applied = applicative.ap(fns, vals);
+
+List<String> result = VSTREAM.narrow(applied).toList().run();
+// ["x1", "x2", "x3", "y1", "y2", "y3"]
+```
+
+---
+
+## Monad: Sequential Composition
+
+`VStreamMonad` provides `flatMap`, which substitutes each element with a sub-stream
+and flattens the results. This is the monadic bind for VStream, and it preserves
+lazy evaluation throughout.
+
+```java
+Monad<VStreamKind.Witness> monad = VStreamMonad.INSTANCE;
+
+Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3));
+
+Kind<VStreamKind.Witness, Integer> expanded = monad.flatMap(
+    n -> VSTREAM.widen(VStream.of(n, n * 10)),
+    stream
+);
+
+List<Integer> result = VSTREAM.narrow(expanded).toList().run();
+// [1, 10, 2, 20, 3, 30]
+```
+
+**Monad laws satisfied**:
+- Left identity: `flatMap(of(a), f)` equals `f(a)`
+- Right identity: `flatMap(stream, of)` equals `stream`
+- Associativity: `flatMap(flatMap(stream, f), g)` equals `flatMap(stream, x -> flatMap(f(x), g))`
+
+---
+
+## Alternative: Empty and Concatenation
+
+`VStreamAlternative` models choice for streams. The `empty()` method returns an
+empty stream (the identity element), and `orElse` concatenates two streams. This
+is consistent with list-like Alternative instances: "try all of stream A, then try
+all of stream B".
+
+```java
+Alternative<VStreamKind.Witness> alt = VStreamAlternative.INSTANCE;
+
+Kind<VStreamKind.Witness, Integer> first = VSTREAM.widen(VStream.of(1, 2));
+Kind<VStreamKind.Witness, Integer> second = VSTREAM.widen(VStream.of(3, 4));
+
+// Concatenation
+Kind<VStreamKind.Witness, Integer> combined = alt.orElse(first, () -> second);
+List<Integer> result = VSTREAM.narrow(combined).toList().run();
+// [1, 2, 3, 4]
+
+// Empty is the identity
+Kind<VStreamKind.Witness, Integer> empty = alt.empty();
+Kind<VStreamKind.Witness, Integer> same = alt.orElse(first, () -> empty);
+// produces [1, 2]
+
+// Guard: filter based on a boolean condition
+Kind<VStreamKind.Witness, Unit> passed = alt.guard(true);   // single Unit
+Kind<VStreamKind.Witness, Unit> failed = alt.guard(false);  // empty
+```
+
+---
+
+## Foldable and Traverse: Finite Streams Only
+
+~~~admonish warning title="Finite Streams Only"
+`foldMap` and `traverse` materialise the entire stream before processing. They are
+**not safe for infinite streams** and will not terminate if the stream has no end.
+Use `take()` or `takeWhile()` to bound the stream before folding or traversing.
+~~~
+
+### Foldable
+
+`foldMap` pulls every element, maps each one through a function, and combines the
+results using a monoid. Because VStream elements are produced via VTask, this is a
+terminal operation that executes the stream.
+
+```java
+VStreamTraverse traverse = VStreamTraverse.INSTANCE;
+
+Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(1, 2, 3, 4, 5));
+
+// Sum using the integer addition monoid
+int sum = traverse.foldMap(Monoid.intSum(), n -> n, stream);
+// 15
+
+// String concatenation
+String csv = traverse.foldMap(
+    Monoid.string(),
+    n -> String.valueOf(n),
+    stream
+);
+// "12345"
+```
+
+### Traverse
+
+`traverse` applies an effectful function to each element and collects the results
+inside an outer applicative context. For VStream, this materialises the stream to a
+list first, traverses the list, and reconstructs the result as a VStream.
+
+```java
+// Traverse with Maybe: if any element maps to Nothing, the whole result is Nothing
+Applicative<MaybeKind.Witness> maybeApp = MaybeMonad.INSTANCE;
+
+Kind<VStreamKind.Witness, Integer> stream = VSTREAM.widen(VStream.of(2, 4, 6));
+
+Kind<MaybeKind.Witness, Kind<VStreamKind.Witness, String>> result =
+    traverse.traverse(
+        maybeApp,
+        n -> n > 0
+            ? MaybeKindHelper.MAYBE.widen(Maybe.just("+" + n))
+            : MaybeKindHelper.MAYBE.widen(Maybe.nothing()),
+        stream
+    );
+
+// All positive, so result is Just(VStream.of("+2", "+4", "+6"))
+```
+
+---
+
+## Writing Generic Functions
+
+The real power of HKT encoding is writing functions that work with any monadic type.
+Here is a function that triples every element in any Functor:
+
+```java
+static <F extends WitnessArity<TypeArity.Unary>>
+Kind<F, Integer> tripleAll(Functor<F> functor, Kind<F, Integer> fa) {
+    return functor.map(n -> n * 3, fa);
+}
+
+// Works with VStream
+Kind<VStreamKind.Witness, Integer> tripled = tripleAll(
+    VStreamMonad.INSTANCE,
+    VSTREAM.widen(VStream.of(1, 2, 3))
+);
+// [3, 6, 9]
+
+// Same function works with Maybe
+Kind<MaybeKind.Witness, Integer> tripledMaybe = tripleAll(
+    MaybeMonad.INSTANCE,
+    MaybeKindHelper.MAYBE.widen(Maybe.just(7))
+);
+// Just(21)
+```
+
+And a function that uses Monad to compose sequential operations:
+
+```java
+static <F extends WitnessArity<TypeArity.Unary>>
+Kind<F, String> fetchAndFormat(
+        Monad<F> monad,
+        Kind<F, Integer> ids) {
+    return monad.flatMap(
+        id -> monad.map(name -> name + " (id=" + id + ")", monad.of("User" + id)),
+        ids
+    );
+}
+
+// With VStream: processes each id, producing a formatted string per element
+Kind<VStreamKind.Witness, String> users = fetchAndFormat(
+    VStreamMonad.INSTANCE,
+    VSTREAM.widen(VStream.of(1, 2, 3))
+);
+// ["User1 (id=1)", "User2 (id=2)", "User3 (id=3)"]
+```
+
+---
+
+## How VStream Compares to Other Instances
+
+| Aspect | VStream | Maybe | List/Stream | VTask |
+|--------|---------|-------|-------------|-------|
+| `of(a)` | Single-element stream | `Just(a)` | Single-element list | Succeed with value |
+| `ap` semantics | Cartesian product | Apply if both present | Cartesian product | Sequential |
+| `flatMap` | Substitute and flatten | Chain if present | Substitute and flatten | Chain effects |
+| `empty` | Empty stream | `Nothing` | Empty list | N/A (no Alternative) |
+| `orElse` | Concatenate streams | First non-empty | Concatenate lists | N/A |
+| `foldMap` | Materialise and fold | Extract or identity | Fold list | N/A (no Foldable) |
+| Lazy evaluation | Yes | N/A (single value) | Eager (materialised) | Yes (deferred) |
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **VStreamKind** is the HKT witness type that lets VStream participate in generic, type-class-based programming
+* **Widen/narrow** via `VStreamKindHelper.VSTREAM` converts safely between VStream and Kind
+* **Functor, Applicative, Monad** all preserve lazy evaluation; no elements are produced until a terminal operation runs
+* **Applicative uses Cartesian product** semantics: every function applied to every value
+* **Alternative uses concatenation**: `orElse` appends the second stream after the first
+* **Foldable and Traverse materialise** the stream; use only on finite streams
+* **Generic functions** written against Functor, Monad, or Alternative work with VStream alongside any other Higher-Kinded-J type
+~~~
+
+~~~admonish info title="Hands-On Learning"
+Practice VStream HKT encoding in [TutorialVStreamHKT](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamHKT.java) (10 exercises, ~12-15 minutes).
+~~~
+
+~~~admonish tip title="See Also"
+- [VStream](vstream.md) - Core VStream type: factories, combinators, terminal operations
+- [VStreamPath](../effect/path_vstream.md) - Fluent Effect Path wrapper for VStream
+- [Higher-Kinded Types](../hkts/hkt_introduction.md) - How the HKT simulation works
+- [Functor](../functional/functor.md) - The Functor type class
+- [Monad](../functional/monad.md) - The Monad type class
+- [Alternative](../functional/alternative.md) - The Alternative type class
+- [Foldable and Traverse](../functional/foldable_and_traverse.md) - Folding and effectful traversal
+~~~
+
+---
+
+**Previous:** [VStream](vstream.md)
+**Next:** [Writer](writer_monad.md)

--- a/hkj-book/src/monads/writer_monad.md
+++ b/hkj-book/src/monads/writer_monad.md
@@ -244,5 +244,5 @@ The Higher-Kinded-J enables these operations to be performed generically using s
 
 ---
 
-**Previous:** [VStream](vstream.md)
+**Previous:** [HKT and Type Classes](vstream_hkt.md)
 **Next:** [Const](const_type.md)

--- a/hkj-book/src/optics/each_typeclass.md
+++ b/hkj-book/src/optics/each_typeclass.md
@@ -8,7 +8,7 @@
 
 ~~~admonish info title="What You'll Learn"
 - How the `Each` type class provides canonical traversals for container types
-- Using `EachInstances` for Java collections (List, Set, Map, Optional, arrays, Stream, String)
+- Using `EachInstances` for Java collections (List, Set, Map, Optional, arrays, Stream, VStream, String)
 - Using `EachExtensions` for HKT types (Maybe, Either, Try, Validated)
 - Indexed traversal support via `eachWithIndex()` for position-aware operations
 - Integration with Focus DSL using `.each(Each)` method
@@ -108,6 +108,7 @@ The interface is simple by design. Implement `each()` to provide a traversal; op
 │  Optional<A>   │   ✓     │       ✗         │     -          │
 │  A[]           │   ✓     │       ✓         │  Integer       │
 │  Stream<A>     │   ✓     │       ✗         │     -          │
+│  VStream<A>    │   ✓     │       ✗         │     -          │
 │  String        │   ✓     │       ✓         │  Integer       │
 └──────────────────────────────────────────────────────────────┘
 ```
@@ -132,6 +133,9 @@ Each<Integer[], Integer> arrayEach = EachInstances.arrayEach();
 
 // Stream traversal (consumed during traversal)
 Each<Stream<String>, String> streamEach = EachInstances.streamEach();
+
+// VStream traversal (materialises during traversal; finite streams only)
+Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
 
 // String character traversal with index support
 Each<String, Character> stringEach = EachInstances.stringCharsEach();
@@ -414,7 +418,7 @@ User updated = allTasks.modifyAll(Task::markReviewed, user);
 
 ~~~admonish info title="Key Takeaways"
 * **Each<S, A>** provides a canonical `Traversal<S, A>` for any container type
-* **EachInstances** covers Java collections: List, Set, Map, Optional, arrays, Stream, String
+* **EachInstances** covers Java collections: List, Set, Map, Optional, arrays, Stream, VStream, String
 * **EachExtensions** covers HKT types: Maybe, Either, Try, Validated
 * **eachWithIndex()** returns an `IndexedTraversal` when the container supports meaningful indices
 * **Focus DSL integration** via `.each(Each)` enables fluent navigation through custom containers

--- a/hkj-core/src/main/java/org/higherkindedj/optics/each/EachInstances.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/each/EachInstances.java
@@ -15,6 +15,7 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Traverse;
 import org.higherkindedj.hkt.TypeArity;
 import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.vstream.VStream;
 import org.higherkindedj.optics.Each;
 import org.higherkindedj.optics.Traversal;
 import org.higherkindedj.optics.focus.FocusPaths;
@@ -266,6 +267,33 @@ public final class EachInstances {
       return TraverseTraversals.forStream();
     }
     // No indexed traversal for Stream
+  }
+
+  // ===== VStream =====
+
+  /**
+   * Creates an {@link Each} instance for {@link VStream} types.
+   *
+   * <p>The returned {@code Each} traverses all elements by materialising the stream. Does not
+   * support indexed access.
+   *
+   * <p><strong>Warning:</strong> The VStream is fully evaluated during traversal. Only use with
+   * finite streams. Infinite streams will cause non-termination.
+   *
+   * @param <A> The element type of the VStream
+   * @return An {@code Each} instance for VStreams
+   * @see VStreamTraversals#forVStream()
+   */
+  public static <A> Each<VStream<A>, A> vstreamEach() {
+    return new VStreamEach<>();
+  }
+
+  private static final class VStreamEach<A> implements Each<VStream<A>, A> {
+    @Override
+    public Traversal<VStream<A>, A> each() {
+      return VStreamTraversals.forVStream();
+    }
+    // No indexed traversal for VStream
   }
 
   // ===== String (Characters) =====

--- a/hkj-core/src/main/java/org/higherkindedj/optics/each/VStreamTraversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/each/VStreamTraversals.java
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.each;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.IndexedTraversals;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Provides a {@link Traversal} instance for {@link VStream} elements.
+ *
+ * <p>The traversal materialises the VStream to a list, sequences each element effect using
+ * copy-safe accumulation via {@link IndexedTraversals#sequenceList}, and reconstructs a VStream
+ * from the result via {@link VStream#fromList}.
+ *
+ * <p><b>Materialisation Warning:</b> The VStream is fully consumed during traversal. This is only
+ * safe for finite streams. Using this traversal on infinite streams will not terminate.
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>{@code
+ * Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+ *
+ * VStream<String> stream = VStream.fromList(List.of("hello", "world"));
+ * VStream<String> upper = Traversals.modify(traversal, String::toUpperCase, stream);
+ * // upper produces: ["HELLO", "WORLD"]
+ *
+ * List<String> all = Traversals.getAll(traversal, stream);
+ * // all: ["hello", "world"]
+ * }</pre>
+ *
+ * @see VStream
+ * @see Traversal
+ * @see EachInstances#vstreamEach()
+ */
+@NullMarked
+public final class VStreamTraversals {
+
+  /** Private constructor to prevent instantiation. */
+  private VStreamTraversals() {}
+
+  /**
+   * Creates a {@link Traversal} for {@link VStream} elements.
+   *
+   * <p>The traversal materialises the stream to a list (consuming it), applies the effectful
+   * function to each element and sequences the results using copy-safe accumulation via {@link
+   * IndexedTraversals#sequenceList}, then converts the result back to a VStream.
+   *
+   * <p><b>Warning:</b> The VStream is fully evaluated during traversal. Only use with finite
+   * streams. Infinite streams will cause non-termination.
+   *
+   * @param <A> the element type within the VStream
+   * @return a Traversal over VStream elements; never null
+   */
+  public static <A> Traversal<VStream<A>, A> forVStream() {
+    return new Traversal<>() {
+      @Override
+      public <G extends WitnessArity<TypeArity.Unary>> Kind<G, VStream<A>> modifyF(
+          Function<A, Kind<G, A>> f, VStream<A> source, Applicative<G> applicative) {
+        // Materialise the VStream to a list (consuming it)
+        List<A> elements = source.toList().run();
+
+        // Apply the effectful function to each element
+        List<Kind<G, A>> modifiedEffects = new ArrayList<>(elements.size());
+        for (A a : elements) {
+          modifiedEffects.add(f.apply(a));
+        }
+
+        // Sequence effects using copy-safe accumulation, then convert back to VStream
+        Kind<G, List<A>> result = IndexedTraversals.sequenceList(modifiedEffects, applicative);
+        return applicative.map(VStream::fromList, result);
+      }
+    };
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/each/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/each/package-info.java
@@ -22,6 +22,7 @@
  *   <tr><td>{@code Validated<E,A>}</td><td>{@code validatedEach()}</td><td>No</td><td>-</td></tr>
  *   <tr><td>{@code A[]}</td><td>{@code arrayEach()}</td><td>Yes</td><td>{@code Integer}</td></tr>
  *   <tr><td>{@code Stream<A>}</td><td>{@code streamEach()}</td><td>No</td><td>-</td></tr>
+ *   <tr><td>{@code VStream<A>}</td><td>{@code vstreamEach()}</td><td>No</td><td>-</td></tr>
  *   <tr><td>{@code String}</td><td>{@code stringCharsEach()}</td><td>Yes</td><td>{@code Integer}</td></tr>
  *   <tr><td>{@code Kind<F,A>}</td><td>{@code fromTraverse(Traverse)}</td><td>No</td><td>-</td></tr>
  * </table>

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalPath.java
@@ -22,6 +22,7 @@ import org.higherkindedj.hkt.effect.MaybePath;
 import org.higherkindedj.hkt.effect.NonDetPath;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.StreamPath;
+import org.higherkindedj.hkt.effect.VStreamPath;
 import org.higherkindedj.optics.Affine;
 import org.higherkindedj.optics.Each;
 import org.higherkindedj.optics.Fold;
@@ -891,6 +892,32 @@ public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTr
    */
   default StreamPath<A> toStreamPath(S source) {
     return Path.streamFromList(getAll(source));
+  }
+
+  /**
+   * Extracts all focused values and wraps them in a {@link VStreamPath}.
+   *
+   * <p>This bridges from the optics domain to the effect domain using lazy, pull-based streaming
+   * semantics with virtual thread execution. The focused values are materialised into a list and
+   * then wrapped in a VStream.
+   *
+   * <h2>Example Usage</h2>
+   *
+   * <pre>{@code
+   * TraversalPath<Company, Employee> employeesPath = CompanyFocus.employees();
+   * Company company = new Company(List.of(emp1, emp2, emp3));
+   *
+   * // Extract employees as a VStreamPath for virtual-thread processing
+   * VStreamPath<String> names = employeesPath.toVStreamPath(company)
+   *     .map(Employee::name)
+   *     .filter(n -> n.startsWith("A"));
+   * }</pre>
+   *
+   * @param source the source structure
+   * @return a VStreamPath streaming all focused values
+   */
+  default VStreamPath<A> toVStreamPath(S source) {
+    return Path.vstreamFromList(getAll(source));
   }
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/optics/each/VStreamEachTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/each/VStreamEachTest.java
@@ -1,0 +1,845 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.each;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.id.IdKindHelper.ID;
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+import static org.higherkindedj.hkt.vtask.VTaskKindHelper.VTASK;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.hkt.validated.ValidatedSelective;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vtask.VTask;
+import org.higherkindedj.hkt.vtask.VTaskApplicative;
+import org.higherkindedj.hkt.vtask.VTaskKind;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Each;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.higherkindedj.optics.indexed.IndexedTraversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("VStream Each and Optics Integration Tests")
+class VStreamEachTest {
+
+  // ===== Basic VStreamTraversals Tests =====
+
+  @Nested
+  @DisplayName("VStreamTraversals.forVStream()")
+  class VStreamTraversalTests {
+
+    @Test
+    @DisplayName("should traverse all elements of a VStream")
+    void traversesAllElements() {
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      VStream<String> stream = VStream.fromList(List.of("a", "b", "c"));
+
+      List<String> elements = Traversals.getAll(traversal, stream);
+
+      assertThat(elements).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("should modify all elements")
+    void modifiesAllElements() {
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      VStream<String> stream = VStream.fromList(List.of("hello", "world"));
+
+      VStream<String> modified = Traversals.modify(traversal, String::toUpperCase, stream);
+
+      assertThat(modified.toList().run()).containsExactly("HELLO", "WORLD");
+    }
+
+    @Test
+    @DisplayName("should handle empty VStream")
+    void handlesEmptyStream() {
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      VStream<String> stream = VStream.empty();
+
+      List<String> elements = Traversals.getAll(traversal, stream);
+
+      assertThat(elements).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should handle single-element VStream")
+    void handlesSingleElement() {
+      Traversal<VStream<Integer>, Integer> traversal = VStreamTraversals.forVStream();
+      VStream<Integer> stream = VStream.of(42);
+
+      List<Integer> elements = Traversals.getAll(traversal, stream);
+
+      assertThat(elements).containsExactly(42);
+    }
+
+    @Test
+    @DisplayName("should set all elements to same value")
+    void setsAllElements() {
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      VStream<String> stream = VStream.fromList(List.of("a", "b", "c"));
+
+      VStream<String> replaced = Traversals.modify(traversal, ignored -> "X", stream);
+
+      assertThat(replaced.toList().run()).containsExactly("X", "X", "X");
+    }
+
+    @Test
+    @DisplayName("should handle VStream with duplicate elements")
+    void handlesDuplicates() {
+      Traversal<VStream<Integer>, Integer> traversal = VStreamTraversals.forVStream();
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 1, 3, 2));
+
+      List<Integer> elements = Traversals.getAll(traversal, stream);
+
+      assertThat(elements).containsExactly(1, 2, 1, 3, 2);
+    }
+  }
+
+  // ===== EachInstances.vstreamEach() Tests =====
+
+  @Nested
+  @DisplayName("EachInstances.vstreamEach()")
+  class VStreamEachInstanceTests {
+
+    private final Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+
+    @Test
+    @DisplayName("each() should return non-null traversal")
+    void eachReturnsTraversal() {
+      Traversal<VStream<String>, String> traversal = vstreamEach.each();
+      assertThat(traversal).isNotNull();
+    }
+
+    @Test
+    @DisplayName("each() should traverse all elements")
+    void eachTraversesAllElements() {
+      VStream<String> stream = VStream.fromList(List.of("a", "b", "c"));
+      Traversal<VStream<String>, String> traversal = vstreamEach.each();
+
+      List<String> elements = Traversals.getAll(traversal, stream);
+
+      assertThat(elements).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("each() should modify all elements")
+    void eachModifiesAllElements() {
+      VStream<String> stream = VStream.fromList(List.of("hello", "world"));
+      Traversal<VStream<String>, String> traversal = vstreamEach.each();
+
+      VStream<String> modified = Traversals.modify(traversal, String::toUpperCase, stream);
+
+      assertThat(modified.toList().run()).containsExactly("HELLO", "WORLD");
+    }
+
+    @Test
+    @DisplayName("each() should handle empty VStream")
+    void eachHandlesEmpty() {
+      VStream<String> stream = VStream.empty();
+      Traversal<VStream<String>, String> traversal = vstreamEach.each();
+
+      List<String> elements = Traversals.getAll(traversal, stream);
+
+      assertThat(elements).isEmpty();
+    }
+
+    @Test
+    @DisplayName("supportsIndexed() should return false for VStream")
+    void supportsIndexedReturnsFalse() {
+      assertThat(vstreamEach.supportsIndexed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("eachWithIndex() should return empty for VStream")
+    void eachWithIndexReturnsEmpty() {
+      Optional<IndexedTraversal<Object, VStream<String>, String>> indexed =
+          vstreamEach.eachWithIndex();
+
+      assertThat(indexed).isEmpty();
+    }
+
+    @Test
+    @DisplayName("vstreamEach() should return new instances")
+    void vstreamEachReturnsNewInstances() {
+      Each<VStream<String>, String> first = EachInstances.vstreamEach();
+      Each<VStream<String>, String> second = EachInstances.vstreamEach();
+
+      assertThat(first).isNotSameAs(second);
+    }
+  }
+
+  // ===== FocusDSL Integration Tests =====
+
+  @Nested
+  @DisplayName("FocusDSL Integration")
+  class FocusDSLIntegrationTests {
+
+    // Simple record for testing lens + each composition
+    record Container(VStream<String> items) {}
+
+    // Lens to access the items field
+    private static final Lens<Container, VStream<String>> ITEMS_LENS =
+        Lens.of(Container::items, (container, items) -> new Container(items));
+
+    @Test
+    @DisplayName("FocusPath.via(lens).each(vstreamEach) navigates into VStream elements")
+    void focusPathWithVStreamEach() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Container, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+
+      Container container = new Container(VStream.fromList(List.of("a", "b", "c")));
+
+      List<String> items = allItems.getAll(container);
+
+      assertThat(items).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("FocusDSL each() modifies all VStream elements")
+    void focusDSLModifiesElements() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Container, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+
+      Container original = new Container(VStream.fromList(List.of("hello", "world")));
+
+      Container modified = allItems.modifyAll(String::toUpperCase, original);
+
+      assertThat(modified.items().toList().run()).containsExactly("HELLO", "WORLD");
+    }
+
+    @Test
+    @DisplayName("FocusDSL each() with empty VStream returns empty getAll")
+    void focusDSLWithEmptyVStream() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Container, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+
+      Container container = new Container(VStream.empty());
+
+      List<String> items = allItems.getAll(container);
+
+      assertThat(items).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FocusDSL filter on VStream elements")
+    void focusDSLFilterElements() {
+      Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+
+      record IntContainer(VStream<Integer> numbers) {}
+
+      Lens<IntContainer, VStream<Integer>> numbersLens =
+          Lens.of(IntContainer::numbers, (c, n) -> new IntContainer(n));
+
+      TraversalPath<IntContainer, Integer> allNumbers = FocusPath.of(numbersLens).each(vstreamEach);
+
+      IntContainer container = new IntContainer(VStream.fromList(List.of(1, 2, 3, 4, 5)));
+
+      TraversalPath<IntContainer, Integer> evens = allNumbers.filter(n -> n % 2 == 0);
+
+      List<Integer> evenNumbers = evens.getAll(container);
+      assertThat(evenNumbers).containsExactly(2, 4);
+    }
+
+    @Test
+    @DisplayName("FocusDSL setAll on VStream elements")
+    void focusDSLSetAll() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Container, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+
+      Container container = new Container(VStream.fromList(List.of("a", "b", "c")));
+
+      Container updated = allItems.setAll("X", container);
+
+      assertThat(updated.items().toList().run()).containsExactly("X", "X", "X");
+    }
+  }
+
+  // ===== TraversalPath.toVStreamPath() Tests =====
+
+  @Nested
+  @DisplayName("TraversalPath.toVStreamPath()")
+  class ToVStreamPathTests {
+
+    @Test
+    @DisplayName("toVStreamPath() extracts focused values into VStreamPath")
+    void toVStreamPathExtractsValues() {
+      Traversal<List<String>, String> listTraversal = Traversals.forList();
+      TraversalPath<List<String>, String> path = TraversalPath.of(listTraversal);
+
+      List<String> source = List.of("a", "b", "c");
+
+      VStreamPath<String> vstreamPath = path.toVStreamPath(source);
+
+      assertThat(vstreamPath.run().toList().run()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("toVStreamPath() returns empty VStreamPath for empty source")
+    void toVStreamPathEmptySource() {
+      Traversal<List<String>, String> listTraversal = Traversals.forList();
+      TraversalPath<List<String>, String> path = TraversalPath.of(listTraversal);
+
+      List<String> source = List.of();
+
+      VStreamPath<String> vstreamPath = path.toVStreamPath(source);
+
+      assertThat(vstreamPath.run().toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toVStreamPath() supports lazy stream operations")
+    void toVStreamPathSupportsLazyOps() {
+      Traversal<List<Integer>, Integer> listTraversal = Traversals.forList();
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(listTraversal);
+
+      List<Integer> source = List.of(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> vstreamPath = path.toVStreamPath(source);
+
+      // Apply lazy operations
+      List<Integer> result = vstreamPath.filter(n -> n > 2).map(n -> n * 10).toList().unsafeRun();
+
+      assertThat(result).containsExactly(30, 40, 50);
+    }
+
+    @Test
+    @DisplayName("toVStreamPath() on single-element traversal")
+    void toVStreamPathSingleElement() {
+      Traversal<List<String>, String> listTraversal = Traversals.forList();
+      TraversalPath<List<String>, String> path = TraversalPath.of(listTraversal);
+
+      List<String> source = List.of("only");
+
+      VStreamPath<String> vstreamPath = path.toVStreamPath(source);
+
+      assertThat(vstreamPath.run().toList().run()).containsExactly("only");
+    }
+  }
+
+  // ===== VStreamPath.fromEach() Tests =====
+
+  @Nested
+  @DisplayName("VStreamPath.fromEach()")
+  class FromEachTests {
+
+    @Test
+    @DisplayName("fromEach() creates VStreamPath from List and listEach")
+    void fromEachWithList() {
+      Each<List<String>, String> listEach = EachInstances.listEach();
+      List<String> source = List.of("a", "b", "c");
+
+      VStreamPath<String> path = VStreamPath.fromEach(source, listEach);
+
+      assertThat(path.run().toList().run()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("fromEach() creates VStreamPath from VStream and vstreamEach")
+    void fromEachWithVStream() {
+      Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+      VStream<Integer> source = VStream.fromList(List.of(1, 2, 3));
+
+      VStreamPath<Integer> path = VStreamPath.fromEach(source, vstreamEach);
+
+      assertThat(path.run().toList().run()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("fromEach() supports chaining operations on result")
+    void fromEachSupportsChainingOps() {
+      Each<List<Integer>, Integer> listEach = EachInstances.listEach();
+      List<Integer> source = List.of(1, 2, 3, 4, 5);
+
+      VStreamPath<Integer> path = VStreamPath.fromEach(source, listEach);
+
+      List<Integer> result = path.filter(n -> n % 2 == 0).map(n -> n * 10).toList().unsafeRun();
+
+      assertThat(result).containsExactly(20, 40);
+    }
+
+    @Test
+    @DisplayName("fromEach() with empty source creates empty VStreamPath")
+    void fromEachWithEmptySource() {
+      Each<List<String>, String> listEach = EachInstances.listEach();
+      List<String> source = List.of();
+
+      VStreamPath<String> path = VStreamPath.fromEach(source, listEach);
+
+      assertThat(path.run().toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("fromEach() throws NullPointerException for null source")
+    void fromEachNullSourceThrows() {
+      Each<List<String>, String> listEach = EachInstances.listEach();
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> VStreamPath.fromEach(null, listEach))
+          .withMessage("source must not be null");
+    }
+
+    @Test
+    @DisplayName("fromEach() throws NullPointerException for null each")
+    void fromEachNullEachThrows() {
+      List<String> source = List.of("a");
+
+      assertThatNullPointerException()
+          .isThrownBy(() -> VStreamPath.fromEach(source, null))
+          .withMessage("each must not be null");
+    }
+
+    @Test
+    @DisplayName("fromEach() with Optional Each extracts present value")
+    void fromEachWithOptionalEach() {
+      Each<Optional<String>, String> optEach = EachInstances.optionalEach();
+      Optional<String> source = Optional.of("hello");
+
+      VStreamPath<String> path = VStreamPath.fromEach(source, optEach);
+
+      assertThat(path.run().toList().run()).containsExactly("hello");
+    }
+
+    @Test
+    @DisplayName("fromEach() with empty Optional creates empty VStreamPath")
+    void fromEachWithEmptyOptional() {
+      Each<Optional<String>, String> optEach = EachInstances.optionalEach();
+      Optional<String> source = Optional.empty();
+
+      VStreamPath<String> path = VStreamPath.fromEach(source, optEach);
+
+      assertThat(path.run().toList().run()).isEmpty();
+    }
+  }
+
+  // ===== modifyF with Different Applicatives =====
+
+  @Nested
+  @DisplayName("modifyF with Different Applicatives")
+  class WithApplicatives {
+
+    private final Traversal<VStream<Integer>, Integer> traversal = VStreamTraversals.forVStream();
+
+    @Test
+    @DisplayName("modifyF with IdApplicative performs pure transformation")
+    void modifyFWithId() {
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 3));
+
+      Kind<IdKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(a -> ID.widen(Id.of(a * 10)), stream, IdMonad.instance());
+
+      VStream<Integer> modified = ID.narrow(result).value();
+      assertThat(modified.toList().run()).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    @DisplayName("modifyF with IdApplicative on empty VStream returns empty")
+    void modifyFWithIdEmpty() {
+      VStream<Integer> stream = VStream.empty();
+
+      Kind<IdKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(a -> ID.widen(Id.of(a * 10)), stream, IdMonad.instance());
+
+      VStream<Integer> modified = ID.narrow(result).value();
+      assertThat(modified.toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("modifyF with MaybeApplicative succeeds when all elements return Just")
+    void modifyFWithMaybeAllJust() {
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 3));
+
+      Function<Integer, Kind<MaybeKind.Witness, Integer>> safeDouble =
+          n -> MAYBE.widen(Maybe.just(n * 2));
+
+      Kind<MaybeKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(safeDouble, stream, MaybeMonad.INSTANCE);
+
+      Maybe<VStream<Integer>> maybeResult = MAYBE.narrow(result);
+      assertThat(maybeResult.isJust()).isTrue();
+      assertThat(maybeResult.orElse(null).toList().run()).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("modifyF with MaybeApplicative fails fast on Nothing")
+    void modifyFWithMaybeFailFast() {
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 3));
+
+      // Return Nothing for element > 1
+      Function<Integer, Kind<MaybeKind.Witness, Integer>> failOnLarge =
+          n -> n > 1 ? MAYBE.widen(Maybe.nothing()) : MAYBE.widen(Maybe.just(n));
+
+      Kind<MaybeKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(failOnLarge, stream, MaybeMonad.INSTANCE);
+
+      Maybe<VStream<Integer>> maybeResult = MAYBE.narrow(result);
+      assertThat(maybeResult.isNothing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("modifyF with OptionalApplicative succeeds when all present")
+    void modifyFWithOptionalAllPresent() {
+      VStream<Integer> stream = VStream.fromList(List.of(10, 20, 30));
+
+      Function<Integer, Kind<OptionalKind.Witness, Integer>> safeHalf =
+          n -> OPTIONAL.widen(Optional.of(n / 2));
+
+      Kind<OptionalKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(safeHalf, stream, OptionalMonad.INSTANCE);
+
+      Optional<VStream<Integer>> optResult = OPTIONAL.narrow(result);
+      assertThat(optResult).isPresent();
+      assertThat(optResult.get().toList().run()).containsExactly(5, 10, 15);
+    }
+
+    @Test
+    @DisplayName("modifyF with OptionalApplicative returns empty when any element fails")
+    void modifyFWithOptionalFailure() {
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 3));
+
+      // Return empty for even numbers
+      Function<Integer, Kind<OptionalKind.Witness, Integer>> failOnEven =
+          n -> n % 2 == 0 ? OPTIONAL.widen(Optional.empty()) : OPTIONAL.widen(Optional.of(n));
+
+      Kind<OptionalKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(failOnEven, stream, OptionalMonad.INSTANCE);
+
+      Optional<VStream<Integer>> optResult = OPTIONAL.narrow(result);
+      assertThat(optResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName("modifyF with ValidatedApplicative accumulates errors")
+    void modifyFWithValidatedAccumulatesErrors() {
+      VStream<Integer> stream = VStream.fromList(List.of(-1, 2, -3));
+
+      ValidatedSelective<String> applicative = ValidatedSelective.instance(Semigroups.string(", "));
+
+      // Negative numbers produce errors
+      Function<Integer, Kind<ValidatedKind.Witness<String>, Integer>> validatePositive =
+          n ->
+              n > 0
+                  ? VALIDATED.widen(Validated.valid(n))
+                  : VALIDATED.widen(Validated.invalid(n + " is negative"));
+
+      Kind<ValidatedKind.Witness<String>, VStream<Integer>> result =
+          traversal.modifyF(validatePositive, stream, applicative);
+
+      Validated<String, VStream<Integer>> validated = VALIDATED.narrow(result);
+      assertThat(validated.isInvalid()).isTrue();
+      assertThat(validated.getError()).contains("-1 is negative");
+      assertThat(validated.getError()).contains("-3 is negative");
+    }
+
+    @Test
+    @DisplayName("modifyF with ValidatedApplicative succeeds when all valid")
+    void modifyFWithValidatedAllValid() {
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 3));
+
+      ValidatedSelective<String> applicative = ValidatedSelective.instance(Semigroups.string(", "));
+
+      Function<Integer, Kind<ValidatedKind.Witness<String>, Integer>> alwaysValid =
+          n -> VALIDATED.widen(Validated.valid(n * 10));
+
+      Kind<ValidatedKind.Witness<String>, VStream<Integer>> result =
+          traversal.modifyF(alwaysValid, stream, applicative);
+
+      Validated<String, VStream<Integer>> validated = VALIDATED.narrow(result);
+      assertThat(validated.isValid()).isTrue();
+      assertThat(validated.get().toList().run()).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    @DisplayName("modifyF with VTaskApplicative performs effectful transformation")
+    void modifyFWithVTask() {
+      VStream<Integer> stream = VStream.fromList(List.of(1, 2, 3));
+
+      Function<Integer, Kind<VTaskKind.Witness, Integer>> asyncDouble =
+          n -> VTASK.widen(VTask.of(() -> n * 2));
+
+      Kind<VTaskKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(asyncDouble, stream, VTaskApplicative.INSTANCE);
+
+      VTask<VStream<Integer>> vtaskResult = VTASK.narrow(result);
+      VStream<Integer> modified = vtaskResult.run();
+      assertThat(modified.toList().run()).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("modifyF with VTaskApplicative on empty VStream returns empty result")
+    void modifyFWithVTaskEmpty() {
+      VStream<Integer> stream = VStream.empty();
+
+      Function<Integer, Kind<VTaskKind.Witness, Integer>> asyncDouble =
+          n -> VTASK.widen(VTask.of(() -> n * 2));
+
+      Kind<VTaskKind.Witness, VStream<Integer>> result =
+          traversal.modifyF(asyncDouble, stream, VTaskApplicative.INSTANCE);
+
+      VTask<VStream<Integer>> vtaskResult = VTASK.narrow(result);
+      VStream<Integer> modified = vtaskResult.run();
+      assertThat(modified.toList().run()).isEmpty();
+    }
+  }
+
+  // ===== Optics Composition =====
+
+  @Nested
+  @DisplayName("Optics Composition")
+  class OpticsComposition {
+
+    @Test
+    @DisplayName("Lens then VStream Each composes correctly")
+    void lensThenVStreamEach() {
+      record Bag(VStream<String> tags) {}
+
+      Lens<Bag, VStream<String>> tagsLens = Lens.of(Bag::tags, (bag, tags) -> new Bag(tags));
+      Traversal<VStream<String>, String> eachTag = EachInstances.<String>vstreamEach().each();
+
+      Traversal<Bag, String> allTags = tagsLens.andThen(eachTag);
+
+      Bag bag = new Bag(VStream.fromList(List.of("java", "kotlin")));
+
+      List<String> tags = Traversals.getAll(allTags, bag);
+      assertThat(tags).containsExactly("java", "kotlin");
+
+      Bag modified = Traversals.modify(allTags, String::toUpperCase, bag);
+      assertThat(modified.tags().toList().run()).containsExactly("JAVA", "KOTLIN");
+    }
+
+    @Test
+    @DisplayName("Nested VStream Each composition (two levels deep)")
+    void nestedVStreamEachTwoLevels() {
+      record Inner(VStream<Integer> values) {}
+
+      Lens<Inner, VStream<Integer>> valuesLens =
+          Lens.of(Inner::values, (inner, vals) -> new Inner(vals));
+
+      // Outer: VStream<Inner>
+      Traversal<VStream<Inner>, Inner> eachInner = VStreamTraversals.forVStream();
+      Traversal<Inner, Integer> innerValues = valuesLens.andThen(VStreamTraversals.forVStream());
+
+      // Compose: VStream<Inner> -> Inner -> Integer (two-level each)
+      Traversal<VStream<Inner>, Integer> allValues = eachInner.andThen(innerValues);
+
+      VStream<Inner> outerStream =
+          VStream.fromList(
+              List.of(
+                  new Inner(VStream.fromList(List.of(1, 2))),
+                  new Inner(VStream.fromList(List.of(3, 4, 5)))));
+
+      List<Integer> allInts = Traversals.getAll(allValues, outerStream);
+      assertThat(allInts).containsExactly(1, 2, 3, 4, 5);
+
+      VStream<Inner> modified = Traversals.modify(allValues, n -> n * 10, outerStream);
+      List<Integer> modifiedInts = Traversals.getAll(allValues, modified);
+      assertThat(modifiedInts).containsExactly(10, 20, 30, 40, 50);
+    }
+
+    @Test
+    @DisplayName("Nested VStream Each via FocusDSL (two levels deep)")
+    void nestedVStreamEachViaFocusDSL() {
+      record Cell(VStream<String> items) {}
+
+      Lens<Cell, VStream<String>> cellItemsLens =
+          Lens.of(Cell::items, (c, items) -> new Cell(items));
+
+      record Grid(VStream<Cell> cells) {}
+
+      Lens<Grid, VStream<Cell>> gridCellsLens = Lens.of(Grid::cells, (g, cells) -> new Grid(cells));
+
+      Each<VStream<Cell>, Cell> cellEach = EachInstances.vstreamEach();
+      Each<VStream<String>, String> stringEach = EachInstances.vstreamEach();
+
+      TraversalPath<Grid, String> allItems =
+          FocusPath.of(gridCellsLens).each(cellEach).via(cellItemsLens).each(stringEach);
+
+      Grid grid =
+          new Grid(
+              VStream.fromList(
+                  List.of(
+                      new Cell(VStream.fromList(List.of("a", "b"))),
+                      new Cell(VStream.fromList(List.of("c"))))));
+
+      List<String> items = allItems.getAll(grid);
+      assertThat(items).containsExactly("a", "b", "c");
+
+      Grid modified = allItems.modifyAll(String::toUpperCase, grid);
+      assertThat(allItems.getAll(modified)).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("VStream Each then Prism composes correctly")
+    void vstreamEachThenPrism() {
+      // Prism for positive integers
+      Prism<Integer, Integer> positivePrism =
+          Prism.of(n -> n > 0 ? Optional.of(n) : Optional.empty(), n -> n);
+
+      Traversal<VStream<Integer>, Integer> eachElement = VStreamTraversals.forVStream();
+      Traversal<VStream<Integer>, Integer> positiveElements = eachElement.andThen(positivePrism);
+
+      VStream<Integer> stream = VStream.fromList(List.of(-1, 2, -3, 4, 5));
+
+      // getAll only returns matched elements
+      List<Integer> positives = Traversals.getAll(positiveElements, stream);
+      assertThat(positives).containsExactly(2, 4, 5);
+
+      // modify only affects matched elements; non-matched remain unchanged
+      VStream<Integer> modified = Traversals.modify(positiveElements, n -> n * 100, stream);
+      assertThat(modified.toList().run()).containsExactly(-1, 200, -3, 400, 500);
+    }
+
+    @Test
+    @DisplayName("VStream Each then Affine composes correctly")
+    void vstreamEachThenAffine() {
+      record Entry(Optional<String> label) {}
+
+      Affine<Entry, String> labelAffine =
+          Affine.of(Entry::label, (entry, lbl) -> new Entry(Optional.of(lbl)));
+
+      Traversal<VStream<Entry>, Entry> eachEntry = VStreamTraversals.forVStream();
+      Traversal<VStream<Entry>, String> allLabels = eachEntry.andThen(labelAffine.asTraversal());
+
+      VStream<Entry> stream =
+          VStream.fromList(
+              List.of(
+                  new Entry(Optional.of("one")),
+                  new Entry(Optional.empty()),
+                  new Entry(Optional.of("three"))));
+
+      // getAll only returns present labels
+      List<String> labels = Traversals.getAll(allLabels, stream);
+      assertThat(labels).containsExactly("one", "three");
+
+      // modify only affects entries with labels present
+      VStream<Entry> modified = Traversals.modify(allLabels, String::toUpperCase, stream);
+      List<Entry> entries = modified.toList().run();
+      assertThat(entries.get(0).label()).contains("ONE");
+      assertThat(entries.get(1).label()).isEmpty(); // unchanged
+      assertThat(entries.get(2).label()).contains("THREE");
+    }
+
+    @Test
+    @DisplayName("Full pipeline: Lens -> Each -> Lens -> modify")
+    void fullPipelineLensEachLensModify() {
+      record Item(String name, int price) {}
+
+      record Cart(VStream<Item> items) {}
+
+      Lens<Cart, VStream<Item>> cartItemsLens =
+          Lens.of(Cart::items, (cart, items) -> new Cart(items));
+      Lens<Item, String> itemNameLens =
+          Lens.of(Item::name, (item, name) -> new Item(name, item.price()));
+
+      Each<VStream<Item>, Item> itemEach = EachInstances.vstreamEach();
+
+      // Lens -> Each -> Lens
+      TraversalPath<Cart, String> allItemNames =
+          FocusPath.of(cartItemsLens).each(itemEach).via(itemNameLens);
+
+      Cart cart = new Cart(VStream.fromList(List.of(new Item("apple", 1), new Item("banana", 2))));
+
+      List<String> names = allItemNames.getAll(cart);
+      assertThat(names).containsExactly("apple", "banana");
+
+      Cart modified = allItemNames.modifyAll(String::toUpperCase, cart);
+      assertThat(allItemNames.getAll(modified)).containsExactly("APPLE", "BANANA");
+    }
+  }
+
+  // ===== Edge Cases =====
+
+  @Nested
+  @DisplayName("Edge Cases")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("VStream traversal preserves element order")
+    void preservesOrder() {
+      Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+      VStream<Integer> stream = VStream.fromList(List.of(3, 1, 4, 1, 5, 9, 2, 6));
+
+      List<Integer> result = Traversals.getAll(vstreamEach.each(), stream);
+
+      assertThat(result).containsExactly(3, 1, 4, 1, 5, 9, 2, 6);
+    }
+
+    @Test
+    @DisplayName("VStream traversal with large collection")
+    void handlesLargeCollection() {
+      Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+      List<Integer> largeList = IntStream.rangeClosed(1, 1000).boxed().toList();
+      VStream<Integer> stream = VStream.fromList(largeList);
+
+      List<Integer> result = Traversals.getAll(vstreamEach.each(), stream);
+
+      assertThat(result).hasSize(1000);
+      assertThat(result.get(0)).isEqualTo(1);
+      assertThat(result.get(999)).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("VStream modify preserves structure for identity function")
+    void modifyIdentityPreservesStructure() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      VStream<String> original = VStream.fromList(List.of("a", "b", "c"));
+
+      VStream<String> result = Traversals.modify(vstreamEach.each(), Function.identity(), original);
+
+      assertThat(result.toList().run()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("VStream traversal with null elements in stream")
+    void handlesNullElements() {
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      List<String> elements = new ArrayList<>();
+      elements.add("a");
+      elements.add(null);
+      elements.add("c");
+      VStream<String> stream = VStream.fromList(elements);
+
+      List<String> result = Traversals.getAll(traversal, stream);
+
+      assertThat(result).containsExactly("a", null, "c");
+    }
+
+    @Test
+    @DisplayName("toVStreamPath and fromEach roundtrip")
+    void toVStreamPathFromEachRoundtrip() {
+      // Start with a list, go to VStreamPath, collect back
+      Each<List<Integer>, Integer> listEach = EachInstances.listEach();
+      List<Integer> original = List.of(10, 20, 30);
+
+      VStreamPath<Integer> vsp = VStreamPath.fromEach(original, listEach);
+      List<Integer> collected = vsp.toList().unsafeRun();
+
+      assertThat(collected).containsExactly(10, 20, 30);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/each/VStreamTraversalLawsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/each/VStreamTraversalLawsTest.java
@@ -1,0 +1,210 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.each;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ * Verifies that the VStream Traversal satisfies the core traversal laws.
+ *
+ * <p>The laws verified are:
+ *
+ * <ul>
+ *   <li><b>Identity:</b> Modifying with the identity function returns the same structure
+ *   <li><b>Composition:</b> Modifying with f then g equals modifying with g.f
+ *   <li><b>Structure preservation:</b> getAll(set(v, s)) returns list of v with same length as
+ *       getAll(s)
+ * </ul>
+ *
+ * <p>VStream equality is determined by materialising both streams and comparing the resulting
+ * lists.
+ */
+@DisplayName("VStream Traversal Laws")
+class VStreamTraversalLawsTest {
+
+  private final Traversal<VStream<Integer>, Integer> traversal = VStreamTraversals.forVStream();
+
+  /** Helper: materialise a VStream to a list for comparison. */
+  private <A> List<A> toList(VStream<A> stream) {
+    return stream.toList().run();
+  }
+
+  // ===== Test Data =====
+
+  private static VStream<Integer> emptyStream() {
+    return VStream.empty();
+  }
+
+  private static VStream<Integer> singleStream() {
+    return VStream.of(42);
+  }
+
+  private static VStream<Integer> multiStream() {
+    return VStream.fromList(List.of(1, 2, 3, 4, 5));
+  }
+
+  private static VStream<Integer> duplicateStream() {
+    return VStream.fromList(List.of(1, 2, 1, 3, 2));
+  }
+
+  // ===== Identity Law =====
+
+  @Nested
+  @DisplayName("Identity Law: modify(id, s) == s")
+  class IdentityLawTests {
+
+    @TestFactory
+    @DisplayName("Identity law holds for various streams")
+    Stream<DynamicTest> identityLawHolds() {
+      record TestCase(String name, VStream<Integer> stream) {}
+
+      return Stream.of(
+              new TestCase("empty stream", emptyStream()),
+              new TestCase("single element", singleStream()),
+              new TestCase("multiple elements", multiStream()),
+              new TestCase("duplicates", duplicateStream()))
+          .map(
+              tc ->
+                  DynamicTest.dynamicTest(
+                      "Identity law for " + tc.name(),
+                      () -> {
+                        VStream<Integer> original = tc.stream();
+                        VStream<Integer> result =
+                            Traversals.modify(traversal, Function.identity(), original);
+
+                        assertThat(toList(result)).isEqualTo(toList(original));
+                      }));
+    }
+  }
+
+  // ===== Composition Law =====
+
+  @Nested
+  @DisplayName("Composition Law: modify(g, modify(f, s)) == modify(g.f, s)")
+  class CompositionLawTests {
+
+    private final Function<Integer, Integer> f = x -> x + 10;
+    private final Function<Integer, Integer> g = x -> x * 2;
+
+    @TestFactory
+    @DisplayName("Composition law holds for various streams")
+    Stream<DynamicTest> compositionLawHolds() {
+      record TestCase(String name, VStream<Integer> stream) {}
+
+      return Stream.of(
+              new TestCase("empty stream", emptyStream()),
+              new TestCase("single element", singleStream()),
+              new TestCase("multiple elements", multiStream()),
+              new TestCase("duplicates", duplicateStream()))
+          .map(
+              tc ->
+                  DynamicTest.dynamicTest(
+                      "Composition law for " + tc.name(),
+                      () -> {
+                        VStream<Integer> original = tc.stream();
+
+                        // Apply f then g
+                        VStream<Integer> step1 = Traversals.modify(traversal, f, original);
+                        VStream<Integer> twoSteps = Traversals.modify(traversal, g, step1);
+
+                        // Apply g.f in one step
+                        VStream<Integer> composed =
+                            Traversals.modify(traversal, f.andThen(g), original);
+
+                        assertThat(toList(twoSteps)).isEqualTo(toList(composed));
+                      }));
+    }
+  }
+
+  // ===== Structure Preservation Law =====
+
+  @Nested
+  @DisplayName("Structure Preservation: getAll(set(v, s)).size() == getAll(s).size()")
+  class StructurePreservationTests {
+
+    @TestFactory
+    @DisplayName("Structure preservation holds for various streams")
+    Stream<DynamicTest> structurePreservationHolds() {
+      record TestCase(String name, VStream<Integer> stream) {}
+
+      return Stream.of(
+              new TestCase("empty stream", emptyStream()),
+              new TestCase("single element", singleStream()),
+              new TestCase("multiple elements", multiStream()),
+              new TestCase("duplicates", duplicateStream()))
+          .map(
+              tc ->
+                  DynamicTest.dynamicTest(
+                      "Structure preservation for " + tc.name(),
+                      () -> {
+                        VStream<Integer> original = tc.stream();
+                        int originalSize = Traversals.getAll(traversal, original).size();
+
+                        // Set all to a constant value
+                        VStream<Integer> replaced =
+                            Traversals.modify(traversal, ignored -> 99, original);
+                        int replacedSize = Traversals.getAll(traversal, replaced).size();
+
+                        assertThat(replacedSize).isEqualTo(originalSize);
+                      }));
+    }
+
+    @Test
+    @DisplayName("All elements after set have the same value")
+    void setAllProducesUniformValues() {
+      VStream<Integer> original = multiStream();
+
+      VStream<Integer> replaced = Traversals.modify(traversal, ignored -> 99, original);
+      List<Integer> result = Traversals.getAll(traversal, replaced);
+
+      assertThat(result).containsOnly(99);
+      assertThat(result).hasSize(5);
+    }
+  }
+
+  // ===== GetAll / Modify Consistency =====
+
+  @Nested
+  @DisplayName("GetAll / Modify Consistency")
+  class GetAllModifyConsistencyTests {
+
+    @Test
+    @DisplayName("getAll retrieves elements that modify can transform")
+    void getAllAndModifyConsistent() {
+      VStream<Integer> original = multiStream();
+
+      // getAll gives us the elements
+      List<Integer> elements = Traversals.getAll(traversal, original);
+
+      // modify transforms each one
+      VStream<Integer> doubled = Traversals.modify(traversal, x -> x * 2, original);
+      List<Integer> doubledElements = Traversals.getAll(traversal, doubled);
+
+      // Each element should be doubled
+      assertThat(doubledElements).hasSize(elements.size()).containsExactly(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    @DisplayName("modify with constant function produces uniform getAll")
+    void modifyConstantProducesUniform() {
+      VStream<Integer> original = VStream.fromList(List.of(1, 2, 3));
+
+      VStream<Integer> replaced = Traversals.modify(traversal, ignored -> 0, original);
+      List<Integer> result = Traversals.getAll(traversal, replaced);
+
+      assertThat(result).containsExactly(0, 0, 0);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/VStreamOpticsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/VStreamOpticsExample.java
@@ -1,0 +1,185 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.optics.Each;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.each.EachInstances;
+import org.higherkindedj.optics.each.VStreamTraversals;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * A runnable example demonstrating VStream integration with the optics ecosystem.
+ *
+ * <p>This example showcases:
+ *
+ * <ul>
+ *   <li><b>VStreamTraversals</b> - Direct traversal of VStream elements
+ *   <li><b>EachInstances.vstreamEach()</b> - Each instance for VStream
+ *   <li><b>FocusDSL integration</b> - Using .each(vstreamEach) to navigate into VStream fields
+ *   <li><b>TraversalPath.toVStreamPath()</b> - Bridging from optics to VStreamPath
+ *   <li><b>VStreamPath.fromEach()</b> - Creating VStreamPath from any Each-traversable source
+ * </ul>
+ */
+public class VStreamOpticsExample {
+
+  // Domain models
+  record Rule(String name, int priority) {}
+
+  record Config(String env, VStream<Rule> rules) {}
+
+  // Lenses
+  static final Lens<Config, VStream<Rule>> RULES_LENS =
+      Lens.of(Config::rules, (config, rules) -> new Config(config.env(), rules));
+
+  static final Lens<Rule, String> RULE_NAME_LENS =
+      Lens.of(Rule::name, (rule, name) -> new Rule(name, rule.priority()));
+
+  static final Lens<Rule, Integer> RULE_PRIORITY_LENS =
+      Lens.of(Rule::priority, (rule, priority) -> new Rule(rule.name(), priority));
+
+  public static void main(String[] args) {
+    System.out.println("=== VStream Optics Integration Examples ===\n");
+
+    demonstrateVStreamTraversal();
+    demonstrateVStreamEach();
+    demonstrateFocusDSLIntegration();
+    demonstrateToVStreamPath();
+    demonstrateFromEach();
+  }
+
+  /** Demonstrates direct use of VStreamTraversals.forVStream(). */
+  private static void demonstrateVStreamTraversal() {
+    System.out.println("--- 1. VStream Traversal ---");
+
+    Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+    VStream<String> stream = VStream.fromList(List.of("hello", "world", "foo"));
+
+    // Get all elements
+    List<String> all = Traversals.getAll(traversal, stream);
+    System.out.println("All elements: " + all);
+
+    // Modify all elements
+    VStream<String> upper = Traversals.modify(traversal, String::toUpperCase, stream);
+    System.out.println("Uppercased:   " + upper.toList().run());
+
+    System.out.println();
+  }
+
+  /** Demonstrates the Each instance for VStream. */
+  private static void demonstrateVStreamEach() {
+    System.out.println("--- 2. VStream Each Instance ---");
+
+    Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+    VStream<Integer> numbers = VStream.fromList(List.of(1, 2, 3, 4, 5));
+
+    // Traverse via Each
+    List<Integer> all = Traversals.getAll(vstreamEach.each(), numbers);
+    System.out.println("Elements:         " + all);
+
+    // Modify via Each
+    VStream<Integer> doubled = Traversals.modify(vstreamEach.each(), x -> x * 2, numbers);
+    System.out.println("Doubled:          " + doubled.toList().run());
+
+    // Check indexed support
+    System.out.println("Supports indexed: " + vstreamEach.supportsIndexed());
+
+    System.out.println();
+  }
+
+  /** Demonstrates FocusDSL integration with VStream fields. */
+  private static void demonstrateFocusDSLIntegration() {
+    System.out.println("--- 3. FocusDSL Integration ---");
+
+    Each<VStream<Rule>, Rule> vstreamEach = EachInstances.vstreamEach();
+
+    // Build traversal path: Config -> rules -> each rule
+    TraversalPath<Config, Rule> allRules = FocusPath.of(RULES_LENS).each(vstreamEach);
+
+    // Build traversal path: Config -> rules -> each rule -> name
+    TraversalPath<Config, String> allRuleNames = allRules.via(RULE_NAME_LENS);
+
+    Config config =
+        new Config(
+            "production",
+            VStream.fromList(
+                List.of(
+                    new Rule("auth-check", 1),
+                    new Rule("rate-limit", 2),
+                    new Rule("cors-allow", 3))));
+
+    // Get all rule names
+    List<String> names = allRuleNames.getAll(config);
+    System.out.println("Rule names: " + names);
+
+    // Modify all rule names to uppercase
+    Config updated = allRuleNames.modifyAll(String::toUpperCase, config);
+    System.out.println("Updated:    " + allRuleNames.getAll(updated));
+
+    // Filter high-priority rules
+    TraversalPath<Config, Rule> highPriority = allRules.filter(r -> r.priority() <= 2);
+    List<Rule> important = highPriority.getAll(config);
+    System.out.println("High priority rules: " + important.stream().map(Rule::name).toList());
+
+    System.out.println();
+  }
+
+  /** Demonstrates TraversalPath.toVStreamPath() bridge. */
+  private static void demonstrateToVStreamPath() {
+    System.out.println("--- 4. TraversalPath to VStreamPath Bridge ---");
+
+    Traversal<List<Integer>, Integer> listTraversal = Traversals.forList();
+    TraversalPath<List<Integer>, Integer> path = TraversalPath.of(listTraversal);
+
+    List<Integer> source = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    // Bridge to VStreamPath
+    VStreamPath<Integer> vstreamPath = path.toVStreamPath(source);
+
+    // Use lazy VStream operations
+    List<Integer> result =
+        vstreamPath.filter(n -> n % 2 == 0).map(n -> n * 10).take(3).toList().unsafeRun();
+
+    System.out.println("Source:   " + source);
+    System.out.println("Filtered (even), mapped (*10), take(3): " + result);
+
+    System.out.println();
+  }
+
+  /** Demonstrates VStreamPath.fromEach() factory. */
+  private static void demonstrateFromEach() {
+    System.out.println("--- 5. VStreamPath.fromEach() Factory ---");
+
+    // From List
+    Each<List<String>, String> listEach = EachInstances.listEach();
+    List<String> names = List.of("Alice", "Bob", "Charlie", "Diana");
+
+    VStreamPath<String> fromList = VStreamPath.fromEach(names, listEach);
+    List<String> greeting = fromList.map(n -> "Hello, " + n + "!").toList().unsafeRun();
+    System.out.println("From List: " + greeting);
+
+    // From VStream
+    Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+    VStream<Integer> numbers = VStream.fromList(List.of(10, 20, 30));
+
+    VStreamPath<Integer> fromVStream = VStreamPath.fromEach(numbers, vstreamEach);
+    List<Integer> incremented = fromVStream.map(n -> n + 1).toList().unsafeRun();
+    System.out.println("From VStream: " + incremented);
+
+    // From Optional
+    Each<Optional<String>, String> optEach = EachInstances.optionalEach();
+    Optional<String> present = Optional.of("world");
+
+    VStreamPath<String> fromOpt = VStreamPath.fromEach(present, optEach);
+    System.out.println("From Optional: " + fromOpt.toList().unsafeRun());
+
+    System.out.println();
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial17_VStreamOptics.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial17_VStreamOptics.java
@@ -1,0 +1,252 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.optics.Each;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.each.EachInstances;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial: VStream Optics Integration
+ *
+ * <p>Learn how VStream integrates with the optics ecosystem (Each, Traversal, FocusDSL) and the
+ * effect path bridges (toVStreamPath, fromEach).
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>VStreamTraversals.forVStream() creates a Traversal for VStream elements
+ *   <li>EachInstances.vstreamEach() provides the Each type class instance
+ *   <li>FocusDSL .each(vstreamEach) navigates into VStream fields
+ *   <li>TraversalPath.toVStreamPath() bridges optics to VStreamPath
+ *   <li>VStreamPath.fromEach() creates VStreamPath from any Each-traversable source
+ * </ul>
+ *
+ * <p>Prerequisites: Familiarity with VStream basics and optics (Lens, Traversal, FocusDSL)
+ *
+ * <p>Estimated time: 15-20 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial: VStream Optics Integration")
+public class Tutorial17_VStreamOptics {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  // ===========================================================================
+  // Part 1: VStream Traversal Basics
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: VStream Traversal Basics")
+  class VStreamTraversalBasics {
+
+    /**
+     * Exercise 1: Create a VStream traversal and get all elements
+     *
+     * <p>VStreamTraversals.forVStream() creates a Traversal<VStream<A>, A> that materialises the
+     * stream and traverses its elements. Use Traversals.getAll() to extract the elements.
+     *
+     * <p>Task: Create a traversal for VStream<String>, then use it to get all elements.
+     */
+    @Test
+    @DisplayName("Exercise 1: Get all elements with VStream traversal")
+    void getAllWithTraversal() {
+      VStream<String> stream = VStream.fromList(List.of("alpha", "beta", "gamma"));
+
+      // TODO: Create a VStream traversal and get all elements
+      // Hint: Use VStreamTraversals.forVStream() and Traversals.getAll()
+      List<String> result = answerRequired();
+
+      assertThat(result).containsExactly("alpha", "beta", "gamma");
+    }
+
+    /**
+     * Exercise 2: Modify all elements with VStream traversal
+     *
+     * <p>Traversals.modify() applies a function to all traversed elements. The VStream traversal
+     * materialises the stream, transforms, and reconstructs.
+     *
+     * <p>Task: Use the traversal to uppercase all strings in the VStream.
+     */
+    @Test
+    @DisplayName("Exercise 2: Modify all elements with VStream traversal")
+    void modifyWithTraversal() {
+      VStream<String> stream = VStream.fromList(List.of("hello", "world"));
+
+      // TODO: Modify all elements to uppercase using VStreamTraversals and Traversals.modify()
+      VStream<String> result = answerRequired();
+
+      assertThat(result.toList().run()).containsExactly("HELLO", "WORLD");
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Each Instance
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: VStream Each Instance")
+  class VStreamEachInstance {
+
+    /**
+     * Exercise 3: Use the VStream Each instance
+     *
+     * <p>EachInstances.vstreamEach() provides an Each instance for VStream. Each.each() returns the
+     * underlying traversal.
+     *
+     * <p>Task: Create a VStream Each instance and use it to get all elements.
+     */
+    @Test
+    @DisplayName("Exercise 3: Use VStream Each to get all elements")
+    void useVStreamEach() {
+      VStream<Integer> numbers = VStream.fromList(List.of(1, 2, 3, 4, 5));
+
+      // TODO: Create a VStream Each instance and use it to get all elements
+      // Hint: EachInstances.vstreamEach() and Traversals.getAll()
+      List<Integer> result = answerRequired();
+
+      assertThat(result).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    /**
+     * Exercise 4: Verify VStream Each does not support indexing
+     *
+     * <p>VStream does not have natural positional indices, so supportsIndexed() returns false.
+     *
+     * <p>Task: Check whether VStream Each supports indexed traversal.
+     */
+    @Test
+    @DisplayName("Exercise 4: Check VStream indexed support")
+    void checkIndexedSupport() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+
+      // TODO: Call the appropriate method to check indexed support
+      boolean result = answerRequired();
+
+      assertThat(result).isFalse();
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: FocusDSL Integration
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: FocusDSL Integration")
+  class FocusDSLIntegration {
+
+    record Inventory(VStream<String> items) {}
+
+    static final Lens<Inventory, VStream<String>> ITEMS_LENS =
+        Lens.of(Inventory::items, (inv, items) -> new Inventory(items));
+
+    /**
+     * Exercise 5: Navigate into VStream with FocusDSL
+     *
+     * <p>Use FocusPath.of(lens).each(vstreamEach) to create a TraversalPath that navigates through
+     * a lens into a VStream field and traverses its elements.
+     *
+     * <p>Task: Create a TraversalPath from Inventory to all item strings.
+     */
+    @Test
+    @DisplayName("Exercise 5: FocusDSL each() with vstreamEach")
+    void focusDSLWithVStream() {
+      Inventory inventory =
+          new Inventory(VStream.fromList(List.of("Widget", "Gadget", "Doohickey")));
+
+      // TODO: Create a TraversalPath<Inventory, String> using FocusDSL
+      // Hint: FocusPath.of(ITEMS_LENS).each(EachInstances.vstreamEach())
+      List<String> result = answerRequired();
+
+      assertThat(result).containsExactly("Widget", "Gadget", "Doohickey");
+    }
+
+    /**
+     * Exercise 6: Modify all VStream elements via FocusDSL
+     *
+     * <p>TraversalPath.modifyAll() modifies all focused elements.
+     *
+     * <p>Task: Use a TraversalPath to uppercase all item names in the Inventory.
+     */
+    @Test
+    @DisplayName("Exercise 6: Modify VStream elements via FocusDSL")
+    void modifyViaFocusDSL() {
+      Inventory inventory = new Inventory(VStream.fromList(List.of("alpha", "beta")));
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Inventory, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+
+      // TODO: Use allItems.modifyAll() to uppercase all items
+      Inventory result = answerRequired();
+
+      List<String> resultItems = allItems.getAll(result);
+      assertThat(resultItems).containsExactly("ALPHA", "BETA");
+    }
+  }
+
+  // ===========================================================================
+  // Part 4: Effect Path Bridges
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 4: Effect Path Bridges")
+  class EffectPathBridges {
+
+    /**
+     * Exercise 7: Bridge from TraversalPath to VStreamPath
+     *
+     * <p>TraversalPath.toVStreamPath(source) extracts all focused values and wraps them in a
+     * VStreamPath for lazy, virtual-thread stream processing.
+     *
+     * <p>Task: Convert a list traversal path to a VStreamPath and apply lazy operations.
+     */
+    @Test
+    @DisplayName("Exercise 7: toVStreamPath() bridge")
+    void toVStreamPathBridge() {
+      Traversal<List<Integer>, Integer> listTraversal = Traversals.forList();
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(listTraversal);
+      List<Integer> source = List.of(1, 2, 3, 4, 5, 6);
+
+      // TODO: Use path.toVStreamPath(source) then filter evens and multiply by 10
+      // Finally collect to list with .toList().unsafeRun()
+      List<Integer> result = answerRequired();
+
+      assertThat(result).containsExactly(20, 40, 60);
+    }
+
+    /**
+     * Exercise 8: Create VStreamPath from Each
+     *
+     * <p>VStreamPath.fromEach(source, each) extracts all elements from a source via an Each
+     * instance and wraps them in a VStreamPath.
+     *
+     * <p>Task: Create a VStreamPath from a List using listEach, then map and collect.
+     */
+    @Test
+    @DisplayName("Exercise 8: VStreamPath.fromEach() factory")
+    void fromEachFactory() {
+      Each<List<String>, String> listEach = EachInstances.listEach();
+      List<String> names = List.of("Alice", "Bob", "Charlie");
+
+      // TODO: Use VStreamPath.fromEach() to create a VStreamPath from names
+      // Then map each name to its length and collect to list
+      List<Integer> result = answerRequired();
+
+      assertThat(result).containsExactly(5, 3, 7);
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial17_VStreamOptics_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial17_VStreamOptics_Solution.java
@@ -1,0 +1,164 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.optics.Each;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.each.EachInstances;
+import org.higherkindedj.optics.each.VStreamTraversals;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.higherkindedj.optics.focus.TraversalPath;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial: VStream Optics Integration
+ *
+ * <p>These are the reference solutions for Tutorial17_VStreamOptics.
+ */
+@DisplayName("Tutorial Solution: VStream Optics Integration")
+public class Tutorial17_VStreamOptics_Solution {
+
+  // ===========================================================================
+  // Part 1: VStream Traversal Basics
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: VStream Traversal Basics")
+  class VStreamTraversalBasics {
+
+    @Test
+    @DisplayName("Exercise 1: Get all elements with VStream traversal")
+    void getAllWithTraversal() {
+      VStream<String> stream = VStream.fromList(List.of("alpha", "beta", "gamma"));
+
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      List<String> result = Traversals.getAll(traversal, stream);
+
+      assertThat(result).containsExactly("alpha", "beta", "gamma");
+    }
+
+    @Test
+    @DisplayName("Exercise 2: Modify all elements with VStream traversal")
+    void modifyWithTraversal() {
+      VStream<String> stream = VStream.fromList(List.of("hello", "world"));
+
+      Traversal<VStream<String>, String> traversal = VStreamTraversals.forVStream();
+      VStream<String> result = Traversals.modify(traversal, String::toUpperCase, stream);
+
+      assertThat(result.toList().run()).containsExactly("HELLO", "WORLD");
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Each Instance
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: VStream Each Instance")
+  class VStreamEachInstance {
+
+    @Test
+    @DisplayName("Exercise 3: Use VStream Each to get all elements")
+    void useVStreamEach() {
+      VStream<Integer> numbers = VStream.fromList(List.of(1, 2, 3, 4, 5));
+
+      Each<VStream<Integer>, Integer> vstreamEach = EachInstances.vstreamEach();
+      List<Integer> result = Traversals.getAll(vstreamEach.each(), numbers);
+
+      assertThat(result).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("Exercise 4: Check VStream indexed support")
+    void checkIndexedSupport() {
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+
+      boolean result = vstreamEach.supportsIndexed();
+
+      assertThat(result).isFalse();
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: FocusDSL Integration
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: FocusDSL Integration")
+  class FocusDSLIntegration {
+
+    record Inventory(VStream<String> items) {}
+
+    static final Lens<Inventory, VStream<String>> ITEMS_LENS =
+        Lens.of(Inventory::items, (inv, items) -> new Inventory(items));
+
+    @Test
+    @DisplayName("Exercise 5: FocusDSL each() with vstreamEach")
+    void focusDSLWithVStream() {
+      Inventory inventory =
+          new Inventory(VStream.fromList(List.of("Widget", "Gadget", "Doohickey")));
+
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Inventory, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+      List<String> result = allItems.getAll(inventory);
+
+      assertThat(result).containsExactly("Widget", "Gadget", "Doohickey");
+    }
+
+    @Test
+    @DisplayName("Exercise 6: Modify VStream elements via FocusDSL")
+    void modifyViaFocusDSL() {
+      Inventory inventory = new Inventory(VStream.fromList(List.of("alpha", "beta")));
+      Each<VStream<String>, String> vstreamEach = EachInstances.vstreamEach();
+      TraversalPath<Inventory, String> allItems = FocusPath.of(ITEMS_LENS).each(vstreamEach);
+
+      Inventory result = allItems.modifyAll(String::toUpperCase, inventory);
+
+      List<String> resultItems = allItems.getAll(result);
+      assertThat(resultItems).containsExactly("ALPHA", "BETA");
+    }
+  }
+
+  // ===========================================================================
+  // Part 4: Effect Path Bridges
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 4: Effect Path Bridges")
+  class EffectPathBridges {
+
+    @Test
+    @DisplayName("Exercise 7: toVStreamPath() bridge")
+    void toVStreamPathBridge() {
+      Traversal<List<Integer>, Integer> listTraversal = Traversals.forList();
+      TraversalPath<List<Integer>, Integer> path = TraversalPath.of(listTraversal);
+      List<Integer> source = List.of(1, 2, 3, 4, 5, 6);
+
+      List<Integer> result =
+          path.toVStreamPath(source).filter(n -> n % 2 == 0).map(n -> n * 10).toList().unsafeRun();
+
+      assertThat(result).containsExactly(20, 40, 60);
+    }
+
+    @Test
+    @DisplayName("Exercise 8: VStreamPath.fromEach() factory")
+    void fromEachFactory() {
+      Each<List<String>, String> listEach = EachInstances.listEach();
+      List<String> names = List.of("Alice", "Bob", "Charlie");
+
+      List<Integer> result =
+          VStreamPath.fromEach(names, listEach).map(String::length).toList().unsafeRun();
+
+      assertThat(result).containsExactly(5, 3, 7);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds comprehensive optics support for `VStream`, enabling seamless integration with the optics ecosystem. The changes include:

1. **VStreamTraversals** - A new `Traversal<VStream<A>, A>` implementation that materializes the stream and traverses its elements using applicative accumulation
2. **EachInstances.vstreamEach()** - An `Each` type class instance for `VStream` that provides canonical traversal support
3. **VStreamPath factory methods** - `VStreamPath.fromEach()` to create effect paths from any `Each`-traversable source
4. **TraversalPath.toVStreamPath()** - Bridges from optics domain to effect domain by extracting focused values into a `VStreamPath`
5. **FocusDSL integration** - Full support for `.each(vstreamEach)` to navigate into `VStream` fields within complex structures

The implementation follows the established patterns in the codebase and includes comprehensive test coverage, traversal law verification, and tutorial examples.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/update
- [x] Documentation update

## How Has This Been Tested?

- **VStreamEachTest** (864 lines) - Comprehensive integration tests covering:
  - Basic traversal operations (getAll, modify, empty/single/duplicate handling)
  - Each instance behavior and indexed support verification
  - FocusDSL integration with lens composition
  - TraversalPath.toVStreamPath() bridge functionality
  - VStreamPath.fromEach() factory method with various Each instances
  - modifyF with multiple applicatives (Id, Maybe, Optional, Validated, VTask)

- **VStreamTraversalLawsTest** - Verifies traversal laws:
  - Identity law: `modify(id, s) == s`
  - Composition law: `modify(g, modify(f, s)) == modify(g.f, s)`
  - Structure preservation: element count invariance

- **Tutorial17_VStreamOptics** - Interactive tutorial with 8 exercises covering all major features
- **VStreamOpticsExample** - Runnable example demonstrating practical usage patterns

All tests pass with `./gradlew test`.

## Checklist:

- [x] My code follows the style guidelines of this project (Google Java Conventions)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (package-info.java, book markdown)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works (864 lines of tests + law verification)
- [x] New and existing unit tests pass locally with my changes
- [x] The GitHub Actions CI build passes with my changes

## Additional Comments

The implementation carefully handles VStream's lazy evaluation semantics while providing eager traversal when needed for optics operations. The materialization is explicit and documented to prevent surprises with infinite streams. The design maintains consistency with existing Each instances (List, Set, Optional, etc.) while respecting VStream's unique characteristics.

fixes #379 