### PR TITLE
Documentation tidy up

### DIFF
--- a/hkj-book/src/effect/advanced_topics.md
+++ b/hkj-book/src/effect/advanced_topics.md
@@ -741,5 +741,5 @@ systems that handle the full spectrum of real-world complexity.
 
 ---
 
-**Previous:** [MutableContext](effect_contexts_mutable.md)
+**Previous:** [Context vs ConfigContext](context_vs_config.md)
 **Next:** [Production Readiness](production_readiness.md)

--- a/hkj-book/src/effect/composition.md
+++ b/hkj-book/src/effect/composition.md
@@ -586,5 +586,5 @@ moving between Path types.
 
 ---
 
-**Previous:** [Path Types](path_types.md)
+**Previous:** [VStreamPath](path_vstream.md)
 **Next:** [ForPath Comprehension](forpath_comprehension.md)

--- a/hkj-book/src/effect/context_request.md
+++ b/hkj-book/src/effect/context_request.md
@@ -811,5 +811,5 @@ Practice request tracing patterns in [Tutorial 03: Request Tracing Patterns](htt
 
 ---
 
-**Previous:** [Effect Contexts Overview](effect_contexts.md)
+**Previous:** [MutableContext](effect_contexts_mutable.md)
 **Next:** [SecurityContext Patterns](context_security.md)

--- a/hkj-book/src/effect/context_vs_config.md
+++ b/hkj-book/src/effect/context_vs_config.md
@@ -488,4 +488,4 @@ static final ScopedValue<DatabaseUrl> DB_URL = ScopedValue.newInstance();
 ---
 
 **Previous:** [SecurityContext Patterns](context_security.md)
-**Next:** [Effect Contexts Overview](effect_contexts.md)
+**Next:** [Advanced Topics](advanced_topics.md)

--- a/hkj-book/src/effect/effect_contexts_mutable.md
+++ b/hkj-book/src/effect/effect_contexts_mutable.md
@@ -410,4 +410,4 @@ StateT<Counter, IOKind.Witness, Integer> transformer = ctx.toStateT();
 ---
 
 **Previous:** [ConfigContext](effect_contexts_config.md)
-**Next:** [Advanced Topics](advanced_topics.md)
+**Next:** [RequestContext](context_request.md)

--- a/hkj-book/src/effect/patterns.md
+++ b/hkj-book/src/effect/patterns.md
@@ -754,5 +754,5 @@ Writer patterns.
 
 ---
 
-**Previous:** [Focus-Effect Integration](focus_integration.md)
+**Previous:** [Capstone: Effects Meet Optics](capstone_focus_effect.md)
 **Next:** [Migration Cookbook](migration_cookbook.md)

--- a/hkj-book/src/functional/abstraction_levels.md
+++ b/hkj-book/src/functional/abstraction_levels.md
@@ -318,4 +318,4 @@ Full monadic power when needed:
 
 ---
 
-**Previous:** [For Comprehension](for_comprehension.md)
+**Previous:** [ForState Comprehension](forstate_comprehension.md)

--- a/hkj-book/src/functional/alternative.md
+++ b/hkj-book/src/functional/alternative.md
@@ -302,7 +302,8 @@ This example demonstrates:
 ---
 
 ~~~admonish tip title="Further Reading"
-- **Cats Documentation**: [Alternative](https://typelevel.org/cats/typeclasses/alternative.html) - Explains Alternative with practical examples including parsing and partitioning
+- **Baeldung**: [Java Optional orElse Patterns](https://www.baeldung.com/java-optional-or-else-optional) - Java's built-in fallback patterns, conceptually similar to Alternative
+- **Project Reactor**: [Mono and Flux Fallbacks](https://projectreactor.io/docs/core/release/reference/) - Reactive Java's approach to alternative and fallback chains
 ~~~
 
 ---

--- a/hkj-book/src/functional/applicative.md
+++ b/hkj-book/src/functional/applicative.md
@@ -1,33 +1,43 @@
-# Applicative: Applying Wrapped Functions
+# Applicative: Combining Independent Computations
 
 ~~~admonish info title="What You'll Learn"
 - How to apply wrapped functions to wrapped values using `ap`
-- The difference between independent computations (Applicative) and dependent ones (Monad)
 - How to combine multiple validation results and accumulate all errors
 - Using `map2`, `map3` and other convenience methods for combining values
 - Real-world validation scenarios with the Validated type
 ~~~
 
-~~~admonish title="Hands On Practice"
+~~~admonish example title="Hands-On Practice"
 [Tutorial03_ApplicativeCombining.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial03_ApplicativeCombining.java)
 ~~~
 
-Whilst a `Functor` excels at applying a *pure* function to a value inside a context, what happens when the function you want to apply is *also* wrapped in a context? This is where the **`Applicative`** type class comes in. It's the next step up in power from a `Functor` and allows you to combine multiple computations within a context in a very powerful way.
+## The Problem: Combining Results That Don't Depend on Each Other
+
+Whilst a `Functor` excels at applying a *pure* function to a value inside a context, what happens when you have **multiple independent computations** whose results you need to combine? And what if you want to see *all* the errors, not just the first one?
+
+```
+  Applicative: independent paths, combined at the end
+
+  validateName("") ────────────┐
+                               ├──> map2 ──> Validated<User>
+  validateEmail("bad") ────────┘
+  (both run, errors accumulate)
+```
+
+This is where the **`Applicative`** type class comes in. It's the next step up in power from a `Functor` and allows you to combine multiple computations within a context in a very powerful way.
 
 ---
 
-## What is it?
+## How Does It Work?
 
-An **`Applicative`** (or Applicative Functor) is a `Functor` that also provides two key operations:
+An **`Applicative`** (or Applicative Functor) is a `Functor` that provides two key operations:
 
 1. **`of`** (also known as `pure`): Lifts a regular value into the applicative context. For example, it can take a `String` and wrap it to become an `Optional<String>`.
 2. **`ap`**: Takes a function that is wrapped in the context (e.g., an `Optional<Function<A, B>>`) and applies it to a value that is also in the context (e.g., an `Optional<A>`).
 
 This ability to apply a *wrapped function* to a *wrapped value* is what makes `Applicative` so powerful. It's the foundation for combining independent computations.
 
-The interface for `Applicative` in `hkj-api` extends `Functor`:
-
-
+~~~admonish note title="Interface Signature"
 ``` java
 @NullMarked
 public interface Applicative<F extends WitnessArity<TypeArity.Unary>> extends Functor<F> {
@@ -48,20 +58,17 @@ public interface Applicative<F extends WitnessArity<TypeArity.Unary>> extends Fu
   }
 }
 ```
-
-The bound `F extends WitnessArity<TypeArity.Unary>` is inherited from `Functor<F>`, ensuring type safety.
+~~~
 
 ---
 
-### Why is it useful?
+## The Killer Use Case: Error Accumulation
 
-The primary use case for `Applicative` is to combine the results of several independent computations that are all inside the same context. The classic example is **data validation**, where you want to validate multiple fields and accumulate all the errors.
+The primary use case for `Applicative` is data validation where you want to validate multiple fields and accumulate **all** the errors. A `Monad` short-circuits on the first failure; an `Applicative` processes all computations independently and combines the results.
 
-Whilst a `Monad` (using `flatMap`) can also combine computations, it cannot accumulate errors in the same way. When a monadic chain fails, it short-circuits, giving you only the *first* error. An `Applicative`, on the other hand, can process all computations independently and combine the results.
+For more on this distinction, see [Choosing Your Abstraction Level](abstraction_levels.md).
 
 **Example: Validating a User Registration Form**
-
-Imagine you have a registration form and you need to validate both the username and the password. Each validation can either succeed or return a list of error messages. We can use the `Applicative` for `Validated` to run both validations and get all the errors back at once.
 
 ``` java
 import org.higherkindedj.hkt.Kind;
@@ -72,10 +79,8 @@ import org.higherkindedj.hkt.Semigroups;
 import java.util.List;
 import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
 
-// A simple User class
 record User(String username, String password) {}
 
-// Validation functions
 public Validated<List<String>, String> validateUsername(String username) {
     if (username.length() < 3) {
         return Validated.invalid(List.of("Username must be at least 3 characters"));
@@ -91,48 +96,51 @@ public Validated<List<String>, String> validatePassword(String password) {
 }
 
 
-// --- Get the Applicative instance for Validated ---
-// We need a Semigroup to tell the Applicative how to combine errors (in this case, by concatenating lists)
+// Get the Applicative for Validated, with a Semigroup that concatenates error lists
 Applicative<Validated.Witness<List<String>>> applicative =
     ValidatedMonad.instance(Semigroups.list());
 
 // --- Scenario 1: All validations pass ---
-Validated<List<String>, String> validUsername = validateUsername("test_user");
-Validated<List<String>, String> validPassword = validatePassword("password123");
-
 Kind<Validated.Witness<List<String>>, User> validResult =
     applicative.map2(
-        VALIDATED.widen(validUsername),
-        VALIDATED.widen(validPassword),
-        User::new // If both are valid, create a new User
-    );
-
-// Result: Valid(User[username=test_user, password=password123])
-System.out.println(VALIDATED.narrow(validResult));
-
-
-// --- Scenario 2: Both validations fail ---
-Validated<List<String>, String> invalidUsername = validateUsername("no");
-Validated<List<String>, String> invalidPassword = validatePassword("bad");
-
-Kind<Validated.Witness<List<String>>, User> invalidResult =
-    applicative.map2(
-        VALIDATED.widen(invalidUsername),
-        VALIDATED.widen(invalidPassword),
+        VALIDATED.widen(validateUsername("test_user")),
+        VALIDATED.widen(validatePassword("password123")),
         User::new
     );
+// Result: Valid(User[username=test_user, password=password123])
 
-// The errors from both validations are accumulated!
+// --- Scenario 2: Both validations fail ---
+Kind<Validated.Witness<List<String>>, User> invalidResult =
+    applicative.map2(
+        VALIDATED.widen(validateUsername("no")),
+        VALIDATED.widen(validatePassword("bad")),
+        User::new
+    );
+// Errors from BOTH validations are accumulated!
 // Result: Invalid([Username must be at least 3 characters, Password must contain a number])
-System.out.println(VALIDATED.narrow(invalidResult));
 ```
 
-This error accumulation is impossible with `Functor` and is one of the key features that makes `Applicative` so indispensable for real-world functional programming.
+This error accumulation is impossible with a `Monad` (which short-circuits) and is one of the key features that makes `Applicative` so indispensable for real-world functional programming.
 
 ---
 
+~~~admonish info title="Key Takeaways"
+* **`Applicative` combines independent computations** where results don't depend on each other
+* **Error accumulation** with `Validated` is the killer use case; you see all errors, not just the first
+* **`map2`, `map3`, etc.** are the practical workhorses for combining two, three, or more values
+* **`of` lifts a plain value** into the applicative context (e.g., wrapping a `String` into an `Optional<String>`)
+~~~
+
+~~~admonish tip title="See Also"
+- [Functor](functor.md) - The simpler foundation that Applicative builds upon
+- [Monad](monad.md) - For dependent computations (but with short-circuiting, not accumulation)
+- [Choosing Your Abstraction Level](abstraction_levels.md) - When to use Applicative vs Selective vs Monad
+- [Validated](../monads/validated_monad.md) - The type designed for error accumulation
+~~~
+
 ~~~admonish tip title="Further Reading"
-- **Cats Documentation**: [Applicative](https://typelevel.org/cats/typeclasses/applicative.html) - Comprehensive coverage of Applicative laws and practical examples
+- **Baeldung**: [Functional Programming in Java](https://www.baeldung.com/java-functional-programming) - Practical functional patterns for Java developers
+- **Mark Seemann**: [Applicative Functors](https://blog.ploeh.dk/2018/10/01/applicative-functors/) - Accessible introduction with practical examples
 ~~~
 
 ~~~admonish info title="Hands-On Learning"

--- a/hkj-book/src/functional/bifunctor.md
+++ b/hkj-book/src/functional/bifunctor.md
@@ -418,8 +418,8 @@ Understanding bifunctors empowers you to write generic, reusable transformation 
 
 ~~~admonish tip title="Further Reading"
 - **Mark Seemann**: [Bifunctors](https://blog.ploeh.dk/2018/12/24/bifunctors/) - Excellent article explaining bifunctors with Either and Tuple examples
-- **The F-words**: [Functor and Friends](https://kubuszok.com/2018/the-f-words-functors-and-friends/) - Comprehensive overview including bifunctors
-- **Cats Documentation**: [Bifunctor](https://typelevel.org/cats/typeclasses/bifunctor.html) - Scala implementation and examples
+- **Mojang/DataFixerUpper**: [DFU on GitHub](https://github.com/Mojang/DataFixerUpper) - Minecraft's Java library that uses bifunctors and profunctors for data migration
+- **Baeldung**: [Introduction to Vavr's Either](https://www.baeldung.com/vavr-either) - Practical look at dual-channel types in Java
 ~~~
 
 ---

--- a/hkj-book/src/functional/forstate_comprehension.md
+++ b/hkj-book/src/functional/forstate_comprehension.md
@@ -383,8 +383,8 @@ Every value is accessed by name. The workflow reads top-to-bottom. Adding or rem
 ---
 
 ~~~admonish tip title="Further Reading"
-- **Scala State Monad**: [Cats State](https://typelevel.org/cats/datatypes/state.html) -- Similar state-threading pattern
-- **Haskell lens library**: [Control.Lens](https://hackage.haskell.org/package/lens) -- The inspiration for optics-based state access
+- **Baeldung**: [Java Record Patterns](https://www.baeldung.com/java-record-keyword) -- Using Java records for immutable state representation
+- **Mojang/DataFixerUpper**: [DFU on GitHub](https://github.com/Mojang/DataFixerUpper) -- Minecraft's Java library using optics for state transformation between game versions
 ~~~
 
 ---

--- a/hkj-book/src/functional/functional_api.md
+++ b/hkj-book/src/functional/functional_api.md
@@ -1,170 +1,87 @@
-# Core API Interfaces: The Building Blocks
+# Core API Interfaces: Quick Reference
 
-The `hkj-api` module contains the heart of the `higher-kinded-j` library: a set of interfaces that define the core functional programming abstractions. These are the building blocks you will use to write powerful, generic, and type-safe code.
-
-This document provides a high-level overview of the most important interfaces, which are often referred to as **type classes**.
+The `hkj-api` module contains the heart of the Higher-Kinded-J library: a set of interfaces that define the core functional programming abstractions. This page provides a quick-reference lookup for all type classes, their key operations, and when to use them.
 
 ~~~admonish info title="What You'll Learn"
-- How the `Kind<F, A>` interface enables higher-kinded types in Java and serves as the foundation for all functional abstractions
-- The monad hierarchy from `Functor` through `Applicative` to `Monad`, plus specialized variants like `MonadError`, `Alternative`, `Selective`, and `MonadZero`
-- How to combine and aggregate data using `Semigroup` and `Monoid` type classes for operations like error accumulation
-- How to iterate over and transform data structures generically using `Foldable` and `Traverse` for tasks like validation and collection processing
-- How dual-parameter type classes like `Profunctor` and `Bifunctor` enable advanced data transformations and power optics
+- A concise overview of every type class in the library
+- The key method(s) each type class provides
+- When to reach for each abstraction
+- Links to the detailed documentation for each type class
 ~~~
-
----
-
-## Core HKT Abstraction
-
-At the very centre of the library is the `Kind` interface, which makes higher-kinded types possible in Java.
-
-* **`Kind<F, A>`**: This is the foundational interface that emulates a higher-kinded type. It represents a type `F` that is generic over a type `A`. For example, `Kind<ListKind.Witness, String>` represents a `List<String>`. You will see this interface used everywhere as the common currency for all our functional abstractions.
 
 ---
 
 ## The Monad Hierarchy
 
-The most commonly used type classes form a hierarchy of power and functionality, starting with `Functor` and building up to `Monad`.
+```
+                    ┌──────────┐
+                    │  Functor │  map
+                    └────┬─────┘
+                         │
+                    ┌────┴─────┐
+                    │Applicative│  of, ap
+                    └────┬─────┘
+                         │
+          ┌──────────────┼──────────────┐
+          │              │              │
+    ┌─────┴─────┐  ┌─────┴─────┐  ┌─────┴─────┐
+    │   Monad   │  │Alternative│  │ Selective │
+    │  flatMap  │  │ orElse    │  │  select   │
+    └─────┬─────┘  └───────────┘  └───────────┘
+          │
+    ┌─────┴─────┐
+    │MonadError │  raiseError, handleErrorWith
+    └───────────┘
+```
 
-### **`Functor<F>`**
-
-A **`Functor`** is a type class for any data structure that can be "mapped over". It provides a single operation, `map`, which applies a function to the value(s) inside the structure without changing the structure itself.
-
-* **Key Method**: `map(Function<A, B> f, Kind<F, A> fa)`
-* **Intuition**: If you have a `List<A>` and a function `A -> B`, a `Functor` for `List` lets you produce a `List<B>`. The same logic applies to `Optional`, `Either`, `Try`, etc.
-
-### **`Applicative<F>`**
-
-An **`Applicative`** (or Applicative Functor) is a `Functor` with more power. It allows you to apply a function that is itself wrapped in the data structure. This is essential for combining multiple independent computations.
-
-* **Key Methods**:
-  * `of(A value)`: Lifts a normal value `A` into the applicative context `F<A>`.
-  * `ap(Kind<F, Function<A, B>> ff, Kind<F, A> fa)`: Applies a wrapped function to a wrapped value.
-* **Intuition**: If you have an `Optional<Function<A, B>>` and an `Optional<A>`, you can use the `Applicative` for `Optional` to get an `Optional<B>`. This is how `Validated` is able to accumulate errors from multiple independent validation steps.
-
-### **`Monad<F>`**
-
-A **`Monad`** is an `Applicative` that adds the power of sequencing dependent computations. It provides a way to chain operations together, where the result of one operation is fed into the next.
-
-* **Key Method**: `flatMap(Function<A, Kind<F, B>> f, Kind<F, A> fa)`
-* **Intuition**: `flatMap` is the powerhouse of monadic composition. It takes a value from a context (like an `Optional<A>`), applies a function that returns a *new* context (`A -> Optional<B>`), and flattens the result into a single context (`Optional<B>`). This is what enables the elegant, chainable workflows you see in the examples.
-
-### **`MonadError<F, E>`**
-
-A **`MonadError`** is a specialised `Monad` that has a defined error type `E`. It provides explicit methods for raising and handling errors within a monadic workflow.
-
-* **Key Methods**:
-  * `raiseError(E error)`: Lifts an error `E` into the monadic context `F<A>`.
-  * `handleErrorWith(Kind<F, A> fa, Function<E, Kind<F, A>> f)`: Provides a way to recover from a failed computation.
-
-### **`Alternative<F>`**
-
-An **`Alternative`** is an `Applicative` that adds the concept of choice and failure. It provides operations for combining alternatives and representing empty/failed computations. Alternative sits at the same level as `Applicative` in the type class hierarchy.
-
-* **Key Methods**:
-  * `empty()`: Returns the empty/failure element for the applicative.
-  * `orElse(Kind<F, A> fa, Supplier<Kind<F, A>> fb)`: Combines two alternatives, preferring the first if it succeeds, otherwise evaluating and returning the second.
-  * `guard(boolean condition)`: Returns success (`of(Unit.INSTANCE)`) if true, otherwise empty.
-* **Use Case**: Essential for parser combinators, fallback chains, non-deterministic computation, and trying multiple alternatives with lazy evaluation.
-
-### **`Selective<F>`**
-
-A **`Selective`** functor sits between `Applicative` and `Monad` in terms of power. It extends `Applicative` with the ability to conditionally apply effects based on the result of a previous computation, whilst maintaining a static structure where all possible branches are visible upfront.
-
-* **Key Methods**:
-  * `select(Kind<F, Choice<A, B>> fab, Kind<F, Function<A, B>> ff)`: Core operation that conditionally applies a function based on a `Choice`.
-  * `whenS(Kind<F, Boolean> fcond, Kind<F, Unit> fa)`: Conditionally executes an effect based on a boolean condition.
-  * `ifS(Kind<F, Boolean> fcond, Kind<F, A> fthen, Kind<F, A> felse)`: Provides if-then-else semantics with both branches visible upfront.
-* **Use Case**: Perfect for feature flags, conditional logging, configuration-based behaviour, and any scenario where you need conditional effects with static analysis capabilities.
-
-### **`MonadZero<F>`**
-
-A **`MonadZero`** is a `Monad` that also extends `Alternative`, combining monadic bind with choice operations. It adds the concept of a "zero" or "empty" element, allowing it to represent failure or absence.
-
-* **Key Methods**:
-  * `zero()`: Returns the zero/empty element for the monad (implements `empty()` from Alternative).
-  * Inherits `orElse()` and `guard()` from `Alternative`.
-* **Use Case**: Primarily enables filtering in for-comprehensions via the `when()` clause at all supported arities (up to 12 bindings). Also provides all Alternative operations for monadic contexts. Implemented by List, Maybe, Optional, and Stream.
+| Type Class | Key Method(s) | Purpose | When to Use | Docs |
+|------------|--------------|---------|-------------|------|
+| **`Functor`** | `map` | Transform values inside a container | You need to apply `A -> B` to a wrapped value | [Functor](functor.md) |
+| **`Applicative`** | `of`, `ap`, `map2` | Combine independent computations | Validation with error accumulation; combining unrelated results | [Applicative](applicative.md) |
+| **`Alternative`** | `empty`, `orElse` | Choice and fallback semantics | Fallback chains; parser combinators; trying multiple sources | [Alternative](alternative.md) |
+| **`Selective`** | `select`, `whenS`, `ifS` | Conditional effects with static structure | Feature flags; config-based branching where both branches are known upfront | [Selective](selective.md) |
+| **`Monad`** | `flatMap` | Sequence dependent computations | Each step's effect depends on the previous step's result | [Monad](monad.md) |
+| **`MonadError`** | `raiseError`, `handleErrorWith` | Typed error handling within monadic workflows | Raising and recovering from domain-specific errors | [MonadError](monad_error.md) |
+| **`MonadZero`** | `zero` | Filtering in monadic chains | Guard clauses in for-comprehensions (`when()`) | [MonadZero](monad_zero.md) |
 
 ---
 
 ## Data Aggregation Type Classes
 
-These type classes define how data can be combined and reduced.
-
-### **`Semigroup<A>`**
-
-A **`Semigroup`** is a simple type class for any type `A` that has an associative `combine` operation. It's the foundation for any kind of data aggregation.
-
-* **Key Method**: `combine(A a1, A a2)`
-* **Use Case**: Its primary use in this library is to tell a `Validated``Applicative` how to accumulate errors.
-
-### **`Monoid<A>`**
-
-A **`Monoid`** is a `Semigroup` that also has an "empty" or "identity" element. This is a value that, when combined with any other value, does nothing.
-
-* **Key Methods**:
-  * `combine(A a1, A a2)` (from `Semigroup`)
-  * `empty()`
-* **Use Case**: Essential for folding data structures, where `empty()` provides the starting value for the reduction.
+| Type Class | Key Method(s) | Purpose | When to Use | Docs |
+|------------|--------------|---------|-------------|------|
+| **`Semigroup`** | `combine` | Associatively merge two values of the same type | Telling `Validated` how to accumulate errors | [Semigroup and Monoid](semigroup_and_monoid.md) |
+| **`Monoid`** | `combine`, `empty` | Semigroup with an identity element | Folding collections (needs a starting value for empty cases) | [Semigroup and Monoid](semigroup_and_monoid.md) |
 
 ---
 
 ## Structure-Iterating Type Classes
 
-These type classes define how to iterate over and manipulate the contents of a data structure in a generic way.
-
-### **`Foldable<F>`**
-
-A **`Foldable`** is a type class for any data structure `F` that can be reduced to a single summary value. It uses a `Monoid` to combine the elements.
-
-* **Key Method**: `foldMap(Monoid<M> monoid, Function<A, M> f, Kind<F, A> fa)`
-* **Intuition**: It abstracts the process of iterating over a collection and aggregating the results.
-
-### **`Traverse<F>`**
-
-A **`Traverse`** is a powerful type class that extends both `Functor` and `Foldable`. It allows you to iterate over a data structure `F<A>` and apply an effectful function `A -> G<B>` at each step, collecting the results into a single effect `G<F<B>>`.
-
-* **Key Method**: `traverse(Applicative<G> applicative, Function<A, Kind<G, B>> f, Kind<F, A> fa)`
-* **Use Case**: This is incredibly useful for tasks like validating every item in a `List`, where the validation returns a `Validated`. The result is a single `Validated` containing either a `List` of all successful results or an accumulation of all errors.
+| Type Class | Key Method(s) | Purpose | When to Use | Docs |
+|------------|--------------|---------|-------------|------|
+| **`Foldable`** | `foldMap` | Reduce a structure to a summary value | Summing, counting, concatenating, or aggregating any collection | [Foldable and Traverse](foldable_and_traverse.md) |
+| **`Traverse`** | `traverse`, `sequenceA` | Iterate with effects, then flip the structure inside-out | Validating every item in a list; batch fetching with error collection | [Foldable and Traverse](foldable_and_traverse.md) |
 
 ---
 
 ## Dual-Parameter Type Classes
 
-These type classes work with types that take two type parameters, such as functions, profunctors, and bifunctors.
+| Type Class | Key Method(s) | Purpose | When to Use | Docs |
+|------------|--------------|---------|-------------|------|
+| **`Profunctor`** | `lmap`, `rmap`, `dimap` | Transform both input (contravariant) and output (covariant) | Adapting functions to different input/output formats; optics foundation | [Profunctor](profunctor.md) |
+| **`Bifunctor`** | `bimap`, `first`, `second` | Transform both parameters of a two-parameter type (both covariant) | Mapping over both sides of `Either`, `Tuple2`, `Validated`, or `Writer` | [Bifunctor](bifunctor.md) |
 
-### **`Profunctor<P>`**
+---
 
-A **`Profunctor`** is a type class for any type constructor `P<A, B>` that is contravariant in its first parameter and covariant in its second. This is the abstraction behind functions and many data transformation patterns.
+## Core HKT Abstraction
 
-~~~admonish note
-New to variance terminology? See the [Glossary](../glossary.md) for detailed explanations of covariant, contravariant, and invariant with Java-focused examples.
+* **`Kind<F, A>`** -- The foundational interface that emulates a higher-kinded type. It represents a type `F` that is generic over a type `A`. For example, `Kind<ListKind.Witness, String>` represents a `List<String>`. This interface is the common currency for all functional abstractions in the library.
+
+~~~admonish tip title="See Also"
+- [Choosing Your Abstraction Level](abstraction_levels.md) - Decision flowchart for Applicative vs Selective vs Monad
+- [For Comprehension](for_comprehension.md) - Readable syntax for composing monadic operations
+- [Natural Transformation](natural_transformation.md) - Polymorphic functions between type constructors
 ~~~
-
-* **Key Methods**:
-  * `lmap(Function<C, A> f, Kind2<P, A, B> pab)`: Pre-process the input (contravariant mapping)
-  * `rmap(Function<B, C> g, Kind2<P, A, B> pab)`: Post-process the output (covariant mapping)
-  * `dimap(Function<C, A> f, Function<B, D> g, Kind2<P, A, B> pab)`: Transform both input and output simultaneously
-* **Use Case**: Essential for building flexible data transformation pipelines, API adapters, and validation frameworks that can adapt to different input and output formats without changing core business logic.
-
-### **Profunctors in Optics**
-
-Importantly, every optic in higher-kinded-j is fundamentally a profunctor. This means that `Lens`, `Prism`, `Iso`, and `Traversal` all support profunctor operations through their `contramap`, `map`, and `dimap` methods. This provides incredible flexibility for adapting optics to work with different data types and structures, making them highly reusable across different contexts and API boundaries.
-
-### **`Bifunctor<F>`**
-
-A **`Bifunctor`** is a type class for any type constructor `F<A, B>` that is covariant in *both* its type parameters. Unlike `Profunctor`, which is contravariant in the first parameter, `Bifunctor` allows you to map over both sides independently or simultaneously.
-
-~~~admonish note
-New to variance terminology? See the [Glossary](../glossary.md) for detailed explanations of covariant, contravariant, and invariant with Java-focused examples.
-~~~
-
-* **Key Methods**:
-  * `bimap(Function<A, C> f, Function<B, D> g, Kind2<F, A, B> fab)`: Transform both type parameters simultaneously
-  * `first(Function<A, C> f, Kind2<F, A, B> fab)`: Map over only the first type parameter
-  * `second(Function<B, D> g, Kind2<F, A, B> fab)`: Map over only the second type parameter
-* **Use Case**: Essential for transforming both channels of sum types (like `Either<L, R>` or `Validated<E, A>`) or product types (like `Tuple2<A, B>` or `Writer<W, A>`), where both parameters hold data rather than representing input/output relationships. Perfect for API response transformation, validation pipelines, data migration, and error handling scenarios.
 
 ---
 

--- a/hkj-book/src/functional/functor.md
+++ b/hkj-book/src/functional/functor.md
@@ -8,35 +8,33 @@
 - When to choose Functor over direct method calls
 ~~~
 
-~~~admonish title="Hands On Practice"
+~~~admonish example title="Hands-On Practice"
 [Tutorial02_FunctorMapping.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial02_FunctorMapping.java)
 ~~~
 
 At the heart of functional programming is the ability to transform data within a container without having to open it. The **`Functor`** type class provides exactly this capability. It's the simplest and most common abstraction for any data structure that can be "mapped over."
 
-If you've ever used `Optional.map()` or `Stream.map()`, you've already been using the Functor pattern! `higher-kinded-j` simply formalises this concept so you can apply it to any data structure.
+If you've ever used `Optional.map()` or `Stream.map()`, you've already been using the Functor pattern! Higher-Kinded-J simply formalises this concept so you can apply it to any data structure.
 
 ---
 
-## What is it?
+## What Does It Do?
 
 A **`Functor`** is a type class for any data structure `F` that supports a `map` operation. This operation takes a function from `A -> B` and applies it to the value(s) inside a container `F<A>`, producing a new container `F<B>` of the same shape.
 
 Think of a `Functor` as a generic "box" that holds a value. The `map` function lets you transform the contents of the box without ever taking the value out. Whether the box is an `Optional` that might be empty, a `List` with many items, or a `Try` that might hold an error, the mapping logic remains the same.
 
-The interface for `Functor` in `hkj-api` is simple and elegant:
-
-
+~~~admonish note title="Interface Signature"
 ``` java
 public interface Functor<F extends WitnessArity<TypeArity.Unary>> {
   <A, B> @NonNull Kind<F, B> map(final Function<? super A, ? extends B> f, final Kind<F, A> fa);
 }
 ```
 
-The `F extends WitnessArity<TypeArity.Unary>` bound ensures that only valid unary witness types (representing single-parameter type constructors like `List<_>` or `Optional<_>`) can be used with Functor.
-
 * `f`: The function to apply to the value inside the Functor.
 * `fa`: The higher-kinded `Functor` instance (e.g., a `Kind<Optional.Witness, String>`).
+* The `F extends WitnessArity<TypeArity.Unary>` bound ensures that only valid unary witness types can be used with Functor.
+~~~
 
 ---
 
@@ -66,15 +64,9 @@ These laws ensure that `map` is only about transformation and preserves the stru
 
 ---
 
-### Why is it useful?
-
-`Functor` allows you to write generic, reusable code that transforms values inside any "mappable" data structure. This is the first step towards abstracting away the boilerplate of dealing with different container types.
-
-**Example: Mapping over an `Optional` and a `List`**
+### Practical Example: Mapping over `Optional` and `List`
 
 Let's see how we can use the `Functor` instances for `Optional` and `List` to apply the same logic to different data structures.
-
-
 
 ``` java
 import org.higherkindedj.hkt.Kind;
@@ -94,11 +86,9 @@ Function<String, Integer> stringLength = String::length;
 // --- Scenario 1: Mapping over an Optional ---
 Functor<OptionalKind.Witness> optionalFunctor = OptionalFunctor.INSTANCE;
 
-// The data
 Kind<OptionalKind.Witness, String> optionalWithValue = OPTIONAL.widen(Optional.of("Hello"));
 Kind<OptionalKind.Witness, String> optionalEmpty = OPTIONAL.widen(Optional.empty());
 
-// Apply the map
 Kind<OptionalKind.Witness, Integer> lengthWithValue = optionalFunctor.map(stringLength, optionalWithValue);
 Kind<OptionalKind.Witness, Integer> lengthEmpty = optionalFunctor.map(stringLength, optionalEmpty);
 
@@ -111,24 +101,35 @@ System.out.println(OPTIONAL.narrow(lengthEmpty));
 // --- Scenario 2: Mapping over a List ---
 Functor<ListKind.Witness> listFunctor = ListFunctor.INSTANCE;
 
-// The data
 Kind<ListKind.Witness, String> listOfStrings = LIST.widen(List.of("one", "two", "three"));
 
-// Apply the map
 Kind<ListKind.Witness, Integer> listOfLengths = listFunctor.map(stringLength, listOfStrings);
 
 // Result: [3, 3, 5]
 System.out.println(LIST.narrow(listOfLengths));
 ```
 
-As you can see, the `Functor` provides a consistent API for transformation, regardless of the underlying data structure. This is the first and most essential step on the path to more powerful abstractions like `Applicative` and `Monad`.
+The `Functor` provides a consistent API for transformation, regardless of the underlying data structure. This is the first and most essential step on the path to more powerful abstractions like `Applicative` and `Monad`.
 
 ---
+
+~~~admonish info title="Key Takeaways"
+* **`map` transforms values inside a container** without changing the container's structure
+* **One interface, many types**: the same `map` operation works with Optional, List, Either, IO, and more
+* **Functor laws** (identity and composition) guarantee predictable, side-effect-free transformations
+* **Functor is the foundation** that Applicative, Monad, and every other type class builds upon
+~~~
+
+~~~admonish tip title="See Also"
+- [Applicative](applicative.md) - The next step up: combining independent computations
+- [Monad](monad.md) - Sequencing dependent computations with `flatMap`
+- [Bifunctor](bifunctor.md) - Mapping over types with two parameters
+~~~
 
 ~~~admonish tip title="Further Reading"
 - **Scott Logic**: [Functors and Monads with Java and Scala](https://blog.scottlogic.com/2025/03/31/functors-monads-with-java-and-scala.html) - Practical guide to functors and monads in Java
 - **Bartosz Milewski**: [Functors](https://bartoszmilewski.com/2015/01/20/functors/) - Comprehensive explanation of functors from category theory to code
-- **Cats Documentation**: [Functor](https://typelevel.org/cats/typeclasses/functor.html) - Scala implementation and examples
+- **Mark Seemann**: [Functors](https://blog.ploeh.dk/2018/03/22/functors/) - A practical introduction with examples in Java-adjacent languages
 ~~~
 
 ~~~admonish info title="Hands-On Learning"

--- a/hkj-book/src/functional/monad.md
+++ b/hkj-book/src/functional/monad.md
@@ -3,36 +3,103 @@
 ~~~admonish info title="What You'll Learn"
 - How to sequence computations where each step depends on previous results
 - The power of `flatMap` for chaining operations that return wrapped values
-- When to use Monad vs Applicative (dependent vs independent computations)
 - Essential utility methods: `as`, `peek`, `flatMapIfOrElse`, and `flatMapN`
 - How to combine multiple monadic values with `flatMap2`, `flatMap3`, etc.
 - How monadic short-circuiting works in practice
 ~~~
 
-~~~admonish title="Hands On Practice"
+~~~admonish example title="Hands-On Practice"
 [Tutorial04_MonadChaining.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial04_MonadChaining.java)
 ~~~
 
-You've seen how `Functor` lets you `map` over a value in a context and how `Applicative` lets you combine independent computations within a context. Now, we'll introduce the most powerful of the trio: **`Monad`**.
+## The Problem: When Each Step Depends on the Last
 
-A `Monad` builds on `Applicative` by adding one crucial ability: sequencing computations that **depend on each other**. If the result of the first operation is needed to determine the second operation, you need a `Monad`.
+You've seen how `Functor` lets you `map` over a value in a context and how `Applicative` lets you combine independent computations. But what happens when the result of one step determines what happens next?
+
+Consider fetching a user, then their account, then their balance. Each step depends on the previous result, and any step could fail. Without `flatMap`, you end up with deeply nested checks:
+
+```java
+Optional<User> user = findUser(1);
+if (user.isPresent()) {
+    Optional<Account> account = findAccount(user.get());
+    if (account.isPresent()) {
+        Optional<Double> balance = getBalance(account.get());
+        if (balance.isPresent()) {
+            System.out.println("Balance: " + balance.get());
+        }
+    }
+}
+```
+
+Three levels of nesting for three steps, and it only gets worse as the workflow grows.
 
 ---
 
-## What is it?
+## The Solution: `flatMap`
 
-A **`Monad`** is an `Applicative` that provides a new function called **`flatMap`** (also known as `bind` in some languages). This is the powerhouse of monadic composition.
+A **`Monad`** builds on `Applicative` by adding one crucial ability: **`flatMap`**. Whilst `map` takes a simple function `A -> B`, `flatMap` takes a function that returns a new value *already wrapped in the monadic context*, i.e., `A -> Kind<F, B>`. It then flattens the nested result into a simple `Kind<F, B>`.
 
-While `map` takes a simple function `A -> B`, `flatMap` takes a function that returns a new value *already wrapped in the monadic context*, i.e., `A -> Kind<F, B>`. `flatMap` then intelligently flattens the nested result `Kind<F, Kind<F, B>>` into a simple `Kind<F, B>`.
+Here is the same workflow, rewritten with `flatMap`:
 
-This flattening behaviour is what enables you to chain operations together in a clean, readable sequence without creating deeply nested structures.
+```java
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import java.util.Optional;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+record User(int id, String name) {}
+record Account(int userId, String accountId) {}
+
+public Kind<Optional.Witness, User> findUser(int id) { /* ... */ }
+public Kind<Optional.Witness, Account> findAccount(User user) { /* ... */ }
+public Kind<Optional.Witness, Double> getBalance(Account account) { /* ... */ }
+
+Monad<Optional.Witness> monad = OptionalMonad.INSTANCE;
+
+// --- Successful workflow ---
+Kind<Optional.Witness, Double> balance = monad.flatMap(user ->
+    monad.flatMap(account ->
+        getBalance(account),
+        findAccount(user)),
+    findUser(1));
+
+// Result: Optional[1000.0]
+System.out.println(OPTIONAL.narrow(balance));
+
+// --- Failing workflow (user not found) ---
+Kind<Optional.Witness, Double> missing = monad.flatMap(user ->
+    monad.flatMap(account -> getBalance(account), findAccount(user)),
+    findUser(2)); // Returns Optional.empty()
+
+// The chain short-circuits immediately.
+// Result: Optional.empty
+System.out.println(OPTIONAL.narrow(missing));
+```
+
+No null checks, no nesting. The chain elegantly handles the "happy path" whilst short-circuiting on failure.
+
+```
+  flatMap chain; each step depends on the previous:
+
+  findUser(1) ──> User ──> findAccount(user) ──> Account ──> getBalance(account)
+       |                         |                                  |
+       v                         v                                  v
+  Optional<User>          Optional<Account>                  Optional<Double>
+
+  If ANY step returns empty, the chain short-circuits:
+
+  findUser(2) ──> empty ──X (chain stops)
+       |
+       v
+  Optional.empty
+```
+
+This pattern is the foundation for the **for-comprehension** builder in Higher-Kinded-J, which transforms a chain of `flatMap` calls into clean, imperative-style code.
 
 ---
 
-## The `Monad` Interface
-
-The interface for `Monad` in `hkj-api` extends `Applicative` and adds `flatMap` along with several useful default methods for common patterns.
-
+~~~admonish note title="Interface Signature"
 ```java
 @NullMarked
 public interface Monad<M extends WitnessArity<TypeArity.Unary>> extends Applicative<M> {
@@ -69,217 +136,126 @@ public interface Monad<M extends WitnessArity<TypeArity.Unary>> extends Applicat
     return flatMap(a -> flatMap(b -> f.apply(a, b), mb), ma);
   }
 
-  default <A, B, C, R> @NonNull Kind<M, R> flatMap3(
-      Kind<M, A> ma, Kind<M, B> mb, Kind<M, C> mc,
-      Function3<? super A, ? super B, ? super C, ? extends Kind<M, R>> f) {
-    return flatMap(a -> flatMap2(mb, mc, (b, c) -> f.apply(a, b, c)), ma);
-  }
-
-  // flatMap4 and flatMap5 build on flatMap3 and flatMap4 respectively...
+  // flatMap3, flatMap4, and flatMap5 build similarly...
 }
 ```
-
-### Monad vs. Applicative
-
-The key difference is simple but profound:
-
-* **`Applicative`** is for combining **independent** computations. The shape and structure of all the computations are known upfront. This is why it can accumulate errors from multiple validations, as it runs all of them.
-* **`Monad`** is for sequencing **dependent** computations. The computation in the second step cannot be known until the first step has completed. This is why it short-circuits on failure: if the first step fails, there is no value to feed into the second step.
+~~~
 
 ---
 
-### Why is it useful?
+## When Should You Use Monad vs Applicative?
 
-`Monad` is essential for building any kind of workflow where steps depend on the result of previous steps, especially when those steps might fail or be asynchronous. It allows you to write what looks like a simple sequence of operations while hiding the complexity of error handling, null checks, or concurrency.
+The short answer: use `Monad` when the next step **depends on** the previous result; use `Applicative` when computations are **independent**.
 
-This pattern is the foundation for the **for-comprehension** builder in `higher-kinded-j`, which transforms a chain of `flatMap` calls into clean, imperative-style code.
-
-#### Core Method: `flatMap`
-
-This is the primary method for chaining dependent operations.
-
-**Example: A Safe Database Workflow**
-
-Imagine a workflow where you need to fetch a user, then use their ID to fetch their account, and finally use the account details to get their balance. Any of these steps could fail (e.g., return an empty `Optional`). With `flatMap`, the chain becomes clean and safe.
-
-```java
-import org.higherkindedj.hkt.Kind;
-import org.higherkindedj.hkt.Monad;
-import org.higherkindedj.hkt.optional.OptionalMonad;
-import java.util.Optional;
-import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
-
-// Mock data records and repository functions from the previous example...
-record User(int id, String name) {}
-record Account(int userId, String accountId) {}
-
-public Kind<Optional.Witness, User> findUser(int id) { /* ... */ }
-public Kind<Optional.Witness, Account> findAccount(User user) { /* ... */ }
-public Kind<Optional.Witness, Double> getBalance(Account account) { /* ... */ }
-
-// --- Get the Monad instance for Optional ---
-Monad<Optional.Witness> monad = OptionalMonad.INSTANCE;
-
-// --- Scenario 1: Successful workflow ---
-Kind<Optional.Witness, Double> balanceSuccess = monad.flatMap(user ->
-    monad.flatMap(account ->
-        getBalance(account),
-        findAccount(user)),
-    findUser(1));
-
-// Result: Optional[1000.0]
-System.out.println(OPTIONAL.narrow(balanceSuccess));
-
-// --- Scenario 2: Failing workflow (user not found) ---
-Kind<Optional.Witness, Double> balanceFailure = monad.flatMap(user ->
-    /* this part is never executed */
-    monad.flatMap(account -> getBalance(account), findAccount(user)),
-    findUser(2)); // This returns Optional.empty()
-
-// The chain short-circuits immediately.
-// Result: Optional.empty
-System.out.println(OPTIONAL.narrow(balanceFailure));
-```
-
-The `flatMap` chain elegantly handles the "happy path" while also providing robust, short-circuiting logic for the failure cases, all without a single null check.
+For a detailed comparison with worked examples and a decision flowchart, see [Choosing Your Abstraction Level](abstraction_levels.md).
 
 ---
 
 ## Utility Methods
 
-`Monad` also provides default methods for common tasks like debugging, conditional logic, and transforming results.
+`Monad` provides default methods for common tasks like debugging, conditional logic, and transforming results.
 
 ### `flatMapIfOrElse`
 
-This is the type-safe way to perform conditional branching in a monadic chain. It applies one of two functions based on a predicate, ensuring that both paths result in the same final type and avoiding runtime errors.
+**The problem:** You need conditional branching in a monadic chain, but using `if/else` inside a `flatMap` lambda is error-prone and hard to read.
 
-Let's imagine we only want to fetch accounts for "standard" users (ID < 100).
+**The solution:** `flatMapIfOrElse` applies one of two functions based on a predicate, ensuring both paths result in the same type.
 
 ```java
-// --- Get the Monad instance for Optional ---
 Monad<Optional.Witness> monad = OptionalMonad.INSTANCE;
 
-// A user who meets the condition
 Kind<Optional.Witness, User> standardUser = OPTIONAL.widen(Optional.of(new User(1, "Alice")));
-// A user who does not
 Kind<Optional.Witness, User> premiumUser = OPTIONAL.widen(Optional.of(new User(101, "Bob")));
 
-// --- Scenario 1: Predicate is true ---
-Kind<Optional.Witness, Account> resultSuccess = monad.flatMapIfOrElse(
-    user -> user.id() < 100,      // Predicate: user is standard
-    user -> findAccount(user),    // Action if true: find their account
-    user -> OPTIONAL.widen(Optional.empty()), // Action if false: return empty
+// Only fetch accounts for standard users (ID < 100)
+Kind<Optional.Witness, Account> result = monad.flatMapIfOrElse(
+    user -> user.id() < 100,
+    user -> findAccount(user),
+    user -> OPTIONAL.widen(Optional.empty()),
     standardUser
 );
 // Result: Optional[Account[userId=1, accountId=acc-123]]
-System.out.println(OPTIONAL.narrow(resultSuccess));
 
-
-// --- Scenario 2: Predicate is false ---
-Kind<Optional.Witness, Account> resultFailure = monad.flatMapIfOrElse(
+Kind<Optional.Witness, Account> empty = monad.flatMapIfOrElse(
     user -> user.id() < 100,
     user -> findAccount(user),
-    user -> OPTIONAL.widen(Optional.empty()), // This path is taken
+    user -> OPTIONAL.widen(Optional.empty()),
     premiumUser
 );
 // Result: Optional.empty
-System.out.println(OPTIONAL.narrow(resultFailure));
 ```
 
 ### `as`
 
-Replaces the value inside a monad while preserving its effect (e.g., success or failure). This is useful when you only care *that* an operation succeeded, not what its result was.
+**The problem:** After a monadic operation, you care *that* it succeeded, not *what* it returned.
+
+**The solution:** `as` replaces the value inside a monad whilst preserving its effect (success or failure).
 
 ```java
-// After finding a user, we just want a confirmation message.
-Kind<Optional.Witness, String> successMessage = monad.as("User found successfully", findUser(1));
-
+Kind<Optional.Witness, String> message = monad.as("User found successfully", findUser(1));
 // Result: Optional["User found successfully"]
-System.out.println(OPTIONAL.narrow(successMessage));
 
-// If the user isn't found, the effect (empty Optional) is preserved.
-Kind<Optional.Witness, String> failureMessage = monad.as("User found successfully", findUser(99));
-
-// Result: Optional.empty
-System.out.println(OPTIONAL.narrow(failureMessage));
+Kind<Optional.Witness, String> missing = monad.as("User found successfully", findUser(99));
+// Result: Optional.empty (effect preserved, value irrelevant)
 ```
 
 ### `peek`
 
-Allows you to perform a side-effect (like logging) on the value inside a monad without altering the flow. The original monadic value is always returned.
+**The problem:** You need to log or inspect a value mid-chain without altering the flow.
+
+**The solution:** `peek` performs a side-effect on the value and returns the original monadic value unchanged.
 
 ```java
-// Log the user's name if they are found
-Kind<Optional.Witness, User> peekSuccess = monad.peek(
+Kind<Optional.Witness, User> logged = monad.peek(
     user -> System.out.println("LOG: Found user -> " + user.name()),
     findUser(1)
 );
-// Console output: LOG: Found user -> Alice
-// Result: Optional[User[id=1, name=Alice]] (The original value is unchanged)
-System.out.println("Return value: " + OPTIONAL.narrow(peekSuccess));
+// Console: LOG: Found user -> Alice
+// Result: Optional[User[id=1, name=Alice]] (unchanged)
 
-
-// If the user isn't found, the action is never executed.
-Kind<Optional.Witness, User> peekFailure = monad.peek(
+Kind<Optional.Witness, User> notFound = monad.peek(
     user -> System.out.println("LOG: Found user -> " + user.name()),
     findUser(99)
 );
-// Console output: (nothing)
+// Console: (nothing; the action is never executed)
 // Result: Optional.empty
-System.out.println("Return value: " + OPTIONAL.narrow(peekFailure));
 ```
 
 ---
 
-## Combining Multiple Monadic Values: `flatMapN` 🔄
+## Combining Multiple Monadic Values: `flatMapN`
 
 Just as `Applicative` provides `map2`, `map3`, etc. for combining independent computations with a pure function, `Monad` provides `flatMap2`, `flatMap3`, `flatMap4`, and `flatMap5` for combining multiple monadic values where the combining function itself returns a monadic value.
 
-These methods are perfect when you need to:
-- Sequence multiple independent computations and then perform a final effectful operation
-- Validate multiple pieces of data together with an operation that may fail
-- Combine results from multiple sources with additional logic that may produce effects
-
 ### `flatMap2`
 
-Combines two monadic values and applies a function that returns a new monadic value.
+**The problem:** You need to fetch data from two sources and then perform an effectful validation that might fail.
 
-**Example: Validating and Combining Two Database Results**
+**The solution:**
 
 ```java
-import java.util.Optional;
-import org.higherkindedj.hkt.Kind;
-import org.higherkindedj.hkt.Monad;
-import org.higherkindedj.hkt.optional.OptionalMonad;
-import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
-
 record User(int id, String name) {}
 record Order(int userId, String item) {}
 record UserOrder(User user, Order order) {}
 
-// Mock repository functions
 public Kind<Optional.Witness, User> findUser(int id) { /* ... */ }
 public Kind<Optional.Witness, Order> findOrder(int orderId) { /* ... */ }
 
-// Validation function that might fail
 public Kind<Optional.Witness, UserOrder> validateAndCombine(User user, Order order) {
     if (order.userId() != user.id()) {
-        return OPTIONAL.widen(Optional.empty()); // Validation failed
+        return OPTIONAL.widen(Optional.empty());
     }
     return OPTIONAL.widen(Optional.of(new UserOrder(user, order)));
 }
 
 Monad<Optional.Witness> monad = OptionalMonad.INSTANCE;
 
-// Combine user and order, then validate
 Kind<Optional.Witness, UserOrder> result = monad.flatMap2(
     findUser(1),
     findOrder(100),
     (user, order) -> validateAndCombine(user, order)
 );
-
 // Result: Optional[UserOrder[...]] if valid, Optional.empty if any step fails
-System.out.println(OPTIONAL.narrow(result));
 ```
 
 ### `flatMap3` and Higher Arities
@@ -293,14 +269,13 @@ record Inventory(int productId, int quantity) {}
 public Kind<Optional.Witness, Product> findProduct(int id) { /* ... */ }
 public Kind<Optional.Witness, Inventory> checkInventory(int productId) { /* ... */ }
 
-// Process an order with user, product, and inventory check
 Kind<Optional.Witness, String> orderResult = monad.flatMap3(
     findUser(1),
     findProduct(100),
     checkInventory(100),
     (user, product, inventory) -> {
         if (inventory.quantity() <= 0) {
-            return OPTIONAL.widen(Optional.empty()); // Out of stock
+            return OPTIONAL.widen(Optional.empty());
         }
         String confirmation = String.format(
             "Order confirmed for %s: %s (qty: %d)",
@@ -313,41 +288,47 @@ Kind<Optional.Witness, String> orderResult = monad.flatMap3(
 
 ### `flatMapN` vs `mapN`
 
-The key difference between `flatMapN` and `mapN` is:
-
-- **`mapN`** (from Applicative): The combining function returns a **pure value** (`(A, B) -> C`)
-- **`flatMapN`** (from Monad): The combining function returns a **monadic value** (`(A, B) -> Kind<M, C>`)
-
-This makes `flatMapN` methods ideal when the combination of values needs to perform additional effects, such as:
-- Additional validation that might fail
-- Database lookups based on combined criteria
-- Computations that may produce side effects
-- Operations that need to maintain monadic context
+| Method | From | Combining Function Returns | Use When |
+|--------|------|----------------------------|----------|
+| `mapN` | Applicative | A pure value: `(A, B) -> C` | Combination is guaranteed to succeed |
+| `flatMapN` | Monad | A monadic value: `(A, B) -> Kind<M, C>` | Combination itself may fail or produce effects |
 
 ```java
-// mapN: Pure combination
-Kind<Optional.Witness, String> mapResult = monad.map2(
+// mapN: Pure combination (cannot fail)
+Kind<Optional.Witness, String> pure = monad.map2(
     findUser(1),
     findOrder(100),
-    (user, order) -> user.name() + " ordered " + order.item() // Pure function
+    (user, order) -> user.name() + " ordered " + order.item()
 );
 
-// flatMapN: Effectful combination
-Kind<Optional.Witness, String> flatMapResult = monad.flatMap2(
+// flatMapN: Effectful combination (may fail)
+Kind<Optional.Witness, String> effectful = monad.flatMap2(
     findUser(1),
     findOrder(100),
-    (user, order) -> validateAndProcess(user, order) // Returns Optional
+    (user, order) -> validateAndProcess(user, order)
 );
 ```
 
-This pattern is especially powerful when combined with error-handling monads like `Either` or `Try`, where the combining function can itself fail with a meaningful error.
-
 ---
+
+~~~admonish info title="Key Takeaways"
+* **`flatMap` is the core operation** that enables sequencing dependent computations
+* **Short-circuiting** happens automatically; if any step fails, the chain stops
+* **Utility methods** (`as`, `peek`, `flatMapIfOrElse`) cover common patterns without manual lambda wrangling
+* **`flatMapN` methods** combine multiple monadic values when the combining function itself produces effects
+* **Choose the least powerful abstraction** that fits your problem; see [Choosing Your Abstraction Level](abstraction_levels.md) for guidance
+~~~
+
+~~~admonish tip title="See Also"
+- [Applicative](applicative.md) - For combining independent computations
+- [For Comprehension](for_comprehension.md) - Readable syntax for `flatMap` chains
+- [Choosing Your Abstraction Level](abstraction_levels.md) - When to use Applicative vs Selective vs Monad
+~~~
 
 ~~~admonish tip title="Further Reading"
 - **Scott Logic**: [Functors and Monads with Java and Scala](https://blog.scottlogic.com/2025/03/31/functors-monads-with-java-and-scala.html) - Practical guide to functors and monads in Java
 - **Bartosz Milewski**: [Monads: Programmer's Definition](https://bartoszmilewski.com/2016/11/21/monads-programmers-definition/) - Practical explanation of monads for programmers
-- **Cats Documentation**: [Monad](https://typelevel.org/cats/typeclasses/monad.html) - Scala implementation and examples
+- **Mark Seemann**: [Monads for the Rest of Us](https://blog.ploeh.dk/2022/03/28/monads/) - Step-by-step monad explanation with Java-style examples
 ~~~
 
 ~~~admonish info title="Hands-On Learning"

--- a/hkj-book/src/functional/monad_error.md
+++ b/hkj-book/src/functional/monad_error.md
@@ -1,36 +1,128 @@
 # MonadError: Handling Errors Gracefully
 
+> *"The test of a first-rate intelligence is the ability to hold two opposed ideas in mind at the same time."*
+>
+> -- F. Scott Fitzgerald, *The Crack-Up*
+
+A resilient workflow must hold two paths in mind simultaneously: the path where everything succeeds, and the path where things go wrong. `MonadError` gives you the tools to express both cleanly.
+
 ~~~admonish info title="What You'll Learn"
 - How MonadError extends Monad with explicit error handling capabilities
 - Using `raiseError` to create failed computations
 - Recovering from errors with `handleErrorWith` and `handleError`
+- Building multi-step workflows with typed errors and layered recovery
 - Writing generic, resilient code that works with any error-capable monad
-- Practical examples with Either and Try
 ~~~
 
-~~~admonish title="Hands On Practice"
+~~~admonish example title="Hands-On Practice"
 [Tutorial05_MonadErrorHandling.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial05_MonadErrorHandling.java)
 ~~~
 
-While a `Monad` is excellent for sequencing operations that might fail (like with `Optional` or `Either`), it doesn't provide a standardised way to *inspect* or *recover* from those failures. The **`MonadError`** type class fills this gap.
+## The Problem: Scattered Try-Catch Blocks
 
-It's a specialised `Monad` that has a defined error type `E`, giving you a powerful and abstract API for raising and handling errors within any monadic workflow.
+Consider a configuration loading workflow: parse a file, validate settings, then connect to a database. Each step can fail with a meaningful error, and you want to handle each failure differently. With imperative Java, you end up with scattered, nested try-catch blocks:
+
+```java
+// Imperative error handling: scattered and hard to compose
+try {
+    Config config = parseConfigFile(path);
+    try {
+        Settings settings = validateSettings(config);
+        try {
+            Connection conn = connectToDatabase(settings);
+            return conn;
+        } catch (DbException e) {
+            return connectToFallbackDb(settings); // recovery
+        }
+    } catch (ValidationException e) {
+        log.error("Bad config: " + e.getMessage());
+        throw e; // no recovery possible
+    }
+} catch (ParseException e) {
+    return loadDefaultConfig(); // fallback to defaults
+}
+```
+
+The error handling logic is tangled with the business logic. Recovery strategies are buried inside catch blocks. And composing or reusing this code is painful.
 
 ---
 
-## What is it?
+## The Solution: `raiseError` and `handleErrorWith`
 
-A **`MonadError`** is a `Monad` that provides two additional, fundamental operations for working with failures:
+**`MonadError`** extends `Monad` with two fundamental operations that formalise the "try-catch" pattern in a purely functional way:
 
-1. **`raiseError(E error)`**: This allows you to construct a failed computation by lifting an error value `E` directly into the monadic context.
-2. **`handleErrorWith(Kind<F, A> fa, ...)`**: This is the recovery mechanism. It allows you to inspect a potential failure and provide a fallback computation to rescue the workflow.
+1. **`raiseError(E error)`** -- Constructs a failed computation by lifting an error into the monadic context.
+2. **`handleErrorWith(fa, handler)`** -- Inspects a potential failure and provides a fallback computation.
 
-By abstracting over a specific error type `E`, `MonadError` allows you to write generic, resilient code that can work with any data structure capable of representing failure, such as `Either<E, A>`, `Try<A>` (where `E` is `Throwable`), or even custom error-handling monads.
+```
+  raiseError("config not found")
+       |
+       v
+  Kind<F, A> = Left("config not found")
+       |
+       +-- handleErrorWith --> recovery function --> Kind<F, A> = Right(defaults)
+       |
+       +-- (if no handler) --> propagates as Left("config not found")
+```
 
-The interface for `MonadError` in `hkj-api` extends `Monad`:
+Here is the same configuration workflow, rewritten with `MonadError` using `Either<String, A>`:
 
+```java
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherMonad;
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 
-``` java
+MonadError<Either.Witness<String>, String> me = EitherMonad.instance();
+
+// Each step returns Either<String, T>, using raiseError for failures
+public Kind<Either.Witness<String>, Config> parseConfig(String path) {
+    if (!Files.exists(Path.of(path))) {
+        return me.raiseError("Config file not found: " + path);
+    }
+    return me.of(Config.parse(path));
+}
+
+public Kind<Either.Witness<String>, Settings> validate(Config config) {
+    if (config.dbHost().isBlank()) {
+        return me.raiseError("Missing required setting: db.host");
+    }
+    return me.of(Settings.from(config));
+}
+
+public Kind<Either.Witness<String>, Connection> connect(Settings settings) {
+    if (!settings.isReachable()) {
+        return me.raiseError("Cannot reach database: " + settings.dbHost());
+    }
+    return me.of(Connection.open(settings));
+}
+
+// Compose the workflow with flatMap, then layer recovery on top
+Kind<Either.Witness<String>, Connection> workflow =
+    me.flatMap(config ->
+        me.flatMap(settings ->
+            connect(settings),
+            validate(config)),
+        parseConfig("/etc/app.conf"));
+
+// Recover from connection failures by trying a fallback database
+Kind<Either.Witness<String>, Connection> resilient = me.handleErrorWith(
+    workflow,
+    error -> {
+        if (error.startsWith("Cannot reach database")) {
+            return connect(Settings.fallback());
+        }
+        return me.raiseError(error); // re-raise other errors
+    }
+);
+```
+
+The business logic reads top-to-bottom. Recovery strategies are layered on separately, and the whole thing composes cleanly.
+
+---
+
+~~~admonish note title="Interface Signature"
+```java
 @NullMarked
 public interface MonadError<F extends WitnessArity<TypeArity.Unary>, E> extends Monad<F> {
 
@@ -40,7 +132,7 @@ public interface MonadError<F extends WitnessArity<TypeArity.Unary>, E> extends 
       final Kind<F, A> ma,
       final Function<? super E, ? extends Kind<F, A>> handler);
 
-  // Default recovery methods like handleError, recover, etc. are also provided
+  // Value-level recovery (unwraps the error into a plain value)
   default <A> @NonNull Kind<F, A> handleError(
       final Kind<F, A> ma,
       final Function<? super E, ? extends A> handler) {
@@ -48,71 +140,89 @@ public interface MonadError<F extends WitnessArity<TypeArity.Unary>, E> extends 
   }
 }
 ```
+~~~
 
 ---
 
-### Why is it useful?
+## Recovery Patterns
 
-`MonadError` formalises the pattern of "try-catch" in a purely functional way. It lets you build complex workflows that need to handle specific types of errors without coupling your logic to a concrete implementation like `Either` or `Try`. You can write a function once, and it will work seamlessly with any data type that has a `MonadError` instance.
+### Value-Level Recovery with `handleError`
 
-This is incredibly useful for building robust applications, separating business logic from error-handling logic, and providing sensible fallbacks when operations fail.
+**The problem:** An operation might fail, but you have a sensible default value.
 
-**Example: A Resilient Division Workflow**
+**The solution:** `handleError` unwraps the error and maps it to a plain value, automatically lifting the result back into the monadic context.
 
-Let's model a division operation that can fail with a specific error message. We'll use `Either<String, A>` as our data type, which is a perfect fit for `MonadError`.
+```java
+MonadError<Either.Witness<String>, String> me = EitherMonad.instance();
 
-
-``` java
-import org.higherkindedj.hkt.Kind;
-import org.higherkindedj.hkt.either.Either;
-import org.higherkindedj.hkt.either.EitherMonad;
-import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
-
-// --- Get the MonadError instance for Either<String, ?> ---
-MonadError<Either.Witness<String>, String> monadError = EitherMonad.instance();
-
-// A function that performs division, raising a specific error on failure
-public Kind<Either.Witness<String>, Integer> safeDivide(int a, int b) {
-    if (b == 0) {
-        return monadError.raiseError("Cannot divide by zero!");
-    }
-    return monadError.of(a / b);
+Kind<Either.Witness<String>, Integer> safeDivide(int a, int b) {
+    return b == 0
+        ? me.raiseError("Cannot divide by zero")
+        : me.of(a / b);
 }
 
-// --- Scenario 1: A successful division ---
-Kind<Either.Witness<String>, Integer> success = safeDivide(10, 2);
-
-// Result: Right(5)
-System.out.println(EITHER.narrow(success));
-
-
-// --- Scenario 2: A failed division ---
-Kind<Either.Witness<String>, Integer> failure = safeDivide(10, 0);
-
-// Result: Left(Cannot divide by zero!)
-System.out.println(EITHER.narrow(failure));
-
-
-// --- Scenario 3: Recovering from the failure ---
-// We can use handleErrorWith to catch the error and return a fallback value.
-Kind<Either.Witness<String>, Integer> recovered = monadError.handleErrorWith(
-    failure,
-    errorMessage -> {
-        System.out.println("Caught an error: " + errorMessage);
-        return monadError.of(0); // Recover with a default value of 0
-    }
+// Value-level recovery: error -> default value
+Kind<Either.Witness<String>, Integer> result = me.handleError(
+    safeDivide(10, 0),
+    error -> 0  // plain value, not wrapped in Either
 );
-
 // Result: Right(0)
-System.out.println(EITHER.narrow(recovered));
 ```
 
-In this example, `raiseError` allows us to create the failure case in a clean, declarative way, while `handleErrorWith` provides a powerful mechanism for recovery, making our code more resilient and predictable.
+### Effect-Level Recovery with `handleErrorWith`
+
+**The problem:** Recovery itself might fail (e.g., trying a fallback service that could also be unavailable).
+
+**The solution:** `handleErrorWith` lets the recovery function return a new monadic value, which can be either a success or another failure.
+
+```java
+// Effect-level recovery: error -> new monadic computation
+Kind<Either.Witness<String>, Integer> result = me.handleErrorWith(
+    safeDivide(10, 0),
+    error -> {
+        log.warn("Division failed: " + error + ", trying alternative");
+        return safeDivide(10, 2); // fallback computation that could also fail
+    }
+);
+// Result: Right(5)
+```
+
+### Chained Recovery
+
+**The problem:** You have multiple fallback strategies, each of which might fail.
+
+**The solution:** Chain `handleErrorWith` calls to try each fallback in order.
+
+```java
+Kind<Either.Witness<String>, Config> config =
+    me.handleErrorWith(
+        me.handleErrorWith(
+            loadConfigFromFile(),
+            err1 -> loadConfigFromEnv()),
+        err2 -> me.of(Config.defaults())
+    );
+// Tries file first, then environment, then defaults
+```
 
 ---
 
+~~~admonish info title="Key Takeaways"
+* **`raiseError`** creates a failed computation declaratively, without throwing exceptions
+* **`handleErrorWith`** provides effect-level recovery where the fallback can itself fail
+* **`handleError`** provides value-level recovery with a plain default value
+* **Recovery composes** by chaining handlers; each layer catches what the previous one missed
+* **Generic code** written against `MonadError<F, E>` works with `Either`, `Try`, or any error-capable monad
+~~~
+
+~~~admonish tip title="See Also"
+- [Monad](monad.md) - The base type class that MonadError extends
+- [Either](../monads/either_monad.md) - The most common MonadError instance for typed errors
+- [Try](../monads/try_monad.md) - MonadError specialised for `Throwable` errors
+~~~
+
 ~~~admonish tip title="Further Reading"
-- **Cats Documentation**: [ApplicativeError](https://typelevel.org/cats/typeclasses/applicativeerror.html) - The foundation that MonadError builds upon
+- **Baeldung**: [Functional Error Handling in Java](https://www.baeldung.com/java-functional-programming) - Practical guide to functional patterns in Java
+- **Mark Seemann**: [An Either Functor](https://blog.ploeh.dk/2019/01/07/either-bifunctor/) - Step-by-step introduction to Either as a functional error-handling tool
 ~~~
 
 ~~~admonish info title="Hands-On Learning"

--- a/hkj-book/src/functional/natural_transformation.md
+++ b/hkj-book/src/functional/natural_transformation.md
@@ -10,7 +10,7 @@
 - Converting between types like Maybe, List, and Either
 ~~~
 
-~~~admonish title="Hands On Practice"
+~~~admonish example title="Hands-On Practice"
 [Tutorial08_NaturalTransformation.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial08_NaturalTransformation.java)
 ~~~
 
@@ -291,8 +291,7 @@ They are a fundamental building block in functional programming, particularly wh
 
 ~~~admonish tip title="Further Reading"
 - **Bartosz Milewski**: [Natural Transformations](https://bartoszmilewski.com/2015/04/07/natural-transformations/) - Accessible introduction with diagrams
-- **Cats Documentation**: [FunctionK](https://typelevel.org/cats/datatypes/functionk.html) - Scala's equivalent (called `~>` or `FunctionK`)
-- **Functional Programming in Scala**: Chapter 11 covers natural transformations in the context of Free monads
+- **Mojang/DataFixerUpper**: [DFU on GitHub](https://github.com/Mojang/DataFixerUpper) - Minecraft's Java library where natural transformations drive data version migration
 ~~~
 
 ~~~admonish info title="Hands-On Learning"

--- a/hkj-book/src/functional/selective.md
+++ b/hkj-book/src/functional/selective.md
@@ -346,8 +346,8 @@ Higher-Kinded-J provides Selective instances for:
 ~~~
 
 ~~~admonish tip title="Further Reading"
-- **Selective Applicative Functors**: [Original Paper](https://dl.acm.org/doi/10.1145/3341694) - The academic paper introducing Selective functors
-- **Haskell Selective Library**: [Hackage](https://hackage.haskell.org/package/selective) - Reference implementation with additional examples
+- **Andrey Mokhov et al.**: [Selective Applicative Functors](https://dl.acm.org/doi/10.1145/3341694) - The academic paper introducing Selective functors
+- **Togglz**: [Feature Flags for Java](https://www.togglz.org/) - A Java feature flag library that addresses the same conditional-execution problem Selective solves at the type level
 ~~~
 
 ---

--- a/hkj-book/src/functional/semigroup_and_monoid.md
+++ b/hkj-book/src/functional/semigroup_and_monoid.md
@@ -128,7 +128,7 @@ Monoid<Boolean> booleanAnd = Monoids.booleanAnd();
 
 A `Monoid` is essential for **folding** (or reducing) a data structure. The `empty` element provides a safe starting value, which means you can correctly fold a collection that might be empty.
 
-This is formalised in the **`Foldable`** typeclass, which has a `foldMap` method. This method maps every element in a structure to a monoidal type and then combines all the results.
+This is formalised in the **`Foldable`** type class, which has a `foldMap` method. This method maps every element in a structure to a monoidal type and then combines all the results.
 
 **Example: Using `foldMap` with different Monoids**
 
@@ -501,16 +501,13 @@ This makes them perfect for aggregation pipelines where you're not certain data 
 
 ---
 
-## **Conclusion**
-
-Semigroups and Monoids are deceptively simple abstractions that unlock powerful patterns for data combination and aggregation. By understanding these type classes, you gain:
-
-- **Composability**: Build complex aggregations from simple, reusable pieces
-- **Type Safety**: Let the compiler ensure your combinations are valid
-- **Flexibility**: Swap monoids to get different behaviours from the same code
-- **Elegance**: Express data aggregation intent clearly and concisely
-
-The new utility methods (`combineAll`, `combineN`, `isEmpty`) and expanded instance library (numeric types, Optional-based aggregations) make these abstractions even more practical for everyday Java development.
+~~~admonish info title="Key Takeaways"
+* **Semigroup provides `combine`** for associatively merging two values of the same type
+* **Monoid adds `empty`** (the identity element), enabling safe folds over potentially empty collections
+* **Swap the Monoid, change the behaviour**: addition, multiplication, concatenation, min/max, all from the same operation
+* **Error accumulation** in `Validated` is powered by Semigroup; it tells the Applicative how to merge errors
+* **Utility methods** (`combineAll`, `combineN`, `isEmpty`) and Optional-based monoids (`firstOptional`, `maximum`, etc.) cover common aggregation patterns
+~~~
 
 ---
 

--- a/hkj-book/src/glossary.md
+++ b/hkj-book/src/glossary.md
@@ -2288,3 +2288,5 @@ Resource<Lock> lock = Resource.make(
 
 ---
 
+**Previous:** [More Functional Thinking](reading.md)
+**Next:** [Release History](release-history.md)

--- a/hkj-book/src/monads/const_type.md
+++ b/hkj-book/src/monads/const_type.md
@@ -366,3 +366,4 @@ Understanding `Const` empowers you to write efficient, compositional code for da
 ---
 
 **Previous:** [Writer](writer_monad.md)
+**Next:** [More Functional Thinking](../reading.md)

--- a/hkj-book/src/monads/reader_monad.md
+++ b/hkj-book/src/monads/reader_monad.md
@@ -281,4 +281,4 @@ For deeper exploration of the Reader monad and dependency injection patterns:
 ---
 
 **Previous:** [Optional](optional_monad.md)
-**Next:** [State](state_monad.md)
+**Next:** [Context](context_scoped.md)

--- a/hkj-book/src/monads/state_monad.md
+++ b/hkj-book/src/monads/state_monad.md
@@ -377,5 +377,5 @@ For deeper exploration of the State monad and its applications:
 
 ---
 
-**Previous:** [Reader](reader_monad.md)
+**Previous:** [Context](context_scoped.md)
 **Next:** [Stream](stream_monad.md)

--- a/hkj-book/src/monads/validated_monad.md
+++ b/hkj-book/src/monads/validated_monad.md
@@ -357,4 +357,4 @@ See [Effect Path Overview](../effect/effect_path_overview.md) for the complete g
 ---
 
 **Previous:** [Try](try_monad.md)
-**Next:** [Writer](writer_monad.md)
+**Next:** [VTask](vtask_monad.md)

--- a/hkj-book/src/optics/advanced_prism_patterns.md
+++ b/hkj-book/src/optics/advanced_prism_patterns.md
@@ -977,5 +977,5 @@ Practice advanced prism patterns in [Tutorial 10: Advanced Prism Patterns](https
 
 ---
 
-**Previous:** [Prisms: A Practical Guide](prisms.md)
-**Next:** [Isomorphisms: Data Equivalence](iso.md)
+**Previous:** [Indexed Access](indexed_access.md)
+**Next:** [Profunctor Optics](profunctor_optics.md)

--- a/hkj-book/src/optics/ch3_intro.md
+++ b/hkj-book/src/optics/ch3_intro.md
@@ -88,4 +88,5 @@ When position matters:
 
 ---
 
+**Previous:** [List Decomposition](list_decomposition.md)
 **Next:** [Filtered Optics](filtered_optics.md)

--- a/hkj-book/src/optics/ch4_intro.md
+++ b/hkj-book/src/optics/ch4_intro.md
@@ -167,4 +167,5 @@ Same program, different execution strategies.
 
 ---
 
+**Previous:** [Profunctor Optics](profunctor_optics.md)
 **Next:** [Focus DSL](focus_dsl.md)

--- a/hkj-book/src/optics/ch5_intro.md
+++ b/hkj-book/src/optics/ch5_intro.md
@@ -130,4 +130,5 @@ See also [Capstone: Effects Meet Optics](../effect/capstone_focus_effect.md) for
 
 ---
 
+**Previous:** [Interpreters](interpreters.md)
 **Next:** [Composing Optics](composing_optics.md)

--- a/hkj-book/src/optics/common_data_structure_traversals.md
+++ b/hkj-book/src/optics/common_data_structure_traversals.md
@@ -557,5 +557,5 @@ By incorporating structure traversals into your optics toolkit, you gain the abi
 
 ---
 
-**Previous:** [String Traversals: Declarative Text Processing](string_traversals.md)
-**Next:** [Indexed Optics: Position-Aware Operations](indexed_optics.md)
+**Previous:** [Setters: Composable Write-Only Modifications](setters.md)
+**Next:** [Limiting Traversals](limiting_traversals.md)

--- a/hkj-book/src/optics/composing_optics.md
+++ b/hkj-book/src/optics/composing_optics.md
@@ -827,5 +827,5 @@ Practice optic composition in [Tutorial 06: Optics Composition](https://github.c
 
 ---
 
-**Previous:** [Profunctor Optics: Advanced Data Transformation](profunctor_optics.md)
+**Previous:** [Integration and Recipes](ch5_intro.md)
 **Next:** [Core Type Integration](core_type_integration.md)

--- a/hkj-book/src/optics/cookbook.md
+++ b/hkj-book/src/optics/cookbook.md
@@ -752,5 +752,5 @@ Practice real-world optics patterns in [Tutorial 08: Real World Optics](https://
 
 ---
 
-**Previous:** [Composition Rules](composition_rules.md)
+**Previous:** [Optics Extensions](optics_extensions.md)
 **Next:** [Auditing Complex Data](auditing_complex_data_example.md)

--- a/hkj-book/src/optics/core_type_integration.md
+++ b/hkj-book/src/optics/core_type_integration.md
@@ -409,4 +409,5 @@ Core Type Integration provides:
 
 ---
 
+**Previous:** [Composing Optics](composing_optics.md)
 **Next:** [Optics Extensions](optics_extensions.md)

--- a/hkj-book/src/optics/filtered_optics.md
+++ b/hkj-book/src/optics/filtered_optics.md
@@ -692,5 +692,5 @@ Filtered optics represent the pinnacle of declarative data manipulation in Java:
 
 ---
 
-**Previous:** [Folds: Querying Immutable Data](folds.md)
+**Previous:** [Precision and Filtering](ch3_intro.md)
 **Next:** [Indexed Optics: Position-Aware Operations](indexed_optics.md)

--- a/hkj-book/src/optics/focus_dsl.md
+++ b/hkj-book/src/optics/focus_dsl.md
@@ -1491,4 +1491,4 @@ Practice the Focus DSL in [Tutorial 12: Focus DSL](https://github.com/higher-kin
 ---
 
 **Previous:** [Introduction](ch4_intro.md)
-**Next:** [Kind Field Support](kind_field_support.md)
+**Next:** [Optics for External Types](importing_optics.md)

--- a/hkj-book/src/optics/folds.md
+++ b/hkj-book/src/optics/folds.md
@@ -1238,4 +1238,4 @@ The key insight: **Folds make queries first-class citizens in your codebase**, j
 ---
 
 **Previous:** [Traversals: Handling Bulk Updates](traversals.md)
-**Next:** [Filtered Optics: Predicate-Based Composition](filtered_optics.md)
+**Next:** [Getters: Composable Read-Only Access](getters.md)

--- a/hkj-book/src/optics/getters.md
+++ b/hkj-book/src/optics/getters.md
@@ -929,5 +929,5 @@ The key insight: **Getters make pure functions first-class composable citizens**
 
 ---
 
-**Previous:** [Indexed Optics: Position-Aware Operations](indexed_optics.md)
+**Previous:** [Folds: Querying Immutable Data](folds.md)
 **Next:** [Setters: Composable Write-Only Modifications](setters.md)

--- a/hkj-book/src/optics/importing_optics.md
+++ b/hkj-book/src/optics/importing_optics.md
@@ -376,4 +376,5 @@ Consider these opportunities to enhance your Higher-Kinded-J integration:
 
 ---
 
+**Previous:** [Focus DSL](focus_dsl.md)
 **Next:** [Taming JSON with Jackson](optics_spec_interfaces.md)

--- a/hkj-book/src/optics/interpreters.md
+++ b/hkj-book/src/optics/interpreters.md
@@ -741,3 +741,4 @@ try {
 ---
 
 **Previous:** [Free Monad DSL](free_monad_dsl.md)
+**Next:** [Integration and Recipes](ch5_intro.md)

--- a/hkj-book/src/optics/kind_field_support.md
+++ b/hkj-book/src/optics/kind_field_support.md
@@ -349,5 +349,5 @@ To enable automatic traversal for unknown types, add `@TraverseField` with the a
 
 ---
 
-**Previous:** [Focus DSL](focus_dsl.md)
+**Previous:** [Focus DSL with External Libraries](focus_external_bridging.md)
 **Next:** [Fluent API](fluent_api.md)

--- a/hkj-book/src/optics/list_decomposition.md
+++ b/hkj-book/src/optics/list_decomposition.md
@@ -387,4 +387,4 @@ Practice list decomposition patterns in [Tutorial 15: List Prisms](https://githu
 ---
 
 **Previous:** [Limiting Traversals](limiting_traversals.md)
-**Next:** [Filtered Optics](../optics/filtered_optics.md)
+**Next:** [Precision and Filtering](ch3_intro.md)

--- a/hkj-book/src/optics/profunctor_optics.md
+++ b/hkj-book/src/optics/profunctor_optics.md
@@ -735,6 +735,6 @@ This profunctor capability makes higher-kinded-j optics incredibly flexible and 
 
 ---
 
-**Previous:** [Setters: Composable Write-Only Modifications](setters.md)
-**Next:** [Capstone Example: Deep Validation](composing_optics.md)
+**Previous:** [Advanced Prism Patterns](advanced_prism_patterns.md)
+**Next:** [Java-Friendly APIs](ch4_intro.md)
 

--- a/hkj-book/src/optics/setters.md
+++ b/hkj-book/src/optics/setters.md
@@ -774,4 +774,4 @@ The key insight: **Setters make modifications first-class composable operations*
 ---
 
 **Previous:** [Getters: Composable Read-Only Access](getters.md)
-**Next:** [Profunctor Optics: Advanced Data Transformation](profunctor_optics.md)
+**Next:** [Common Data Structures](common_data_structure_traversals.md)

--- a/hkj-book/src/optics/traversals.md
+++ b/hkj-book/src/optics/traversals.md
@@ -849,5 +849,5 @@ Practice traversal basics in [Tutorial 05: Traversal Basics](https://github.com/
 
 ---
 
-**Previous:** [Isomorphisms: Data Equivalence](iso.md)
+**Previous:** [Introduction to Collection Optics](ch2_intro.md)
 **Next:** [Folds: Querying Immutable Data](folds.md)

--- a/hkj-book/src/reading.md
+++ b/hkj-book/src/reading.md
@@ -27,3 +27,8 @@ In this post, we will see how Higher Kinded Types can help increase the flexibil
 - [Recursion, Thunks and Trampolines with Java and Scala](https://blog.scottlogic.com/2025/05/02/recursion-thunks-trampolines-with-java-and-scala.html)
 
 In this post, we will see how Thunks and Trampolines can help solve problems by converting deep stack-based recursion into heap-based iteration, helping to prevent StackOverflowErrors.
+
+---
+
+**Previous:** [Const](monads/const_type.md)
+**Next:** [Glossary](glossary.md)

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -225,3 +225,8 @@ Major release introducing the unified Effect Path API and Focus DSL integration.
 - [GitHub Releases](https://github.com/higher-kinded-j/higher-kinded-j/releases) -- Full changelogs and assets
 - [Contributing](CONTRIBUTING.md) -- How to contribute to Higher-Kinded-J
 ~~~
+
+---
+
+**Previous:** [Glossary](glossary.md)
+**Next:** [Benchmarks & Performance](benchmarks.md)

--- a/hkj-book/src/tutorials/concurrency/scope_resource_journey.md
+++ b/hkj-book/src/tutorials/concurrency/scope_resource_journey.md
@@ -327,4 +327,7 @@ After completing this journey:
 
 ---
 
+**Previous:** [Concurrency: VTask](vtask_journey.md)
+**Next:** [Optics: Lens & Prism](../optics/lens_prism_journey.md)
+
 **Related**: [VTask Journey](vtask_journey.md) | [Structured Concurrency](../../monads/vtask_scope.md) | [Resource Management](../../monads/vtask_resource.md) | [VTaskPath](../../effect/path_vtask.md)

--- a/hkj-book/src/tutorials/concurrency/vtask_journey.md
+++ b/hkj-book/src/tutorials/concurrency/vtask_journey.md
@@ -263,4 +263,7 @@ After completing this journey:
 
 ---
 
+**Previous:** [Effect API](../effect/effect_journey.md)
+**Next:** [Scope & Resource](scope_resource_journey.md)
+
 **Related**: [VTask Guide](../../monads/vtask_monad.md) | [VTaskPath Guide](../../effect/path_vtask.md) | [Monad Guide](../../functional/monad.md) | [Effect Path Overview](../../effect/effect_path_overview.md)

--- a/hkj-book/src/tutorials/coretypes/advanced_journey.md
+++ b/hkj-book/src/tutorials/coretypes/advanced_journey.md
@@ -213,5 +213,5 @@ Congratulations! You've completed the Core Types track. You now understand:
 
 ---
 
-**Previous**: [Core Types: Error Handling](error_handling_journey.md)
-**Next**: [Effect API Journey](../effect/effect_journey.md)
+**Previous:** [Core Types: Error Handling](error_handling_journey.md)
+**Next:** [Effect API](../effect/effect_journey.md)

--- a/hkj-book/src/tutorials/coretypes/error_handling_journey.md
+++ b/hkj-book/src/tutorials/coretypes/error_handling_journey.md
@@ -146,5 +146,5 @@ After completing this journey:
 
 ---
 
-**Previous**: [Core Types: Foundations](foundations_journey.md)
-**Next Journey**: [Core Types: Advanced Patterns](advanced_journey.md)
+**Previous:** [Core Types: Foundations](foundations_journey.md)
+**Next:** [Core Types: Advanced Patterns](advanced_journey.md)

--- a/hkj-book/src/tutorials/coretypes/foundations_journey.md
+++ b/hkj-book/src/tutorials/coretypes/foundations_journey.md
@@ -147,4 +147,5 @@ After completing this journey:
 
 ---
 
-**Next Journey**: [Core Types: Error Handling](error_handling_journey.md)
+**Previous:** [Interactive Tutorials](../tutorials_intro.md)
+**Next:** [Core Types: Error Handling](error_handling_journey.md)

--- a/hkj-book/src/tutorials/effect/effect_journey.md
+++ b/hkj-book/src/tutorials/effect/effect_journey.md
@@ -146,5 +146,5 @@ After completing the Effect API journey:
 
 ---
 
-**Previous**: [Learning Paths](../learning_paths.md)
-**Next**: [Core Types: Foundations](../coretypes/foundations_journey.md)
+**Previous:** [Core Types: Advanced](../coretypes/advanced_journey.md)
+**Next:** [Concurrency: VTask](../concurrency/vtask_journey.md)

--- a/hkj-book/src/tutorials/expression/forstate_journey.md
+++ b/hkj-book/src/tutorials/expression/forstate_journey.md
@@ -67,3 +67,8 @@ Master the complete ForState API through progressive exercises, including the `t
 | 9a | Basic `toState()` bridge from For | Intermediate |
 | 9b | Multi-value `toState()` with spread-style | Intermediate |
 | 9c | Filterable `toState()` with MonadZero guards | Advanced |
+
+---
+
+**Previous:** [Optics: Focus DSL](../optics/focus_dsl_journey.md)
+**Next:** [Learning Paths](../learning_paths.md)

--- a/hkj-book/src/tutorials/learning_paths.md
+++ b/hkj-book/src/tutorials/learning_paths.md
@@ -169,5 +169,5 @@ Focus: Master virtual threads, structured concurrency, and resource management i
 
 ---
 
-**Previous**: [Interactive Tutorials](tutorials_intro.md)
-**Next**: [Solutions Guide](solutions_guide.md)
+**Previous:** [Expression: ForState](expression/forstate_journey.md)
+**Next:** [Solutions Guide](solutions_guide.md)

--- a/hkj-book/src/tutorials/optics/fluent_free_journey.md
+++ b/hkj-book/src/tutorials/optics/fluent_free_journey.md
@@ -194,5 +194,5 @@ After completing this journey:
 
 ---
 
-**Previous**: [Optics: Traversals & Practice](traversals_journey.md)
-**Next Journey**: [Optics: Focus DSL](focus_dsl_journey.md)
+**Previous:** [Optics: Traversals & Practice](traversals_journey.md)
+**Next:** [Optics: Focus DSL](focus_dsl_journey.md)

--- a/hkj-book/src/tutorials/optics/focus_dsl_journey.md
+++ b/hkj-book/src/tutorials/optics/focus_dsl_journey.md
@@ -239,5 +239,5 @@ Congratulations! You've completed the Optics track. You now understand:
 
 ---
 
-**Previous**: [Optics: Fluent & Free DSL](fluent_free_journey.md)
-**Next**: [Effect API Journey](../effect/effect_journey.md)
+**Previous:** [Optics: Fluent & Free DSL](fluent_free_journey.md)
+**Next:** [Expression: ForState](../expression/forstate_journey.md)

--- a/hkj-book/src/tutorials/optics/lens_prism_journey.md
+++ b/hkj-book/src/tutorials/optics/lens_prism_journey.md
@@ -213,4 +213,5 @@ After completing this journey:
 
 ---
 
-**Next Journey**: [Optics: Traversals & Practice](traversals_journey.md)
+**Previous:** [Scope & Resource](../concurrency/scope_resource_journey.md)
+**Next:** [Optics: Traversals & Practice](traversals_journey.md)

--- a/hkj-book/src/tutorials/optics/traversals_journey.md
+++ b/hkj-book/src/tutorials/optics/traversals_journey.md
@@ -197,5 +197,5 @@ After completing this journey:
 
 ---
 
-**Previous**: [Optics: Lens & Prism](lens_prism_journey.md)
-**Next Journey**: [Optics: Fluent & Free DSL](fluent_free_journey.md)
+**Previous:** [Optics: Lens & Prism](lens_prism_journey.md)
+**Next:** [Optics: Fluent & Free DSL](fluent_free_journey.md)

--- a/hkj-book/src/tutorials/solutions_guide.md
+++ b/hkj-book/src/tutorials/solutions_guide.md
@@ -354,5 +354,5 @@ Take your time. Struggle productively. Learn deeply.
 
 ---
 
-**Previous:** [Optics Track](optics_track.md)
+**Previous:** [Learning Paths](learning_paths.md)
 **Next:** [Troubleshooting](troubleshooting.md)


### PR DESCRIPTION
## documentation tidy up

- Add missing nav to 12 tutorial journey pages (foundations, error handling, effect, vtask, scope_resource, lens_prism, forstate, etc.)
- Fix incorrect links in effect_journey, focus_dsl_journey, learning_paths
- Standardize "Next Journey:" labels to "Next:" for consistency
- Add nav to reading.md, glossary.md, release-history.md, const_type.md

The optics module was originally a single chapter and later split into five, but nav links were never updated. Pages jumped across chapters (e.g. folds→filtered_optics skipped from ch2 to ch3, setters→profunctor jumped ch2 to ch3). Chapter intro pages were orphaned with no Previous.

Fixes 21 navigation links across 19 files to match SUMMARY.md ordering:
- Ch2: ch2_intro → traversals → folds → getters → setters → common_data_structures → limiting → list_decomposition
- Ch3: ch3_intro → filtered → indexed → each → string → indexed_access → advanced_prism → profunctor
- Ch4: ch4_intro → focus_dsl → importing → ... → kind_field_support → ...
- Ch5: ch5_intro → composing → core_type_integration → extensions → cookbook → auditing
- Cross-chapter: list_decomposition → ch3_intro, profunctor → ch4_intro, interpreters → ch5_intro

Align nav links with SUMMARY.md ordering:
- functional: abstraction_levels Previous now points to forstate_comprehension
- effect: fix chain through context subpages and composition
- monads: fix reader → context_scoped → state chain, validated → vtask
- tutorials: fix broken link to nonexistent optics_track.md

Improve Extended Arity Example with toState() side-by-side Replace the generic ForState tip with a concrete rewrite of the same "Alice" workflow using toState(), so readers see the direct before/after comparison instead of an unrelated example.

Improve monad typeclass docs: problem-first narrative, ASCII diagrams, Java-focused links

Restructure monad, monad_error, and monad_zero pages with problem-first narrative that shows the pain before introducing the solution. Add ASCII flow diagrams for flatMap chaining, error recovery, MonadZero filtering, and traverse inside-out flipping.

Deduplicate the Monad-vs-Applicative comparison that appeared in 5+ places by consolidating into abstraction_levels.md with cross-links. Restructure functional_api.md from redundant prose summaries into a quick-reference lookup table with hierarchy diagram.

