### PR TITLE
Refresh hkj-book documentation (monads)

### DIFF
--- a/hkj-book/puml/supported_types.puml
+++ b/hkj-book/puml/supported_types.puml
@@ -1,57 +1,75 @@
 @startuml supported_types
 !include https://raw.githubusercontent.com/ncosta-ic/catppuccin-macchiato-plantuml-theme/main/theme.puml
 hide empty members
-
 left to right direction
+skinparam packageStyle rectangle
+skinparam nodesep 8
+skinparam ranksep 20
 
-package "Supported Types (Monad Implementations)" {
-    class ListMonad
-    class StreamMonad
-    class OptionalMonad
-    class MaybeMonad
-    class "EitherMonad<L>" as EitherMonad
-    class CompletableFutureMonad
-    class TryMonad
-    class IOMonad
-    class LazyMonad
-    class IdMonad
-    class "ReaderMonad<R>" as ReaderMonad
-    class "StateMonad<S>" as StateMonad
-    class "WriterMonad<W>" as WriterMonad
-    class "ValidatedMonad<E>" as ValidatedMonad
-    class TrampolineMonad
-    class "FreeMonad<F>" as FreeMonad
+title Supported Types — Typeclass Instances
 
-    ListMonad <|.. CoreInterfaces.Monad
-    StreamMonad <|.. CoreInterfaces.MonadZero
-    OptionalMonad <|.. CoreInterfaces.MonadError
-    MaybeMonad <|.. CoreInterfaces.MonadError
-    EitherMonad <|.. CoreInterfaces.MonadError
-    CompletableFutureMonad <|.. CoreInterfaces.MonadError
-    TryMonad <|.. CoreInterfaces.MonadError
-    ValidatedMonad <|.. CoreInterfaces.MonadError
-    IdMonad <|.. CoreInterfaces.Monad
-    IOMonad <|.. CoreInterfaces.Monad
-    LazyMonad <|.. CoreInterfaces.Monad
-    ReaderMonad <|.. CoreInterfaces.Monad
-    StateMonad <|.. CoreInterfaces.Monad
-    WriterMonad <|.. CoreInterfaces.Monad
-    TrampolineMonad <|.. CoreInterfaces.Monad
-    FreeMonad <|.. CoreInterfaces.Monad
-
-    ' Example relation for Optional
-    OptionalMonad ..> "Simulation Plumbing.OptionalKind" : operates on witness
+package "Value & Error Types" as VE {
+    class "IdMonad" as IdM <<Monad>> <<Selective>> <<Traverse>>
+    class "MaybeMonad" as MaybeM <<MonadError>> <<Selective>> <<Traverse>>
+    class "OptionalMonad" as OptM <<MonadError>> <<Selective>> <<Traverse>>
+    class "EitherMonad<L>" as EitherM <<MonadError>> <<Selective>> <<Traverse>>
+    class "TryMonad" as TryM <<MonadError>> <<Traverse>>
+    class "ValidatedMonad<E>" as ValM <<MonadError>> <<Selective>> <<Traverse>>
 }
 
-'package "Bifunctor Implementations" {
-'    class ConstBifunctor
-'
-'    ConstBifunctor <|.. CoreInterfaces.Bifunctor
-'
-'    note right of ConstBifunctor
-'        Const<C, A> holds constant value C
-'        with phantom type parameter A
-'    end note
-'}
+package "Effect & Computation Types" as EC {
+    class "IOMonad" as IOM <<Monad>> <<Selective>>
+    class "LazyMonad" as LazyM <<Monad>>
+    class "CompletableFutureMonad" as CFM <<MonadError>>
+    class "VTaskMonad" as VTM <<MonadError>>
+    class "ReaderMonad<R>" as ReadM <<Monad>> <<Selective>>
+    class "ContextMonad<R>" as CtxM <<Monad>>
+    class "StateMonad<S>" as StateM <<Monad>>
+    class "WriterMonad<W>" as WritM <<Monad>>
+}
+
+package "Collection Types" as CO {
+    class "ListMonad" as ListM <<Monad>> <<Selective>> <<Traverse>>
+    class "StreamMonad" as StrmM <<MonadZero>> <<Traverse>>
+    class "VStreamMonad" as VStrmM <<Monad>> <<Alternative>> <<Traverse>>
+}
+
+package "Recursion & DSL Types" as RD {
+    class "TrampolineMonad" as TramM <<Monad>>
+    class "FreeMonad<F>" as FreeM <<Monad>>
+    class "FreeApApplicative<F>" as FreeApA <<Applicative>>
+    class "CoyonedaFunctor<F>" as CoyoF <<Functor>>
+}
+
+package "Structural Types" as ST {
+    class "ConstApplicative<M>" as ConstA <<Applicative>>
+    class "Tuple2Bifunctor" as Tup2B <<Bifunctor>>
+    class "FunctionProfunctor" as FuncP <<Profunctor>>
+}
+
+package "Monad Transformers" as MT {
+    class "MaybeTMonad<F>" as MaybeTM <<MonadError>>
+    class "EitherTMonad<F,L>" as EitherTM <<MonadError>>
+    class "OptionalTMonad<F>" as OptTM <<MonadError>>
+    class "ReaderTMonad<F,R>" as ReadTM <<Monad>>
+    class "StateTMonad<S,F>" as StateTM <<Monad>>
+}
+
+package "Bifunctor Support" as BF {
+    class "EitherBifunctor" as EitherBF <<Bifunctor>>
+    class "ValidatedBifunctor" as ValBF <<Bifunctor>>
+    class "WriterBifunctor" as WritBF <<Bifunctor>>
+    class "ConstBifunctor" as ConstBF <<Bifunctor>>
+}
+
+note as TypeclassKey
+    **Typeclass Hierarchy**
+    Functor ← Applicative ← Monad ← MonadError
+    Functor ← Traverse (+ Foldable)
+    Functor ← Selective (requires Applicative)
+    MonadZero ← Alternative (Monad + zero)
+    Bifunctor: maps over both type parameters
+    Profunctor: maps input contravariantly, output covariantly
+end note
 
 @enduml

--- a/hkj-book/src/examples/examples_draughts.md
+++ b/hkj-book/src/examples/examples_draughts.md
@@ -236,3 +236,4 @@ hkj-examples/src/main/java/org/higherkindedj/example/draughts/
 ---
 
 **Previous:** [Order Processing Workflow](examples_order.md)
+**Next:** [Building the Game](../hkts/draughts.md)

--- a/hkj-book/src/hkts/draughts.md
+++ b/hkj-book/src/hkts/draughts.md
@@ -836,4 +836,4 @@ The `GameLogic` class is completely pure; you can test the entire rules engine b
 
 ---
 
-**Previous:** [Concurrency and Scale](order-concurrency.md)
+**Previous:** [Draughts (Checkers) Game](../examples/examples_draughts.md)

--- a/hkj-book/src/monads/either_monad.md
+++ b/hkj-book/src/monads/either_monad.md
@@ -230,6 +230,17 @@ To use `Either` within Higher-Kinded-J framework:
    ```
 ~~~
 
+## When to Use Either
+
+| Scenario | Use |
+|----------|-----|
+| Domain-specific typed errors (validation, business rules) | `Either<MyError, A>` — error type carries context |
+| Sequential operations where any step can fail | `Either` with `flatMap` — short-circuits on `Left` |
+| Combining typed errors with async or other effects | [EitherT](../transformers/eithert_transformer.md) transformer — see the [Order Example](../hkts/order-walkthrough.md) |
+| Exception-based error handling (wrapping `Throwable`) | Prefer [Try](./try_monad.md) — specialised `Either<Throwable, A>` |
+| Accumulating multiple validation errors | Prefer [Validated](./validated_monad.md) with applicative operations |
+| Application-level error pipelines with fluent API | Prefer [EitherPath](../effect/path_either.md) |
+
 ~~~admonish important  title="Key Points:"
 
 - Explicitly modelling and handling domain-specific errors (e.g., validation failures, resource not found, business rule violations).

--- a/hkj-book/src/monads/free_monad.md
+++ b/hkj-book/src/monads/free_monad.md
@@ -1,86 +1,80 @@
 # The Free Monad:
-## _Building Composable DSLs and Interpreters_
+## _Programs as Data, Interpreters as Plug-Ins_
 
 ~~~admonish info title="What You'll Learn"
-- How to build domain-specific languages (DSLs) as data structures
-- Separating program description from execution
-- Creating multiple interpreters for the same program
-- Using `pure`, `suspend`, and `liftF` to construct Free programs
-- Implementing stack-safe interpreters with `foldMap`
-- When Free monads solve real architectural problems
-- Comparing Free monads with traditional Java patterns
+- Why separating "what to do" from "how to do it" changes everything
+- Building a domain-specific language (DSL) as a data structure
+- Running the same program with production, test, and logging interpreters
+- Using `pure`, `suspend`, `liftF`, and `foldMap` to build and run Free programs
+- When Free monads solve real architectural problems (and when they don't)
 ~~~
 
 ~~~ admonish example title="See Example Code:"
 - [ConsoleProgram.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/free/ConsoleProgram.java)
+- [FreePathExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/effect/FreePathExample.java)
 - [FreeMonadTest.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/test/java/org/higherkindedj/hkt/free/FreeMonadTest.java)
-- [FreeFactoryTest.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/test/java/org/higherkindedj/hkt/free/FreeFactoryTest.java) - Demonstrates improved type inference with FreeFactory
 ~~~
 
-## Purpose
+## The Idea: Your Program Is a Shopping List
 
-In traditional Java programming, when you want to execute side effects (like printing to the console, reading files, or making database queries), you directly execute them:
+Imagine writing a shopping list. The list *describes* what to buy — it doesn't actually buy anything. The same list could be:
 
-```java
-// Traditional imperative approach
-System.out.println("What is your name?");
-String name = scanner.nextLine();
-System.out.println("Hello, " + name + "!");
+- **Executed** at the supermarket (production)
+- **Priced up** without buying anything (dry-run)
+- **Checked** against the pantry (testing)
+- **Delegated** to someone else (different interpreter)
+
+The Free monad works the same way. Instead of executing side effects directly, you build a **program as a data structure**. Then you choose an **interpreter** to run it:
+
+```
+Program (data structure):            Interpreter 1 (real I/O):
+  printLine("What is your name?")      → System.out.println(...)
+  readLine()                           → scanner.nextLine()
+  printLine("Hello, " + name + "!")    → System.out.println(...)
+
+                                     Interpreter 2 (testing):
+  (same program, zero changes)         → output.add(...)
+                                       → return "Alice" from list
+                                       → output.add(...)
+
+                                     Interpreter 3 (logging):
+  (same program, zero changes)         → log.info(...)
+                                       → return cached input
+                                       → log.info(...)
 ```
 
-This approach tightly couples **what** you want to do with **how** it's done. The **Free monad** provides a fundamentally different approach: instead of executing effects immediately, you build programs as **data structures** that can be interpreted in different ways.
+One program. Three interpreters. Zero code changes between them.
 
-Think of it like writing a recipe (the data structure) versus actually cooking the meal (the execution). The recipe can be:
-- Executed in a real kitchen (production)
-- Simulated for testing
-- Optimised before cooking
-- Translated to different cuisines
+## The Payoff: See It Before You Build It
 
-The Free monad enables this separation in functional programming. A `Free<F, A>` represents a program built from instructions of type `F` that, when interpreted, will produce a value of type `A`.
+Before diving into infrastructure, here is the punchline. Given this program:
 
-### Key Benefits
-
-1. **Testability**: Write pure tests without actual side effects. Test database code without a database.
-2. **Multiple Interpretations**: One program, many interpreters (production, testing, logging, optimisation).
-3. **Composability**: Build complex programs from simple, reusable building blocks.
-4. **Inspection**: Programs are data, so you can analyse, optimise, or transform them before execution.
-5. **Stack Safety**: Interpretation uses constant stack space, preventing `StackOverflowError`.
-
-### Comparison with Traditional Java Patterns
-
-If you're familiar with the **Strategy pattern**, Free monads extend this concept:
-
-**Strategy Pattern**: Choose algorithm at runtime
 ```java
-interface PaymentStrategy {
-    void pay(int amount);
-}
-// Pick one: creditCardStrategy, payPalStrategy, etc.
+Free<ConsoleOpKind.Witness, Unit> program =
+    printLine("What is your name?")
+        .flatMap(ignored -> readLine()
+            .flatMap(name -> printLine("Hello, " + name + "!")));
 ```
 
-**Free Monad**: Build an **entire program** as data, then pick how to execute it
+Run it with a **real** interpreter — it talks to the console:
+
 ```java
-Free<PaymentOp, Receipt> program = ...;
-// Pick interpreter: realPayment, testPayment, loggingPayment, etc.
+ioInterpreter.run(program);
+// Console: What is your name?
+// User types: Alice
+// Console: Hello, Alice!
 ```
 
-Similarly, the **Command pattern** encapsulates actions as objects:
+Run the **same program** with a **test** interpreter — no console, pure assertions:
 
-**Command Pattern**: Single action as object
 ```java
-interface Command {
-    void execute();
-}
+TestInterpreter test = new TestInterpreter(List.of("Alice"));
+test.run(program);
+
+assertEquals(List.of("What is your name?", "Hello, Alice!"), test.getOutput());
 ```
 
-**Free Monad**: Entire workflows with sequencing, branching, and composition
-```java
-Free<Command, Result> workflow =
-    sendEmail(...)
-        .flatMap(receipt -> saveToDatabase(...))
-        .flatMap(id -> sendNotification(...));
-// Interpret with real execution or test mock
-```
+That is the Free monad's value: **write once, interpret many ways**.
 
 ## Core Components
 
@@ -96,893 +90,278 @@ Free<Command, Result> workflow =
 
 ![free_monad.svg](../images/puml/free_monad.svg)
 
-The `Free` functionality is built upon several related components:
+| Component | Role |
+|-----------|------|
+| `Free<F, A>` | A program built from instructions `F` that produces `A`. Sealed: `Pure`, `Suspend`, `FlatMapped` |
+| `FreeKind<F, A>` / `FreeKindHelper` | HKT bridge: `widen()`, `narrow()` |
+| `FreeFunctor<F>` / `FreeMonad<F>` | Type class instances: `map`, `flatMap`, `of` |
+| `FreeFactory<F>` | Captures the functor type once — fixes Java's type inference for chained operations |
+| `Free.liftF(fa, functor)` | Lifts a single instruction into a Free program |
+| `free.foldMap(transform, monad)` | Interprets the program using a natural transformation — stack-safe via Trampoline |
 
-1. **`Free<F, A>`**: The core sealed interface representing a program. It has three constructors:
-   * `Pure<F, A>`: Represents a terminal value: the final result.
-   * `Suspend<F, A>`: Represents a suspended computation: an instruction `Kind<F, Free<F, A>>` to be interpreted later.
-   * `FlatMapped<F, X, A>`: Represents monadic sequencing: chains computations together in a stack-safe manner.
-
-2. **`FreeKind<F, A>`**: The HKT marker interface (`Kind<FreeKind.Witness<F>, A>`) for `Free`. This allows `Free` to be treated as a generic type constructor in type classes. The witness type is `FreeKind.Witness<F>`, where `F` is the instruction set functor.
-
-3. **`FreeKindHelper`**: The essential utility class for working with `Free` in the HKT simulation. It provides:
-   * `widen(Free<F, A>)`: Wraps a concrete `Free<F, A>` instance into its HKT representation.
-   * `narrow(Kind<FreeKind.Witness<F>, A>)`: Unwraps a `FreeKind<F, A>` back to the concrete `Free<F, A>`.
-
-4. **`FreeFunctor<F>`**: Implements `Functor<FreeKind.Witness<F>>`. Provides the `map` operation to transform result values.
-
-5. **`FreeMonad<F>`**: Extends `FreeFunctor<F>` and implements `Monad<FreeKind.Witness<F>>`. Provides `of` (to lift a pure value) and `flatMap` (to sequence Free computations).
-
-## Purpose and Usage
-
-* **Building DSLs**: Create domain-specific languages as composable data structures.
-* **Natural Transformations**: Write interpreters as transformations from your instruction set `F` to a target monad `M`.
-* **Stack-Safe Execution**: The `foldMap` method uses Higher-Kinded-J's own `Trampoline` monad internally, demonstrating the library's composability whilst preventing stack overflow.
-* **Multiple Interpreters**: Execute the same program with different interpreters (production vs. testing vs. logging).
-* **Program Inspection**: Since programs are data, you can analyse, optimise, or transform them before execution.
-
-**Key Methods:**
-- `Free.pure(value)`: Creates a terminal computation holding a final value.
-- `Free.suspend(computation)`: Suspends a computation for later interpretation.
-- `Free.liftF(fa, functor)`: Lifts a functor value into a Free monad.
-- `free.map(f)`: Transforms the result value without executing.
-- `free.flatMap(f)`: Sequences Free computations whilst maintaining stack safety.
-- `free.foldMap(transform, monad)`: Interprets the Free program using a natural transformation.
-
-**FreeFactory for Improved Type Inference:**
-
-Java's type inference can struggle when chaining operations directly on `Free.pure()`:
-
-```java
-// This fails to compile - Java can't infer F
-Free<IdKind.Witness, Integer> result = Free.pure(2).map(x -> x * 2); // ERROR
-
-// Workaround: explicit type parameters (verbose)
-Free<IdKind.Witness, Integer> result = Free.<IdKind.Witness, Integer>pure(2).map(x -> x * 2);
+~~~admonish note title="How foldMap Works"
 ```
-
-The `FreeFactory<F>` class solves this by capturing the functor type parameter once:
-
-```java
-// Create a factory with your functor type
-FreeFactory<IdKind.Witness> FREE = FreeFactory.of();
-// or with a monad instance for clarity:
-FreeFactory<IdKind.Witness> FREE = FreeFactory.withMonad(IdMonad.instance());
-
-// Now type inference works perfectly
-Free<IdKind.Witness, Integer> result = FREE.pure(2).map(x -> x * 2); // Works!
-
-// Chain operations fluently
-Free<IdKind.Witness, Integer> program = FREE.pure(10)
-    .map(x -> x + 1)
-    .flatMap(x -> FREE.pure(x * 2))
-    .map(x -> x - 5);
-
-// Other factory methods
-Free<F, A> pure = FREE.pure(value);
-Free<F, A> suspended = FREE.suspend(computation);
-Free<F, A> lifted = FREE.liftF(fa, functor);
+Free program (tree):                  foldMap walks it:
+  FlatMapped                          1. Interpret Suspend → target monad
+    ├── Suspend(PrintLine("Hi"))      2. Apply continuation (flatMap fn)
+    └── fn: name →                    3. Interpret next Suspend
+        Suspend(PrintLine("Hello,     4. Combine via target monad's flatMap
+                " + name))           5. Return final result in target monad
 ```
+`foldMap` converts each instruction from your DSL (`F`) into a target monad (`M`) using a natural transformation, then sequences the results. It uses Higher-Kinded-J's own `Trampoline` internally for stack safety.
+~~~
 
-`FreeFactory` is particularly useful in:
-- Test code where you build many Free programs
-- DSL implementations where type inference is important
-- Any code that chains `map`/`flatMap` operations on `Free.pure()`
-
-~~~admonish example title="Example 1: Building a Console DSL"
-
-Let's build a simple DSL for console interactions. We'll define instructions, build programs, and create multiple interpreters.
+## Building a DSL: Step by Step
 
 ### Step 1: Define Your Instruction Set
 
-First, create a sealed interface representing all possible operations in your DSL:
+Create a sealed interface for every operation in your domain:
 
 ```java
 public sealed interface ConsoleOp<A> {
     record PrintLine(String text) implements ConsoleOp<Unit> {}
-    record ReadLine() implements ConsoleOp<String> {}
-}
-
-public record Unit() {
-    public static final Unit INSTANCE = new Unit();
+    record ReadLine()             implements ConsoleOp<String> {}
 }
 ```
 
-This is your vocabulary. `PrintLine` returns `Unit` (like `void`), `ReadLine` returns `String`.
+This is your vocabulary. `PrintLine` returns `Unit` (like void). `ReadLine` returns `String`.
 
-### Step 2: Create HKT Bridge for Your DSL
+### Step 2: HKT Plumbing
 
-To use your DSL with the Free monad, you need the HKT simulation components:
+~~~admonish tip title="HKT Bridge (expand to see boilerplate)"
+Every instruction set needs an HKT bridge and a Functor. This is mechanical:
 
 ```java
+// HKT marker
 public interface ConsoleOpKind<A> extends Kind<ConsoleOpKind.Witness, A> {
-    final class Witness {
-        private Witness() {}
-    }
+    final class Witness { private Witness() {} }
 }
 
+// Widen/narrow helper
 public enum ConsoleOpKindHelper {
     CONSOLE;
-
     record ConsoleOpHolder<A>(ConsoleOp<A> op) implements ConsoleOpKind<A> {}
-
     public <A> Kind<ConsoleOpKind.Witness, A> widen(ConsoleOp<A> op) {
         return new ConsoleOpHolder<>(op);
     }
-
     public <A> ConsoleOp<A> narrow(Kind<ConsoleOpKind.Witness, A> kind) {
         return ((ConsoleOpHolder<A>) kind).op();
     }
 }
-```
 
-### Step 3: Create a Functor for Your DSL
-
-The Free monad requires a `Functor` for your instruction set:
-
-```java
+// Functor instance
 public class ConsoleOpFunctor implements Functor<ConsoleOpKind.Witness> {
-    private static final ConsoleOpKindHelper CONSOLE = ConsoleOpKindHelper.CONSOLE;
-
     @Override
     public <A, B> Kind<ConsoleOpKind.Witness, B> map(
             Function<? super A, ? extends B> f,
             Kind<ConsoleOpKind.Witness, A> fa) {
-        ConsoleOp<A> op = CONSOLE.narrow(fa);
-        // For immutable operations, mapping is identity
-        // (actual mapping happens during interpretation)
         return (Kind<ConsoleOpKind.Witness, B>) fa;
     }
 }
 ```
+~~~
 
-### Step 4: Create DSL Helper Functions
+### Step 3: Create DSL Helpers
 
-Provide convenient methods for building Free programs:
+Wrap `liftF` calls in friendly methods:
 
 ```java
 public class ConsoleOps {
-    /** Prints a line to the console. */
+    private static final ConsoleOpFunctor FUNCTOR = new ConsoleOpFunctor();
+
     public static Free<ConsoleOpKind.Witness, Unit> printLine(String text) {
-        ConsoleOp<Unit> op = new ConsoleOp.PrintLine(text);
-        Kind<ConsoleOpKind.Witness, Unit> kindOp =
-            ConsoleOpKindHelper.CONSOLE.widen(op);
-        return Free.liftF(kindOp, new ConsoleOpFunctor());
+        return Free.liftF(ConsoleOpKindHelper.CONSOLE.widen(
+            new ConsoleOp.PrintLine(text)), FUNCTOR);
     }
 
-    /** Reads a line from the console. */
     public static Free<ConsoleOpKind.Witness, String> readLine() {
-        ConsoleOp<String> op = new ConsoleOp.ReadLine();
-        Kind<ConsoleOpKind.Witness, String> kindOp =
-            ConsoleOpKindHelper.CONSOLE.widen(op);
-        return Free.liftF(kindOp, new ConsoleOpFunctor());
-    }
-
-    /** Pure value in the Free monad. */
-    public static <A> Free<ConsoleOpKind.Witness, A> pure(A value) {
-        return Free.pure(value);
+        return Free.liftF(ConsoleOpKindHelper.CONSOLE.widen(
+            new ConsoleOp.ReadLine()), FUNCTOR);
     }
 }
 ```
 
-Now you can build programs using familiar Java syntax:
+### Step 4: Write Programs
+
+Now build programs using familiar `flatMap` chains:
 
 ```java
-Free<ConsoleOpKind.Witness, Unit> program =
-    ConsoleOps.printLine("What is your name?")
-        .flatMap(ignored ->
-            ConsoleOps.readLine()
-                .flatMap(name ->
-                    ConsoleOps.printLine("Hello, " + name + "!")));
+import static ConsoleOps.*;
+
+Free<ConsoleOpKind.Witness, Unit> greetingProgram =
+    printLine("What is your name?")
+        .flatMap(ignored -> readLine()
+            .flatMap(name -> printLine("Hello, " + name + "!")));
 ```
 
-**Key Insight**: At this point, **nothing has executed**. You've built a data structure describing what should happen.
-~~~
+**Nothing has executed.** You have built a data structure that *describes* what should happen.
 
-~~~admonish example title="Example 2: Building Programs with map and flatMap"
+## Multiple Interpreters: The Payoff
 
-The Free monad supports `map` and `flatMap`, making it easy to compose programs:
-
-```java
-import static org.higherkindedj.example.free.ConsoleProgram.ConsoleOps.*;
-
-// Simple sequence
-Free<ConsoleOpKind.Witness, String> getName =
-    printLine("Enter your name:")
-        .flatMap(ignored -> readLine());
-
-// Using map to transform results
-Free<ConsoleOpKind.Witness, String> getUpperName =
-    getName.map(String::toUpperCase);
-
-// Building complex workflows
-Free<ConsoleOpKind.Witness, Unit> greetingWorkflow =
-    printLine("Welcome to the application!")
-        .flatMap(ignored -> getName)
-        .flatMap(name -> printLine("Hello, " + name + "!"))
-        .flatMap(ignored -> printLine("Have a great day!"));
-
-// Calculator example with error handling
-Free<ConsoleOpKind.Witness, Unit> calculator =
-    printLine("Enter first number:")
-        .flatMap(ignored1 -> readLine())
-        .flatMap(num1 ->
-            printLine("Enter second number:")
-                .flatMap(ignored2 -> readLine())
-                .flatMap(num2 -> {
-                    try {
-                        int sum = Integer.parseInt(num1) + Integer.parseInt(num2);
-                        return printLine("Sum: " + sum);
-                    } catch (NumberFormatException e) {
-                        return printLine("Invalid numbers!");
-                    }
-                }));
-```
-
-**Composability**: Notice how we can build `getName` once and reuse it in multiple programs. This promotes code reuse and testability.
-~~~
-
-~~~admonish example title="Example 3: IO Interpreter for Real Execution"
-
-Now let's create an interpreter that actually executes console operations:
-
+~~~admonish example title="IO Interpreter — Real Execution"
 ```java
 public class IOInterpreter {
-    private final Scanner scanner = new Scanner(System.in);
+    private static final Scanner scanner = new Scanner(System.in);
 
     public <A> A run(Free<ConsoleOpKind.Witness, A> program) {
-        // Create a natural transformation from ConsoleOp to IO
-        Function<Kind<ConsoleOpKind.Witness, ?>, Kind<IOKind.Witness, ?>> transform =
+        Function<Kind<ConsoleOpKind.Witness, ?>, Kind<IdKind.Witness, ?>> transform =
             kind -> {
-                ConsoleOp<?> op = ConsoleOpKindHelper.CONSOLE.narrow(
-                    (Kind<ConsoleOpKind.Witness, Object>) kind);
-
-                // Execute the instruction and wrap result in Free.pure
-                Free<ConsoleOpKind.Witness, ?> freeResult = switch (op) {
-                    case ConsoleOp.PrintLine print -> {
-                        System.out.println(print.text());
-                        yield Free.pure(Unit.INSTANCE);
-                    }
-                    case ConsoleOp.ReadLine read -> {
-                        String line = scanner.nextLine();
-                        yield Free.pure(line);
-                    }
+                ConsoleOp<?> op = ConsoleOpKindHelper.CONSOLE.narrow(kind);
+                Object result = switch (op) {
+                    case ConsoleOp.PrintLine p -> { System.out.println(p.text()); yield Unit.INSTANCE; }
+                    case ConsoleOp.ReadLine r  -> scanner.nextLine();
                 };
-
-                // Wrap the Free result in the target monad (IO)
-                return IOKindHelper.IO.widen(new IO<>(freeResult));
+                return Id.of(result);
             };
-
-        // Interpret the program using foldMap
-        Kind<IOKind.Witness, A> result = program.foldMap(transform, new IOMonad());
-        return IOKindHelper.IO.narrow(result).value();
+        return IdKindHelper.ID.narrow(
+            program.foldMap(transform, IdMonad.instance())).value();
     }
 }
-
-// Simple IO type for the interpreter
-record IO<A>(A value) {}
-
-// Run the program
-IOInterpreter interpreter = new IOInterpreter();
-interpreter.run(greetingProgram());
-// Actual console interaction happens here!
 ```
-
-**Natural Transformation**: The `transform` function is a natural transformation; it converts each `ConsoleOp` instruction into an `IO` operation whilst preserving structure.
-
-**Critical Detail**: Notice we wrap instruction results in `Free.pure()`. This is essential: the natural transformation receives `Kind<F, Free<F, A>>` and must return `Kind<M, Free<F, A>>`, not just the raw result.
 ~~~
 
-~~~admonish example title="Example 4: Test Interpreter for Pure Testing"
-
-One of the most powerful aspects of Free monads is testability. Create a test interpreter that doesn't perform real I/O:
-
+~~~admonish example title="Test Interpreter — Pure Assertions"
 ```java
 public class TestInterpreter {
     private final List<String> input;
     private final List<String> output = new ArrayList<>();
     private int inputIndex = 0;
 
-    public TestInterpreter(List<String> input) {
-        this.input = input;
-    }
+    public TestInterpreter(List<String> input) { this.input = input; }
 
     public <A> A run(Free<ConsoleOpKind.Witness, A> program) {
-        // Create natural transformation to TestResult
-        Function<Kind<ConsoleOpKind.Witness, ?>, Kind<TestResultKind.Witness, ?>> transform =
+        Function<Kind<ConsoleOpKind.Witness, ?>, Kind<IdKind.Witness, ?>> transform =
             kind -> {
-                ConsoleOp<?> op = ConsoleOpKindHelper.CONSOLE.narrow(
-                    (Kind<ConsoleOpKind.Witness, Object>) kind);
-
-                // Simulate the instruction
-                Free<ConsoleOpKind.Witness, ?> freeResult = switch (op) {
-                    case ConsoleOp.PrintLine print -> {
-                        output.add(print.text());
-                        yield Free.pure(Unit.INSTANCE);
-                    }
-                    case ConsoleOp.ReadLine read -> {
-                        String line = inputIndex < input.size()
-                            ? input.get(inputIndex++)
-                            : "";
-                        yield Free.pure(line);
-                    }
+                ConsoleOp<?> op = ConsoleOpKindHelper.CONSOLE.narrow(kind);
+                Object result = switch (op) {
+                    case ConsoleOp.PrintLine p -> { output.add(p.text()); yield Unit.INSTANCE; }
+                    case ConsoleOp.ReadLine r  -> input.get(inputIndex++);
                 };
-
-                return TestResultKindHelper.TEST.widen(new TestResult<>(freeResult));
+                return Id.of(result);
             };
-
-        Kind<TestResultKind.Witness, A> result =
-            program.foldMap(transform, new TestResultMonad());
-        return TestResultKindHelper.TEST.narrow(result).value();
+        return IdKindHelper.ID.narrow(
+            program.foldMap(transform, IdMonad.instance())).value();
     }
 
-    public List<String> getOutput() {
-        return output;
-    }
+    public List<String> getOutput() { return output; }
 }
 
-// Pure test - no actual I/O!
-@Test
-void testGreetingProgram() {
-    TestInterpreter interpreter = new TestInterpreter(List.of("Alice"));
-    interpreter.run(Programs.greetingProgram());
-
-    List<String> output = interpreter.getOutput();
-    assertEquals(2, output.size());
-    assertEquals("What is your name?", output.get(0));
-    assertEquals("Hello, Alice!", output.get(1));
+// Pure test — no console, no I/O, no flakiness
+@Test void testGreeting() {
+    var test = new TestInterpreter(List.of("Alice"));
+    test.run(greetingProgram);
+    assertEquals(List.of("What is your name?", "Hello, Alice!"), test.getOutput());
 }
 ```
-
-**Testability**: The same `greetingProgram()` can be tested without any actual console I/O. You control inputs and verify outputs deterministically.
 ~~~
 
-~~~admonish example title="Example 5: Composing Larger programs from Smaller Ones"
+## Composing Programs from Building Blocks
 
-The real power emerges when building complex programs from simple, reusable pieces:
+Free programs compose like Lego. Build small pieces, snap them together:
 
 ```java
 // Reusable building blocks
 Free<ConsoleOpKind.Witness, String> askQuestion(String question) {
-    return printLine(question)
-        .flatMap(ignored -> readLine());
+    return printLine(question).flatMap(ignored -> readLine());
 }
 
-Free<ConsoleOpKind.Witness, Unit> confirmAction(String action) {
-    return printLine(action + " - Are you sure? (yes/no)")
-        .flatMap(ignored -> readLine())
-        .flatMap(response ->
-            response.equalsIgnoreCase("yes")
-                ? printLine("Confirmed!")
-                : printLine("Cancelled."));
+Free<ConsoleOpKind.Witness, Unit> confirm(String action) {
+    return askQuestion(action + " — sure? (yes/no)")
+        .flatMap(answer -> answer.equalsIgnoreCase("yes")
+            ? printLine("Confirmed.")
+            : printLine("Cancelled."));
 }
 
-// Composed program
-Free<ConsoleOpKind.Witness, Unit> userRegistration() {
-    return askQuestion("Enter username:")
-        .flatMap(username ->
-            askQuestion("Enter email:")
-                .flatMap(email ->
-                    confirmAction("Register user " + username)
-                        .flatMap(ignored ->
-                            printLine("Registration complete for " + username))));
-}
-
-// Even more complex composition
-Free<ConsoleOpKind.Witness, List<String>> gatherMultipleInputs(int count) {
-    Free<ConsoleOpKind.Witness, List<String>> start = Free.pure(new ArrayList<>());
-
-    for (int i = 0; i < count; i++) {
-        final int index = i;
-        start = start.flatMap(list ->
-            askQuestion("Enter item " + (index + 1) + ":")
-                .map(item -> {
-                    list.add(item);
-                    return list;
-                }));
-    }
-
-    return start;
+// Composed program — built from pieces
+Free<ConsoleOpKind.Witness, Unit> registration() {
+    return askQuestion("Username:")
+        .flatMap(user -> askQuestion("Email:")
+            .flatMap(email -> confirm("Register " + user + "?")
+                .flatMap(ignored -> printLine("Done! Welcome, " + user))));
 }
 ```
 
-**Modularity**: Each function returns a `Free` program that can be:
-- Tested independently
-- Composed with others
-- Interpreted in different ways
-- Reused across your application
-~~~
+Each building block is independently testable and reusable.
 
-~~~admonish example title="Example 6: Using Free.liftF for Single Operations"
+## FreeFactory: Fixing Java's Type Inference
 
-The `liftF` method provides a convenient way to lift single functor operations into Free:
+Java struggles to infer the functor type `F` when chaining operations on `Free.pure()`:
 
 ```java
-// Instead of manually creating Suspend
-Free<ConsoleOpKind.Witness, String> createManualReadLine() {
-    ConsoleOp<String> op = new ConsoleOp.ReadLine();
-    Kind<ConsoleOpKind.Witness, String> kindOp =
-        ConsoleOpKindHelper.CONSOLE.widen(op);
-    return Free.suspend(
-        new ConsoleOpFunctor().map(Free::pure, kindOp)
-    );
-}
+// Fails to compile — Java can't infer F
+Free<IdKind.Witness, Integer> result = Free.pure(2).map(x -> x * 2); // ERROR
 
-// Using liftF (simpler!)
-Free<ConsoleOpKind.Witness, String> createLiftedReadLine() {
-    ConsoleOp<String> op = new ConsoleOp.ReadLine();
-    Kind<ConsoleOpKind.Witness, String> kindOp =
-        ConsoleOpKindHelper.CONSOLE.widen(op);
-    return Free.liftF(kindOp, new ConsoleOpFunctor());
-}
+// FreeFactory captures F once, then inference works everywhere
+FreeFactory<IdKind.Witness> FREE = FreeFactory.of();
 
-// Even simpler with helper method
-Free<ConsoleOpKind.Witness, String> simpleReadLine =
-    ConsoleOps.readLine();
+Free<IdKind.Witness, Integer> result = FREE.pure(2).map(x -> x * 2); // Works!
+
+Free<IdKind.Witness, Integer> program = FREE.pure(10)
+    .map(x -> x + 1)
+    .flatMap(x -> FREE.pure(x * 2))
+    .map(x -> x - 5);
 ```
-
-**Best Practice**: Create helper methods (like `ConsoleOps.readLine()`) that use `liftF` internally. This provides a clean API for building programs.
-~~~
 
 ## When to Use Free Monad
 
-### Use Free Monad When:
+| Scenario | Use |
+|----------|-----|
+| Building a DSL for your domain (workflows, queries, rules) | Free monad |
+| Same logic needs production, test, and logging modes | Free monad — one program, many interpreters |
+| Testing complex logic without real side effects | Free monad — pure, deterministic tests |
+| Analysing or optimising programs before running them | Free monad — programs are inspectable data |
+| Simple side effects (read file, call API) | Prefer [IO](./io_monad.md) — less boilerplate |
+| Single interpretation, no testing benefit | Direct code — Free adds unnecessary complexity |
+| Performance-critical hot paths | Direct code — Free has ~2-10x interpretation overhead |
 
-1. **Building DSLs**: You need a domain-specific language for your problem domain (financial calculations, workflow orchestration, build systems, etc.).
+## Free Monad vs Traditional Java Patterns
 
-2. **Multiple Interpretations**: The same logic needs different execution modes:
-   - Production (real database, real network)
-   - Testing (mocked, pure)
-   - Logging (record all operations)
-   - Optimisation (analyse before execution)
-   - Dry-run (validate without executing)
+| Pattern | What It Does | Free Monad Advantage |
+|---------|-------------|---------------------|
+| Strategy | Swap one algorithm at runtime | Free swaps **entire program interpretation** |
+| Command | Encapsulate a single action as an object | Free composes **workflows** with sequencing and data flow |
+| Observer | React to events with multiple listeners | Free makes event streams **first-class, composable, replayable** |
 
-3. **Testability is Critical**: You need to test complex logic without actual side effects. Example: testing database transactions without a database.
-
-4. **Program Analysis**: You need to inspect, optimise, or transform programs before execution:
-   - Query optimisation
-   - Batch operations
-   - Caching strategies
-   - Cost analysis
-
-5. **Separation of Concerns**: Business logic must be decoupled from execution details. Example: workflow definition separate from workflow engine.
-
-6. **Stack Safety Required**: Your DSL involves deep recursion or many sequential operations (verified with 10,000+ operations).
-
-### Avoid Free Monad When:
-
-1. **Simple Effects**: For straightforward side effects, use `IO`, `Reader`, or `State` directly. Free adds unnecessary complexity.
-
-2. **Performance Critical**: Free monads have overhead:
-   - Heap allocation for program structure
-   - Interpretation overhead
-   - Not suitable for hot paths or tight loops
-
-3. **Single Interpretation**: If you only ever need one way to execute your program, traditional imperative code or simpler monads are clearer.
-
-4. **Team Unfamiliarity**: Free monads require understanding of:
-   - Algebraic data types
-   - Natural transformations
-   - Monadic composition
-
-   If your team isn't comfortable with these concepts, simpler patterns might be more maintainable.
-
-5. **Small Scale**: For small scripts or simple applications, the architectural benefits don't justify the complexity.
-
-### Comparison with Alternatives
-
-**Free Monad vs. Direct Effects**:
-- Free: Testable, multiple interpreters, program inspection
-- Direct: Simpler, better performance, easier to understand
-
-**Free Monad vs. Tagless Final**:
-- Free: programs are data structures, can be inspected
-- Tagless Final: Better performance, less boilerplate, but programs aren't inspectable
-
-**Free Monad vs. Effect Systems (like ZIO/Cats Effect)**:
-- Free: Simpler concept, custom DSLs
-- Effect Systems: More powerful, better performance, ecosystem support
+All three patterns solve part of the problem. Free monad unifies them: your entire program is data that can be inspected, composed, transformed, and interpreted in multiple ways.
 
 ## Advanced Topics
 
-### Free Applicative vs. Free Monad
+~~~admonish tip title="Free Applicative"
+When operations are **independent** (not dependent on previous results), use Free Applicative instead of Free Monad. This enables:
+- Parallel execution or batching of independent operations
+- Upfront analysis of all operations before execution
+- Query optimisation (e.g., batching database reads)
 
-~~~admonish tip title="See Also"
-For comprehensive coverage of Free Applicative, see the dedicated [Free Applicative](free_applicative.md) documentation.
+See [Free Applicative](free_applicative.md) for details.
 ~~~
 
-The **Free Applicative** is a related but distinct structure:
+~~~admonish tip title="Coyoneda Optimisation"
+Don't want to write a Functor for your instruction set? The **Coyoneda lemma** gives you one for free. It also enables map fusion — consecutive `.map(f).map(g).map(h)` calls collapse into a single `.map(f.andThen(g).andThen(h))`.
 
-```java
-// Free Monad: Sequential, dependent operations
-Free<F, C> sequential =
-    operationA()                           // A
-        .flatMap(a ->                      // depends on A
-            operationB(a)                  // B
-                .flatMap(b ->              // depends on B
-                    operationC(a, b)));    // C
-
-// Free Applicative: Independent, parallel operations
-Applicative<F, C> parallel =
-    map3(
-        operationA(),                      // A (independent)
-        operationB(),                      // B (independent)
-        operationC(),                      // C (independent)
-        (a, b, c) -> combine(a, b, c)
-    );
-```
-
-**When to use Free Applicative**:
-- Operations are **independent** and can run in parallel
-- You want to **analyse** all operations upfront (batch database queries, parallel API calls)
-- **Optimisation**: Can reorder, batch, or parallelise operations
-
-**When to use Free Monad**:
-- Operations are **dependent** on previous results
-- Need full monadic **sequencing** power
-- Building workflows with conditional logic
-
-**Example**: Fetching data from multiple independent sources
-
-```java
-// Free Applicative can batch these into a single round-trip
-Applicative<DatabaseQuery, Report> report =
-    map3(
-        fetchUsers(),           // Independent
-        fetchOrders(),          // Independent
-        fetchProducts(),        // Independent
-        (users, orders, products) -> generateReport(users, orders, products)
-    );
-
-// Interpreter can optimise: "SELECT * FROM users, orders, products"
-```
-
-### Coyoneda Optimisation
-
-~~~admonish tip title="See Also"
-For comprehensive coverage of Coyoneda, see the dedicated [Coyoneda](coyoneda.md) documentation.
+See [Coyoneda](coyoneda.md) for details.
 ~~~
 
-The **Coyoneda lemma** states that every type constructor can be made into a Functor. This allows Free monads to work with non-functor instruction sets:
-
-```java
-// Without Coyoneda: instruction set must be a Functor
-public sealed interface DatabaseOp<A> {
-    record Query(String sql) implements DatabaseOp<ResultSet> {}
-    record Update(String sql) implements DatabaseOp<Integer> {}
-}
-
-// Must implement Functor<DatabaseOp> - can be tedious!
-
-// With Coyoneda: automatic functor lifting
-class Coyoneda<F, A> {
-    Kind<F, Object> fa;
-    Function<Object, A> f;
-
-    static <F, A> Coyoneda<F, A> lift(Kind<F, A> fa) {
-        return new Coyoneda<>(fa, Function.identity());
-    }
-}
-
-// Now you can use any F without writing a Functor instance!
-Free<Coyoneda<DatabaseOp, ?>, Result> program = ...;
-```
-
-**Benefits**:
-- Less boilerplate (no manual Functor implementation)
-- Works with any instruction set
-- **Trade-off**: Slightly more complex interpretation
-
-**When to use**: Large DSLs where writing Functor instances for every instruction type is burdensome.
-
-### Tagless Final Style (Alternative Approach)
-
-An alternative to Free monads is the **Tagless Final** encoding:
-
-```java
-// Free Monad approach
-sealed interface ConsoleOp<A> { ... }
-Free<ConsoleOp, Result> program = ...;
-
-// Tagless Final approach
-interface Console<F extends WitnessArity<?>> {
-    Kind<F, Unit> printLine(String text);
-    Kind<F, String> readLine();
-}
-
-<F extends WitnessArity<TypeArity.Unary>> Kind<F, Unit> program(Console<F> console, Monad<F> monad) {
-    Kind<F, Unit> printName = console.printLine("What is your name?");
-    Kind<F, String> readName = monad.flatMap(ignored -> console.readLine(), printName);
-    return monad.flatMap(name -> console.printLine("Hello, " + name + "!"), readName);
-}
-
-// Different interpreters
-Kind<IO.Witness, Unit> prod = program(ioConsole, ioMonad);
-Kind<Test.Witness, Unit> test = program(testConsole, testMonad);
-```
-
-**Tagless Final vs. Free Monad**:
+~~~admonish tip title="Tagless Final: The Alternative"
+Tagless Final achieves similar goals (multiple interpreters, testability) without building programs as data:
 
 | Aspect | Free Monad | Tagless Final |
-|--------|------------|---------------|
-| **programs** | Data structures | Abstract functions |
-| **Inspection** | ✅ Can analyse before execution | ❌ Cannot inspect |
-| **Performance** | Slower (interpretation overhead) | Faster (direct execution) |
-| **Boilerplate** | More (HKT bridges, helpers) | Less (just interfaces) |
-| **Flexibility** | ✅ Multiple interpreters, transformations | ✅ Multiple interpreters |
-| **Learning Curve** | Steeper | Moderate |
-
-**When to use Tagless Final**:
-- Performance matters
-- Don't need program inspection
-- Prefer less boilerplate
-
-**When to use Free Monad**:
-- Need to analyse/optimise programs before execution
-- Want programs as first-class values
-- Building complex DSLs with transformations
-
-## Performance Characteristics
-
-Understanding the performance trade-offs of Free monads is crucial for production use:
-
-**Stack Safety**: O(1) stack space regardless of program depth
-- Uses Higher-Kinded-J's `Trampoline` monad internally for `foldMap`
-- Demonstrates library composability: Free uses Trampoline for stack safety
-- Verified with 10,000+ sequential operations without stack overflow
-
-**Heap Allocation**: O(n) where n is program size
-- Each `flatMap` creates a `FlatMapped` node
-- Each `suspend` creates a `Suspend` node
-- **Consideration**: For very large programs (millions of operations), this could be significant
-
-**Interpretation Time**: O(n) where n is program size
-- Each operation must be pattern-matched and interpreted
-- Additional indirection compared to direct execution
-- **Rough estimate**: 2-10x slower than direct imperative code (depends on interpreter complexity)
-
-**Optimisation Strategies**:
-
-1. **Batch Operations**: Accumulate independent operations and execute in bulk
-   ```java
-   // Instead of 1000 individual database inserts
-   Free<DB, Unit> manyInserts = ...;
-
-   // Batch into single multi-row insert
-   interpreter.optimise(program); // Detects pattern, batches
-   ```
-
-2. **Fusion**: Combine consecutive `map` operations
-   ```java
-   program.map(f).map(g).map(h)
-   // Optimiser fuses to: program.map(f.andThen(g).andThen(h))
-   ```
-
-3. **Short-Circuiting**: Detect early termination
-   ```java
-   // If program returns early, skip remaining operations
-   ```
-
-4. **Caching**: Memoize pure computations
-   ```java
-   // Cache results of expensive pure operations
-   ```
-
-**Benchmarks** (relative to direct imperative code):
-- Simple programs (< 100 operations): 2-3x slower
-- Complex programs (1000+ operations): 3-5x slower
-- With optimisation: Can approach parity for batch operations
-
-## Implementation Notes
-
-The `foldMap` method leverages Higher-Kinded-J's own `Trampoline` monad to ensure stack-safe execution. This elegant design demonstrates that the library's abstractions are practical and composable:
-
-```java
-public <M> Kind<M, A> foldMap(
-        Function<Kind<F, ?>, Kind<M, ?>> transform,
-        Monad<M> monad) {
-    // Delegate to Trampoline for stack-safe execution
-    return interpretFree(this, transform, monad).run();
-}
-
-private static <F, M, A> Trampoline<Kind<M, A>> interpretFree(
-        Free<F, A> free,
-        Function<Kind<F, ?>, Kind<M, ?>> transform,
-        Monad<M> monad) {
-
-    return switch (free) {
-        case Pure<F, A> pure ->
-            // Terminal case: lift the pure value into the target monad
-            Trampoline.done(monad.of(pure.value()));
-
-        case Suspend<F, A> suspend -> {
-            // Transform the suspended computation and recursively interpret
-            Kind<M, Free<F, A>> transformed =
-                (Kind<M, Free<F, A>>) transform.apply(suspend.computation());
-
-            yield Trampoline.done(
-                monad.flatMap(
-                    innerFree -> interpretFree(innerFree, transform, monad).run(),
-                    transformed));
-        }
-
-        case FlatMapped<F, ?, A> flatMapped -> {
-            // Handle FlatMapped by deferring the interpretation
-            FlatMapped<F, Object, A> fm = (FlatMapped<F, Object, A>) flatMapped;
-
-            yield Trampoline.defer(() ->
-                interpretFree(fm.sub(), transform, monad)
-                    .map(kindOfX ->
-                        monad.flatMap(
-                            x -> {
-                                Free<F, A> next = fm.continuation().apply(x);
-                                return interpretFree(next, transform, monad).run();
-                            },
-                            kindOfX)));
-        }
-    };
-}
-```
-
-**Key Design Decisions**:
-
-1. **Trampoline Integration**: Uses `Trampoline.done()` for terminal cases and `Trampoline.defer()` for recursive cases, ensuring stack safety.
-
-2. **Library Composability**: Demonstrates that Higher-Kinded-J's abstractions are practical; Free monad uses Trampoline internally.
-
-3. **Pattern Matching**: Uses sealed interface with switch expressions for type-safe case handling.
-
-4. **Separation of Concerns**: Trampoline handles stack safety; Free handles DSL interpretation.
-
-5. **Type Safety**: Uses careful casting to maintain type safety whilst leveraging Trampoline's proven stack-safe execution.
-
-**Benefits of Using Trampoline**:
-- Single source of truth for stack-safe recursion
-- Proven implementation with 100% test coverage
-- Elegant demonstration of library cohesion
-- Improvements to Trampoline automatically benefit Free monad
-
-## Comparison with Traditional Java Patterns
-
-Let's see how Free monads compare to familiar Java patterns:
-
-### Strategy Pattern
-
-**Traditional Strategy**:
-```java
-interface SortStrategy {
-    void sort(List<Integer> list);
-}
-
-class QuickSort implements SortStrategy { ... }
-class MergeSort implements SortStrategy { ... }
-
-// Choose algorithm at runtime
-SortStrategy strategy = useQuickSort ? new QuickSort() : new MergeSort();
-strategy.sort(myList);
-```
-
-**Free Monad Equivalent**:
-```java
-sealed interface SortOp<A> {
-    record Compare(int i, int j) implements SortOp<Boolean> {}
-    record Swap(int i, int j) implements SortOp<Unit> {}
-}
-
-Free<SortOp, Unit> quickSort(List<Integer> list) {
-    // Build program as data
-    return ...;
-}
-
-// Multiple interpreters
-interpreter1.run(program); // In-memory sort
-interpreter2.run(program); // Log operations
-interpreter3.run(program); // Visualise algorithm
-```
-
-**Advantage of Free**: The **entire algorithm** is a data structure that can be inspected, optimised, or visualised.
-
-### Command Pattern
-
-**Traditional Command**:
-```java
-interface Command {
-    void execute();
-}
-
-class SendEmailCommand implements Command { ... }
-class SaveToDBCommand implements Command { ... }
-
-List<Command> commands = List.of(
-    new SendEmailCommand(...),
-    new SaveToDBCommand(...)
-);
-
-commands.forEach(Command::execute);
-```
-
-**Free Monad Equivalent**:
-```java
-sealed interface AppOp<A> {
-    record SendEmail(String to, String body) implements AppOp<Receipt> {}
-    record SaveToDB(Data data) implements AppOp<Id> {}
-}
-
-Free<AppOp, Result> workflow =
-    sendEmail("user@example.com", "Welcome!")
-        .flatMap(receipt -> saveToDatabase(receipt))
-        .flatMap(id -> sendNotification(id));
-
-// One program, many interpreters
-productionInterpreter.run(workflow); // Real execution
-testInterpreter.run(workflow);       // Pure testing
-loggingInterpreter.run(workflow);    // Audit trail
-```
-
-**Advantage of Free**: Commands compose with `flatMap`, results flow between commands, and you get multiple interpreters for free.
-
-### Observer Pattern
-
-**Traditional Observer**:
-```java
-interface Observer {
-    void update(Event event);
-}
-
-class Logger implements Observer { ... }
-class Notifier implements Observer { ... }
-
-subject.registerObserver(logger);
-subject.registerObserver(notifier);
-subject.notifyObservers(event);
-```
-
-**Free Monad Equivalent**:
-```java
-sealed interface EventOp<A> {
-    record Emit(Event event) implements EventOp<Unit> {}
-    record React(Event event) implements EventOp<Unit> {}
-}
-
-Free<EventOp, Unit> eventStream =
-    emit(userLoggedIn)
-        .flatMap(ignored -> emit(pageViewed))
-        .flatMap(ignored -> emit(itemPurchased));
-
-// Different observation strategies
-loggingInterpreter.run(eventStream);     // Log to file
-analyticsInterpreter.run(eventStream);   // Send to analytics
-testInterpreter.run(eventStream);        // Collect for assertions
-```
-
-**Advantage of Free**: Event streams are first-class values that can be composed, transformed, and replayed.
-
-## Summary
-
-The Free monad provides a powerful abstraction for building domain-specific languages in Java:
-
-- **Separation of Concerns**: Program description (data) vs. execution (interpreters)
-- **Testability**: Pure testing without actual side effects
-- **Flexibility**: Multiple interpreters for the same program
-- **Stack Safety**: Handles deep recursion without stack overflow (verified with 10,000+ operations)
-- **Composability**: Build complex programs from simple building blocks
-
-**When to use**:
-- Building DSLs
-- Need multiple interpretations
-- Testability is critical
-- Program analysis/optimisation required
-
-**When to avoid**:
-- Performance-critical code
-- Simple, single-interpretation effects
-- Team unfamiliar with advanced functional programming
-
-For detailed implementation examples and complete working code, see:
-- [ConsoleProgram.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/free/ConsoleProgram.java) - Complete DSL with multiple interpreters
-- [FreeMonadTest.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-core/src/test/java/org/higherkindedj/hkt/free/FreeMonadTest.java) - Comprehensive test suite including monad laws and stack safety
-
-The Free monad represents a sophisticated approach to building composable, testable, and maintainable programs in Java. Whilst it requires understanding of advanced functional programming concepts, it pays dividends in large-scale applications where flexibility and testability are paramount.
+|--------|-----------|---------------|
+| Programs | Data structures (inspectable) | Abstract functions (opaque) |
+| Performance | Slower (interpretation overhead) | Faster (direct execution) |
+| Boilerplate | More (HKT bridges, helpers) | Less (just interfaces) |
+| Inspection | Can analyse before execution | Cannot inspect programs |
+
+Choose **Free** when you need program inspection/optimisation. Choose **Tagless Final** when you want less boilerplate and better performance.
+~~~
+
+~~~admonish important title="Key Points"
+- `Free<F, A>` turns any instruction set `F` into a monad — programs become composable data structures.
+- **`foldMap`** is the engine: it walks the program tree, transforms each instruction via a natural transformation, and sequences results in a target monad. Stack-safe via Trampoline.
+- **Testability** is the killer feature: write one program, test it with a pure interpreter, run it with a real one.
+- **FreeFactory** solves Java's type inference limitations when chaining `map`/`flatMap` on `Free.pure()`.
+- Programs compose with `flatMap` — build small DSL operations, snap them together into complex workflows.
+- Free monad has overhead (~2-10x vs direct code). Use it when testability and flexibility outweigh raw performance.
+~~~
 
 ---
 

--- a/hkj-book/src/monads/lazy_monad.md
+++ b/hkj-book/src/monads/lazy_monad.md
@@ -3,17 +3,60 @@
 
 ~~~admonish info title="What You'll Learn"
 - How to defer expensive computations until their results are actually needed
-- Understanding memoisation and how results are cached after first evaluation
-- Handling exceptions in lazy computations with ThrowableSupplier
-- Composing lazy operations while preserving laziness
-- Building efficient pipelines that avoid unnecessary work
+- Understanding memoization: compute once, read many times
+- Composing lazy operations with `map` and `flatMap` while preserving laziness
+- Handling exceptions in lazy computations with `ThrowableSupplier`
+- Choosing between `Lazy` and `IO` for deferred work
 ~~~
 
 ~~~ admonish example title="See Example Code:"
 [LazyExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/lazy/LazyExample.java)
 ~~~
 
-This article introduces the `Lazy<A>` type and its associated components within the `higher-kinded-j` library. `Lazy` provides a mechanism for deferred computation, where a value is calculated only when needed and the result (or any exception thrown during calculation) is memoised (cached).
+## The Problem: Doing Work You'll Throw Away
+
+Imagine a dashboard that assembles a user summary from three data sources:
+
+```java
+String buildDashboard(String userId) {
+    var profile         = fetchUserProfile(userId);      // 200ms
+    var recommendations = fetchRecommendations(userId);  // 800ms
+    var analytics       = fetchAnalytics(userId);        // 500ms
+    return summarize(profile, recommendations, analytics);
+}
+```
+
+Every call pays the full 1500ms cost. But 90% of callers only need the profile. The other two results are assembled, inspected, and thrown away. That is 1300ms of wasted work on nearly every request.
+
+```
+EAGER (always runs everything):         LAZY (runs on demand):
+  fetchUserProfile()    -> 200ms done     defer(fetchUserProfile)     -> 0ms
+  fetchRecommendations()-> 800ms waste    defer(fetchRecommendations) -> 0ms
+  fetchAnalytics()      -> 500ms waste    defer(fetchAnalytics)       -> 0ms
+  Total: 1500ms                          force(userProfile)          -> 200ms
+                                         Total: 200ms (saved 87%)
+```
+
+With `Lazy`, each computation is wrapped in a deferred shell. Nothing runs until you explicitly call `force()`. If you never force a value, you never pay its cost.
+
+This is not a niche optimization. Any time your code builds a data structure with fields that are expensive to populate but cheap to skip, laziness eliminates wasted work at zero architectural cost. The calling code decides what to evaluate -- not the producer.
+
+## The Fix: Defer and Force
+
+`Lazy<A>` stores a computation without executing it. Call `defer()` to wrap the work; call `force()` when you actually need the result. After the first `force()`, the result is cached -- subsequent calls return instantly with zero recomputation.
+
+```java
+Kind<LazyKind.Witness, String> profile = LAZY.defer(() -> fetchUserProfile(userId));
+// Nothing has executed yet.
+
+String result = LAZY.force(profile);  // Now it runs -- once.
+String cached = LAZY.force(profile);  // Returns the cached value instantly.
+```
+
+This is the "compute once, read many" guarantee. Whether you force the value twice or two thousand times, the underlying supplier runs exactly once. The first caller pays the cost; every subsequent caller gets the answer for free.
+
+Contrast this with a raw `Supplier<T>`, which re-executes on every `.get()` call. `Lazy` gives you the same deferred interface with built-in caching and exception handling baked in.
+
 ## Core Components
 
 **The Lazy Type**
@@ -28,149 +71,162 @@ This article introduces the `Lazy<A>` type and its associated components within 
 
 ![lazy_monad.svg](../images/puml/lazy_monad.svg)
 
-The lazy evaluation feature revolves around these key types:
+| Component | Role |
+|-----------|------|
+| `ThrowableSupplier<T>` | Like `Supplier`, but its `get()` may throw any `Throwable` -- the computation source for `Lazy` |
+| `Lazy<A>` | Core class: wraps a supplier, evaluates on `force()`, and memoizes the result (or exception) |
+| `LazyKind<A>` | HKT marker (`Kind<LazyKind.Witness, A>`) so `Lazy` can participate in generic typeclass code |
+| `LazyKindHelper` | Bridge utilities: `widen`, `narrow`, `defer`, `now`, `force` for converting between `Lazy` and `LazyKind` |
+| `LazyMonad` | Typeclass instance implementing `Monad`, `Applicative`, and `Functor` for `LazyKind.Witness` |
 
-1. **`ThrowableSupplier<T>`**: A functional interface similar to `java.util.function.Supplier`, but its `get()` method is allowed to throw any `Throwable` (including checked exceptions). This is used as the underlying computation for `Lazy`.
-2. **`Lazy<A>`**: The core class representing a computation that produces a value of type `A` lazily. It takes a `ThrowableSupplier<? extends A>` during construction (`Lazy.defer`). Evaluation is triggered only by the `force()` method, and the result or exception is cached. `Lazy.now(value)` creates an already evaluated instance.
-3. **`LazyKind<A>`**: The HKT marker interface (`Kind<LazyKind.Witness, A>`) for `Lazy`, allowing it to be used generically with type classes like `Functor` and `Monad`.
-4. **`LazyKindHelper`**: A utility class providing static methods to bridge between the concrete `Lazy<A>` type and its HKT representation `LazyKind<A>`. It includes:
-   * `widen(Lazy<A>)`: Wraps a `Lazy` instance into `LazyKind`.
-   * `narrow(Kind<LazyKind.Witness, A>)`: Unwraps `LazyKind` back to `Lazy`. Throws `KindUnwrapException` if the input Kind is invalid.
-   * `defer(ThrowableSupplier<A>)`: Factory to create a `LazyKind` from a computation.
-   * `now(A value)`: Factory to create an already evaluated `LazyKind`.
-   * `force(Kind<LazyKind.Witness, A>)`: Convenience method to unwrap and force evaluation.
-5. **`LazyMonad`**: The type class instance implementing `Monad<LazyKind.Witness>`, `Applicative<LazyKind.Witness>`, and `Functor<LazyKind.Witness>`. It provides standard monadic operations (`map`, `flatMap`, `of`, `ap`) for `LazyKind`, ensuring laziness is maintained during composition.
+`LazyKindHelper` deserves special attention. It is your primary API surface when working with `Lazy` in generic HKT code. Its static methods handle the wrapping and unwrapping so you can stay in the `Kind<LazyKind.Witness, A>` world without manual casting:
 
-## Purpose and Usage
+- **`defer(supplier)`** -- create a deferred `LazyKind` from a `ThrowableSupplier`
+- **`now(value)`** -- create an already-evaluated `LazyKind`
+- **`force(kind)`** -- unwrap and evaluate, returning the cached result or throwing the cached exception
+- **`widen(lazy)`** / **`narrow(kind)`** -- convert between `Lazy<A>` and `Kind<LazyKind.Witness, A>`
 
-* **Deferred Computation**: Use `Lazy` when you have potentially expensive computations that should only execute if their result is actually needed.
-* **Memoization**: The result (or exception) of the computation is stored after the first call to `force()`, subsequent calls return the cached result without re-computation.
-* **Exception Handling**: Computations wrapped in `Lazy.defer` can throw any `Throwable`. This exception is caught, memoised, and re-thrown by `force()`.
-* **Functional Composition**: `LazyMonad` allows chaining lazy computations using `map` and `flatMap` while preserving laziness. The composition itself doesn't trigger evaluation; only forcing the final `LazyKind` does.
-* **HKT Integration**: `LazyKind` and `LazyMonad` enable using lazy computations within generic functional code expecting `Kind<F, A>` where `F extends WitnessArity<?>` and `Monad<F>` where `F extends WitnessArity<TypeArity.Unary>`.
+~~~admonish note title="How Lazy Evaluation Works"
+```
+defer(() -> compute())          force()            force()
+       |                           |                  |
+       v                           v                  v
+  [unevaluated]  -------->  [compute & cache]  --->  [return cached]
+   Supplier stored       Supplier called once     No recomputation
+```
 
-~~~admonish example title="Example: Creating Lazy Instances"
+The `Supplier` is stored on creation, invoked exactly once on the first `force()`, and the result (or exception) is cached for all subsequent calls.
+~~~
 
-- [LazyExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/lazy/LazyExample.java)
+~~~admonish tip title="Memoization in Action"
+The first `force()` pays the full computation cost. Every call after that is effectively free:
+
+```
+force() #1  -->  supplier runs  -->  result stored  -->  200ms
+force() #2  -->  cache hit      -->  result returned -->    0ms
+force() #3  -->  cache hit      -->  result returned -->    0ms
+  ...
+force() #N  -->  cache hit      -->  result returned -->    0ms
+```
+
+This makes `Lazy` ideal for values that are expensive to produce but read frequently -- configuration lookups, parsed templates, compiled patterns, and similar compute-once artifacts.
+~~~
+
+~~~admonish example title="Example 1: Deferred Computation"
+Creating lazy values does no work. Forcing them does -- exactly once.
 
 ```java
+AtomicInteger counter = new AtomicInteger(0);
 
-// 1. Deferring a computation (that might throw checked exception)
-java.util.concurrent.atomic.AtomicInteger counter = new java.util.concurrent.atomic.AtomicInteger(0);
-Kind<LazyKind.Witness, String> deferredLazy = LAZY.defer(() -> {
-    System.out.println("Executing expensive computation...");
+// Deferred: the supplier is stored, not called
+Kind<LazyKind.Witness, String> deferred = LAZY.defer(() -> {
     counter.incrementAndGet();
-    // Simulate potential failure
-    if (System.currentTimeMillis() % 2 == 0) {
-         // Throwing a checked exception is allowed by ThrowableSupplier
-         throw new java.io.IOException("Simulated IO failure");
-    }
-    Thread.sleep(50); // Simulate work
+    Thread.sleep(50); // simulate work
     return "Computed Value";
 });
 
-// 2. Creating an already evaluated Lazy
-Kind<LazyKind.Witness, String> nowLazy = LAZY.now("Precomputed Value");
+// Already-evaluated: no supplier to call later
+Kind<LazyKind.Witness, String> ready = LAZY.now("Precomputed Value");
 
-// 3. Using the underlying Lazy type directly (less common when using HKT)
-Lazy<String> directLazy = Lazy.defer(() -> { counter.incrementAndGet(); return "Direct Lazy"; });
+System.out.println("Counter after creation: " + counter.get()); // 0
+
+String result1 = LAZY.force(deferred);  // runs the supplier
+System.out.println(result1);            // "Computed Value"
+System.out.println("Counter: " + counter.get()); // 1
+
+String result2 = LAZY.force(deferred);  // returns cached value
+System.out.println("Counter: " + counter.get()); // still 1 -- no recomputation
+
+String resultNow = LAZY.force(ready);   // "Precomputed Value" -- counter unchanged
 ```
+
+Exceptions follow the same rule: if the computation throws on the first `force()`, that exception is cached. Every subsequent `force()` rethrows the same exception without re-executing the supplier. This means error behavior is deterministic -- you will never see a computation fail once, then succeed on retry through the same `Lazy` instance.
 ~~~
 
-~~~admonish example title="Example: Forcing Evaluation"
-
-- [LazyExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/lazy/LazyExample.java)
-
-Evaluation only happens when `force()` is called (directly or via the helper).
+~~~admonish example title="Example 2: Composing with map and flatMap"
+`LazyMonad` lets you chain transformations without triggering evaluation. Only the final `force()` runs the entire pipeline.
 
 ```java
-// (Continuing from above)
-System.out.println("Lazy instances created. Counter: " + counter.get()); // Output: 0
-
-try {
-    // Force the deferred computation
-    String result1 = LAZY.force(deferredLazy); // force() throws Throwable
-    System.out.println("Result 1: " + result1);
-    System.out.println("Counter after first force: " + counter.get()); // Output: 1
-
-    // Force again - uses memoised result
-    String result2 = LAZY.force(deferredLazy);
-    System.out.println("Result 2: " + result2);
-    System.out.println("Counter after second force: " + counter.get()); // Output: 1 (not re-computed)
-
-    // Force the 'now' instance
-    String resultNow = LAZY.force(nowLazy);
-    System.out.println("Result Now: " + resultNow);
-    System.out.println("Counter after forcing 'now': " + counter.get()); // Output: 1 (no computation ran for 'now')
-
-} catch (Throwable t) { // Catch Throwable because force() can re-throw anything
-    System.err.println("Caught exception during force: " + t);
-    // Exception is also memoised:
-    try {
-        LAZY.force(deferredLazy);
-    } catch (Throwable t2) {
-        System.err.println("Caught memoised exception: " + t2);
-        System.out.println("Counter after failed force: " + counter.get()); // Output: 1
-    }
-}
-```
-~~~
-
-~~~admonish example title="Example: Using _LazyMonad_ (_map_ and _flatMap_)"
-
-- [LazyExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/lazy/LazyExample.java)
-
-```java
-
 LazyMonad lazyMonad = LazyMonad.INSTANCE;
-counter.set(0); // Reset counter for this example
+AtomicInteger counter = new AtomicInteger(0);
 
-Kind<LazyKind.Witness, Integer> initialLazy = LAZY.defer(() -> { counter.incrementAndGet(); return 10; });
+Kind<LazyKind.Witness, Integer> base = LAZY.defer(() -> {
+    counter.incrementAndGet();
+    return 10;
+});
 
-// --- map ---
-// Apply a function lazily
-Function<Integer, String> toStringMapper = i -> "Value: " + i;
-Kind<LazyKind.Witness, String> mappedLazy = lazyMonad.map(toStringMapper, initialLazy);
+// map: transform the eventual value without forcing it
+Kind<LazyKind.Witness, String> mapped = lazyMonad.map(i -> "Value: " + i, base);
+System.out.println("Counter after map: " + counter.get()); // 0
 
-System.out.println("Mapped Lazy created. Counter: " + counter.get()); // Output: 0
+System.out.println(LAZY.force(mapped)); // "Value: 10"
+System.out.println("Counter: " + counter.get()); // 1
 
-try {
-    System.out.println("Mapped Result: " + LAZY.force(mappedLazy)); // Triggers evaluation of initialLazy & map
-    // Output: Mapped Result: Value: 10
-    System.out.println("Counter after forcing mapped: " + counter.get()); // Output: 1
-} catch (Throwable t) { /* ... */ }
-
-
-// --- flatMap ---
-// Sequence lazy computations
-Function<Integer, Kind<LazyKind.Witness, String>> multiplyAndStringifyLazy =
-    i -> LAZY.defer(() -> { // Inner computation is also lazy
-        int result = i * 5;
-        return "Multiplied: " + result;
-    });
-
-Kind<LazyKind.Witness, String> flatMappedLazy = lazyMonad.flatMap(multiplyAndStringifyLazy, initialLazy);
-
-System.out.println("FlatMapped Lazy created. Counter: " + counter.get()); // Output: 1 (map already forced initialLazy)
-
-try {
-    System.out.println("FlatMapped Result: " + force(flatMappedLazy)); // Triggers evaluation of inner lazy
-    // Output: FlatMapped Result: Multiplied: 50
-} catch (Throwable t) { /* ... */ }
-
-// --- Chaining ---
-Kind<LazyKind.Witness, String> chainedLazy = lazyMonad.flatMap(
-    value1 -> lazyMonad.map(
-        value2 -> "Combined: " + value1 + " & " + value2, // Combine results
-        LAZY.defer(()->value1 * 2) // Second lazy step, depends on result of first
+// flatMap: sequence two lazy computations
+Kind<LazyKind.Witness, String> chained = lazyMonad.flatMap(
+    v1 -> lazyMonad.map(
+        v2 -> "Combined: " + v1 + " & " + v2,
+        LAZY.defer(() -> v1 * 2)  // second step depends on first
     ),
-    LAZY.defer(()->5) // First lazy step
+    LAZY.defer(() -> 5)           // first step
 );
 
-try{
-    System.out.println("Chained Result: "+force(chainedLazy)); // Output: Combined: 5 & 10
-}catch(Throwable t){/* ... */}
+System.out.println(LAZY.force(chained)); // "Combined: 5 & 10"
 ```
+
+Neither `map` nor `flatMap` triggers evaluation -- they build a new `Lazy` that will run the full chain when forced. This means you can construct an entire pipeline of transformations upfront, and the cost of the whole pipeline is paid only at the single point where `force()` is called.
+~~~
+
+~~~admonish warning title="Lazy vs IO: Know the Difference"
+**`Lazy`** defers **pure computation** -- work that depends only on its inputs and always produces the same result. The memoized value is safe to reuse because it never changes.
+
+**`IO`** defers **side effects** -- work that reads files, calls APIs, writes to databases, or depends on external state. Each execution may produce a different result, so memoization would give stale answers.
+
+| Question | Answer |
+|----------|--------|
+| Does it read a file, call an API, or write to a database? | Use `IO` |
+| Does it compute a value from pure inputs? | Use `Lazy` |
+| Should repeated calls return the same cached result? | Use `Lazy` |
+| Should repeated calls re-execute the effect? | Use `IO` |
+
+**Rule of thumb:** if your computation talks to the outside world, use [`IO`](./io_monad.md). If it only crunches data, use `Lazy`.
+~~~
+
+## When to Use Lazy
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Deferring expensive computation until needed | `Lazy` / `LazyMonad` |
+| Composing deferred computations while preserving laziness | `LazyMonad` -- `map`/`flatMap` don't trigger evaluation |
+| Caching computation results (memoization) | `Lazy` -- result is cached after first `force()` |
+| Computations that may throw checked exceptions | `Lazy` -- wraps `ThrowableSupplier` |
+| Building data structures with optional expensive fields | `Lazy` -- callers force only what they need |
+| Configuration values loaded once and reused | `Lazy` -- natural fit for compute-once semantics |
+| Deferred side effects with execution control | Prefer [IO](./io_monad.md) instead |
+
+~~~admonish important title="Key Points"
+- `Lazy<A>` wraps a `ThrowableSupplier<A>` -- nothing executes until `force()` is called.
+- Results are **memoized**: the first `force()` computes and caches; subsequent calls return the cached value instantly.
+- Exceptions are also memoized -- if the computation throws on first `force()`, the same exception is rethrown on subsequent calls.
+- `map` and `flatMap` via `LazyMonad` produce new `Lazy` values without triggering evaluation of the input.
+- `Lazy.now(value)` creates an already-evaluated instance -- useful for lifting pure values into the Lazy context.
+- `ThrowableSupplier` allows checked exceptions -- no need for awkward `try`/`catch` inside lambdas.
+- Thread safety: `Lazy` ensures the supplier runs at most once, even under concurrent `force()` calls.
+~~~
+
+---
+
+~~~admonish example title="Benchmarks"
+Lazy has dedicated JMH benchmarks measuring deferred construction, memoization overhead, and chain depth. Key expectations:
+
+- **Construction** (`defer`, `now`) is very fast -- Lazy is a thin wrapper with no immediate execution
+- **First `force()`** incurs the full computation cost; subsequent calls return the cached result
+- **Deep chains (50+)** of `map`/`flatMap` complete without error -- composition overhead dominates at depth
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*LazyBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details and how to interpret results.
 ~~~
 
 ---

--- a/hkj-book/src/monads/list_monad.md
+++ b/hkj-book/src/monads/list_monad.md
@@ -1,248 +1,195 @@
 # The ListMonad:
-## _Monadic Operations on Java Lists_
+## _Non-Deterministic Computation with Java Lists_
 
 ~~~admonish info title="What You'll Learn"
-- How to work with Lists as contexts representing multiple possible values
-- Using `flatMap` for non-deterministic computations and combinations
-- Generating Cartesian products and filtering results
-- Understanding how List models choice and branching computations
+- How to model non-deterministic computations where each step produces multiple results
+- Using `flatMap` to explore all combinations and `ap` to produce Cartesian products
 - Building search algorithms and combinatorial problems with monadic operations
+- Generating and filtering results within the higher-kinded type system
 ~~~
 
 ~~~ admonish example title="See Example Code:"
 [ListMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/list/ListMonadExample.java)
 ~~~
 
-## Purpose
+## The Problem: Non-Deterministic Computation
 
-The `ListMonad` in the `Higher-Kinded-J` library provides a monadic interface for Java's standard `java.util.List`. It allows developers to work with lists in a more functional style, enabling operations like `map`, `flatMap`, and `ap` (apply) within the higher-kinded type system. This is particularly useful for sequencing operations that produce lists, transforming list elements, and applying functions within a list context, all while integrating with the generic `Kind<F, A>` abstractions.
+Some computations don't have a single answer — they have many. Consider finding all valid moves for a chess piece, all paths through a grid, or all ways to make change for a dollar. In each case, every intermediate step branches into multiple possibilities, and you need to explore *all* of them.
 
-Key benefits include:
-
-* **Functional Composition:** Easily chain operations on lists, where each operation might return a list itself.
-* **HKT Integration:** `ListKind` (the higher-kinded wrapper for `List`) and `ListMonad` allow `List` to be used with generic functions and type classes expecting `Kind<F, A>` where `F extends WitnessArity<?>`, along with type classes like `Functor<F>`, `Applicative<F>`, or `Monad<F>` where `F extends WitnessArity<TypeArity.Unary>`.
-* **Standard List Behaviour:** Leverages the familiar behaviour of Java lists, such as non-uniqueness of elements and order preservation. `flatMap` corresponds to applying a function that returns a list to each element and then concatenating the results.
-
-It implements `Monad<ListKind<A>>`, inheriting from `Functor<ListKind<A>>` and `Applicative<ListKind<A>>`.
-
-## Structure
-
-![list_monad.svg](../images/puml/list_monad.svg)
-
-## How to Use `ListMonad` and `ListKind`
-
-### Creating Instances
-
-`ListKind<A>` is the higher-kinded type representation for `java.util.List<A>`. You typically create `ListKind` instances using the `ListKindHelper` utility class or the `of` method from `ListMonad`.
-
-~~~admonish title="_LIST.widen(List<A>)_"
-
-Converts a standard `java.util.List<A>` into a `Kind<ListKind.Witness, A>`.
+With plain Java, this means nested loops, manual concatenation, and tangled control flow:
 
 ```java
-List<String> stringList = Arrays.asList("a", "b", "c");
-Kind<ListKind.Witness, String> listKind1 = LIST.widen(stringList);
-
-List<Integer> intList = Collections.singletonList(10);
-Kind<ListKind.Witness, Integer> listKind2 = LIST.widen(intList);
-
-List<Object> emptyList = Collections.emptyList();
-Kind<ListKind.Witness, Object> listKindEmpty = LIST.widen(emptyList);
-
-```
-~~~
-
-
-~~~admonish title="_listMonad.of(A value)_"  
-
-Lifts a single value into the `ListKind` context, creating a singleton list. A `null` input value results in an empty `ListKind`.
-
-```java
-ListMonad listMonad = ListMonad.INSTANCE;
-
-Kind<ListKind.Witness, String> listKindOneItem = listMonad.of("hello"); // Contains a list with one element: "hello"
-Kind<ListKind.Witness, Integer> listKindAnotherItem = listMonad.of(42);  // Contains a list with one element: 42
-Kind<ListKind.Witness, Object> listKindFromNull = listMonad.of(null); // Contains an empty list
-```
-~~~
-
-~~~admonish title="_LIST.narrow()_"  
-
-To get the underlying `java.util.List<A>` from a `Kind<ListKind.Witness, A>`, use `LIST.narrow()`:
-
-```java
-Kind<ListKind.Witness, A> listKind = LIST.widen(List.of("example"));
-List<String> unwrappedList = LIST.narrow(listKind); // Returns Arrays.asList("example")
-System.out.println(unwrappedList);
-```
-~~~
-
-### Key Operations
-
-The `ListMonad` provides standard monadic operations:
-~~~admonish  title="_map(Function<A, B> f, Kind<ListKind.Witness, A> fa)_"
-**`map(Function<A, B> f, Kind<ListKind.Witness, A> fa)`:**
-
-Applies a function `f` to each element of the list within `fa`, returning a new `ListKind` containing the transformed elements.
-
-```java
-
-ListMonad listMonad = ListMonad.INSTANCE;
-ListKind<Integer> numbers = LIST.widen(Arrays.asList(1, 2, 3));
-
-Function<Integer, String> intToString = i -> "Number: " + i;
-ListKind<String> strings = listMonad.map(intToString, numbers);
-
-// LIST.narrow(strings) would be: ["Number: 1", "Number: 2", "Number: 3"]
-System.out.println(LIST.narrow(strings));
-```
-~~~
-
-~~~admonish  title="_flatMap(Function<A, Kind<ListKind.Witness, B>> f, Kind<ListKind.Witness, A> ma)_"
-**`flatMap(Function<A, Kind<ListKind.Witness, B>> f, Kind<ListKind.Witness, A> ma)`:**
-
-Applies a function `f` to each element of the list within `ma`. The function `f` itself returns a `ListKind<B>`. `flatMap` then concatenates (flattens) all these resulting lists into a single `ListKind<B>`.
-
-```java
-
-ListMonad listMonad = ListMonad.INSTANCE;
-Kind<ListKind.Witness, Integer> initialValues = LIST.widen(Arrays.asList(1, 2, 3));
-
-// Function that takes an integer and returns a list of itself and itself + 10
-Function<Integer, Kind<ListKind.Witness, Integer>> replicateAndAddTen =
-    i -> LIST.widen(Arrays.asList(i, i + 10));
-
-Kind<ListKind.Witness, Integer> flattenedList = listMonad.flatMap(replicateAndAddTen, initialValues);
-
-// LIST.narrow(flattenedList) would be: [1, 11, 2, 12, 3, 13]
-System.out.println(LIST.narrow(flattenedList));
-
-// Example with empty list results
-Function<Integer, Kind<ListKind.Witness, String>> toWordsIfEven =
-    i -> (i % 2 == 0) ?
-         LIST.widen(Arrays.asList("even", String.valueOf(i))) :
-         LIST.widen(new ArrayList<>()); // empty list for odd numbers
-
-Kind<ListKind.Witness, String> wordsList = listMonad.flatMap(toWordsIfEven, initialValues);
-// LIST.narrow(wordsList) would be: ["even", "2"]
- System.out.println(LIST.narrow(wordsList));
-```
-~~~
-
-~~~admonish  title="_ap(Kind<ListKind.Witness, Function<A, B>> ff, Kind<ListKind.Witness, A> fa)_"
-**`ap(Kind<ListKind.Witness, Function<A, B>> ff, Kind<ListKind.Witness, A> fa)`:**
-
-Applies a list of functions `ff` to a list of values `fa`. This results in a new list where each function from `ff` is applied to each value in `fa` (Cartesian product style).
-
-```java
-
-ListMonad listMonad = ListMonad.INSTANCE;
-
-Function<Integer, String> addPrefix = i -> "Val: " + i;
-Function<Integer, String> multiplyAndString = i -> "Mul: " + (i * 2);
-
-Kind<ListKind.Witness, Function<Integer, String>> functions =
-    LIST.widen(Arrays.asList(addPrefix, multiplyAndString));
-Kind<ListKind.Witness, Integer> values = LIST.widen(Arrays.asList(10, 20));
-
-Kind<ListKind.Witness, String> appliedResults = listMonad.ap(functions, values);
-
-// LIST.narrow(appliedResults) would be:
-// ["Val: 10", "Val: 20", "Mul: 20", "Mul: 40"]
-System.out.println(LIST.narrow(appliedResults));
-```
-~~~
-
-
-~~~admonish example title="Example: Using ListMonad"
-
-- [ListMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/list/ListMonadExample.java)
-
-To use `ListMonad` in generic contexts that operate over `Kind<F, A>`:
-
-1. **Get an instance of `ListMonad`:**
-
-```java
-ListMonad listMonad = ListMonad.INSTANCE;
-```
-
-2. **Wrap your List into `Kind`:**
-
-```java
-List<Integer> myList = Arrays.asList(10, 20, 30);
-Kind<ListKind.Witness, Integer> listKind = LIST.widen(myList);
-```
-
-3. **Use `ListMonad` methods:**
-
-```java
-import org.higherkindedj.hkt.Kind;
-import org.higherkindedj.hkt.list.ListKind;
-import org.higherkindedj.hkt.list.ListKindHelper;
-import org.higherkindedj.hkt.list.ListMonad;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-public class ListMonadExample {
-   public static void main(String[] args) {
-      ListMonad listMonad = ListMonad.INSTANCE;
-
-      // 1. Create a ListKind
-      Kind<ListKind.Witness, Integer> numbersKind = LIST.widen(Arrays.asList(1, 2, 3, 4));
-
-      // 2. Use map
-      Function<Integer, String> numberToDecoratedString = n -> "*" + n + "*";
-      Kind<ListKind.Witness, String> stringsKind = listMonad.map(numberToDecoratedString, numbersKind);
-      System.out.println("Mapped: " + LIST.narrow(stringsKind));
-      // Expected: Mapped: [*1*, *2*, *3*, *4*]
-
-      // 3. Use flatMap
-      // Function: integer -> ListKind of [integer, integer*10] if even, else empty ListKind
-      Function<Integer, Kind<ListKind.Witness, Integer>> duplicateIfEven = n -> {
-         if (n % 2 == 0) {
-            return LIST.widen(Arrays.asList(n, n * 10));
-         } else {
-            return LIST.widen(List.of()); // Empty list
-         }
-      };
-      Kind<ListKind.Witness, Integer> flatMappedKind = listMonad.flatMap(duplicateIfEven, numbersKind);
-      System.out.println("FlatMapped: " + LIST.narrow(flatMappedKind));
-      // Expected: FlatMapped: [2, 20, 4, 40]
-
-      // 4. Use of
-      Kind<ListKind.Witness, String> singleValueKind = listMonad.of("hello world");
-      System.out.println("From 'of': " + LIST.narrow(singleValueKind));
-      // Expected: From 'of': [hello world]
-
-      Kind<ListKind.Witness, String> fromNullOf = listMonad.of(null);
-      System.out.println("From 'of' with null: " + LIST.narrow(fromNullOf));
-      // Expected: From 'of' with null: []
-
-
-      // 5. Use ap
-      Kind<ListKind.Witness, Function<Integer, String>> listOfFunctions =
-              LIST.widen(Arrays.asList(
-                      i -> "F1:" + i,
-                      i -> "F2:" + (i * i)
-              ));
-      Kind<ListKind.Witness, Integer> inputNumbersForAp = LIST.widen(Arrays.asList(5, 6));
-
-      Kind<ListKind.Witness, String> apResult = listMonad.ap(listOfFunctions, inputNumbersForAp);
-      System.out.println("Ap result: " + LIST.narrow(apResult));
-      // Expected: Ap result: [F1:5, F1:6, F2:25, F2:36]
-
-
-      // Unwrap to get back the standard List
-      List<Integer> finalFlatMappedList = LIST.narrow(flatMappedKind);
-      System.out.println("Final unwrapped flatMapped list: " + finalFlatMappedList);
-   }
+// Find all paths of length 2 from a starting node
+List<List<String>> paths = new ArrayList<>();
+for (String first : neighbors(start)) {
+    for (String second : neighbors(first)) {
+        paths.add(List.of(start, first, second));
+    }
 }
 ```
 
-This example demonstrates how to wrap Java Lists into `ListKind`, apply monadic operations using `ListMonad`, and then unwrap them back to standard Lists.
+Each level of nesting adds another loop. If the number of steps is dynamic, you need recursion with manual list-building. The structure of the problem — "for each possibility, explore further" — is buried under bookkeeping.
+
+The `ListMonad` captures this pattern directly. A `List` represents multiple possible values, `flatMap` explores all combinations by applying a function to each element and concatenating the results, and `ap` produces Cartesian products. The nested-loop problem above becomes:
+
+```java
+ListMonad listMonad = ListMonad.INSTANCE;
+Kind<ListKind.Witness, String> starts = listMonad.of(start);
+
+Kind<ListKind.Witness, String> step1 = listMonad.flatMap(
+    node -> LIST.widen(neighbors(node)), starts);
+
+Kind<ListKind.Witness, String> step2 = listMonad.flatMap(
+    node -> LIST.widen(neighbors(node)), step1);
+// step2 contains every node reachable in exactly 2 hops
+```
+
+Each `flatMap` expands one level of the search tree. No nested loops, no manual concatenation — the monad handles it.
+
+## Core Components
+
+![list_monad.svg](../images/puml/list_monad.svg)
+
+| Component | Role |
+|-----------|------|
+| `List<A>` | Standard Java list — the underlying data structure |
+| `ListKind<A>` / `ListKindHelper` | HKT bridge: `widen()` wraps a `List` into `Kind`, `narrow()` unwraps it back |
+| `ListMonad` | `Monad<ListKind.Witness>` — provides `map`, `flatMap`, `of`, and `ap` over lists |
+
+~~~admonish note title="How the Operations Map"
+The monad operations correspond to familiar list operations:
+
+| Type Class Operation | What It Does |
+|---------------------|--------------|
+| `listMonad.of(value)` | Create a singleton list containing `value` (`null` produces an empty list) |
+| `listMonad.map(f, fa)` | Apply `f` to every element — same as `stream().map(f).toList()` |
+| `listMonad.flatMap(f, fa)` | Apply `f` to each element (where `f` returns a list), concatenate all results — same as `stream().flatMap(...)` |
+| `listMonad.ap(ff, fa)` | Apply every function in `ff` to every value in `fa` — Cartesian product |
+
+The key insight: `flatMap` on lists *is* non-deterministic computation. Each element branches into zero or more results, and all branches are collected into a single list.
+~~~
+
+### How `ap` Produces a Cartesian Product
+
+The `ap` operation applies *every* function to *every* value, producing all combinations:
+
+```text
+functions: [f1, f2]       values: [a, b, c]
+                ↓ ap ↓
+results:  [f1(a), f1(b), f1(c), f2(a), f2(b), f2(c)]
+```
+
+This is the applicative Cartesian product — if you have `n` functions and `m` values, `ap` produces `n * m` results.
+
+## Working with ListMonad
+
+The following examples demonstrate creating list contexts, composing operations, and building combinatorial pipelines.
+
+~~~admonish example title="Creating Instances and Basic Operations"
+
+- [ListMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/list/ListMonadExample.java)
+
+```java
+ListMonad listMonad = ListMonad.INSTANCE;
+
+// --- Wrap a standard List into the Kind system ---
+Kind<ListKind.Witness, Integer> numbers = LIST.widen(Arrays.asList(1, 2, 3, 4));
+
+// --- Lift a single value into a singleton list ---
+Kind<ListKind.Witness, String> single = listMonad.of("hello"); // ["hello"]
+Kind<ListKind.Witness, Object> empty  = listMonad.of(null);    // []
+
+// --- Unwrap back to a standard List ---
+List<Integer> unwrapped = LIST.narrow(numbers); // [1, 2, 3, 4]
+
+// --- map: transform every element ---
+Kind<ListKind.Witness, String> decorated = listMonad.map(
+    n -> "*" + n + "*", numbers);
+// LIST.narrow(decorated) => ["*1*", "*2*", "*3*", "*4*"]
+```
+~~~
+
+~~~admonish example title="Composing with flatMap — Exploring All Combinations"
+
+- [ListMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/list/ListMonadExample.java)
+
+`flatMap` is where the non-deterministic power lives. Each element branches into multiple results, and all branches are collected.
+
+```java
+ListMonad listMonad = ListMonad.INSTANCE;
+Kind<ListKind.Witness, Integer> values = LIST.widen(Arrays.asList(1, 2, 3));
+
+// Each number branches into itself and itself + 10
+Function<Integer, Kind<ListKind.Witness, Integer>> branch =
+    i -> LIST.widen(Arrays.asList(i, i + 10));
+
+Kind<ListKind.Witness, Integer> expanded = listMonad.flatMap(branch, values);
+// [1, 11, 2, 12, 3, 13]
+
+// Filtering: return an empty list to eliminate a branch
+Function<Integer, Kind<ListKind.Witness, String>> evenOnly =
+    i -> (i % 2 == 0)
+        ? LIST.widen(Arrays.asList("even", String.valueOf(i)))
+        : LIST.widen(List.of()); // empty — odd numbers are dropped
+
+Kind<ListKind.Witness, String> filtered = listMonad.flatMap(evenOnly, values);
+// ["even", "2"]
+```
+~~~
+
+~~~admonish example title="Cartesian Products with ap"
+
+- [ListMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/list/ListMonadExample.java)
+
+`ap` applies a list of functions to a list of values, producing every combination.
+
+```java
+ListMonad listMonad = ListMonad.INSTANCE;
+
+Function<Integer, String> addPrefix      = i -> "Val: " + i;
+Function<Integer, String> multiplyString = i -> "Mul: " + (i * 2);
+
+Kind<ListKind.Witness, Function<Integer, String>> functions =
+    LIST.widen(Arrays.asList(addPrefix, multiplyString));
+Kind<ListKind.Witness, Integer> inputs = LIST.widen(Arrays.asList(10, 20));
+
+Kind<ListKind.Witness, String> results = listMonad.ap(functions, inputs);
+// ["Val: 10", "Val: 20", "Mul: 20", "Mul: 40"]
+```
+
+This is the same Cartesian product shown in the diagram above — 2 functions applied to 2 values yields 4 results.
+~~~
+
+## When to Use ListMonad
+
+| Scenario | Use |
+|----------|-----|
+| Non-deterministic computation — exploring all possibilities | `ListMonad` with `flatMap` to branch and collect |
+| Generating combinations or Cartesian products | `ListMonad` with `ap` |
+| Writing generic code that works across monads | `ListMonad` — your logic programs against `Kind<F, A>` |
+| Filtering within a pipeline (guard-style) | Return empty lists from `flatMap` to prune branches |
+| Single-value computation with optionality | Prefer [Maybe](maybe_monad.md) instead |
+
+~~~admonish important title="Key Points"
+- `ListMonad` implements `Monad<ListKind.Witness>`, giving you `map`, `flatMap`, `of`, and `ap` over standard Java lists.
+- `flatMap` is non-deterministic composition: each element can produce zero, one, or many results, and all results are concatenated.
+- `ap` produces the Cartesian product of a list of functions and a list of values — O(n*m) results.
+- `of(null)` produces an empty list, not a singleton containing `null`.
+- For the HKT bridge: `LIST.widen()` wraps a `List` into `Kind`, `LIST.narrow()` unwraps it back. Both are low-cost cast operations.
+~~~
+
+~~~admonish example title="Benchmarks"
+List has dedicated JMH benchmarks measuring map, flatMap, and ap composition. Key expectations:
+
+- **`map`** scales linearly with list size
+- **`flatMap`** performance depends on the output size of the mapping function
+- **`ap`** produces Cartesian products — O(n*m) where n = functions, m = values
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*ListBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details.
+~~~
 
 ---
 

--- a/hkj-book/src/monads/maybe_monad.md
+++ b/hkj-book/src/monads/maybe_monad.md
@@ -327,6 +327,16 @@ public static <A, B> Kind<MaybeKind.Witness, B> processData(
 This example highlights how `MaybeMonad` facilitates working with optional values in a functional, type-safe manner, especially when dealing with the HKT abstractions and requiring non-null guarantees for present values.
 ~~~
 
+## When to Use Maybe
+
+| Scenario | Use |
+|----------|-----|
+| Green-field code representing optional values | `Maybe` — strict non-null guarantee in `Just` |
+| JDK interop (APIs returning `java.util.Optional`) | Prefer [Optional](./optional_monad.md) to avoid conversion overhead |
+| Optional values with typed error context | Convert with `maybeUser.toEither("not found")` → use [Either](./either_monad.md) |
+| Generic monadic code that works across any `Kind<F, A>` | `MaybeMonad` — implements `MonadError<MaybeKind.Witness, Unit>` |
+| Application-level pipelines with fluent API | Prefer [MaybePath](../effect/path_maybe.md) |
+
 ---
 
 ~~~admonish tip title="Effect Path Alternative"

--- a/hkj-book/src/monads/state_monad.md
+++ b/hkj-book/src/monads/state_monad.md
@@ -377,5 +377,21 @@ For deeper exploration of the State monad and its applications:
 
 ---
 
+~~~admonish example title="Benchmarks"
+State has dedicated JMH benchmarks measuring state threading overhead, composition depth, and `get`/`set`/`modify` performance. Key expectations:
+
+- **`get` / `inspect`** are very fast — they read state without transformation
+- **`flatMap` chains** thread state through each step with minimal overhead beyond the step's own computation
+- **Deep chains (50+)** complete without error — composition is stack-safe for typical depths
+- State threading adds constant overhead per step regardless of state size
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*StateBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details and how to interpret results.
+~~~
+
+---
+
 **Previous:** [Context](context_scoped.md)
 **Next:** [Stream](stream_monad.md)

--- a/hkj-book/src/monads/try_monad.md
+++ b/hkj-book/src/monads/try_monad.md
@@ -237,6 +237,20 @@ TryPath<String> value = Path.tryOf(() -> loadConfig())
 See [Effect Path Overview](../effect/effect_path_overview.md) for the complete guide.
 ~~~
 
+~~~admonish example title="Benchmarks"
+Try has dedicated JMH benchmarks measuring instance reuse, short-circuit efficiency, and recovery operations. Key expectations:
+
+- **`failureMap`** reuses the same Failure instance with zero allocation (like Either.Left)
+- **`failureLongChain`** is significantly faster than `successLongChain` — sustained reuse benefit over deep chains
+- **`recover` / `recoverWith`** add minimal overhead — pattern matching on the exception type is the dominant cost
+- If Failure operations allocate memory, instance reuse is broken
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*TryBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details, expected ratios, and how to interpret results.
+~~~
+
 ---
 
 **Previous:** [Coyoneda](coyoneda.md)

--- a/hkj-book/src/monads/validated_monad.md
+++ b/hkj-book/src/monads/validated_monad.md
@@ -1,334 +1,247 @@
 # The ValidatedMonad:
-## _Handling Valid or Invalid Operations_
+## _Accumulating Errors with `Validated`_
 
 ~~~admonish info title="What You'll Learn"
-- How to distinguish between valid and invalid data with explicit types
-- Using Validated as a MonadError for fail-fast error handling
-- Understanding when to use monadic operations (fail-fast) vs applicative operations (error accumulation)
-- The difference between fail-fast validation (Monad/MonadError) and error-accumulating validation (Applicative with Semigroup)
-- Real-world input validation scenarios with detailed error reporting
+- Why fail-fast validation frustrates your users (and how to fix it)
+- The difference between `flatMap` (fail-fast) and `ap` with `Semigroup` (error-accumulating)
+- Building a complete form validator that reports ALL errors in one pass
+- Using `ValidatedMonad` as a `MonadError` for recovery and error transformation
+- When to reach for `Validated` vs `Either` vs `ValidationPath`
 ~~~
 
 ~~~ admonish example title="See Example Code:"
 [ValidatedMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/validated/ValidatedMonadExample.java)
 ~~~
 
-## Purpose
+## The Problem: Death by a Thousand Submits
 
-The `Validated<E, A>` type in `Higher-Kinded-J` represents a value that can either be `Valid<A>` (correct) or `Invalid<E>` (erroneous). It is commonly used in scenarios like input validation where you want to clearly distinguish between a successful result and an error. Unlike types like `Either` which are often used for general-purpose sum types, `Validated` is specifically focused on the valid/invalid dichotomy. Operations like `map`, `flatMap`, and `ap` are right-biased, meaning they operate on the `Valid` value and propagate `Invalid` values unchanged.
+A user fills out your registration form. They make three mistakes — empty name, malformed email, and age below 18. They hit Submit.
 
-The `ValidatedMonad<E>` provides a monadic interface for `Validated<E, A>` (where the error type `E` is fixed for the monad instance), allowing for functional composition and integration with the Higher-Kinded-J framework. This facilitates chaining operations that can result in either a valid outcome or an error.
+Your validation reports: **"Name is required."**
 
-~~~admonish info title="Key benefits include:"
+They fix the name, hit Submit again. Now they see: **"Invalid email format."**
 
-* **Explicit Validation Outcome:** The type signature `Validated<E, A>` makes it clear that a computation can result in either a success (`Valid<A>`) or an error (`Invalid<E>`).
-* **Functional Composition:** Enables chaining of operations using `map`, `flatMap`, and `ap`. If an operation results in an `Invalid`, subsequent operations in the chain are typically short-circuited, propagating the `Invalid` state.
-* **HKT Integration:** `ValidatedKind<E, A>` (the HKT wrapper for `Validated<E, A>`) and `ValidatedMonad<E>` allow `Validated` to be used with generic functions and type classes that expect `Kind<F, A>` where `F extends WitnessArity<?>`, along with type classes like `Functor<F>`, `Applicative<F>`, or `Monad<M>` where `F extends WitnessArity<TypeArity.Unary>`.
-* **Clear Error Handling:** Provides methods like `fold`, `ifValid`, `ifInvalid` to handle both `Valid` and `Invalid` cases explicitly.
-* **Standardized Error Handling:** As a `MonadError<ValidatedKind.Witness<E>, E>`, it offers `raiseError` to construct error states and `handleErrorWith` for recovery, integrating with generic error-handling combinators.
+They fix the email, hit Submit a third time. Finally: **"Must be at least 18."**
+
+Three round-trips. Three frustrations. Three errors that were all knowable from the very first submission.
+
+This is fail-fast validation. With a monadic chain (`flatMap`), each step depends on the previous one succeeding, so the first failure stops everything:
+
+```java
+// flatMap chain — validation stops at the FIRST error
+validateName("")         // Invalid(["Name is required"])   <-- STOPS HERE
+  .flatMap(name ->
+    validateEmail("x@@")   // never reached
+      .flatMap(email ->
+        validateAge(15)));   // never reached
+```
+
+What you actually want is to run ALL validations independently and collect every error in one pass. That is exactly what `Validated` with applicative operations gives you.
+
+~~~admonish note title="Fail-Fast vs Error Accumulation"
+```
+FAIL-FAST (flatMap):                  ACCUMULATE (ap + Semigroup):
+
+validateName("")  --> Invalid         validateName("")  --> Invalid("Name is required")
+       |                              validateEmail("x@@") --> Invalid("Invalid email")
+    STOP HERE                         validateAge(15)   --> Invalid("Must be 18+")
+                                           |
+                                      combine all errors
+                                           |
+                                      Invalid(["Name is required",
+                                               "Invalid email",
+                                               "Must be 18+"])
+```
+
+- **flatMap**: Each step depends on the previous result. If step 1 fails, steps 2 and 3 never run. Use this when validations are **dependent**.
+- **ap + Semigroup**: All steps run independently. Errors are combined using a `Semigroup<E>`. Use this when validations are **independent**.
 ~~~
 
-`ValidatedMonad<E>` implements `MonadError<ValidatedKind.Witness<E>, E>`, which transitively includes `Monad<ValidatedKind.Witness<E>>`, `Applicative<ValidatedKind.Witness<E>>`, and `Functor<ValidatedKind.Witness<E>>`.
+## Core Components
 
-## Structure
+**Validated Type** — `Valid(value)` or `Invalid(error)`:
 
-**Validated Type** Conceptually, `Validated<E, A>` has two sub-types:
-
-* `Valid<A>`: Contains a valid value of type `A`.
-* `Invalid<E>`: Contains an error value of type `E`.
 ![validated_type.svg](../images/puml/validated_type.svg)
 
-**Monadic Structure** The `ValidatedMonad<E>` enables monadic operations on `ValidatedKind.Witness<E>`.
+**Monadic Structure** — `ValidatedMonad<E>` enables monadic operations on `ValidatedKind.Witness<E>`:
+
 ![validated_monad.svg](../images/puml/validated_monad.svg)
 
-~~~admonish note title="Related Types"
-Unlike [Either Monad](./either_monad.md) which is fail-fast in both Monad and Applicative contexts, `Validated` can be used with `Applicative` operations for error accumulation (when `E` has a `Semigroup` instance). When used as a Monad via `ValidatedMonad`, it behaves fail-fast like Either.
+| Component | Role |
+|-----------|------|
+| `Validated<E, A>` | `Valid(value)` or `Invalid(error)` — like Either but validation-focused |
+| `ValidatedKind<E, A>` / `ValidatedKindHelper` | HKT bridge: `widen()`, `narrow()`, `valid()`, `invalid()` |
+| `ValidatedMonad<E>` | `MonadError<ValidatedKind.Witness<E>, E>` — fail-fast `map`/`flatMap`, plus `raiseError`/`handleErrorWith` |
+
+~~~admonish note title="Validated vs Either"
+Both represent success or failure. The difference is in **applicative** behaviour:
+- `Either`: Always fail-fast in both Monad and Applicative contexts.
+- `Validated`: Fail-fast as a Monad (`flatMap`), but can **accumulate errors** as an Applicative (`ap` with `Semigroup`).
+
+If you only ever need fail-fast semantics, use [Either](./either_monad.md).
 ~~~
 
-## How to Use `ValidatedMonad<E>` and `Validated<E, A>`
+## Building a Complete Form Validator
 
-- [ValidatedMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/validated/ValidatedMonadExample.java)
+Let's build a registration validator that validates username, email, and age — reporting ALL errors in one pass.
 
-### Creating Instances
+~~~admonish example title="Step 1: Define Individual Validators"
 
-`Validated<E, A>` instances can be created directly using static factory methods on `Validated`. For HKT integration, `ValidatedKindHelper` and `ValidatedMonad` are used. `ValidatedKind<E, A>` is the HKT wrapper.
+Each validator is an independent function that returns `Validated<List<String>, T>`:
 
-**Direct `Validated` Creation & HKT Helpers:** Refer to `ValidatedMonadExample.java` (Section 1) for runnable examples.
-
-
-~~~admonish title="Creating _Valid_, _Invalid_ and HKT Wrappers"
-
-Creates a `Valid` instance holding a **non-null** value.
-```java
-Validated<List<String>, String> validInstance = Validated.valid("Success!"); // Valid("Success!")
-```
-
-Creates an `Invalid` instance holding a **non-null** error.
-```java
-Validated<List<String>, String> invalidInstance = Validated.invalid(Collections.singletonList("Error: Something went wrong.")); // Invalid([Error: Something went wrong.])
-```
-
-Converts a `Validated<E, A>` to `Kind<ValidatedKind.Witness<E>, A>` using `VALIDATED.widen()`.
-```java
-Kind<ValidatedKind.Witness<List<String>>, String> kindValid = VALIDATED.widen(Validated.valid("Wrapped"));
-```
-Converts a `Kind<ValidatedKind.Witness<E>, A>` back to `Validated<E, A>` using `VALIDATED.narrow()`.
-```java
-Validated<List<String>, String> narrowedValidated = VALIDATED.narrow(kindValid);
-```
-Convenience for `widen(Validated.valid(value))`using `VALIDATED.valid()`.
-```java
-Kind<ValidatedKind.Witness<List<String>>, Integer> kindValidInt = VALIDATED.valid(123);
-```
-Convenience for `widen(Validated.invalid(error))` using `VALIDATED.invalid()`.
-```java
-Kind<ValidatedKind.Witness<List<String>>, Integer> kindInvalidInt = VALIDATED.invalid(Collections.singletonList("Bad number"));
-```
-~~~
-
-### `ValidatedMonad<E>` Instance Methods:
-Refer to `ValidatedMonadExample.java` (Sections 1 & 6) for runnable examples.
-
-~~~admonish title="_validatedMonad.of(A value)_"
-Lifts a value into `ValidatedKind.Witness<E>`, creating a `Valid(value)`. This is part of the `Applicative` interface.
 ```java
 ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-Kind<ValidatedKind.Witness<List<String>>, String> kindFromMonadOf = validatedMonad.of("Monadic Valid"); // Valid("Monadic Valid")
-System.out.println("From monad.of(): " + VALIDATED.narrow(kindFromMonadOf));
-```
 
-Lifts an error `E` into the `ValidatedKind` context, creating an `Invalid(error)`. This is part of the `MonadError` interface.
-```java
-ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-List<String> errorPayload = Collections.singletonList("Raised error condition");
-Kind<ValidatedKind.Witness<List<String>>, String> raisedError =
-    validatedMonad.raiseError(errorPayload); // Invalid(["Raised error condition"])
-System.out.println("From monad.raiseError(): " + VALIDATED.narrow(raisedError));
-```
-~~~
+static Validated<List<String>, String> validateName(String name) {
+    return (name == null || name.isBlank())
+        ? Validated.invalid(List.of("Name is required"))
+        : Validated.valid(name.trim());
+}
 
-### Interacting with `Validated<E, A>` values
+static Validated<List<String>, String> validateEmail(String email) {
+    return (email == null || !email.matches("^[^@]+@[^@]+\\.[^@]+$"))
+        ? Validated.invalid(List.of("Invalid email format"))
+        : Validated.valid(email.trim());
+}
 
-The `Validated<E, A>` interface itself provides useful methods: Refer to `ValidatedMonadExample.java` (Section 5) for runnable examples of `fold`, `ifValid`, `ifInvalid`.
-
-* `isValid()`: Returns `true` if it's a `Valid`.
-* `isInvalid()`: Returns `true` if it's an `Invalid`.
-* `get()`: Returns the value if `Valid`, otherwise throws `NoSuchElementException`. _Use with caution._
-* `getError()`: Returns the error if `Invalid`, otherwise throws `NoSuchElementException`. _Use with caution._
-* `orElse(@NonNull A other)`: Returns the value if `Valid`, otherwise returns `other`.
-* `orElseGet(@NonNull Supplier<? extends @NonNull A> otherSupplier)`: Returns the value if `Valid`, otherwise invokes `otherSupplier.get()`.
-* `orElseThrow(@NonNull Supplier<? extends X> exceptionSupplier)`: Returns the value if `Valid`, otherwise throws the exception from the supplier.
-* `ifValid(@NonNull Consumer<? super A> consumer)`: Performs action if `Valid`.
-* `ifInvalid(@NonNull Consumer<? super E> consumer)`: Performs action if `Invalid`.
-* `fold(@NonNull Function<? super E, ? extends T> invalidMapper, @NonNull Function<? super A, ? extends T> validMapper)`: Applies one of two functions depending on the state.
-* `Validated` also has its own `map`, `flatMap`, and `ap` methods that operate directly on `Validated` instances.
-
-### Key Operations (via `ValidatedMonad<E>`)
-
-These operations are performed on the HKT wrapper `Kind<ValidatedKind.Witness<E>, A>`. Refer to `ValidatedMonadExample.java` (Sections 2, 3, 4) for runnable examples of `map`, `flatMap`, and `ap`.
-
-Applies `f` to the value inside `kind` if it's `Valid`. If `kind` is `Invalid`, or if `f` throws an exception (The behaviour depends on `Validated.map` internal error handling, typically an `Invalid` from `Validated.map` would be a new `Invalid`), the result is `Invalid`.
-
-
-~~~admonish title="Transforming Values (_map_)"
-```java
-// From ValidatedMonadExample.java (Section 2)
-ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-Kind<ValidatedKind.Witness<List<String>>, Integer> validKindFromOf = validatedMonad.of(42);
-Kind<ValidatedKind.Witness<List<String>>, Integer> invalidIntKind =
-    VALIDATED.invalid(Collections.singletonList("Initial error for map"));
-
-Function<Integer, String> intToString = i -> "Value: " + i;
-
-Kind<ValidatedKind.Witness<List<String>>, String> mappedValid =
-    validatedMonad.map(intToString, validKindFromOf); // Valid("Value: 42")
-System.out.println("Map (Valid input): " + VALIDATED.narrow(mappedValid));
-
-Kind<ValidatedKind.Witness<List<String>>, String> mappedInvalid =
-    validatedMonad.map(intToString, invalidIntKind); // Invalid(["Initial error for map"])
-System.out.println("Map (Invalid input): " + VALIDATED.narrow(mappedInvalid));
-```
-~~~
-
-
-~~~admonish title="Transforming Values (_flatMap_)"
-
-If `kind` is `Valid(a)`, applies `f` to `a`. `f` must return a `Kind<ValidatedKind.Witness<E>, B>`. If `kind` is `Invalid`, or `f` returns an `Invalid Kind`, the result is `Invalid`.
-
-```java
-// From ValidatedMonadExample.java (Section 3)
-ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-Kind<ValidatedKind.Witness<List<String>>, Integer> positiveNumKind = validatedMonad.of(10);
-Kind<ValidatedKind.Witness<List<String>>, Integer> nonPositiveNumKind = validatedMonad.of(-5);
-Kind<ValidatedKind.Witness<List<String>>, Integer> invalidIntKind =
-        VALIDATED.invalid(Collections.singletonList("Initial error for flatMap"));
-
-
-Function<Integer, Kind<ValidatedKind.Witness<List<String>>, String>> intToValidatedStringKind =
-    i -> {
-      if (i > 0) {
-        return VALIDATED.valid("Positive: " + i);
-      } else {
-        return VALIDATED.invalid(Collections.singletonList("Number not positive: " + i));
-      }
-    };
-
-Kind<ValidatedKind.Witness<List<String>>, String> flatMappedToValid =
-    validatedMonad.flatMap(intToValidatedStringKind, positiveNumKind); // Valid("Positive: 10")
-System.out.println("FlatMap (Valid to Valid): " + VALIDATED.narrow(flatMappedToValid));
-
-Kind<ValidatedKind.Witness<List<String>>, String> flatMappedToInvalid =
-    validatedMonad.flatMap(intToValidatedStringKind, nonPositiveNumKind); // Invalid(["Number not positive: -5"])
-System.out.println("FlatMap (Valid to Invalid): " + VALIDATED.narrow(flatMappedToInvalid));
-
-Kind<ValidatedKind.Witness<List<String>>, String> flatMappedFromInvalid =
-    validatedMonad.flatMap(intToValidatedStringKind, invalidIntKind); // Invalid(["Initial error for flatMap"])
-System.out.println("FlatMap (Invalid input): " + VALIDATED.narrow(flatMappedFromInvalid));
-```
-
-~~~
-
-
-~~~admonish title="Applicative Operation (ap)"
-
-
-- If `ff` is `Valid(f)` and `fa` is `Valid(a)`, applies `f` to `a`, resulting in `Valid(f(a))`. 
-- If either `ff` or `fa` is `Invalid`, the result is `Invalid`. Specifically, if `ff` is `Invalid`, its error is returned. 
-- If `ff` is `Valid` but `fa` is `Invalid`, then `fa`'s error is returned. If both are `Invalid`, `ff`'s error takes precedence. 
-
-Note: This `ap` behaviour is right-biased and does not accumulate errors in the way some applicative validations might; it propagates the first encountered `Invalid` or the `Invalid` function.
-
-
-```java
-// From ValidatedMonadExample.java (Section 4)
-ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-Kind<ValidatedKind.Witness<List<String>>, Function<Integer, String>> validFnKind =
-    VALIDATED.valid(i -> "Applied: " + (i * 2));
-Kind<ValidatedKind.Witness<List<String>>, Function<Integer, String>> invalidFnKind =
-    VALIDATED.invalid(Collections.singletonList("Function is invalid"));
-
-Kind<ValidatedKind.Witness<List<String>>, Integer> validValueForAp = validatedMonad.of(25);
-Kind<ValidatedKind.Witness<List<String>>, Integer> invalidValueForAp =
-    VALIDATED.invalid(Collections.singletonList("Value is invalid"));
-
-// Valid function, Valid value
-Kind<ValidatedKind.Witness<List<String>>, String> apValidFnValidVal =
-    validatedMonad.ap(validFnKind, validValueForAp); // Valid("Applied: 50")
-System.out.println("Ap (ValidFn, ValidVal): " + VALIDATED.narrow(apValidFnValidVal));
-
-// Invalid function, Valid value
-Kind<ValidatedKind.Witness<List<String>>, String> apInvalidFnValidVal =
-    validatedMonad.ap(invalidFnKind, validValueForAp); // Invalid(["Function is invalid"])
-System.out.println("Ap (InvalidFn, ValidVal): " + VALIDATED.narrow(apInvalidFnValidVal));
-
-// Valid function, Invalid value
-Kind<ValidatedKind.Witness<List<String>>, String> apValidFnInvalidVal =
-    validatedMonad.ap(validFnKind, invalidValueForAp); // Invalid(["Value is invalid"])
-System.out.println("Ap (ValidFn, InvalidVal): " + VALIDATED.narrow(apValidFnInvalidVal));
-
-// Invalid function, Invalid value
-Kind<ValidatedKind.Witness<List<String>>, String> apInvalidFnInvalidVal =
-    validatedMonad.ap(invalidFnKind, invalidValueForAp); // Invalid(["Function is invalid"])
-System.out.println("Ap (InvalidFn, InvalidVal): " + VALIDATED.narrow(apInvalidFnInvalidVal));
-```
-~~~
-
-### MonadError Operations
-As `ValidatedMonad<E>` implements `MonadError<ValidatedKind.Witness<E>, E>`, it provides standardised ways to create and handle errors. Refer to ValidatedMonadExample.java (Section 6) for detailed examples.
-
-~~~admonish title="_recover_ and _recoverWith_"
-
-```java
-// From ValidatedMonadExample.java (Section 6)
-ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-List<String> initialError = Collections.singletonList("Initial Failure");
-
-// 1. Create an Invalid Kind using raiseError
-Kind<ValidatedKind.Witness<List<String>>, Integer> invalidKindRaised = // Renamed to avoid conflict
-    validatedMonad.raiseError(initialError);
-System.out.println("Raised error: " + VALIDATED.narrow(invalidKindRaised)); // Invalid([Initial Failure])
-
-// 2. Handle the error: recover to a Valid state
-Function<List<String>, Kind<ValidatedKind.Witness<List<String>>, Integer>> recoverToValid =
-    errors -> {
-        System.out.println("MonadError: Recovery handler called with errors: " + errors);
-        return validatedMonad.of(0); // Recover with default value 0
-    };
-Kind<ValidatedKind.Witness<List<String>>, Integer> recoveredValid =
-    validatedMonad.handleErrorWith(invalidKindRaised, recoverToValid);
-System.out.println("Recovered to Valid: " + VALIDATED.narrow(recoveredValid)); // Valid(0)
-
-// 3. Handle the error: transform to another Invalid state
-Function<List<String>, Kind<ValidatedKind.Witness<List<String>>, Integer>> transformError =
-    errors -> validatedMonad.raiseError(Collections.singletonList("Transformed Error: " + errors.get(0)));
-Kind<ValidatedKind.Witness<List<String>>, Integer> transformedInvalid =
-    validatedMonad.handleErrorWith(invalidKindRaised, transformError);
-System.out.println("Transformed to Invalid: " + VALIDATED.narrow(transformedInvalid)); // Invalid([Transformed Error: Initial Failure])
-
-// 4. Handle a Valid Kind: handler is not called
-Kind<ValidatedKind.Witness<List<String>>, Integer> validKindOriginal = validatedMonad.of(100);
-Kind<ValidatedKind.Witness<List<String>>, Integer> notHandled =
-    validatedMonad.handleErrorWith(validKindOriginal, recoverToValid); // Handler not called
-System.out.println("Handling Valid (no change): " + VALIDATED.narrow(notHandled)); // Valid(100)
-
-// 5. Using a default method like handleError
-Kind<ValidatedKind.Witness<List<String>>, Integer> errorForHandle = validatedMonad.raiseError(Collections.singletonList("Error for handleError"));
-Function<List<String>, Integer> plainValueRecoveryHandler = errors -> -1; // Returns plain value
-Kind<ValidatedKind.Witness<List<String>>, Integer> recoveredWithHandle = validatedMonad.handleError(errorForHandle, plainValueRecoveryHandler);
-System.out.println("Recovered with handleError: " + VALIDATED.narrow(recoveredWithHandle)); // Valid(-1)
-```
-The default `recover` and `recoverWith` methods from `MonadError` are also available.
-~~~
-
-
-~~~admonish title="Combining operations for simple validation"
-
-This example demonstrates how `ValidatedMonad` along with `Validated` can be used to chain operations that might succeed or fail. With `ValidatedMonad` now implementing `MonadError`, operations like `raiseError` can be used for clearer error signalling, and `handleErrorWith` (or other `MonadError` methods) can be used for more robust recovery strategies within such validation flows.
-
--  [ValidatedMonadExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/validated/ValidatedMonadExample.java) _see "Combined Validation Scenario"_.
-
-
-```java
-// Simplified from the ValidatedMonadExample.java
-public void combinedValidationScenarioWithMonadError() {
-  ValidatedMonad<List<String>> validatedMonad = ValidatedMonad.instance();
-  Kind<ValidatedKind.Witness<List<String>>, String> userInput1 = validatedMonad.of("123");
-  Kind<ValidatedKind.Witness<List<String>>, String> userInput2 = validatedMonad.of("abc"); // This will lead to an Invalid
-
-  Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseToIntKindMonadError =
-      (String s) -> {
-        try {
-          return validatedMonad.of(Integer.parseInt(s)); // Lifts to Valid
-        } catch (NumberFormatException e) {
-          // Using raiseError for semantic clarity
-          return validatedMonad.raiseError(
-              Collections.singletonList("'" + s + "' is not a number (via raiseError)."));
-        }
-      };
-
-  Kind<ValidatedKind.Witness<List<String>>, Integer> parsed1 =
-      validatedMonad.flatMap(parseToIntKindMonadError, userInput1);
-  Kind<ValidatedKind.Witness<List<String>>, Integer> parsed2 =
-      validatedMonad.flatMap(parseToIntKindMonadError, userInput2); // Will be Invalid
-
-  System.out.println("Parsed Input 1 (Combined): " + VALIDATED.narrow(parsed1)); // Valid(123)
-  System.out.println("Parsed Input 2 (Combined): " + VALIDATED.narrow(parsed2)); // Invalid(['abc' is not a number...])
-
-  // Example of recovering the parse of userInput2 using handleErrorWith
-  Kind<ValidatedKind.Witness<List<String>>, Integer> parsed2Recovered =
-      validatedMonad.handleErrorWith(
-          parsed2,
-          errors -> {
-            System.out.println("Combined scenario recovery: " + errors);
-            return validatedMonad.of(0); // Default to 0 if parsing failed
-          });
-  System.out.println(
-      "Parsed Input 2 (Recovered to 0): " + VALIDATED.narrow(parsed2Recovered)); // Valid(0)
+static Validated<List<String>, Integer> validateAge(int age) {
+    return (age < 18)
+        ? Validated.invalid(List.of("Must be at least 18 years old"))
+        : Validated.valid(age);
 }
 ```
-This example demonstrates how `ValidatedMonad` along with `Validated` can be used to chain operations that might succeed or fail, propagating errors and allowing for clear handling of either outcome, further enhanced by `MonadError` capabilities.
 
+Each validator works independently. None depends on another's result. This is the key to accumulation.
+~~~
 
+~~~admonish example title="Step 2: Compose with flatMap (Fail-Fast)"
+
+When validations **depend** on each other, use `flatMap`. The chain stops at the first failure:
+
+```java
+// Dependent validation: email domain must match company based on user's role
+Kind<ValidatedKind.Witness<List<String>>, String> result =
+    validatedMonad.flatMap(
+        name -> validatedMonad.flatMap(
+            email -> VALIDATED.valid("User: " + name + " <" + email + ">"),
+            VALIDATED.widen(validateEmail("alice@example.com"))
+        ),
+        VALIDATED.widen(validateName("Alice"))
+    );
+// Valid("User: Alice <alice@example.com>")
+
+// If the first step fails, everything stops:
+Kind<ValidatedKind.Witness<List<String>>, String> failed =
+    validatedMonad.flatMap(
+        name -> validatedMonad.flatMap(
+            email -> VALIDATED.valid("User: " + name + " <" + email + ">"),
+            VALIDATED.widen(validateEmail("bad@@"))      // never reached
+        ),
+        VALIDATED.widen(validateName(""))                 // Invalid — stops here
+    );
+// Invalid(["Name is required"])
+```
+~~~
+
+~~~admonish example title="Step 3: Compose with ap (Error Accumulation)"
+
+When validations are **independent**, use `ap` with a `Semigroup`. All validators run, and errors combine:
+
+```java
+// All three validators run regardless of individual failures
+Validated<List<String>, String>  name  = validateName("");           // Invalid
+Validated<List<String>, String>  email = validateEmail("bad@@");     // Invalid
+Validated<List<String>, Integer> age   = validateAge(15);            // Invalid
+
+// Using map3 to combine — ALL errors are collected:
+Kind<ValidatedKind.Witness<List<String>>, String> result = validatedMonad.map3(
+    VALIDATED.widen(name),
+    VALIDATED.widen(email),
+    VALIDATED.widen(age),
+    (n, e, a) -> "User(" + n + ", " + e + ", age=" + a + ")"
+);
+
+Validated<List<String>, String> finalResult = VALIDATED.narrow(result);
+// Invalid(["Name is required", "Invalid email format", "Must be at least 18 years old"])
+//         ^^^ ALL three errors in one pass!
+```
+
+`map3` uses `ap` under the hood — it lifts the combining function into the `Validated` context and applies each argument, accumulating errors via the `Semigroup`. The `mapN` family (`map2`, `map3`, `map4`) is the recommended way to combine independent validations without writing curried functions manually.
+~~~
+
+~~~admonish example title="Step 4: Recover from Errors"
+
+`ValidatedMonad<E>` implements `MonadError`, so you get structured recovery:
+
+```java
+Kind<ValidatedKind.Witness<List<String>>, Integer> failed =
+    validatedMonad.raiseError(List.of("Something went wrong"));
+
+// handleErrorWith — recover to a Valid state
+Kind<ValidatedKind.Witness<List<String>>, Integer> recovered =
+    validatedMonad.handleErrorWith(failed, errors -> validatedMonad.of(0));
+// Valid(0)
+
+// handleErrorWith — transform the error
+Kind<ValidatedKind.Witness<List<String>>, Integer> transformed =
+    validatedMonad.handleErrorWith(failed,
+        errors -> validatedMonad.raiseError(
+            List.of("Transformed: " + errors.getFirst())));
+// Invalid(["Transformed: Something went wrong"])
+
+// handleError — recover with a plain value
+Kind<ValidatedKind.Witness<List<String>>, Integer> fallback =
+    validatedMonad.handleError(failed, errors -> -1);
+// Valid(-1)
+
+// Valid values pass through untouched — handler is never called
+Kind<ValidatedKind.Witness<List<String>>, Integer> ok = validatedMonad.of(42);
+Kind<ValidatedKind.Witness<List<String>>, Integer> stillOk =
+    validatedMonad.handleErrorWith(ok, errors -> validatedMonad.of(0));
+// Valid(42) — handler was never invoked
+```
+~~~
+
+### Working with `Validated<E, A>` Directly
+
+Beyond the typeclass, the `Validated` type itself offers useful methods:
+
+* `isValid()` / `isInvalid()` — check the state.
+* `get()` / `getError()` — extract value or error (throws `NoSuchElementException` on wrong case).
+* `orElse(other)` / `orElseGet(supplier)` / `orElseThrow(supplier)` — safe extraction with fallbacks.
+* `fold(invalidMapper, validMapper)` — eliminate both cases into a single result.
+* `map`, `flatMap`, `ap` — also available directly on `Validated` instances.
+
+~~~admonish note title="Which Composition to Choose?"
+```
+Does step B depend on step A's result?
+  |
+  +-- YES --> flatMap (fail-fast)
+  |           "Validate email, THEN check if domain matches company"
+  |
+  +-- NO  --> ap + Semigroup (accumulate)
+              "Validate name AND email AND age independently"
+```
+Many real-world forms mix both: independent field validations (accumulate), followed by cross-field checks (fail-fast).
+~~~
+
+## When to Use Validated
+
+| Scenario | Use |
+|----------|-----|
+| Form/input validation — want ALL errors at once | `Validated` with `ap` + `Semigroup` |
+| Sequential validation — later steps depend on earlier results | `ValidatedMonad` (fail-fast via `flatMap`) |
+| Typed errors with arbitrary branching | Prefer [Either](./either_monad.md) |
+| Application-level validation with fluent API | Prefer [ValidationPath](../effect/path_validation.md) |
+| Mix of independent + dependent validations | Independent fields via `ap`, then cross-field checks via `flatMap` |
+
+~~~admonish important title="Key Points"
+- `Validated<E, A>` is `Valid(value)` or `Invalid(error)` — explicitly models validation outcomes.
+- **Monadic** operations (`flatMap` via `ValidatedMonad`) are **fail-fast**: the first `Invalid` short-circuits the chain.
+- **Applicative** operations (`ap` with a `Semigroup<E>`) **accumulate** errors from independent validations.
+- `ValidatedMonad<E>` implements `MonadError<ValidatedKind.Witness<E>, E>`, giving you `raiseError` and `handleErrorWith` for structured recovery.
+- The choice between `flatMap` and `ap` is a design decision: **dependent** validations use flatMap, **independent** validations use ap.
+- `ValidatedKindHelper` provides zero-cost `widen()`/`narrow()` casts for HKT integration.
 ~~~
 
 ---
@@ -352,6 +265,19 @@ ValidationPath<List<Error>, Order> order = Path.validation(validateUser(input))
 ```
 
 See [Effect Path Overview](../effect/effect_path_overview.md) for the complete guide.
+~~~
+
+~~~admonish example title="Benchmarks"
+Validated has dedicated JMH benchmarks. Key expectations:
+
+- **`invalidMap`** reuses the same Invalid instance with zero allocation (like Either.Left)
+- **`invalidLongChain`** benefits from sustained instance reuse over deep chains
+- If Invalid operations allocate memory, instance reuse is broken
+
+```bash
+./gradlew :hkj-benchmarks:jmh --includes=".*ValidatedBenchmark.*"
+```
+See [Benchmarks & Performance](../benchmarks.md) for full details.
 ~~~
 
 ---

--- a/hkj-book/src/reading.md
+++ b/hkj-book/src/reading.md
@@ -1,32 +1,62 @@
-# A Blog on Types and Functional Patterns
+# More Functional Thinking
 
-This blog series provides excellent background reading whilst you're learning the techniques used in Higher-Kinded-J. Each post builds foundational knowledge that will deepen your understanding of functional programming patterns in Java.
+~~~admonish info title="Two Blog Series, One Journey"
+These companion blog series chart a path from foundational type theory to production-ready optics in Java. Start with the **Foundations** if you're new to functional programming in Java, or jump straight to the **Functional Optics** series to see Higher-Kinded-J in action.
+~~~
 
-This web series explores the foundational ideas that inspired Higher-Kinded-J's development.
+---
 
-- [Algebraic Data Types and Pattern Matching with Java](https://blog.scottlogic.com/2025/01/20/algebraic-data-types-with-java.html)
+## Functional Optics for Modern Java <span style="font-size:0.7em; vertical-align:middle; background:#a6da95; color:#24273a; padding:2px 8px; border-radius:4px; font-weight:bold;">NEW — 6 Part Series</span>
 
-In this post, we explore the power of Algebraic Data Types (ADT) with Pattern Matching in Java. We look at how they help us model complex business domains and how using them together gives improvements on the traditional Visitor Pattern.
+Java records and sealed interfaces make immutable data modelling elegant — but **updating** deeply nested immutable structures still means tedious copy-constructor cascades. This series closes that gap. Across six posts you'll move from the problem, through the theory, and into a fully working production pipeline built with Higher-Kinded-J.
 
-- [Variance in Generics, Phantom and Existential types with Java and Scala](https://blog.scottlogic.com/2025/02/17/variance-in-java-and-scala.html)
+### Part 1 — [The Immutability Gap: Why Java Records Need Optics](https://blog.scottlogic.com/2026/01/09/java-the-immutability-gap.html)
 
-In this post, we look at Variance in Generics and how it is handled in Java and Scala. We consider use-site and declaration-site approaches and the trade-offs of erasure. Finally, we take a look at Phantom and Existential types and how they can enhance the capabilities of the type system when it comes to modelling.
+Pattern matching solves the *read* side beautifully — but what about writes? This opening post reveals how operations that should be one-liners balloon into 25+ lines of manual reconstruction, and introduces optics as the composable answer.
 
-- [Intersection and Union types with Java and Scala](https://blog.scottlogic.com/2025/03/05/intersection-and-union-types-with-java-and-scala.html)
+> *"Pattern matching is half the puzzle; optics complete it."*
 
-In this post, we will see how Intersection types help us better model type constraints, promoting reuse, and how Union types increase code flexibility. We will compare and contrast approaches and how to use them in the latest Java and Scala.
+### Part 2 — [Optics Fundamentals: Lenses, Prisms, and Traversals](https://blog.scottlogic.com/2026/01/16/optics-fundamentals.html)
 
-- [Functors and Monads with Java and Scala](https://blog.scottlogic.com/2025/03/31/functors-monads-with-java-and-scala.html)
+Meet the three core optic types: **Lenses** for product-type fields, **Prisms** for sum-type variants, and **Traversals** for collections. Learn the lens laws, see how `@GenerateLenses` and `@GeneratePrisms` eliminate boilerplate, and discover how small, focused optics compose into powerful navigation paths.
 
-Learn about how Functors and Monads provide patterns to write cleaner, more composable, and robust code that helps us deal with operations like handling nulls, managing errors and sequencing asynchronous actions.
+### Part 3 — [Optics in Practice: An Expression Language AST](https://blog.scottlogic.com/2026/01/23/ast-basic-optics.html)
 
-- [Higher Kinded Types with Java and Scala](https://blog.scottlogic.com/2025/04/11/higher-kinded-types-with-java-and-scala.html)
+Theory meets code. Build a complete expression language using sealed interfaces and records, then apply lenses, prisms, and the **Focus DSL** to implement constant folding and identity simplification — all without hand-written recursion.
 
-In this post, we will see how Higher Kinded Types can help increase the flexibility of our code and reduce duplication.
+### Part 4 — [The Focus DSL: Traversals and Pattern Rewrites](https://blog.scottlogic.com/2026/01/30/traversals-rewrites.html)
 
-- [Recursion, Thunks and Trampolines with Java and Scala](https://blog.scottlogic.com/2025/05/02/recursion-thunks-trampolines-with-java-and-scala.html)
+Scale up from single nodes to entire trees. `TraversalPath` and bottom-up/top-down strategies handle recursive descent, while `modifyWhen` and `foldMap` enable filtered updates and aggregation. A multi-pass optimisation pipeline brings constant folding, dead-branch elimination, and common-subexpression detection together.
 
-In this post, we will see how Thunks and Trampolines can help solve problems by converting deep stack-based recursion into heap-based iteration, helping to prevent StackOverflowErrors.
+### Part 5 — [The Effect Path API: Railway-Style Error Handling](https://blog.scottlogic.com/2026/02/09/effect-polymorphic-optics.html)
+
+Introduce effects into optics. `MaybePath`, `EitherPath`, `ValidationPath`, and `VTaskPath` let the same traversal code work across different computational contexts — fail-fast for quick feedback, accumulating for comprehensive validation, and concurrent via virtual threads.
+
+### Part 6 — [From Theory to Practice](https://blog.scottlogic.com/2026/02/12/mfj-from-theory-to-practice.html)
+
+The capstone. Wire Focus DSL + Effect Paths into a four-phase expression pipeline, integrate with **Spring Boot** via `hkj-spring-boot-starter`, generate optics for third-party types with `@ImportOptics`, and map out a pragmatic incremental migration path for real teams.
+
+~~~admonish tip title="Companion Code"
+All six parts have runnable examples in the [expression-language-example](https://github.com/higher-kinded-j/expression-language-example) repository. Clone it and follow along.
+~~~
+
+---
+
+## Foundations: Types and Functional Patterns
+
+This earlier series explores the foundational ideas that inspired Higher-Kinded-J's development. Each post builds the theoretical knowledge that underpins the optics series above.
+
+- [Algebraic Data Types and Pattern Matching with Java](https://blog.scottlogic.com/2025/01/20/algebraic-data-types-with-java.html) — How ADTs and pattern matching model complex domains and improve on the traditional Visitor Pattern.
+
+- [Variance in Generics, Phantom and Existential Types with Java and Scala](https://blog.scottlogic.com/2025/02/17/variance-in-java-and-scala.html) — Use-site vs declaration-site variance, erasure trade-offs, and how phantom and existential types extend the type system.
+
+- [Intersection and Union Types with Java and Scala](https://blog.scottlogic.com/2025/03/05/intersection-and-union-types-with-java-and-scala.html) — Modelling tighter constraints with intersection types and increasing flexibility with union types.
+
+- [Functors and Monads with Java and Scala](https://blog.scottlogic.com/2025/03/31/functors-monads-with-java-and-scala.html) — Cleaner, more composable code for null handling, error management, and asynchronous sequencing.
+
+- [Higher Kinded Types with Java and Scala](https://blog.scottlogic.com/2025/04/11/higher-kinded-types-with-java-and-scala.html) — How higher-kinded types reduce duplication and unlock flexible, generic abstractions.
+
+- [Recursion, Thunks and Trampolines with Java and Scala](https://blog.scottlogic.com/2025/05/02/recursion-thunks-trampolines-with-java-and-scala.html) — Converting deep stack-based recursion into safe, heap-based iteration.
 
 ---
 


### PR DESCRIPTION
Rewrite monad pages (cf, io, identity, optional, list, validated, lazy, writer, reader, either, maybe, state, try, free, trampoline) with problem-first structure, real-world analogies, and consistent formatting. Update supported-types.md to cover all 29 types with decision flowchart and narrative descriptions. Refresh supported_types.puml diagram. Add Scott Logic blog acknowledgement to trampoline page. Fix draughts page navigation. Refresh reading.md landing page.
