### PR TITLE
Add build plugins and compile-time Path type checking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,23 @@ Unsure where to begin contributing? You can start by looking through `good first
     * Run tests: `./gradlew test`
     * Generate JaCoCo coverage reports: `./gradlew test jacocoTestReport` (HTML report at `build/reports/jacoco/test/html/index.html`)
 
+## Project Modules
+
+The project is organised into several modules:
+
+* **hkj-core** -- Core library with HKT simulation, Effect Path API, and Optics
+* **hkj-api** -- Public API interfaces
+* **hkj-annotations** -- Annotations for code generation
+* **hkj-processor / hkj-processor-plugins** -- Annotation processor and extensible plugins
+* **hkj-checker** -- Javac compiler plugin for compile-time Path type mismatch detection
+* **plugins/hkj-gradle-plugin** -- Gradle plugin for one-line project setup
+* **plugins/hkj-maven-plugin** -- Maven plugin for automated build configuration
+* **hkj-spring** -- Spring Boot integration (autoconfigure, starter, example)
+* **hkj-openrewrite** -- OpenRewrite recipes for automated migrations
+* **hkj-examples** -- Example projects
+* **hkj-benchmarks** -- JMH performance benchmarks
+* **hkj-book** -- Documentation (mdbook)
+
 ## Coding Style
 
 Please follow the [**Google Java Style Guide**](https://google.github.io/styleguide/javaguide.html). Keep code simple, readable, and well-tested. Consistent formatting is encouraged.

--- a/README.md
+++ b/README.md
@@ -258,31 +258,47 @@ The hkj-spring-boot-starter requires Spring Boot 4.0.1 or later with Jackson 3.x
 
 ## How to Use This Library
 
-Add the following dependencies to your `build.gradle.kts`:
+### Gradle -- With HKJ Plugin (Recommended)
 
 ```gradle
-dependencies {
-    implementation("io.github.higher-kinded-j:hkj-core:LATEST_VERSION")
-    annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:LATEST_VERSION")
-}
-
-// Required: enable Java preview features
-tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("--enable-preview")
-}
-
-tasks.withType<Test>().configureEach {
-    jvmArgs("--enable-preview")
-}
-
-tasks.withType<JavaExec>().configureEach {
-    jvmArgs("--enable-preview")
+// build.gradle.kts
+plugins {
+    id("io.github.higher-kinded-j.hkj") version "LATEST_VERSION"
 }
 ```
 
-The annotation processor generates Focus paths and Effect paths for your records, enabling seamless integration between effects and data navigation.
+This single line configures dependencies, preview features, annotation processors, and compile-time Path type checking automatically.
 
-See the **[Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart.html)** for full setup including Maven configuration.
+### Maven -- With HKJ Plugin (Recommended)
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.github.higher-kinded-j</groupId>
+            <artifactId>hkj-maven-plugin</artifactId>
+            <version>LATEST_VERSION</version>
+            <extensions>true</extensions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+The Maven plugin hooks into the build lifecycle to add `hkj-core`, annotation processors, compile-time checks, and `--enable-preview` flags automatically. Configure options in a `<configuration>` block:
+
+```xml
+<configuration>
+    <preview>true</preview>              <!-- add --enable-preview flags (default: true) -->
+    <spring>false</spring>               <!-- add hkj-spring-boot-starter (default: false) -->
+    <pathTypeMismatch>true</pathTypeMismatch>  <!-- enable compile-time checks (default: true) -->
+</configuration>
+```
+
+Run `mvn hkj:diagnostics` to inspect your current HKJ configuration.
+
+### Manual Setup
+
+See the **[Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart.html)** for manual Gradle and Maven configuration including preview flags and annotation processors.
 
 **For SNAPSHOTS:**
 
@@ -360,6 +376,10 @@ graph TD;
     root --> hkj_core["hkj-core"];
     root --> hkj_processor["hkj-processor"];
     hkj_processor --> hkj_processor_plugins["hkj-processor-plugins"];
+    root --> hkj_checker["hkj-checker"];
+    root --> plugins["plugins"];
+    plugins --> hkj_gradle_plugin["hkj-gradle-plugin"];
+    plugins --> hkj_maven_plugin["hkj-maven-plugin"];
     root --> hkj_spring["hkj-spring"];
     hkj_spring --> hkj_spring_autoconfigure["autoconfigure"];
     hkj_spring --> hkj_spring_starter["starter"];
@@ -375,6 +395,9 @@ graph TD;
 * **hkj-core**: Core implementation of HKT simulation, Effect Path API, and Optics
 * **hkj-processor**: Annotation processor for generating boilerplate
 * **hkj-processor-plugins**: Extensible plugins for code generation
+* **hkj-checker**: Javac compiler plugin for compile-time Path type mismatch detection
+* **hkj-gradle-plugin**: Gradle plugin for one-line project setup
+* **hkj-maven-plugin**: Maven plugin for automated build configuration
 * **hkj-spring**: Spring Boot integration (autoconfigure, starter, example)
 * **hkj-openrewrite**: OpenRewrite recipes for automated migrations
 * **hkj-benchmarks**: JMH benchmarks for performance testing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,19 +32,26 @@ rewrite {
 }
 
 
+// Modules that use java-platform instead of java-library
+val platformModules = setOf("hkj-bom")
+
 // Configure all submodules
 subprojects {
-    // Apply necessary plugins to each submodule
-    plugins.apply("java-library")
-    plugins.apply("com.diffplug.spotless")
-
     group = rootProject.group
     version = rootProject.version
 
-    // Set Java version for all submodules
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(25))
+    // Apply necessary plugins to each submodule (skip java-library for platform modules)
+    if (project.name !in platformModules) {
+        plugins.apply("java-library")
+    }
+    plugins.apply("com.diffplug.spotless")
+
+    // Set Java version for all submodules with Java sources
+    if (project.name !in platformModules) {
+        java {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(25))
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,11 @@ jackson = "3.0.0"
 # JOOQ - Database access library (for spec interface examples)
 jooq = "3.19.18"
 
+# Maven Plugin API (for hkj-maven-plugin)
+maven-plugin-api = "3.9.9"
+maven-core = "3.9.9"
+maven-plugin-annotations = "3.13.1"
+
 # Code quality
 google-java-format = "1.32.0"
 
@@ -99,6 +104,12 @@ jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations
 
 # Micrometer
 micrometer-core = { module = "io.micrometer:micrometer-core" }
+
+# Maven Plugin API
+maven-plugin-api = { module = "org.apache.maven:maven-plugin-api", version.ref = "maven-plugin-api" }
+maven-core = { module = "org.apache.maven:maven-core", version.ref = "maven-core" }
+maven-plugin-annotations = { module = "org.apache.maven.plugin-tools:maven-plugin-annotations", version.ref = "maven-plugin-annotations" }
+javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 
 # JOOQ
 jooq = { module = "org.jooq:jooq", version.ref = "jooq" }

--- a/hkj-bom/build.gradle.kts
+++ b/hkj-bom/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    `java-platform`
+    id("com.vanniktech.maven.publish")
+}
+
+javaPlatform {
+    allowDependencies()
+}
+
+dependencies {
+    constraints {
+        api(project(":hkj-core"))
+        api(project(":hkj-api"))
+        api(project(":hkj-annotations"))
+        api(project(":hkj-processor-plugins"))
+        api(project(":hkj-checker"))
+        api(project(":hkj-spring:starter"))
+        api(project(":hkj-spring:autoconfigure"))
+        api(project(":hkj-openrewrite"))
+    }
+}
+
+// Central configuration for publishing
+mavenPublishing {
+    publishToMavenCentral()
+
+    signAllPublications()
+
+    coordinates(
+        groupId = project.group.toString(),
+        artifactId = "hkj-bom",
+        version = project.version.toString()
+    )
+
+    pom {
+        name.set("Higher-Kinded-J BOM")
+        description.set("Bill of Materials for Higher-Kinded-J, managing versions of all HKJ modules")
+        url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+
+        licenses {
+            license {
+                name.set("The MIT License")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("higher-kinded-j")
+                name.set("Magnus Smith")
+                email.set("simulation-hkt@gmail.com")
+            }
+        }
+        scm {
+            connection.set("scm:git:git://github.com/higher-kinded-j/higher-kinded-j.git")
+            developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+        }
+    }
+}

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -133,6 +133,11 @@
   - [Cookbook](optics/cookbook.md)
   - [Auditing Complex Data](optics/auditing_complex_data_example.md)
 
+- [Tooling](tooling/ch_intro.md)
+  - [Build Plugins](tooling/gradle_plugin.md)
+  - [Compile-Time Checks](tooling/compile_checks.md)
+  - [Diagnostics](tooling/diagnostics.md)
+
 - [Integration Guides](spring/ch_intro.md)
   - [Spring Boot Integration](spring/spring_boot_integration.md)
   - [Migrating to Functional Errors](spring/migrating_to_functional_errors.md)

--- a/hkj-book/src/effect/ch_intro.md
+++ b/hkj-book/src/effect/ch_intro.md
@@ -38,13 +38,19 @@ If you've used the Focus DSL from the optics chapters, the patterns will feel fa
 
 - **[Migration Cookbook](migration_cookbook.md)** – Pattern-by-pattern translations from imperative Java to Effect Path. Six recipes covering try/catch, Optional chains, null checks, CompletableFuture, validation, and nested record updates.
 
-- **[Common Compiler Errors](compiler_errors.md)** – The five most common compiler errors when using the Effect Path API, with full error messages, minimal triggers, and fixes.
+- **[Common Compiler Errors](compiler_errors.md)** -- The five most common compiler errors when using the Effect Path API, with full error messages, minimal triggers, and fixes.
 
 - **[Advanced Effects](advanced_effects.md)** – Reader, State, and Writer paths for environment access, stateful computation, and logging accumulation.
 
 - **[Advanced Topics](advanced_topics.md)** – Stack-safe recursion, DSL building with Free structures, resource management, parallel execution, and resilience patterns.
 
 - **[Production Readiness](production_readiness.md)** – Stack traces, allocation overhead, and stack safety. The honest answers to the questions senior engineers ask before adopting a library.
+~~~
+
+~~~admonish note title="Compile-Time Safety"
+The HKJ Gradle plugin can detect Path type mismatches at compile time,
+catching errors that would otherwise surface as runtime exceptions.
+See [Compile-Time Checks](../tooling/compile_checks.md) for setup.
 ~~~
 
 ~~~admonish example title="See Example Code"

--- a/hkj-book/src/effect/compiler_errors.md
+++ b/hkj-book/src/effect/compiler_errors.md
@@ -253,6 +253,18 @@ Option 1 is preferred for new code. Option 2 is useful when integrating with exi
 
 ---
 
+## Compile-Time Path Type Mismatch Detection
+
+~~~admonish tip title="Automated Detection"
+The HKJ Gradle plugin includes a compile-time checker that catches
+Path type mismatches before runtime. Rather than debugging an
+`IllegalArgumentException` in production, the checker reports the
+error during compilation. See [Compile-Time Checks](../tooling/compile_checks.md)
+for setup and details.
+~~~
+
+---
+
 ## Quick Diagnostic Table
 
 | Symptom | Likely Cause | Fix |

--- a/hkj-book/src/quickstart.md
+++ b/hkj-book/src/quickstart.md
@@ -18,6 +18,21 @@ The library uses Java preview features including stable values and flexible cons
 
 ## Gradle Setup
 
+### With HKJ Gradle Plugin (Recommended)
+
+```gradle
+// build.gradle.kts
+plugins {
+    id("io.github.higher-kinded-j.hkj") version "LATEST_VERSION"
+}
+```
+
+This single line configures dependencies, preview features, annotation processors, and compile-time Path type checking automatically. See the [Gradle Plugin](tooling/gradle_plugin.md) documentation for the full DSL reference.
+
+### Manual Setup
+
+If you prefer to configure dependencies yourself:
+
 ```gradle
 // build.gradle.kts
 plugins { java }
@@ -63,6 +78,27 @@ repositories {
 ---
 
 ## Maven Setup
+
+### With HKJ Maven Plugin (Recommended)
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.github.higher-kinded-j</groupId>
+            <artifactId>hkj-maven-plugin</artifactId>
+            <version>LATEST_VERSION</version>
+            <extensions>true</extensions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+The plugin automatically adds `hkj-core`, annotation processors, compile-time checks, and `--enable-preview` flags. See the [Build Plugins](tooling/gradle_plugin.md) documentation for the full configuration reference.
+
+### Manual Setup
+
+If you prefer to configure dependencies yourself:
 
 ```xml
 <properties>

--- a/hkj-book/src/tooling/ch_intro.md
+++ b/hkj-book/src/tooling/ch_intro.md
@@ -1,0 +1,28 @@
+# Tooling: Build-Time Safety for Higher-Kinded-J
+
+> _"Make illegal states unrepresentable."_
+> -- Yaron Minsky
+
+Every Path type in Higher-Kinded-J can only chain with the same type. Mix a `MaybePath` into an `EitherPath` chain, and you get an `IllegalArgumentException` at runtime. The code compiles; the tests pass (until someone hits that branch); production breaks at 2 AM.
+
+The HKJ tooling catches these mistakes before your code ever runs. Both Gradle and Maven are supported with dedicated build plugins.
+
+---
+
+~~~admonish info title="In This Chapter"
+- **[Build Plugins](gradle_plugin.md)** -- One-line setup for Gradle or Maven that configures dependencies, preview features, and compile-time checks automatically. Replaces multi-block boilerplate configuration with a single plugin application.
+
+- **[Compile-Time Checks](compile_checks.md)** -- A javac plugin that detects Path type mismatches at compile time, preventing runtime `IllegalArgumentException` errors. Follows a strict no-false-positives policy.
+
+- **[Diagnostics](diagnostics.md)** -- The `hkjDiagnostics` Gradle task or `mvn hkj:diagnostics` Maven goal that reports your current HKJ configuration, showing exactly which dependencies, compiler arguments, and checks are active.
+~~~
+
+## Chapter Contents
+
+1. [Build Plugins](gradle_plugin.md) - One-line project setup for Gradle and Maven
+2. [Compile-Time Checks](compile_checks.md) - Path type mismatch detection
+3. [Diagnostics](diagnostics.md) - Configuration reporting and troubleshooting
+
+---
+
+**Next:** [Build Plugins](gradle_plugin.md)

--- a/hkj-book/src/tooling/compile_checks.md
+++ b/hkj-book/src/tooling/compile_checks.md
@@ -1,0 +1,212 @@
+# Compile-Time Checks: Catching Path Mismatches Early
+
+~~~admonish info title="What You'll Learn"
+- Why Path type mismatches are dangerous and hard to catch in tests
+- How the HKJ compile-time checker detects mismatches before runtime
+- Which methods and Path types the checker covers
+- Known limitations and the no-false-positives policy
+~~~
+
+---
+
+## The Problem
+
+Each Path type can only chain with the same type. This code compiles without errors:
+
+```java
+MaybePath<Integer> result = Path.just(1)
+    .via(n -> Path.io(() -> n + 1));    // returns IOPath, not MaybePath
+```
+
+But at runtime it throws `IllegalArgumentException`:
+
+```
+java.lang.IllegalArgumentException: Type mismatch in via():
+    expected MaybePath but mapper returned IOPath.
+    Each Path type can only chain with the same type.
+    Use conversion methods (toEitherPath, toMaybePath, etc.) to change types.
+```
+
+This class of bug is particularly insidious because:
+
+- The code compiles successfully
+- It passes type checking (generics erasure hides the mismatch)
+- It only fails at runtime when the specific code path executes
+- In branching logic, the mismatch may lurk in a rarely-tested branch
+
+---
+
+## The Solution
+
+The HKJ checker is a javac compiler plugin that detects Path type mismatches during compilation. With the Gradle plugin, it is enabled by default:
+
+```gradle
+plugins {
+    id("io.github.higher-kinded-j.hkj") version "0.3.7-SNAPSHOT"
+}
+```
+
+Now the same code produces a compile-time error:
+
+```
+error: Path type mismatch in via(): expected MaybePath but received IOPath.
+    Each Path type can only chain with the same type.
+    Use conversion methods (toEitherPath, toMaybePath, etc.) to change types.
+    .via(n -> Path.io(() -> n + 1));
+                   ^
+```
+
+The fix is to convert at the boundary:
+
+```java
+MaybePath<Integer> result = Path.just(1)
+    .via(n -> Path.io(() -> n + 1).toMaybePath());    // explicit conversion
+```
+
+---
+
+## What the Checker Detects
+
+The checker inspects calls to Path composition methods and verifies that the receiver and argument resolve to the same Path family.
+
+| Method | What Is Checked |
+|--------|----------------|
+| `via(Function)` | Return type of the function matches the receiver's Path type |
+| `then(Supplier)` | Return type of the supplier matches the receiver's Path type |
+| `zipWith(Combinable, BiFunction)` | Type of the first argument matches the receiver's Path type |
+| `zipWith3(Combinable, Combinable, TriFunction)` | Types of both `Combinable` arguments match the receiver |
+| `recoverWith(Function)` | Return type of the recovery function matches the receiver's Path type |
+| `orElse(Supplier)` | Return type of the supplier matches the receiver's Path type |
+
+---
+
+## How It Works
+
+The checker is a standard `com.sun.source.util.Plugin` that hooks into the Java compiler's `ANALYZE` phase:
+
+1. **Registration** -- The `HKJCheckerPlugin` registers a `TaskListener` that fires after type attribution is complete
+2. **Tree scanning** -- A `TreeScanner` visits every method invocation in the compilation unit
+3. **Method matching** -- The scanner identifies calls to `via`, `then`, `zipWith`, `recoverWith`, and `orElse`
+4. **Type resolution** -- Using the compiler's type information, it resolves the concrete Path types of the receiver and argument
+5. **Family comparison** -- If both types are concrete Path types, it checks they belong to the same family
+6. **Diagnostic reporting** -- Mismatches are reported as compiler errors at the exact source location
+
+The checker runs as part of normal compilation. There is no separate build step or additional tool to invoke.
+
+---
+
+## Configuration
+
+### Enabling (Default)
+
+The Gradle plugin enables the checker by default. No configuration is needed:
+
+```gradle
+plugins {
+    id("io.github.higher-kinded-j.hkj") version "0.3.7-SNAPSHOT"
+}
+```
+
+### Disabling
+
+To disable compile-time checks:
+
+```gradle
+hkj {
+    checks {
+        pathTypeMismatch = false
+    }
+}
+```
+
+### Maven Plugin
+
+The Maven plugin also enables the checker by default:
+
+```xml
+<plugin>
+    <groupId>io.github.higher-kinded-j</groupId>
+    <artifactId>hkj-maven-plugin</artifactId>
+    <version>0.3.7-SNAPSHOT</version>
+    <extensions>true</extensions>
+</plugin>
+```
+
+To disable:
+
+```xml
+<configuration>
+    <pathTypeMismatch>false</pathTypeMismatch>
+</configuration>
+```
+
+### Manual Setup (Without Build Plugins)
+
+**Gradle:**
+
+```gradle
+dependencies {
+    annotationProcessor("io.github.higher-kinded-j:hkj-checker:0.3.7-SNAPSHOT")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xplugin:HKJChecker")
+}
+```
+
+**Maven:**
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <annotationProcessorPaths>
+            <path>
+                <groupId>io.github.higher-kinded-j</groupId>
+                <artifactId>hkj-checker</artifactId>
+                <version>0.3.7-SNAPSHOT</version>
+            </path>
+        </annotationProcessorPaths>
+        <compilerArgs>
+            <arg>-Xplugin:HKJChecker</arg>
+        </compilerArgs>
+    </configuration>
+</plugin>
+```
+
+---
+
+## Limitations
+
+The checker follows a strict **no-false-positives policy**. It is better to miss a real mismatch than to report a false error.
+
+~~~admonish warning title="Cases the Checker Cannot Detect"
+- **Generic type parameters** -- When a method returns `T` where `T` extends a Path type, the concrete type may not be resolvable at compile time
+- **Complex lambda inference** -- Deeply nested lambdas or method references with ambiguous return types may prevent type resolution
+- **Indirect construction** -- Path instances created through helper methods, factories, or dependency injection are not tracked
+- **Runtime polymorphism** -- When the Path type is determined by a runtime condition (e.g., a method that returns different Path types based on input)
+~~~
+
+In these cases, the checker silently skips the check. Runtime type checking in the Path implementations provides a safety net for cases the compiler cannot catch.
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **Path type mismatches** compile successfully but fail at runtime, making them hard to catch in testing
+* **The HKJ checker** is a javac plugin that detects these mismatches during compilation
+* **Enabled by default** when using the HKJ Gradle or Maven plugin; no configuration needed
+* **No false positives** -- the checker only reports errors it is certain about
+* **Runtime checks** in the Path implementations catch anything the compile-time checker misses
+~~~
+
+~~~admonish tip title="See Also"
+- [Build Plugins](gradle_plugin.md) - Plugin setup and configuration
+- [Type Conversions](../effect/conversions.md) - How to convert between Path types
+- [Common Compiler Errors](../effect/compiler_errors.md) - Other compile-time issues and fixes
+~~~
+
+---
+
+**Previous:** [Build Plugins](gradle_plugin.md)
+**Next:** [Diagnostics](diagnostics.md)

--- a/hkj-book/src/tooling/diagnostics.md
+++ b/hkj-book/src/tooling/diagnostics.md
@@ -1,0 +1,112 @@
+# Diagnostics: Understanding Your HKJ Configuration
+
+~~~admonish info title="What You'll Learn"
+- How to run the `hkjDiagnostics` task to inspect your configuration
+- How to read the diagnostics output
+- Common configuration issues and their fixes
+~~~
+
+---
+
+## Running the Diagnostics Task
+
+### Gradle
+
+The HKJ Gradle plugin registers an `hkjDiagnostics` task in the `help` group. Run it from the command line:
+
+```bash
+./gradlew hkjDiagnostics
+```
+
+### Maven
+
+The HKJ Maven plugin provides a `diagnostics` goal. Run it from the command line:
+
+```bash
+mvn hkj:diagnostics
+```
+
+---
+
+## Reading the Output
+
+With default configuration, the task prints:
+
+```
+HKJ Configuration:
+  Version:            0.3.7-SNAPSHOT
+  Preview features:   enabled
+  Spring integration: disabled
+  Compile-time checks:
+    Path type mismatch: enabled
+  Dependencies added:
+    implementation:          io.github.higher-kinded-j:hkj-core:0.3.7-SNAPSHOT
+    annotationProcessor:     io.github.higher-kinded-j:hkj-processor-plugins:0.3.7-SNAPSHOT
+    annotationProcessor:     io.github.higher-kinded-j:hkj-checker:0.3.7-SNAPSHOT
+  Compiler args added:
+    --enable-preview
+    -Xplugin:HKJChecker
+```
+
+### Sections Explained
+
+| Section | What It Shows |
+|---------|--------------|
+| **Version** | The HKJ library version used for all dependencies |
+| **Preview features** | Whether `--enable-preview` is added to compile, test, exec, and javadoc tasks |
+| **Spring integration** | Whether `hkj-spring-boot-starter` is included |
+| **Compile-time checks** | Which compile-time checks are active |
+| **Dependencies added** | The exact Maven coordinates added to each configuration |
+| **Compiler args added** | Additional arguments passed to `javac` |
+
+---
+
+## Common Issues and Fixes
+
+### Dependencies Not Resolving
+
+**Symptom:** Build fails with "Could not resolve" errors for HKJ dependencies.
+
+**Check:** Run `hkjDiagnostics` to verify the version is correct, then ensure Maven Central (or the Sonatype snapshots repository for SNAPSHOTs) is configured:
+
+```gradle
+repositories {
+    mavenCentral()
+}
+```
+
+### Preview Features Not Working
+
+**Symptom:** Compilation fails with errors about preview features.
+
+**Check:** Run `hkjDiagnostics` and verify "Preview features: enabled" appears. If you have set `preview = false`, you must configure preview flags manually.
+
+### Checker Not Running
+
+**Symptom:** Path type mismatches are not caught at compile time.
+
+**Check:** Run `hkjDiagnostics` and verify:
+- "Path type mismatch: enabled" appears under Compile-time checks
+- `hkj-checker` appears in the Dependencies section
+- `-Xplugin:HKJChecker` appears in the Compiler args section
+
+If any of these are missing, check your `hkj { }` block for `checks { pathTypeMismatch = false }`.
+
+### Version Mismatch Between Modules
+
+**Symptom:** Runtime errors from incompatible HKJ module versions.
+
+**Check:** Run `hkjDiagnostics` and confirm all dependencies show the same version. The plugin always uses a single version for all modules. If you have manual dependency declarations elsewhere in your build file, they may override the plugin's version.
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **`hkjDiagnostics` (Gradle) or `mvn hkj:diagnostics` (Maven)** provides a single view of your entire HKJ configuration
+* **Check it first** when troubleshooting build or compilation issues
+* **All dependencies** use the same version, eliminating version mismatch problems
+~~~
+
+---
+
+**Previous:** [Compile-Time Checks](compile_checks.md)
+**Next:** [Spring Boot Integration](../spring/spring_boot_integration.md)

--- a/hkj-book/src/tooling/gradle_plugin.md
+++ b/hkj-book/src/tooling/gradle_plugin.md
@@ -1,0 +1,269 @@
+# Build Plugins: One-Line HKJ Setup
+
+~~~admonish info title="What You'll Learn"
+- How to replace multi-block build configuration with a single plugin for Gradle or Maven
+- The full Gradle `hkj { }` extension DSL and its defaults
+- Maven plugin configuration via `<configuration>` block
+- How to enable Spring Boot integration
+- How to override the HKJ library version
+- Manual setup for projects not using the plugins
+~~~
+
+---
+
+## Before and After
+
+### Without the Plugin
+
+```gradle
+// build.gradle.kts
+plugins { java }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    implementation("io.github.higher-kinded-j:hkj-core:0.3.7-SNAPSHOT")
+    annotationProcessor("io.github.higher-kinded-j:hkj-processor-plugins:0.3.7-SNAPSHOT")
+    annotationProcessor("io.github.higher-kinded-j:hkj-checker:0.3.7-SNAPSHOT")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.addAll(listOf("--enable-preview", "-Xplugin:HKJChecker"))
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("--enable-preview")
+}
+
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs("--enable-preview")
+}
+```
+
+### With the Plugin
+
+```gradle
+// build.gradle.kts
+plugins {
+    id("io.github.higher-kinded-j.hkj") version "0.3.7-SNAPSHOT"
+}
+```
+
+That is it. The plugin handles dependencies, preview flags, compile-time checks, and Javadoc configuration automatically.
+
+---
+
+## Extension DSL Reference
+
+The plugin creates an `hkj` extension block with these options:
+
+```gradle
+hkj {
+    version = "0.3.7-SNAPSHOT"       // HKJ library version (default: project version)
+    preview = true           // add --enable-preview flags (default: true)
+    spring = false           // add hkj-spring-boot-starter (default: false)
+    checks {
+        pathTypeMismatch = true   // enable compile-time Path type checking (default: true)
+    }
+}
+```
+
+### Defaults
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `version` | Project version | Version of HKJ libraries to use |
+| `preview` | `true` | Adds `--enable-preview` to compile, test, exec, and javadoc tasks |
+| `spring` | `false` | Adds `hkj-spring-boot-starter` to implementation dependencies |
+| `checks.pathTypeMismatch` | `true` | Enables compile-time Path type mismatch detection |
+
+With default settings, the plugin adds:
+
+- `hkj-core` to `implementation`
+- `hkj-processor-plugins` to `annotationProcessor`
+- `hkj-checker` to `annotationProcessor`
+- `--enable-preview` to `JavaCompile`, `Test`, `JavaExec`, and `Javadoc` tasks
+- `-Xplugin:HKJChecker` to compiler arguments
+
+---
+
+## Spring Boot Mode
+
+Enable Spring Boot integration to add the HKJ Spring Boot starter:
+
+```gradle
+hkj {
+    spring = true
+}
+```
+
+This adds `hkj-spring-boot-starter` to the `implementation` configuration, which provides auto-configuration for using HKJ types with Spring's dependency injection and web layer.
+
+~~~admonish tip title="See Also"
+- [Spring Boot Integration](../spring/spring_boot_integration.md) - Full guide to using HKJ with Spring Boot
+~~~
+
+---
+
+## Version Management
+
+By default, the plugin uses your project's version for HKJ dependencies. Override this to pin a specific version:
+
+```gradle
+hkj {
+    version = "0.2.2"    // use an older version
+}
+```
+
+All HKJ dependencies (`hkj-core`, `hkj-processor-plugins`, `hkj-checker`, `hkj-spring-boot-starter`) use the same version.
+
+---
+
+## Disabling Features
+
+### Disable Preview Features
+
+If your project manages preview flags separately:
+
+```gradle
+hkj {
+    preview = false
+}
+```
+
+~~~admonish warning
+Higher-Kinded-J requires `--enable-preview` on Java 25. Disabling this means you must configure the flags yourself, or compilation will fail.
+~~~
+
+### Disable Compile-Time Checks
+
+To skip Path type mismatch detection:
+
+```gradle
+hkj {
+    checks {
+        pathTypeMismatch = false
+    }
+}
+```
+
+This removes `hkj-checker` from the annotation processor path and omits the `-Xplugin:HKJChecker` compiler argument.
+
+---
+
+## Maven Users
+
+### With the HKJ Maven Plugin
+
+The HKJ Maven plugin provides similar automation to the Gradle plugin. Add it with `<extensions>true</extensions>` so it can configure dependencies and compiler settings automatically:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.higher-kinded-j</groupId>
+            <artifactId>hkj-bom</artifactId>
+            <version>0.3.7-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.github.higher-kinded-j</groupId>
+            <artifactId>hkj-maven-plugin</artifactId>
+            <version>0.3.7-SNAPSHOT</version>
+            <extensions>true</extensions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+The plugin automatically adds `hkj-core`, annotation processors, compile-time checks, and preview feature flags. Configure options in the `<configuration>` block:
+
+```xml
+<configuration>
+    <version>0.3.7-SNAPSHOT</version>   <!-- HKJ library version (default: project version) -->
+    <preview>true</preview>              <!-- add --enable-preview flags (default: true) -->
+    <spring>false</spring>               <!-- add hkj-spring-boot-starter (default: false) -->
+    <pathTypeMismatch>true</pathTypeMismatch>  <!-- enable compile-time checks (default: true) -->
+</configuration>
+```
+
+Run diagnostics with: `mvn hkj:diagnostics`
+
+### Manual Maven Setup
+
+If you prefer not to use the plugin, configure dependencies and compiler settings manually:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.higher-kinded-j</groupId>
+            <artifactId>hkj-bom</artifactId>
+            <version>0.3.7-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>io.github.higher-kinded-j</groupId>
+        <artifactId>hkj-core</artifactId>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <release>25</release>
+                <enablePreview>true</enablePreview>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>io.github.higher-kinded-j</groupId>
+                        <artifactId>hkj-processor-plugins</artifactId>
+                        <version>0.3.7-SNAPSHOT</version>
+                    </path>
+                    <path>
+                        <groupId>io.github.higher-kinded-j</groupId>
+                        <artifactId>hkj-checker</artifactId>
+                        <version>0.3.7-SNAPSHOT</version>
+                    </path>
+                </annotationProcessorPaths>
+                <compilerArgs>
+                    <arg>-Xplugin:HKJChecker</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+See the [Quickstart](../quickstart.md) page for a complete Maven configuration including test and execution plugins.
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **One line** (Gradle) or a short plugin block (Maven) replaces extensive build configuration
+* **Sensible defaults** enable preview features and compile-time checks out of the box
+* **Everything is optional** and can be disabled or overridden through DSL/configuration
+* **The BOM** manages versions across all HKJ modules for both Gradle and Maven
+~~~
+
+---
+
+**Previous:** [Tooling](ch_intro.md)
+**Next:** [Compile-Time Checks](compile_checks.md)

--- a/hkj-checker/build.gradle.kts
+++ b/hkj-checker/build.gradle.kts
@@ -1,0 +1,88 @@
+plugins {
+    `java-library`
+    id("com.vanniktech.maven.publish")
+}
+
+dependencies {
+    // No external runtime dependencies; uses only JDK-provided com.sun.source.* APIs
+
+    // Test dependencies
+    testImplementation(project(":hkj-core"))
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.compile.testing)
+    testImplementation(libs.truth)
+    testImplementation(libs.bundles.jqwik)
+}
+
+tasks.named<JavaCompile>("compileJava") {
+    options.compilerArgs.addAll(
+        listOf(
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.api=org.higherkindedj.checker",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.code=org.higherkindedj.checker",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=org.higherkindedj.checker",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.util=org.higherkindedj.checker",
+        )
+    )
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    options.compilerArgs.addAll(
+        listOf(
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        )
+    )
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    jvmArgs(
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    )
+}
+
+// Central configuration for publishing
+mavenPublishing {
+    publishToMavenCentral()
+
+    signAllPublications()
+
+    coordinates(
+        groupId = project.group.toString(),
+        artifactId = "hkj-checker",
+        version = project.version.toString()
+    )
+
+    pom {
+        name.set("Higher-Kinded-J Checker")
+        description.set("Compile-time Path type mismatch detection for Higher-Kinded-J")
+        url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+
+        licenses {
+            license {
+                name.set("The MIT License")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("higher-kinded-j")
+                name.set("Magnus Smith")
+                email.set("simulation-hkt@gmail.com")
+            }
+        }
+        scm {
+            connection.set("scm:git:git://github.com/higher-kinded-j/higher-kinded-j.git")
+            developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+        }
+    }
+}

--- a/hkj-checker/src/main/java/module-info.java
+++ b/hkj-checker/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+/** Compile-time checker for Higher-Kinded-J Path type mismatches. */
+module org.higherkindedj.checker {
+  requires jdk.compiler;
+
+  provides com.sun.source.util.Plugin with
+      org.higherkindedj.checker.HKJCheckerPlugin;
+}

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/DiagnosticMessages.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/DiagnosticMessages.java
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import java.util.Optional;
+
+/**
+ * Centralised error message formatting for the HKJ checker.
+ *
+ * <p>This class provides consistent error messages across all check sites. Messages follow the
+ * pattern: describe what was expected, what was received, and how to fix it.
+ */
+public final class DiagnosticMessages {
+
+  private DiagnosticMessages() {}
+
+  /**
+   * Formats a Path type mismatch error message.
+   *
+   * @param methodName the method where the mismatch was detected (e.g., "via", "zipWith")
+   * @param expectedType the simple name of the expected Path type (e.g., "MaybePath")
+   * @param actualType the simple name of the actual Path type (e.g., "IOPath")
+   * @return a formatted error message
+   */
+  public static String pathTypeMismatch(String methodName, String expectedType, String actualType) {
+    String base =
+        "Path type mismatch in %s(): expected %s but received %s. "
+                .formatted(methodName, expectedType, actualType)
+            + "Each Path type can only chain with the same type.";
+
+    Optional<String> conversion = PathTypeRegistry.suggestedConversion(actualType, expectedType);
+    if (conversion.isPresent()) {
+      return base + " Use conversion methods like " + conversion.get() + " to convert.";
+    }
+    return base + " Use conversion methods (toEitherPath, toMaybePath, etc.) to change types.";
+  }
+}

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/HKJCheckerPlugin.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/HKJCheckerPlugin.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.Plugin;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.Trees;
+
+/**
+ * A javac compiler plugin that detects Path type mismatches at compile time.
+ *
+ * <p>This plugin hooks into javac's {@code ANALYZE} phase (after type attribution) and runs the
+ * {@link PathTypeMismatchChecker} over each compilation unit. It reports errors when different
+ * concrete Path types are mixed in chain operations like {@code via()}, {@code zipWith()}, and
+ * {@code recoverWith()}.
+ *
+ * <h2>Usage</h2>
+ *
+ * <p>Add the checker jar to the annotation processor path and enable the plugin:
+ *
+ * <pre>{@code
+ * // build.gradle.kts
+ * dependencies {
+ *     annotationProcessor("io.github.higher-kinded-j:hkj-checker:VERSION")
+ * }
+ * tasks.withType<JavaCompile>().configureEach {
+ *     options.compilerArgs.add("-Xplugin:HKJChecker")
+ * }
+ * }</pre>
+ *
+ * <p>Or use the HKJ Gradle plugin which configures this automatically.
+ *
+ * <h2>Registration</h2>
+ *
+ * <p>This plugin is registered via {@code META-INF/services/com.sun.source.util.Plugin} and via the
+ * {@code module-info.java} provides clause.
+ */
+public class HKJCheckerPlugin implements Plugin {
+
+  /** The plugin name used with {@code -Xplugin:HKJChecker}. */
+  public static final String PLUGIN_NAME = "HKJChecker";
+
+  @Override
+  public String getName() {
+    return PLUGIN_NAME;
+  }
+
+  @Override
+  public void init(JavacTask task, String... args) {
+    Trees trees = Trees.instance(task);
+
+    task.addTaskListener(
+        new TaskListener() {
+          @Override
+          public void finished(TaskEvent event) {
+            if (event.getKind() == TaskEvent.Kind.ANALYZE) {
+              var compilationUnit = event.getCompilationUnit();
+              if (compilationUnit != null) {
+                new PathTypeMismatchChecker(trees).scan(compilationUnit, null);
+              }
+            }
+          }
+        });
+  }
+}

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/PathTypeMismatchChecker.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/PathTypeMismatchChecker.java
@@ -1,0 +1,269 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.tools.Diagnostic;
+
+/**
+ * A {@link TreeScanner} that detects Path type mismatches in method invocations.
+ *
+ * <p>This scanner visits method invocation nodes in the AST and checks whether the receiver's
+ * concrete Path type matches the type returned by lambda arguments or passed as parameters. It
+ * targets the following methods:
+ *
+ * <ul>
+ *   <li>{@code via(Function)} and {@code flatMap(Function)} - checks the lambda's return type
+ *   <li>{@code then(Supplier)} - checks the supplier's return type
+ *   <li>{@code zipWith(Combinable, BiFunction)} - checks the first argument's type
+ *   <li>{@code zipWith3(Combinable, Combinable, Function3)} - checks the first two arguments' types
+ *   <li>{@code recoverWith(Function)} - checks the lambda's return type
+ *   <li>{@code orElse(Supplier)} - checks the supplier's return type
+ * </ul>
+ *
+ * <p>This checker follows a <b>no false positives</b> policy: if a type cannot be resolved, the
+ * check is silently skipped.
+ */
+public class PathTypeMismatchChecker extends TreeScanner<Void, Void> {
+
+  private static final Set<String> CHECKED_METHODS =
+      Set.of("via", "flatMap", "then", "zipWith", "zipWith3", "recoverWith", "orElse");
+
+  /** Methods where the first argument is the "other" Path to check. */
+  private static final Set<String> ARGUMENT_TYPE_METHODS = Set.of("zipWith", "zipWith3");
+
+  /** Methods where we check the return type of the lambda/supplier argument. */
+  private static final Set<String> LAMBDA_RETURN_METHODS =
+      Set.of("via", "flatMap", "then", "recoverWith", "orElse");
+
+  private final Trees trees;
+
+  /**
+   * Creates a new checker using the given Trees instance.
+   *
+   * @param trees the Trees utility from the javac task; must not be null
+   */
+  public PathTypeMismatchChecker(Trees trees) {
+    this.trees = trees;
+  }
+
+  @Override
+  public Void visitMethodInvocation(MethodInvocationTree node, Void unused) {
+    String methodName = extractMethodName(node);
+    if (methodName != null && CHECKED_METHODS.contains(methodName)) {
+      checkPathTypeMismatch(node, methodName);
+    }
+    return super.visitMethodInvocation(node, unused);
+  }
+
+  private void checkPathTypeMismatch(MethodInvocationTree node, String methodName) {
+    // Resolve the receiver type
+    Optional<String> receiverType = resolveReceiverPathType(node);
+    if (receiverType.isEmpty()) {
+      return; // Cannot resolve receiver; skip silently (no false positives)
+    }
+
+    if (ARGUMENT_TYPE_METHODS.contains(methodName)) {
+      checkArgumentTypes(node, methodName, receiverType.get());
+    } else if (LAMBDA_RETURN_METHODS.contains(methodName)) {
+      checkLambdaReturnType(node, methodName, receiverType.get());
+    }
+  }
+
+  /**
+   * For zipWith/zipWith3, check the concrete type of the first argument (and second for zipWith3).
+   */
+  private void checkArgumentTypes(
+      MethodInvocationTree node, String methodName, String receiverCategory) {
+    List<? extends ExpressionTree> args = node.getArguments();
+    if (args.isEmpty()) {
+      return;
+    }
+
+    // Check the first argument (the "other" Combinable)
+    checkArgumentType(node, args.getFirst(), methodName, receiverCategory);
+
+    // For zipWith3, also check the second argument
+    if ("zipWith3".equals(methodName) && args.size() >= 2) {
+      checkArgumentType(node, args.get(1), methodName, receiverCategory);
+    }
+  }
+
+  private void checkArgumentType(
+      MethodInvocationTree node, ExpressionTree arg, String methodName, String receiverCategory) {
+    Optional<String> argType = resolveExpressionPathType(arg);
+    if (argType.isEmpty()) {
+      return;
+    }
+
+    if (!argType.get().equals(receiverCategory)) {
+      reportMismatch(node, methodName, receiverCategory, argType.get());
+    }
+  }
+
+  /** For via/flatMap/then/recoverWith/orElse, check the return type of the lambda/supplier. */
+  private void checkLambdaReturnType(
+      MethodInvocationTree node, String methodName, String receiverCategory) {
+    List<? extends ExpressionTree> args = node.getArguments();
+    if (args.isEmpty()) {
+      return;
+    }
+
+    ExpressionTree lambdaArg = args.getFirst();
+
+    // Try to resolve the lambda's return type from its body
+    Optional<String> returnType = resolveLambdaReturnPathType(lambdaArg);
+    if (returnType.isEmpty()) {
+      return; // Cannot resolve; skip silently
+    }
+
+    if (!returnType.get().equals(receiverCategory)) {
+      reportMismatch(node, methodName, receiverCategory, returnType.get());
+    }
+  }
+
+  /**
+   * Resolves the concrete Path type of the receiver expression.
+   *
+   * @return the Path category simple name, or empty if not a known Path type
+   */
+  private Optional<String> resolveReceiverPathType(MethodInvocationTree node) {
+    ExpressionTree methodSelect = node.getMethodSelect();
+    ExpressionTree receiver = null;
+
+    if (methodSelect instanceof MemberSelectTree memberSelect) {
+      receiver = memberSelect.getExpression();
+    }
+
+    if (receiver == null) {
+      return Optional.empty();
+    }
+
+    return resolveExpressionPathType(receiver);
+  }
+
+  /**
+   * Resolves the concrete Path type of an expression by examining its attributed type from javac.
+   */
+  private Optional<String> resolveExpressionPathType(ExpressionTree expr) {
+    try {
+      Type type = getAttributedType(expr);
+      if (type == null) {
+        return Optional.empty();
+      }
+      return resolvePathTypeFromType(type);
+    } catch (Exception e) {
+      // If type resolution fails for any reason, skip silently (no false positives)
+      return Optional.empty();
+    }
+  }
+
+  /** Attempts to resolve the return type of a lambda expression or supplier. */
+  private Optional<String> resolveLambdaReturnPathType(ExpressionTree lambdaArg) {
+    if (lambdaArg instanceof LambdaExpressionTree lambda) {
+      return resolveLambdaBodyReturnType(lambda);
+    }
+    // For method references or other expressions, we cannot easily determine
+    // the return type without deep type analysis, so skip
+    return Optional.empty();
+  }
+
+  /** Resolves the return type from a lambda body. */
+  private Optional<String> resolveLambdaBodyReturnType(LambdaExpressionTree lambda) {
+    // For expression lambdas (e.g., x -> Path.just(x)), the body is the expression
+    if (lambda.getBodyKind() == LambdaExpressionTree.BodyKind.EXPRESSION) {
+      return resolveExpressionPathType((ExpressionTree) lambda.getBody());
+    }
+
+    // For statement lambdas, scan for return statements
+    ReturnTypeFinder finder = new ReturnTypeFinder();
+    finder.scan(lambda.getBody(), null);
+    return finder.getReturnPathType();
+  }
+
+  /**
+   * Gets the attributed type from a javac expression tree node.
+   *
+   * <p>After the ANALYZE phase, javac attaches resolved types to expression nodes via the internal
+   * {@code JCTree.JCExpression.type} field. This method accesses that field through the internal
+   * javac API (accessible via {@code --add-exports}).
+   */
+  private Type getAttributedType(ExpressionTree expr) {
+    if (expr instanceof JCTree.JCExpression jcExpr) {
+      return jcExpr.type;
+    }
+    return null;
+  }
+
+  /** Resolves a javac Type to a Path type category if it is a known Path type. */
+  private Optional<String> resolvePathTypeFromType(Type type) {
+    String qualifiedName = extractQualifiedName(type);
+    if (qualifiedName == null) {
+      return Optional.empty();
+    }
+    return PathTypeRegistry.getPathCategory(qualifiedName);
+  }
+
+  /** Extracts the fully qualified name from a javac Type, stripping generic type parameters. */
+  private String extractQualifiedName(Type type) {
+    if (type.tsym != null) {
+      return type.tsym.getQualifiedName().toString();
+    }
+    // Fallback: parse from toString, stripping generics
+    String str = type.toString();
+    int angleBracket = str.indexOf('<');
+    if (angleBracket >= 0) {
+      str = str.substring(0, angleBracket);
+    }
+    return str;
+  }
+
+  /** Extracts the method name from a method invocation. */
+  private String extractMethodName(MethodInvocationTree node) {
+    ExpressionTree methodSelect = node.getMethodSelect();
+    if (methodSelect instanceof MemberSelectTree memberSelect) {
+      return memberSelect.getIdentifier().toString();
+    }
+    return null;
+  }
+
+  /** Reports a Path type mismatch diagnostic at the given node's source location. */
+  private void reportMismatch(
+      MethodInvocationTree node, String methodName, String expectedType, String actualType) {
+    String message = DiagnosticMessages.pathTypeMismatch(methodName, expectedType, actualType);
+    trees.printMessage(Diagnostic.Kind.ERROR, message, node, null);
+  }
+
+  /**
+   * Inner scanner that finds return statements in a lambda body and resolves their Path types.
+   *
+   * <p>Collects the first resolvable return type found. If multiple return statements return
+   * different types, only the first is used.
+   */
+  private class ReturnTypeFinder extends TreeScanner<Void, Void> {
+    private String returnPathType;
+
+    @Override
+    public Void visitReturn(ReturnTree node, Void unused) {
+      if (returnPathType == null && node.getExpression() != null) {
+        resolveExpressionPathType(node.getExpression()).ifPresent(type -> returnPathType = type);
+      }
+      return super.visitReturn(node, unused);
+    }
+
+    Optional<String> getReturnPathType() {
+      return Optional.ofNullable(returnPathType);
+    }
+  }
+}

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/PathTypeRegistry.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/PathTypeRegistry.java
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Static registry of all concrete Path types and their relationships.
+ *
+ * <p>This registry is used by the {@link PathTypeMismatchChecker} to determine whether two types
+ * belong to the same Path family. It maps fully qualified class names to their simple names and
+ * provides lookup methods for type comparison.
+ */
+public final class PathTypeRegistry {
+
+  private PathTypeRegistry() {}
+
+  /** Set of all registered Path type simple names. */
+  private static final Set<String> PATH_SIMPLE_NAMES =
+      Set.of(
+          // Effect paths
+          "MaybePath",
+          "EitherPath",
+          "TryPath",
+          "IOPath",
+          "VTaskPath",
+          "DefaultVTaskPath",
+          "ValidationPath",
+          "IdPath",
+          "OptionalPath",
+          "GenericPath",
+          "TrampolinePath",
+          "FreePath",
+          "FreeApPath",
+          "ListPath",
+          "StreamPath",
+          "VStreamPath",
+          "DefaultVStreamPath",
+          "NonDetPath",
+          "ReaderPath",
+          "WithStatePath",
+          "WriterPath",
+          "LazyPath",
+          "CompletableFuturePath",
+          // Expression path
+          "ForPath",
+          // Optics paths
+          "FocusPath",
+          "AffinePath",
+          "TraversalPath");
+
+  /** Maps fully qualified class names to their simple names. */
+  private static final Map<String, String> QUALIFIED_TO_SIMPLE =
+      Map.ofEntries(
+          Map.entry("org.higherkindedj.hkt.effect.MaybePath", "MaybePath"),
+          Map.entry("org.higherkindedj.hkt.effect.EitherPath", "EitherPath"),
+          Map.entry("org.higherkindedj.hkt.effect.TryPath", "TryPath"),
+          Map.entry("org.higherkindedj.hkt.effect.IOPath", "IOPath"),
+          Map.entry("org.higherkindedj.hkt.effect.VTaskPath", "VTaskPath"),
+          Map.entry("org.higherkindedj.hkt.effect.DefaultVTaskPath", "DefaultVTaskPath"),
+          Map.entry("org.higherkindedj.hkt.effect.ValidationPath", "ValidationPath"),
+          Map.entry("org.higherkindedj.hkt.effect.IdPath", "IdPath"),
+          Map.entry("org.higherkindedj.hkt.effect.OptionalPath", "OptionalPath"),
+          Map.entry("org.higherkindedj.hkt.effect.GenericPath", "GenericPath"),
+          Map.entry("org.higherkindedj.hkt.effect.TrampolinePath", "TrampolinePath"),
+          Map.entry("org.higherkindedj.hkt.effect.FreePath", "FreePath"),
+          Map.entry("org.higherkindedj.hkt.effect.FreeApPath", "FreeApPath"),
+          Map.entry("org.higherkindedj.hkt.effect.ListPath", "ListPath"),
+          Map.entry("org.higherkindedj.hkt.effect.StreamPath", "StreamPath"),
+          Map.entry("org.higherkindedj.hkt.effect.VStreamPath", "VStreamPath"),
+          Map.entry("org.higherkindedj.hkt.effect.DefaultVStreamPath", "DefaultVStreamPath"),
+          Map.entry("org.higherkindedj.hkt.effect.NonDetPath", "NonDetPath"),
+          Map.entry("org.higherkindedj.hkt.effect.ReaderPath", "ReaderPath"),
+          Map.entry("org.higherkindedj.hkt.effect.WithStatePath", "WithStatePath"),
+          Map.entry("org.higherkindedj.hkt.effect.WriterPath", "WriterPath"),
+          Map.entry("org.higherkindedj.hkt.effect.LazyPath", "LazyPath"),
+          Map.entry("org.higherkindedj.hkt.effect.CompletableFuturePath", "CompletableFuturePath"),
+          Map.entry("org.higherkindedj.hkt.expression.ForPath", "ForPath"),
+          Map.entry("org.higherkindedj.optics.focus.FocusPath", "FocusPath"),
+          Map.entry("org.higherkindedj.optics.focus.AffinePath", "AffinePath"),
+          Map.entry("org.higherkindedj.optics.focus.TraversalPath", "TraversalPath"));
+
+  /** Suggested conversion methods between Path types. */
+  private static final Map<String, String> CONVERSION_METHODS =
+      Map.ofEntries(
+          Map.entry("toEitherPath", "EitherPath"),
+          Map.entry("toMaybePath", "MaybePath"),
+          Map.entry("toTryPath", "TryPath"),
+          Map.entry("toOptionalPath", "OptionalPath"),
+          Map.entry("toValidationPath", "ValidationPath"),
+          Map.entry("toIdPath", "IdPath"));
+
+  /**
+   * Returns the total number of registered Path types.
+   *
+   * @return the count of registered Path types
+   */
+  public static int registeredTypeCount() {
+    return QUALIFIED_TO_SIMPLE.size();
+  }
+
+  /**
+   * Returns an unmodifiable set of all registered Path type simple names.
+   *
+   * @return set of simple names
+   */
+  public static Set<String> allSimpleNames() {
+    return PATH_SIMPLE_NAMES;
+  }
+
+  /**
+   * Checks whether the given fully qualified type name is a registered Path type.
+   *
+   * @param qualifiedName the fully qualified class name
+   * @return true if it is a registered Path type
+   */
+  public static boolean isPathType(String qualifiedName) {
+    return QUALIFIED_TO_SIMPLE.containsKey(qualifiedName);
+  }
+
+  /**
+   * Checks whether the given simple name is a registered Path type.
+   *
+   * @param simpleName the simple class name
+   * @return true if it is a registered Path type simple name
+   */
+  public static boolean isPathTypeBySimpleName(String simpleName) {
+    return PATH_SIMPLE_NAMES.contains(simpleName);
+  }
+
+  /**
+   * Returns the Path category (simple name) for a given fully qualified type name.
+   *
+   * @param qualifiedName the fully qualified class name
+   * @return the simple name if registered, or empty if not a known Path type
+   */
+  public static Optional<String> getPathCategory(String qualifiedName) {
+    return Optional.ofNullable(QUALIFIED_TO_SIMPLE.get(qualifiedName));
+  }
+
+  /**
+   * Checks whether two fully qualified type names belong to the same Path family.
+   *
+   * <p>Two types are in the same family if they resolve to the same simple name in the registry.
+   * For example, "org.higherkindedj.hkt.effect.MaybePath" and itself are the same family.
+   *
+   * @param qualifiedName1 the first fully qualified class name
+   * @param qualifiedName2 the second fully qualified class name
+   * @return true if both are registered Path types with the same simple name
+   */
+  public static boolean areSamePathFamily(String qualifiedName1, String qualifiedName2) {
+    String simple1 = QUALIFIED_TO_SIMPLE.get(qualifiedName1);
+    String simple2 = QUALIFIED_TO_SIMPLE.get(qualifiedName2);
+    if (simple1 == null || simple2 == null) {
+      return false;
+    }
+    return simple1.equals(simple2);
+  }
+
+  /**
+   * Suggests a conversion method to convert from one Path type to another.
+   *
+   * @param fromType the simple name of the source Path type
+   * @param toType the simple name of the target Path type
+   * @return the conversion method name if one exists, or empty
+   */
+  public static Optional<String> suggestedConversion(String fromType, String toType) {
+    for (Map.Entry<String, String> entry : CONVERSION_METHODS.entrySet()) {
+      if (entry.getValue().equals(toType)) {
+        return Optional.of(entry.getKey() + "()");
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/hkj-checker/src/main/resources/META-INF/services/com.sun.source.util.Plugin
+++ b/hkj-checker/src/main/resources/META-INF/services/com.sun.source.util.Plugin
@@ -1,0 +1,1 @@
+org.higherkindedj.checker.HKJCheckerPlugin

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/DiagnosticMessagesTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/DiagnosticMessagesTest.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("DiagnosticMessages")
+class DiagnosticMessagesTest {
+
+  @Nested
+  @DisplayName("pathTypeMismatch")
+  class PathTypeMismatch {
+
+    @Test
+    @DisplayName("includes method name, expected type, and actual type")
+    void pathTypeMismatch_containsAllFields() {
+      String message = DiagnosticMessages.pathTypeMismatch("via", "MaybePath", "IOPath");
+
+      assertThat(message)
+          .contains("via()")
+          .contains("MaybePath")
+          .contains("IOPath")
+          .contains("Path type mismatch");
+    }
+
+    @Test
+    @DisplayName("mentions conversion methods")
+    void pathTypeMismatch_mentionsConversion() {
+      String message = DiagnosticMessages.pathTypeMismatch("via", "MaybePath", "IOPath");
+
+      assertThat(message).contains("conversion methods");
+    }
+
+    @Test
+    @DisplayName("includes same-type chaining rule")
+    void pathTypeMismatch_includesChainRule() {
+      String message = DiagnosticMessages.pathTypeMismatch("zipWith", "MaybePath", "EitherPath");
+
+      assertThat(message).contains("Each Path type can only chain with the same type");
+    }
+
+    @Test
+    @DisplayName("suggests specific conversion when target has a known conversion method")
+    void pathTypeMismatch_suggestsSpecificConversion() {
+      String message = DiagnosticMessages.pathTypeMismatch("via", "EitherPath", "MaybePath");
+
+      // MaybePath -> EitherPath has a known conversion: toEitherPath()
+      assertThat(message).contains("toEitherPath()");
+    }
+
+    @Test
+    @DisplayName("works for all checked methods")
+    void pathTypeMismatch_allMethods() {
+      for (String method :
+          new String[] {"via", "then", "zipWith", "zipWith3", "recoverWith", "orElse"}) {
+        String message = DiagnosticMessages.pathTypeMismatch(method, "MaybePath", "IOPath");
+        assertThat(message)
+            .as("Message for method %s should be non-empty", method)
+            .isNotEmpty()
+            .contains(method + "()");
+      }
+    }
+
+    @Test
+    @DisplayName("produces non-empty message for any input")
+    void pathTypeMismatch_neverEmpty() {
+      String message = DiagnosticMessages.pathTypeMismatch("custom", "TypeA", "TypeB");
+      assertThat(message).isNotEmpty();
+    }
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/HKJCheckerPluginTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/HKJCheckerPluginTest.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HKJCheckerPlugin")
+class HKJCheckerPluginTest {
+
+  @Nested
+  @DisplayName("getName")
+  class GetName {
+
+    @Test
+    @DisplayName("returns 'HKJChecker'")
+    void getName_returnsPluginName() {
+      var plugin = new HKJCheckerPlugin();
+      assertThat(plugin.getName()).isEqualTo("HKJChecker");
+    }
+
+    @Test
+    @DisplayName("matches the PLUGIN_NAME constant")
+    void getName_matchesConstant() {
+      var plugin = new HKJCheckerPlugin();
+      assertThat(plugin.getName()).isEqualTo(HKJCheckerPlugin.PLUGIN_NAME);
+    }
+  }
+
+  @Nested
+  @DisplayName("PLUGIN_NAME")
+  class PluginName {
+
+    @Test
+    @DisplayName("is a non-empty string")
+    void pluginName_isNonEmpty() {
+      assertThat(HKJCheckerPlugin.PLUGIN_NAME).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("does not contain spaces")
+    void pluginName_noSpaces() {
+      assertThat(HKJCheckerPlugin.PLUGIN_NAME).doesNotContain(" ");
+    }
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/PathTypeMismatchCheckerTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/PathTypeMismatchCheckerTest.java
@@ -1,0 +1,329 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PathTypeMismatchChecker")
+class PathTypeMismatchCheckerTest {
+
+  /**
+   * Compiles the given source with the HKJChecker plugin enabled.
+   *
+   * <p>Note: The compile-testing library runs javac in-process. We pass the plugin argument to
+   * activate our checker.
+   */
+  private Compilation compileWithChecker(JavaFileObject... sources) {
+    return javac()
+        .withOptions("-Xplugin:HKJChecker", "--enable-preview", "--release", "25")
+        .compile(sources);
+  }
+
+  @Nested
+  @DisplayName("correct usage")
+  class CorrectUsageTests {
+
+    @Test
+    @DisplayName("compiles without errors when no Path types are used")
+    void correctUsage_noPathTypes_compiles() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.SimpleCode",
+              """
+              package test;
+
+              public class SimpleCode {
+                  public void doSomething() {
+                      int x = 1 + 2;
+                      String s = String.valueOf(x);
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("compiles without errors when Path-like method names are used on non-Path types")
+    void correctUsage_nonPathVia_compiles() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.NonPathVia",
+              """
+              package test;
+
+              public class NonPathVia {
+                  public String via(java.util.function.Function<String, String> f) {
+                      return f.apply("hello");
+                  }
+
+                  public void test() {
+                      via(s -> s.toUpperCase());
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+  }
+
+  @Nested
+  @DisplayName("correct usage with real Path types")
+  class CorrectPathUsageTests {
+
+    @Test
+    @DisplayName("compiles without errors when same Path type is used throughout via chain")
+    void correctUsage_sameTypeVia_compiles() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.SameTypeVia",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class SameTypeVia {
+                  public void sameTypeChaining() {
+                      Path.just(1).via(_ -> Path.just(2));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("compiles without errors when same Path type is used in zipWith")
+    void correctUsage_sameTypeZipWith_compiles() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.SameTypeZipWith",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class SameTypeZipWith {
+                  public void sameTypeZipWith() {
+                      Path.just(1).zipWith(Path.just(2), Integer::sum);
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("compiles without errors when same Path type is used in then")
+    void correctUsage_sameTypeThen_compiles() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.SameTypeThen",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class SameTypeThen {
+                  public void sameTypeThen() {
+                      Path.just(1).then(() -> Path.just(2));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+  }
+
+  @Nested
+  @DisplayName("mismatch detection")
+  class MismatchDetectionTests {
+
+    @Test
+    @DisplayName("reports error when via lambda returns a different Path type")
+    void mismatch_inVia_reportsError() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.MismatchVia",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class MismatchVia {
+                  public void mismatchedVia() {
+                      Path.just(1).via(_ -> Path.io(() -> 2));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("Path type mismatch in via()");
+      assertThat(compilation).hadErrorContaining("expected MaybePath but received IOPath");
+    }
+
+    @Test
+    @DisplayName("reports error when zipWith argument is a different Path type")
+    void mismatch_inZipWith_reportsError() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.MismatchZipWith",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class MismatchZipWith {
+                  public void mismatchedZipWith() {
+                      Path.just(1).zipWith(Path.right("x"), (a, b) -> a + b.length());
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("Path type mismatch in zipWith()");
+      assertThat(compilation).hadErrorContaining("expected MaybePath but received EitherPath");
+    }
+
+    @Test
+    @DisplayName("reports error when then supplier returns a different Path type")
+    void mismatch_inThen_reportsError() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.MismatchThen",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class MismatchThen {
+                  public void mismatchedThen() {
+                      Path.right("a").then(() -> Path.just(1));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("Path type mismatch in then()");
+      assertThat(compilation).hadErrorContaining("expected EitherPath but received MaybePath");
+    }
+
+    @Test
+    @DisplayName("reports error when recoverWith lambda returns a different Path type")
+    void mismatch_inRecoverWith_reportsError() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.MismatchRecoverWith",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.Semigroup;
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class MismatchRecoverWith {
+                  private static final Semigroup<String> CONCAT = (a, b) -> a + b;
+
+                  public void mismatchedRecoverWith() {
+                      Path.right(1).recoverWith(_ -> Path.valid(42, CONCAT));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("Path type mismatch in recoverWith()");
+      assertThat(compilation).hadErrorContaining("expected EitherPath but received ValidationPath");
+    }
+
+    @Test
+    @DisplayName("reports error when orElse supplier returns a different Path type")
+    void mismatch_inOrElse_reportsError() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.MismatchOrElse",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.Semigroup;
+              import org.higherkindedj.hkt.effect.Path;
+
+              public class MismatchOrElse {
+                  private static final Semigroup<String> CONCAT = (a, b) -> a + b;
+
+                  public void mismatchedOrElse() {
+                      Path.<String, Integer>right(1).orElse(() -> Path.valid(2, CONCAT));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("Path type mismatch in orElse()");
+      assertThat(compilation).hadErrorContaining("expected EitherPath but received ValidationPath");
+    }
+  }
+
+  @Nested
+  @DisplayName("no false positives")
+  class NoFalsePositiveTests {
+
+    @Test
+    @DisplayName("does not report error for generic Chainable receiver")
+    void noFalsePositive_genericReceiver_compiles() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.GenericReceiver",
+              """
+              package test;
+
+              import org.higherkindedj.hkt.effect.Path;
+              import org.higherkindedj.hkt.effect.capability.Chainable;
+
+              public class GenericReceiver {
+                  public <A> void genericReceiver(Chainable<A> path) {
+                      path.via(_ -> Path.just(1));
+                  }
+              }
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+  }
+
+  @Nested
+  @DisplayName("plugin registration")
+  class PluginRegistration {
+
+    @Test
+    @DisplayName("plugin loads and processes source without crashing")
+    void plugin_loadsSuccessfully() {
+      JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "test.Empty",
+              """
+              package test;
+              public class Empty {}
+              """);
+
+      Compilation compilation = compileWithChecker(source);
+      assertThat(compilation).succeeded();
+    }
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/PathTypeRegistryPropertyTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/PathTypeRegistryPropertyTest.java
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+/**
+ * Property-based tests for {@link PathTypeRegistry} and {@link DiagnosticMessages}.
+ *
+ * <p>These tests generate random inputs to verify invariants hold across all possible combinations.
+ */
+class PathTypeRegistryPropertyTest {
+
+  private static final List<String> ALL_SIMPLE_NAMES =
+      List.copyOf(PathTypeRegistry.allSimpleNames());
+
+  @Provide
+  Arbitrary<String> pathSimpleNames() {
+    return Arbitraries.of(ALL_SIMPLE_NAMES);
+  }
+
+  @Provide
+  Arbitrary<String> methodNames() {
+    return Arbitraries.of("via", "flatMap", "then", "zipWith", "zipWith3", "recoverWith", "orElse");
+  }
+
+  @Property
+  void areSamePathFamily_isReflexive(@ForAll("pathSimpleNames") String name) {
+    // Construct a qualified name from the simple name
+    // Use the effect package as default; this works because areSamePathFamily uses the map
+    String qualified = findQualifiedName(name);
+    if (qualified != null) {
+      assertThat(PathTypeRegistry.areSamePathFamily(qualified, qualified))
+          .as("areSamePathFamily should be reflexive for %s", name)
+          .isTrue();
+    }
+  }
+
+  @Property
+  void areSamePathFamily_isSymmetric(
+      @ForAll("pathSimpleNames") String name1, @ForAll("pathSimpleNames") String name2) {
+    String qualified1 = findQualifiedName(name1);
+    String qualified2 = findQualifiedName(name2);
+    if (qualified1 != null && qualified2 != null) {
+      assertThat(PathTypeRegistry.areSamePathFamily(qualified1, qualified2))
+          .as("areSamePathFamily should be symmetric for %s and %s", name1, name2)
+          .isEqualTo(PathTypeRegistry.areSamePathFamily(qualified2, qualified1));
+    }
+  }
+
+  @Property
+  void pathTypeMismatch_alwaysProducesNonEmptyMessage(
+      @ForAll("methodNames") String method,
+      @ForAll("pathSimpleNames") String expected,
+      @ForAll("pathSimpleNames") String actual) {
+    String message = DiagnosticMessages.pathTypeMismatch(method, expected, actual);
+    assertThat(message).as("Message should never be empty").isNotEmpty();
+  }
+
+  @Property
+  void pathTypeMismatch_alwaysContainsMethodName(
+      @ForAll("methodNames") String method,
+      @ForAll("pathSimpleNames") String expected,
+      @ForAll("pathSimpleNames") String actual) {
+    String message = DiagnosticMessages.pathTypeMismatch(method, expected, actual);
+    assertThat(message).contains(method + "()");
+  }
+
+  @Property
+  void pathTypeMismatch_alwaysContainsExpectedAndActualTypes(
+      @ForAll("methodNames") String method,
+      @ForAll("pathSimpleNames") String expected,
+      @ForAll("pathSimpleNames") String actual) {
+    String message = DiagnosticMessages.pathTypeMismatch(method, expected, actual);
+    assertThat(message).contains(expected).contains(actual);
+  }
+
+  @Property
+  void isPathType_consistentWithGetPathCategory(@ForAll("pathSimpleNames") String name) {
+    String qualified = findQualifiedName(name);
+    if (qualified != null) {
+      assertThat(PathTypeRegistry.isPathType(qualified))
+          .as("isPathType and getPathCategory should be consistent for %s", name)
+          .isEqualTo(PathTypeRegistry.getPathCategory(qualified).isPresent());
+    }
+  }
+
+  /** Finds the qualified name for a given simple name by searching the registry. */
+  private String findQualifiedName(String simpleName) {
+    // Build a reverse lookup
+    String[] packages = {
+      "org.higherkindedj.hkt.effect.",
+      "org.higherkindedj.hkt.expression.",
+      "org.higherkindedj.optics.focus."
+    };
+    for (String pkg : packages) {
+      String qualified = pkg + simpleName;
+      if (PathTypeRegistry.isPathType(qualified)) {
+        return qualified;
+      }
+    }
+    return null;
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/PathTypeRegistryTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/PathTypeRegistryTest.java
@@ -1,0 +1,222 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("PathTypeRegistry")
+class PathTypeRegistryTest {
+
+  /** All registered Path types with their fully qualified names. */
+  static Stream<Arguments> allPathTypes() {
+    return Stream.of(
+        Arguments.of("org.higherkindedj.hkt.effect.MaybePath", "MaybePath"),
+        Arguments.of("org.higherkindedj.hkt.effect.EitherPath", "EitherPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.TryPath", "TryPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.IOPath", "IOPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.VTaskPath", "VTaskPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.DefaultVTaskPath", "DefaultVTaskPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.ValidationPath", "ValidationPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.IdPath", "IdPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.OptionalPath", "OptionalPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.GenericPath", "GenericPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.TrampolinePath", "TrampolinePath"),
+        Arguments.of("org.higherkindedj.hkt.effect.FreePath", "FreePath"),
+        Arguments.of("org.higherkindedj.hkt.effect.FreeApPath", "FreeApPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.ListPath", "ListPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.StreamPath", "StreamPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.VStreamPath", "VStreamPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.DefaultVStreamPath", "DefaultVStreamPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.NonDetPath", "NonDetPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.ReaderPath", "ReaderPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.WithStatePath", "WithStatePath"),
+        Arguments.of("org.higherkindedj.hkt.effect.WriterPath", "WriterPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.LazyPath", "LazyPath"),
+        Arguments.of("org.higherkindedj.hkt.effect.CompletableFuturePath", "CompletableFuturePath"),
+        Arguments.of("org.higherkindedj.hkt.expression.ForPath", "ForPath"),
+        Arguments.of("org.higherkindedj.optics.focus.FocusPath", "FocusPath"),
+        Arguments.of("org.higherkindedj.optics.focus.AffinePath", "AffinePath"),
+        Arguments.of("org.higherkindedj.optics.focus.TraversalPath", "TraversalPath"));
+  }
+
+  @Nested
+  @DisplayName("registeredTypeCount")
+  class RegisteredTypeCount {
+
+    @Test
+    @DisplayName("returns 27 for all registered Path types")
+    void registeredTypeCount_returnsExpectedCount() {
+      assertThat(PathTypeRegistry.registeredTypeCount()).isEqualTo(27);
+    }
+  }
+
+  @Nested
+  @DisplayName("isPathType")
+  class IsPathType {
+
+    @ParameterizedTest(name = "{1} is a registered Path type")
+    @MethodSource("org.higherkindedj.checker.PathTypeRegistryTest#allPathTypes")
+    @DisplayName("returns true for all registered Path types")
+    void isPathType_registeredType_returnsTrue(String qualifiedName, String simpleName) {
+      assertThat(PathTypeRegistry.isPathType(qualifiedName))
+          .as("Expected %s to be a registered Path type", simpleName)
+          .isTrue();
+    }
+
+    @ParameterizedTest(name = "{0} is not a Path type")
+    @ValueSource(
+        strings = {
+          "java.lang.String",
+          "java.util.Optional",
+          "org.higherkindedj.hkt.maybe.Maybe",
+          "com.example.CustomPath"
+        })
+    @DisplayName("returns false for non-Path types")
+    void isPathType_unregisteredType_returnsFalse(String qualifiedName) {
+      assertThat(PathTypeRegistry.isPathType(qualifiedName)).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("isPathTypeBySimpleName")
+  class IsPathTypeBySimpleName {
+
+    @ParameterizedTest(name = "{1} is recognised by simple name")
+    @MethodSource("org.higherkindedj.checker.PathTypeRegistryTest#allPathTypes")
+    @DisplayName("returns true for registered simple names")
+    void isPathTypeBySimpleName_registered_returnsTrue(String qualifiedName, String simpleName) {
+      assertThat(PathTypeRegistry.isPathTypeBySimpleName(simpleName)).isTrue();
+    }
+
+    @Test
+    @DisplayName("returns false for unknown simple names")
+    void isPathTypeBySimpleName_unknown_returnsFalse() {
+      assertThat(PathTypeRegistry.isPathTypeBySimpleName("CustomPath")).isFalse();
+      assertThat(PathTypeRegistry.isPathTypeBySimpleName("String")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("getPathCategory")
+  class GetPathCategory {
+
+    @ParameterizedTest(name = "{0} maps to {1}")
+    @MethodSource("org.higherkindedj.checker.PathTypeRegistryTest#allPathTypes")
+    @DisplayName("returns simple name for registered types")
+    void getPathCategory_registered_returnsSimpleName(String qualifiedName, String simpleName) {
+      assertThat(PathTypeRegistry.getPathCategory(qualifiedName)).isPresent().hasValue(simpleName);
+    }
+
+    @Test
+    @DisplayName("returns empty for unregistered types")
+    void getPathCategory_unregistered_returnsEmpty() {
+      assertThat(PathTypeRegistry.getPathCategory("java.lang.String")).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("areSamePathFamily")
+  class AreSamePathFamily {
+
+    @ParameterizedTest(name = "{1} is same family as itself")
+    @MethodSource("org.higherkindedj.checker.PathTypeRegistryTest#allPathTypes")
+    @DisplayName("returns true when both types are the same (reflexive)")
+    void areSamePathFamily_sameType_returnsTrue(String qualifiedName, String simpleName) {
+      assertThat(PathTypeRegistry.areSamePathFamily(qualifiedName, qualifiedName))
+          .as("Expected %s to be the same family as itself", simpleName)
+          .isTrue();
+    }
+
+    @Test
+    @DisplayName("returns false for different Path types")
+    void areSamePathFamily_differentTypes_returnsFalse() {
+      assertThat(
+              PathTypeRegistry.areSamePathFamily(
+                  "org.higherkindedj.hkt.effect.MaybePath", "org.higherkindedj.hkt.effect.IOPath"))
+          .isFalse();
+    }
+
+    @Test
+    @DisplayName("returns false when either type is unknown")
+    void areSamePathFamily_unknownType_returnsFalse() {
+      assertThat(
+              PathTypeRegistry.areSamePathFamily(
+                  "org.higherkindedj.hkt.effect.MaybePath", "java.lang.String"))
+          .isFalse();
+
+      assertThat(
+              PathTypeRegistry.areSamePathFamily(
+                  "java.lang.String", "org.higherkindedj.hkt.effect.MaybePath"))
+          .isFalse();
+    }
+
+    @Test
+    @DisplayName("returns false when both types are unknown")
+    void areSamePathFamily_bothUnknown_returnsFalse() {
+      assertThat(PathTypeRegistry.areSamePathFamily("java.lang.String", "java.lang.Integer"))
+          .isFalse();
+    }
+
+    @Test
+    @DisplayName("is symmetric")
+    void areSamePathFamily_symmetric() {
+      String maybe = "org.higherkindedj.hkt.effect.MaybePath";
+      String io = "org.higherkindedj.hkt.effect.IOPath";
+      assertThat(PathTypeRegistry.areSamePathFamily(maybe, io))
+          .isEqualTo(PathTypeRegistry.areSamePathFamily(io, maybe));
+    }
+  }
+
+  @Nested
+  @DisplayName("suggestedConversion")
+  class SuggestedConversion {
+
+    @Test
+    @DisplayName("suggests toEitherPath() when target is EitherPath")
+    void suggestedConversion_toEitherPath_returnsSuggestion() {
+      Optional<String> conversion = PathTypeRegistry.suggestedConversion("MaybePath", "EitherPath");
+      assertThat(conversion).isPresent().hasValue("toEitherPath()");
+    }
+
+    @Test
+    @DisplayName("suggests toMaybePath() when target is MaybePath")
+    void suggestedConversion_toMaybePath_returnsSuggestion() {
+      Optional<String> conversion = PathTypeRegistry.suggestedConversion("EitherPath", "MaybePath");
+      assertThat(conversion).isPresent().hasValue("toMaybePath()");
+    }
+
+    @Test
+    @DisplayName("returns empty when no conversion exists")
+    void suggestedConversion_noConversion_returnsEmpty() {
+      assertThat(PathTypeRegistry.suggestedConversion("MaybePath", "IOPath")).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("allSimpleNames")
+  class AllSimpleNames {
+
+    @Test
+    @DisplayName("returns all registered simple names")
+    void allSimpleNames_containsAllExpectedNames() {
+      assertThat(PathTypeRegistry.allSimpleNames())
+          .contains("MaybePath", "EitherPath", "TryPath", "IOPath", "FocusPath", "ForPath");
+    }
+
+    @Test
+    @DisplayName("has same size as registeredTypeCount")
+    void allSimpleNames_sameSize() {
+      assertThat(PathTypeRegistry.allSimpleNames()).hasSize(PathTypeRegistry.registeredTypeCount());
+    }
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/CorrectUsage.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/CorrectUsage.java
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+/**
+ * Test data file: correct Path usage that should compile without errors.
+ *
+ * <p>All chains use the same Path type throughout.
+ */
+public class CorrectUsage {
+
+  public void correctViaChain() {
+    // Same-type via chaining is correct
+    String result = "hello";
+    result.length();
+  }
+
+  public void simpleCode() {
+    // Simple code that does not use Path types at all
+    int x = 1 + 2;
+    String s = String.valueOf(x);
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/GenericPathUsage.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/GenericPathUsage.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.capability.Chainable;
+
+/**
+ * Test data file: generic Path usage that should not trigger false positives.
+ *
+ * <p>This file exercises various patterns where the checker should remain silent, including
+ * same-type chaining and generic/interface-typed receivers.
+ */
+public class GenericPathUsage {
+
+  public void sameTypeChaining() {
+    // Same-type via chaining is correct
+    Path.just(1).via(_ -> Path.just(2));
+  }
+
+  public void sameTypeZipWith() {
+    // Same-type zipWith is correct
+    Path.just(1).zipWith(Path.just(2), Integer::sum);
+  }
+
+  public void sameTypeThen() {
+    // Same-type then is correct
+    Path.just(1).then(() -> Path.just(2));
+  }
+
+  public <A> void genericReceiver(Chainable<A> path) {
+    // Generic receiver: checker cannot resolve type, should skip silently
+    path.via(_ -> Path.just(1));
+  }
+
+  public void multipleCorrectChains() {
+    // Multiple operations chained correctly
+    MaybePath<String> result =
+        Path.just(1).via(_ -> Path.just(2)).map(String::valueOf).via(_ -> Path.just("hello"));
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInOrElse.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInOrElse.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+import org.higherkindedj.hkt.Semigroup;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.Path;
+
+/**
+ * Test data file: Path type mismatch in orElse().
+ *
+ * <p>The receiver is an EitherPath but the supplier returns a ValidationPath. Both share the same
+ * error type parameter, so this compiles but is a semantic mismatch the checker should detect.
+ */
+public class MismatchInOrElse {
+
+  private static final Semigroup<String> CONCAT = (a, b) -> a + b;
+
+  public void mismatchedOrElse() {
+    EitherPath<String, Integer> either = Path.right(1);
+    // Mismatch: EitherPath.orElse() returns ValidationPath
+    either.orElse(() -> Path.valid(2, CONCAT));
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInRecoverWith.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInRecoverWith.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+import org.higherkindedj.hkt.Semigroup;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.Path;
+
+/**
+ * Test data file: Path type mismatch in recoverWith().
+ *
+ * <p>The receiver is an EitherPath but the recovery function returns a ValidationPath. Both share
+ * the same error type parameter, so this compiles but is a semantic mismatch the checker should
+ * detect.
+ */
+public class MismatchInRecoverWith {
+
+  private static final Semigroup<String> CONCAT = (a, b) -> a + b;
+
+  public void mismatchedRecoverWith() {
+    EitherPath<String, Integer> either = Path.right(1);
+    // Mismatch: EitherPath.recoverWith() returns ValidationPath
+    either.recoverWith(_ -> Path.valid(42, CONCAT));
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInThen.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInThen.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.Path;
+
+/**
+ * Test data file: Path type mismatch in then().
+ *
+ * <p>The receiver is an EitherPath but the supplier returns a MaybePath. The checker should report
+ * an error.
+ */
+public class MismatchInThen {
+
+  public void mismatchedThen() {
+    EitherPath<String, String> either = Path.right("a");
+    // Mismatch: EitherPath.then() returns MaybePath
+    either.then(() -> Path.just(1));
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInVia.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInVia.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.Path;
+
+/**
+ * Test data file: Path type mismatch in via().
+ *
+ * <p>The receiver is a MaybePath but the lambda returns an IOPath. The checker should report an
+ * error.
+ */
+public class MismatchInVia {
+
+  public void mismatchedVia() {
+    MaybePath<Integer> maybe = Path.just(1);
+    // Mismatch: MaybePath.via() returns IOPath
+    maybe.via(_ -> Path.io(() -> 2));
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInZipWith.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/testdata/MismatchInZipWith.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker.testdata;
+
+import org.higherkindedj.hkt.effect.MaybePath;
+import org.higherkindedj.hkt.effect.Path;
+
+/**
+ * Test data file: Path type mismatch in zipWith().
+ *
+ * <p>The receiver is a MaybePath but the first argument is an EitherPath. The checker should report
+ * an error.
+ */
+public class MismatchInZipWith {
+
+  public void mismatchedZipWith() {
+    MaybePath<Integer> maybe = Path.just(1);
+    // Mismatch: MaybePath.zipWith() with EitherPath argument
+    maybe.zipWith(Path.right("x"), (a, b) -> a + b.length());
+  }
+}

--- a/plugins/hkj-gradle-plugin/build.gradle.kts
+++ b/plugins/hkj-gradle-plugin/build.gradle.kts
@@ -1,0 +1,65 @@
+plugins {
+    `java-gradle-plugin`
+    id("com.vanniktech.maven.publish")
+}
+
+gradlePlugin {
+    plugins {
+        create("hkj") {
+            id = "io.github.higher-kinded-j.hkj"
+            implementationClass = "org.higherkindedj.gradle.HKJPlugin"
+            displayName = "Higher-Kinded-J Plugin"
+            description = "Configures HKJ dependencies, preview features, and compile-time checks"
+        }
+    }
+}
+
+dependencies {
+    // Test dependencies
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.assertj.core)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}
+
+// Central configuration for publishing
+mavenPublishing {
+    publishToMavenCentral()
+
+    signAllPublications()
+
+    coordinates(
+        groupId = project.group.toString(),
+        artifactId = "hkj-gradle-plugin",
+        version = project.version.toString()
+    )
+
+    pom {
+        name.set("Higher-Kinded-J Gradle Plugin")
+        description.set("Gradle plugin that configures HKJ dependencies, preview features, and compile-time checks")
+        url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+
+        licenses {
+            license {
+                name.set("The MIT License")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("higher-kinded-j")
+                name.set("Magnus Smith")
+                email.set("simulation-hkt@gmail.com")
+            }
+        }
+        scm {
+            connection.set("scm:git:git://github.com/higher-kinded-j/higher-kinded-j.git")
+            developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+        }
+    }
+}

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJChecksExtension.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJChecksExtension.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.gradle;
+
+import org.gradle.api.provider.Property;
+
+/** Configuration for HKJ compile-time checks. */
+public abstract class HKJChecksExtension {
+
+  /** Enable Path type mismatch detection. Defaults to true. */
+  public abstract Property<Boolean> getPathTypeMismatch();
+}

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJExtension.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJExtension.java
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.gradle;
+
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+/**
+ * Extension DSL for the HKJ Gradle plugin.
+ *
+ * <pre>{@code
+ * hkj {
+ *     version = "0.3.7-SNAPSHOT"
+ *     preview = true
+ *     spring = false
+ *     checks {
+ *         pathTypeMismatch = true
+ *     }
+ * }
+ * }</pre>
+ */
+public abstract class HKJExtension {
+
+  private final HKJChecksExtension checks;
+
+  @Inject
+  public HKJExtension(ObjectFactory objects) {
+    this.checks = objects.newInstance(HKJChecksExtension.class);
+  }
+
+  /** HKJ library version. Defaults to the plugin version. */
+  public abstract Property<String> getVersion();
+
+  /** Whether to add --enable-preview flags. Defaults to true. */
+  public abstract Property<Boolean> getPreview();
+
+  /** Whether to add hkj-spring-boot-starter. Defaults to false. */
+  public abstract Property<Boolean> getSpring();
+
+  /** Compile-time check configuration. */
+  public HKJChecksExtension getChecks() {
+    return checks;
+  }
+
+  /** Configures compile-time checks. */
+  public void checks(Action<? super HKJChecksExtension> action) {
+    action.execute(checks);
+  }
+}

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJPlugin.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJPlugin.java
@@ -1,0 +1,199 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.gradle;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+
+/**
+ * Gradle plugin for Higher-Kinded-J projects.
+ *
+ * <p>This plugin configures HKJ dependencies, Java preview features, and compile-time Path type
+ * mismatch checking. Apply it with:
+ *
+ * <pre>{@code
+ * plugins {
+ *     id("io.github.higher-kinded-j.hkj")
+ * }
+ * }</pre>
+ *
+ * <p>Configuration is available through the {@code hkj} extension block. See {@link HKJExtension}
+ * for available options.
+ */
+public class HKJPlugin implements Plugin<Project> {
+
+  private static final String GROUP_ID = "io.github.higher-kinded-j";
+  private static final String EXTENSION_NAME = "hkj";
+
+  @Override
+  public void apply(Project project) {
+    project.getPluginManager().apply("java");
+
+    HKJExtension extension = project.getExtensions().create(EXTENSION_NAME, HKJExtension.class);
+
+    // Set defaults
+    extension.getVersion().convention(project.provider(() -> project.getVersion().toString()));
+    extension.getPreview().convention(true);
+    extension.getSpring().convention(false);
+    extension.getChecks().getPathTypeMismatch().convention(true);
+
+    project.afterEvaluate(p -> configure(p, extension));
+
+    registerDiagnosticsTask(project, extension);
+  }
+
+  private void configure(Project project, HKJExtension extension) {
+    String version = extension.getVersion().get();
+    DependencyHandler deps = project.getDependencies();
+
+    // Always add hkj-core and hkj-processor-plugins
+    deps.add("implementation", GROUP_ID + ":hkj-core:" + version);
+    deps.add("annotationProcessor", GROUP_ID + ":hkj-processor-plugins:" + version);
+
+    // Preview features
+    if (Boolean.TRUE.equals(extension.getPreview().get())) {
+      configurePreviewFeatures(project);
+    }
+
+    // Compile-time checks
+    if (Boolean.TRUE.equals(extension.getChecks().getPathTypeMismatch().get())) {
+      deps.add("annotationProcessor", GROUP_ID + ":hkj-checker:" + version);
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task -> {
+                if (!task.getOptions().getCompilerArgs().contains("-Xplugin:HKJChecker")) {
+                  task.getOptions().getCompilerArgs().add("-Xplugin:HKJChecker");
+                }
+              });
+    }
+
+    // Spring integration
+    if (Boolean.TRUE.equals(extension.getSpring().get())) {
+      deps.add("implementation", GROUP_ID + ":hkj-spring-boot-starter:" + version);
+    }
+  }
+
+  private void configurePreviewFeatures(Project project) {
+    project
+        .getTasks()
+        .withType(JavaCompile.class)
+        .configureEach(
+            task -> {
+              if (!task.getOptions().getCompilerArgs().contains("--enable-preview")) {
+                task.getOptions().getCompilerArgs().add("--enable-preview");
+              }
+            });
+
+    project
+        .getTasks()
+        .withType(Test.class)
+        .configureEach(
+            task -> {
+              if (task.getJvmArgs() == null || !task.getJvmArgs().contains("--enable-preview")) {
+                task.jvmArgs("--enable-preview");
+              }
+            });
+
+    project
+        .getTasks()
+        .withType(JavaExec.class)
+        .configureEach(
+            task -> {
+              if (task.getJvmArgs() == null || !task.getJvmArgs().contains("--enable-preview")) {
+                task.jvmArgs("--enable-preview");
+              }
+            });
+
+    project
+        .getTasks()
+        .withType(Javadoc.class)
+        .configureEach(
+            task -> {
+              StandardJavadocDocletOptions options =
+                  (StandardJavadocDocletOptions) task.getOptions();
+              options.addBooleanOption("-enable-preview", true);
+            });
+  }
+
+  private void registerDiagnosticsTask(Project project, HKJExtension extension) {
+    project
+        .getTasks()
+        .register(
+            "hkjDiagnostics",
+            task -> {
+              task.setGroup("help");
+              task.setDescription("Prints the current HKJ plugin configuration");
+              task.doLast(
+                  t -> {
+                    String version = extension.getVersion().get();
+                    boolean preview = Boolean.TRUE.equals(extension.getPreview().get());
+                    boolean spring = Boolean.TRUE.equals(extension.getSpring().get());
+                    boolean checks =
+                        Boolean.TRUE.equals(extension.getChecks().getPathTypeMismatch().get());
+
+                    List<String> depsAdded = new ArrayList<>();
+                    depsAdded.add("implementation:          " + GROUP_ID + ":hkj-core:" + version);
+                    depsAdded.add(
+                        "annotationProcessor:     "
+                            + GROUP_ID
+                            + ":hkj-processor-plugins:"
+                            + version);
+                    if (checks) {
+                      depsAdded.add(
+                          "annotationProcessor:     " + GROUP_ID + ":hkj-checker:" + version);
+                    }
+                    if (spring) {
+                      depsAdded.add(
+                          "implementation:          "
+                              + GROUP_ID
+                              + ":hkj-spring-boot-starter:"
+                              + version);
+                    }
+
+                    List<String> compilerArgs = new ArrayList<>();
+                    if (preview) {
+                      compilerArgs.add("--enable-preview");
+                    }
+                    if (checks) {
+                      compilerArgs.add("-Xplugin:HKJChecker");
+                    }
+
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("HKJ Configuration:\n");
+                    sb.append("  Version:            ").append(version).append("\n");
+                    sb.append("  Preview features:   ")
+                        .append(preview ? "enabled" : "disabled")
+                        .append("\n");
+                    sb.append("  Spring integration: ")
+                        .append(spring ? "enabled" : "disabled")
+                        .append("\n");
+                    sb.append("  Compile-time checks:\n");
+                    sb.append("    Path type mismatch: ")
+                        .append(checks ? "enabled" : "disabled")
+                        .append("\n");
+                    sb.append("  Dependencies added:\n");
+                    for (String dep : depsAdded) {
+                      sb.append("    ").append(dep).append("\n");
+                    }
+                    if (!compilerArgs.isEmpty()) {
+                      sb.append("  Compiler args added:\n");
+                      for (String arg : compilerArgs) {
+                        sb.append("    ").append(arg).append("\n");
+                      }
+                    }
+
+                    project.getLogger().lifecycle(sb.toString().stripTrailing());
+                  });
+            });
+  }
+}

--- a/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginFunctionalTest.java
+++ b/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginFunctionalTest.java
@@ -1,0 +1,334 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("HKJPlugin functional tests")
+class HKJPluginFunctionalTest {
+
+  @TempDir Path testProjectDir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    // Create settings.gradle
+    Files.writeString(
+        testProjectDir.resolve("settings.gradle"), "rootProject.name = 'test-project'\n");
+  }
+
+  private void writeBuildFile(String content) throws IOException {
+    Files.writeString(testProjectDir.resolve("build.gradle"), content);
+  }
+
+  private GradleRunner runner(String... args) {
+    return GradleRunner.create()
+        .withProjectDir(testProjectDir.toFile())
+        .withPluginClasspath()
+        .withArguments(args)
+        .forwardOutput();
+  }
+
+  @Test
+  @DisplayName("build succeeds with default configuration")
+  void build_succeeds_withDefaultConfiguration() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    // Create a minimal Java source file
+    Path srcDir = testProjectDir.resolve("src/main/java/test");
+    Files.createDirectories(srcDir);
+    Files.writeString(
+        srcDir.resolve("App.java"),
+        """
+        package test;
+        public class App {}
+        """);
+
+    // We only test that the plugin applies without error and tasks are configured.
+    // Actual compilation would require published HKJ artifacts on the classpath.
+    BuildResult result = runner("tasks", "--all").build();
+    assertThat(result.getOutput()).contains("hkjDiagnostics");
+  }
+
+  @Test
+  @DisplayName("diagnostics task prints configuration")
+  void diagnostics_task_printsConfiguration() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        version = '1.0.0'
+
+        hkj {
+            version = '0.3.0'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("hkjDiagnostics").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("HKJ Configuration:");
+    assertThat(output).contains("Version:            0.3.0");
+    assertThat(output).contains("Preview features:   enabled");
+    assertThat(output).contains("Spring integration: disabled");
+    assertThat(output).contains("Path type mismatch: enabled");
+    assertThat(output).contains("hkj-core:0.3.0");
+    assertThat(output).contains("hkj-processor-plugins:0.3.0");
+    assertThat(output).contains("hkj-checker:0.3.0");
+    assertThat(output).contains("--enable-preview");
+    assertThat(output).contains("-Xplugin:HKJChecker");
+  }
+
+  @Test
+  @DisplayName("diagnostics task reflects disabled preview")
+  void diagnostics_task_reflectsDisabledPreview() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+            preview = false
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("hkjDiagnostics").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("Preview features:   disabled");
+    assertThat(output).doesNotContain("--enable-preview");
+  }
+
+  @Test
+  @DisplayName("diagnostics task reflects spring enabled")
+  void diagnostics_task_reflectsSpringEnabled() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+            spring = true
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("hkjDiagnostics").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("Spring integration: enabled");
+    assertThat(output).contains("hkj-spring-boot-starter:0.3.0");
+  }
+
+  @Test
+  @DisplayName("custom version overrides default")
+  void customVersion_overridesDefault() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.2.2'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("hkjDiagnostics").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("Version:            0.2.2");
+    assertThat(output).contains("hkj-core:0.2.2");
+  }
+
+  @Test
+  @DisplayName("checks closure DSL disables path type mismatch")
+  void checks_closure_disablesPathTypeMismatch() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+            checks {
+                pathTypeMismatch = false
+            }
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("hkjDiagnostics").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("Path type mismatch: disabled");
+    assertThat(output).doesNotContain("hkj-checker");
+    assertThat(output).doesNotContain("-Xplugin:HKJChecker");
+  }
+
+  @Test
+  @DisplayName("dependencies task lists hkj-core in implementation")
+  void dependencies_listsCoreDependency() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("dependencies", "--configuration", "implementation").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("io.github.higher-kinded-j:hkj-core:0.3.0");
+  }
+
+  @Test
+  @DisplayName("dependencies task lists checker in annotationProcessor")
+  void dependencies_listsCheckerDependency() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("dependencies", "--configuration", "annotationProcessor").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("io.github.higher-kinded-j:hkj-checker:0.3.0");
+    assertThat(output).contains("io.github.higher-kinded-j:hkj-processor-plugins:0.3.0");
+  }
+
+  @Test
+  @DisplayName("dependencies task excludes checker when checks disabled")
+  void dependencies_excludesCheckerWhenDisabled() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+            checks {
+                pathTypeMismatch = false
+            }
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("dependencies", "--configuration", "annotationProcessor").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("io.github.higher-kinded-j:hkj-processor-plugins:0.3.0");
+    assertThat(output).doesNotContain("hkj-checker");
+  }
+
+  @Test
+  @DisplayName("all options combined configures correctly")
+  void allOptionsCombined() throws IOException {
+    writeBuildFile(
+        """
+        plugins {
+            id 'java'
+            id 'io.github.higher-kinded-j.hkj'
+        }
+
+        hkj {
+            version = '0.3.0'
+            preview = false
+            spring = true
+            checks {
+                pathTypeMismatch = false
+            }
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """);
+
+    BuildResult result = runner("hkjDiagnostics").build();
+    String output = result.getOutput();
+
+    assertThat(output).contains("Version:            0.3.0");
+    assertThat(output).contains("Preview features:   disabled");
+    assertThat(output).contains("Spring integration: enabled");
+    assertThat(output).contains("Path type mismatch: disabled");
+    assertThat(output).contains("hkj-spring-boot-starter:0.3.0");
+    assertThat(output).doesNotContain("hkj-checker");
+    assertThat(output).doesNotContain("--enable-preview");
+    assertThat(output).doesNotContain("-Xplugin:HKJChecker");
+  }
+}

--- a/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginTest.java
+++ b/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginTest.java
@@ -1,0 +1,215 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HKJPlugin")
+class HKJPluginTest {
+
+  private Project project;
+
+  @BeforeEach
+  void setUp() {
+    project = ProjectBuilder.builder().build();
+  }
+
+  private void applyPlugin() {
+    project.getPluginManager().apply("io.github.higher-kinded-j.hkj");
+  }
+
+  private void evaluateProject() {
+    // Force afterEvaluate callbacks to run
+    ((ProjectInternal) project).evaluate();
+  }
+
+  private Set<String> dependencyNotations(String configurationName) {
+    Configuration config = project.getConfigurations().findByName(configurationName);
+    if (config == null) {
+      return Set.of();
+    }
+    return config.getDependencies().stream()
+        .map(dep -> dep.getGroup() + ":" + dep.getName() + ":" + dep.getVersion())
+        .collect(Collectors.toSet());
+  }
+
+  @Nested
+  @DisplayName("plugin application")
+  class PluginApplication {
+
+    @Test
+    @DisplayName("applies successfully without exception")
+    void plugin_appliesSuccessfully() {
+      assertThatCode(() -> applyPlugin()).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("creates hkj extension")
+    void plugin_createsHKJExtension() {
+      applyPlugin();
+      assertThat(project.getExtensions().findByName("hkj")).isNotNull();
+      assertThat(project.getExtensions().findByType(HKJExtension.class)).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("default configuration")
+  class DefaultConfiguration {
+
+    @Test
+    @DisplayName("adds hkj-core to implementation")
+    void plugin_addsCoreDependency() {
+      applyPlugin();
+      evaluateProject();
+
+      assertThat(dependencyNotations("implementation")).anyMatch(dep -> dep.contains("hkj-core"));
+    }
+
+    @Test
+    @DisplayName("adds hkj-processor-plugins to annotationProcessor")
+    void plugin_addsProcessorDependency() {
+      applyPlugin();
+      evaluateProject();
+
+      assertThat(dependencyNotations("annotationProcessor"))
+          .anyMatch(dep -> dep.contains("hkj-processor-plugins"));
+    }
+
+    @Test
+    @DisplayName("adds --enable-preview to JavaCompile tasks when preview is enabled")
+    void plugin_addsPreviewFlags_whenEnabled() {
+      applyPlugin();
+      evaluateProject();
+
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task -> assertThat(task.getOptions().getCompilerArgs()).contains("--enable-preview"));
+    }
+
+    @Test
+    @DisplayName("adds hkj-checker to annotationProcessor when checks are enabled")
+    void plugin_addsCheckerDependency_whenEnabled() {
+      applyPlugin();
+      evaluateProject();
+
+      assertThat(dependencyNotations("annotationProcessor"))
+          .anyMatch(dep -> dep.contains("hkj-checker"));
+    }
+
+    @Test
+    @DisplayName("adds -Xplugin:HKJChecker to compiler args when checks are enabled")
+    void plugin_addsXpluginArg_whenChecksEnabled() {
+      applyPlugin();
+      evaluateProject();
+
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task ->
+                  assertThat(task.getOptions().getCompilerArgs()).contains("-Xplugin:HKJChecker"));
+    }
+
+    @Test
+    @DisplayName("registers hkjDiagnostics task in help group")
+    void plugin_registersHKJDiagnosticsTask() {
+      applyPlugin();
+
+      Task diagnosticsTask = project.getTasks().findByName("hkjDiagnostics");
+      assertThat(diagnosticsTask).isNotNull();
+      assertThat(diagnosticsTask.getGroup()).isEqualTo("help");
+    }
+  }
+
+  @Nested
+  @DisplayName("custom configuration")
+  class CustomConfiguration {
+
+    @Test
+    @DisplayName("skips --enable-preview when preview is disabled")
+    void plugin_skipsPreviewFlags_whenDisabled() {
+      applyPlugin();
+      HKJExtension ext = project.getExtensions().getByType(HKJExtension.class);
+      ext.getPreview().set(false);
+      evaluateProject();
+
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task ->
+                  assertThat(task.getOptions().getCompilerArgs())
+                      .doesNotContain("--enable-preview"));
+    }
+
+    @Test
+    @DisplayName("skips checker when pathTypeMismatch is disabled")
+    void plugin_skipsChecker_whenDisabled() {
+      applyPlugin();
+      HKJExtension ext = project.getExtensions().getByType(HKJExtension.class);
+      ext.getChecks().getPathTypeMismatch().set(false);
+      evaluateProject();
+
+      assertThat(dependencyNotations("annotationProcessor"))
+          .noneMatch(dep -> dep.contains("hkj-checker"));
+
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task ->
+                  assertThat(task.getOptions().getCompilerArgs())
+                      .doesNotContain("-Xplugin:HKJChecker"));
+    }
+
+    @Test
+    @DisplayName("adds hkj-spring-boot-starter when spring is enabled")
+    void plugin_addsSpringStarter_whenEnabled() {
+      applyPlugin();
+      HKJExtension ext = project.getExtensions().getByType(HKJExtension.class);
+      ext.getSpring().set(true);
+      evaluateProject();
+
+      assertThat(dependencyNotations("implementation"))
+          .anyMatch(dep -> dep.contains("hkj-spring-boot-starter"));
+    }
+
+    @Test
+    @DisplayName("checks(Action) DSL configures pathTypeMismatch")
+    void plugin_checksActionDSL_configuresPathTypeMismatch() {
+      applyPlugin();
+      HKJExtension ext = project.getExtensions().getByType(HKJExtension.class);
+      ext.checks(checks -> checks.getPathTypeMismatch().set(false));
+      evaluateProject();
+
+      assertThat(dependencyNotations("annotationProcessor"))
+          .noneMatch(dep -> dep.contains("hkj-checker"));
+    }
+
+    @Test
+    @DisplayName("checks extension is accessible and has correct defaults")
+    void plugin_checksExtension_hasCorrectDefaults() {
+      applyPlugin();
+      HKJExtension ext = project.getExtensions().getByType(HKJExtension.class);
+
+      assertThat(ext.getChecks()).isNotNull();
+      assertThat(ext.getChecks().getPathTypeMismatch().get()).isTrue();
+    }
+  }
+}

--- a/plugins/hkj-maven-plugin/build.gradle.kts
+++ b/plugins/hkj-maven-plugin/build.gradle.kts
@@ -1,0 +1,79 @@
+plugins {
+    `java-library`
+    id("com.vanniktech.maven.publish")
+}
+
+dependencies {
+    compileOnly(libs.maven.plugin.api)
+    compileOnly(libs.maven.core)
+    compileOnly(libs.maven.plugin.annotations)
+    compileOnly(libs.javax.inject)
+
+    // Test dependencies
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.maven.core)
+    testImplementation(libs.maven.plugin.api)
+}
+
+// Maven plugin classes must not use --enable-preview so they can load in any Java 25+ JVM
+tasks.withType<JavaCompile>().configureEach {
+    doFirst {
+        options.compilerArgs.removeIf { it == "--enable-preview" }
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    // Tests don't need preview features either
+    doFirst {
+        jvmArgs?.removeIf { it == "--enable-preview" }
+    }
+}
+
+tasks.withType<JavaExec>().configureEach {
+    doFirst {
+        jvmArgs?.removeIf { it == "--enable-preview" }
+    }
+}
+
+// Central configuration for publishing
+mavenPublishing {
+    publishToMavenCentral()
+
+    signAllPublications()
+
+    coordinates(
+        groupId = project.group.toString(),
+        artifactId = "hkj-maven-plugin",
+        version = project.version.toString()
+    )
+
+    pom {
+        name.set("Higher-Kinded-J Maven Plugin")
+        description.set("Maven plugin that configures HKJ dependencies, preview features, and compile-time checks")
+        packaging = "maven-plugin"
+        url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+
+        licenses {
+            license {
+                name.set("The MIT License")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("higher-kinded-j")
+                name.set("Magnus Smith")
+                email.set("simulation-hkt@gmail.com")
+            }
+        }
+        scm {
+            connection.set("scm:git:git://github.com/higher-kinded-j/higher-kinded-j.git")
+            developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j")
+        }
+    }
+}

--- a/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJConfiguration.java
+++ b/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJConfiguration.java
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.maven;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+/**
+ * Reads and holds the HKJ Maven plugin configuration.
+ *
+ * <p>Configuration is read from the plugin's {@code <configuration>} block in the POM:
+ *
+ * <pre>{@code
+ * <configuration>
+ *     <version>0.3.7-SNAPSHOT</version>
+ *     <preview>true</preview>
+ *     <spring>false</spring>
+ *     <pathTypeMismatch>true</pathTypeMismatch>
+ * </configuration>
+ * }</pre>
+ */
+record HKJConfiguration(String version, boolean preview, boolean spring, boolean pathTypeMismatch) {
+
+  /** Reads configuration from the plugin declaration, applying defaults for missing values. */
+  static HKJConfiguration fromPlugin(Plugin plugin, MavenProject project) {
+    Xpp3Dom config = (Xpp3Dom) plugin.getConfiguration();
+
+    String version = readString(config, "version", project.getVersion());
+    boolean preview = readBoolean(config, "preview", true);
+    boolean spring = readBoolean(config, "spring", false);
+    boolean pathTypeMismatch = readBoolean(config, "pathTypeMismatch", true);
+
+    return new HKJConfiguration(version, preview, spring, pathTypeMismatch);
+  }
+
+  private static String readString(Xpp3Dom config, String name, String defaultValue) {
+    if (config == null) {
+      return defaultValue;
+    }
+    Xpp3Dom child = config.getChild(name);
+    if (child == null || child.getValue() == null || child.getValue().isBlank()) {
+      return defaultValue;
+    }
+    return child.getValue().trim();
+  }
+
+  private static boolean readBoolean(Xpp3Dom config, String name, boolean defaultValue) {
+    if (config == null) {
+      return defaultValue;
+    }
+    Xpp3Dom child = config.getChild(name);
+    if (child == null || child.getValue() == null || child.getValue().isBlank()) {
+      return defaultValue;
+    }
+    return Boolean.parseBoolean(child.getValue().trim());
+  }
+}

--- a/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJDiagnosticsMojo.java
+++ b/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJDiagnosticsMojo.java
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.maven;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Prints the current HKJ configuration for diagnostics and troubleshooting.
+ *
+ * <p>Usage: {@code mvn hkj:diagnostics}
+ */
+@Mojo(name = "diagnostics", requiresProject = true)
+public class HKJDiagnosticsMojo extends AbstractMojo {
+
+  private static final String GROUP_ID = "io.github.higher-kinded-j";
+  private static final String PLUGIN_KEY = GROUP_ID + ":hkj-maven-plugin";
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
+  @Override
+  public void execute() {
+    Plugin hkjPlugin = findHKJPlugin();
+    HKJConfiguration config;
+    if (hkjPlugin != null) {
+      config = HKJConfiguration.fromPlugin(hkjPlugin, project);
+    } else {
+      config = new HKJConfiguration(project.getVersion(), true, false, true);
+    }
+
+    List<String> depsAdded = new ArrayList<>();
+    for (Dependency dep : project.getDependencies()) {
+      if (GROUP_ID.equals(dep.getGroupId())) {
+        depsAdded.add(
+            dep.getScope()
+                + ": "
+                + dep.getGroupId()
+                + ":"
+                + dep.getArtifactId()
+                + ":"
+                + dep.getVersion());
+      }
+    }
+
+    List<String> compilerArgs = new ArrayList<>();
+    if (config.preview()) {
+      compilerArgs.add("--enable-preview");
+    }
+    if (config.pathTypeMismatch()) {
+      compilerArgs.add("-Xplugin:HKJChecker");
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("HKJ Configuration:\n");
+    sb.append("  Version:            ").append(config.version()).append("\n");
+    sb.append("  Preview features:   ")
+        .append(config.preview() ? "enabled" : "disabled")
+        .append("\n");
+    sb.append("  Spring integration: ")
+        .append(config.spring() ? "enabled" : "disabled")
+        .append("\n");
+    sb.append("  Compile-time checks:\n");
+    sb.append("    Path type mismatch: ")
+        .append(config.pathTypeMismatch() ? "enabled" : "disabled")
+        .append("\n");
+
+    if (!depsAdded.isEmpty()) {
+      sb.append("  Dependencies found:\n");
+      for (String dep : depsAdded) {
+        sb.append("    ").append(dep).append("\n");
+      }
+    }
+
+    if (!compilerArgs.isEmpty()) {
+      sb.append("  Compiler args configured:\n");
+      for (String arg : compilerArgs) {
+        sb.append("    ").append(arg).append("\n");
+      }
+    }
+
+    getLog().info(sb.toString().stripTrailing());
+  }
+
+  private Plugin findHKJPlugin() {
+    for (Plugin plugin : project.getBuildPlugins()) {
+      if (PLUGIN_KEY.equals(plugin.getKey())) {
+        return plugin;
+      }
+    }
+    return null;
+  }
+}

--- a/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJLifecycleParticipant.java
+++ b/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJLifecycleParticipant.java
@@ -1,0 +1,195 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.maven;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+/**
+ * Maven lifecycle participant that configures HKJ dependencies, preview features, and compile-time
+ * checks.
+ *
+ * <p>This extension runs early in the Maven build lifecycle (before dependency resolution),
+ * allowing it to add dependencies and configure compiler settings automatically.
+ *
+ * <p>Activated when the {@code hkj-maven-plugin} is declared with {@code
+ * <extensions>true</extensions>}.
+ */
+@Named("hkj")
+@Singleton
+public class HKJLifecycleParticipant extends AbstractMavenLifecycleParticipant {
+
+  private static final String GROUP_ID = "io.github.higher-kinded-j";
+  private static final String PLUGIN_KEY = GROUP_ID + ":hkj-maven-plugin";
+  private static final String COMPILER_PLUGIN_KEY =
+      "org.apache.maven.plugins:maven-compiler-plugin";
+  private static final String SUREFIRE_PLUGIN_KEY =
+      "org.apache.maven.plugins:maven-surefire-plugin";
+
+  @Override
+  public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
+    for (MavenProject project : session.getProjects()) {
+      Plugin hkjPlugin = findHKJPlugin(project);
+      if (hkjPlugin == null) {
+        continue;
+      }
+
+      HKJConfiguration config = HKJConfiguration.fromPlugin(hkjPlugin, project);
+      configureDependencies(project, config);
+      configureCompilerPlugin(project, config);
+      configureSurefirePlugin(project, config);
+    }
+  }
+
+  private Plugin findHKJPlugin(MavenProject project) {
+    for (Plugin plugin : project.getBuildPlugins()) {
+      if (PLUGIN_KEY.equals(plugin.getKey())) {
+        return plugin;
+      }
+    }
+    return null;
+  }
+
+  private void configureDependencies(MavenProject project, HKJConfiguration config) {
+    addDependency(project, "hkj-core", config.version(), "compile");
+    addDependency(project, "hkj-processor-plugins", config.version(), "provided");
+
+    if (config.pathTypeMismatch()) {
+      addDependency(project, "hkj-checker", config.version(), "provided");
+    }
+
+    if (config.spring()) {
+      addDependency(project, "hkj-spring-boot-starter", config.version(), "compile");
+    }
+  }
+
+  private void addDependency(
+      MavenProject project, String artifactId, String version, String scope) {
+    // Check if already declared
+    for (Dependency dep : project.getDependencies()) {
+      if (GROUP_ID.equals(dep.getGroupId()) && artifactId.equals(dep.getArtifactId())) {
+        return;
+      }
+    }
+
+    Dependency dep = new Dependency();
+    dep.setGroupId(GROUP_ID);
+    dep.setArtifactId(artifactId);
+    dep.setVersion(version);
+    dep.setScope(scope);
+    project.getDependencies().add(dep);
+  }
+
+  private void configureCompilerPlugin(MavenProject project, HKJConfiguration config) {
+    Plugin compilerPlugin = findOrCreatePlugin(project, COMPILER_PLUGIN_KEY);
+    Xpp3Dom pluginConfig = getOrCreateConfiguration(compilerPlugin);
+
+    // Set release and preview
+    if (config.preview()) {
+      setChildValue(pluginConfig, "release", "25");
+      setChildValue(pluginConfig, "enablePreview", "true");
+    }
+
+    // Configure annotation processor paths
+    Xpp3Dom annotationProcessorPaths = getOrCreateChild(pluginConfig, "annotationProcessorPaths");
+    addAnnotationProcessorPath(annotationProcessorPaths, "hkj-processor-plugins", config.version());
+    if (config.pathTypeMismatch()) {
+      addAnnotationProcessorPath(annotationProcessorPaths, "hkj-checker", config.version());
+    }
+
+    // Configure compiler args
+    if (config.pathTypeMismatch()) {
+      Xpp3Dom compilerArgs = getOrCreateChild(pluginConfig, "compilerArgs");
+      addArgIfMissing(compilerArgs, "-Xplugin:HKJChecker");
+    }
+  }
+
+  private void configureSurefirePlugin(MavenProject project, HKJConfiguration config) {
+    if (!config.preview()) {
+      return;
+    }
+
+    Plugin surefirePlugin = findOrCreatePlugin(project, SUREFIRE_PLUGIN_KEY);
+    Xpp3Dom pluginConfig = getOrCreateConfiguration(surefirePlugin);
+    Xpp3Dom argLine = getOrCreateChild(pluginConfig, "argLine");
+    if (argLine.getValue() == null || !argLine.getValue().contains("--enable-preview")) {
+      String existing = argLine.getValue() != null ? argLine.getValue() + " " : "";
+      argLine.setValue(existing + "--enable-preview");
+    }
+  }
+
+  private Plugin findOrCreatePlugin(MavenProject project, String pluginKey) {
+    String[] parts = pluginKey.split(":");
+    String groupId = parts[0];
+    String artifactId = parts[1];
+
+    for (Plugin plugin : project.getBuildPlugins()) {
+      if (pluginKey.equals(plugin.getKey())) {
+        return plugin;
+      }
+    }
+
+    Plugin plugin = new Plugin();
+    plugin.setGroupId(groupId);
+    plugin.setArtifactId(artifactId);
+    project.getBuild().addPlugin(plugin);
+    return plugin;
+  }
+
+  private Xpp3Dom getOrCreateConfiguration(Plugin plugin) {
+    Xpp3Dom config = (Xpp3Dom) plugin.getConfiguration();
+    if (config == null) {
+      config = new Xpp3Dom("configuration");
+      plugin.setConfiguration(config);
+    }
+    return config;
+  }
+
+  private Xpp3Dom getOrCreateChild(Xpp3Dom parent, String name) {
+    Xpp3Dom child = parent.getChild(name);
+    if (child == null) {
+      child = new Xpp3Dom(name);
+      parent.addChild(child);
+    }
+    return child;
+  }
+
+  private void setChildValue(Xpp3Dom parent, String name, String value) {
+    Xpp3Dom child = getOrCreateChild(parent, name);
+    child.setValue(value);
+  }
+
+  private void addAnnotationProcessorPath(Xpp3Dom parent, String artifactId, String version) {
+    // Check if already present
+    for (Xpp3Dom path : parent.getChildren("path")) {
+      Xpp3Dom aid = path.getChild("artifactId");
+      if (aid != null && artifactId.equals(aid.getValue())) {
+        return;
+      }
+    }
+
+    Xpp3Dom path = new Xpp3Dom("path");
+    setChildValue(path, "groupId", GROUP_ID);
+    setChildValue(path, "artifactId", artifactId);
+    setChildValue(path, "version", version);
+    parent.addChild(path);
+  }
+
+  private void addArgIfMissing(Xpp3Dom compilerArgs, String arg) {
+    for (Xpp3Dom child : compilerArgs.getChildren("arg")) {
+      if (arg.equals(child.getValue())) {
+        return;
+      }
+    }
+    Xpp3Dom argElement = new Xpp3Dom("arg");
+    argElement.setValue(arg);
+    compilerArgs.addChild(argElement);
+  }
+}

--- a/plugins/hkj-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/plugins/hkj-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin>
+    <name>Higher-Kinded-J Maven Plugin</name>
+    <description>Maven plugin that configures HKJ dependencies, preview features, and compile-time checks</description>
+    <groupId>io.github.higher-kinded-j</groupId>
+    <artifactId>hkj-maven-plugin</artifactId>
+    <goalPrefix>hkj</goalPrefix>
+    <isolatedRealm>false</isolatedRealm>
+    <inheritedByDefault>true</inheritedByDefault>
+    <mojos>
+        <mojo>
+            <goal>diagnostics</goal>
+            <description>Prints the current HKJ configuration for diagnostics and troubleshooting</description>
+            <requiresDirectInvocation>false</requiresDirectInvocation>
+            <requiresProject>true</requiresProject>
+            <requiresReports>false</requiresReports>
+            <aggregator>false</aggregator>
+            <requiresOnline>false</requiresOnline>
+            <inheritedByDefault>true</inheritedByDefault>
+            <implementation>org.higherkindedj.maven.HKJDiagnosticsMojo</implementation>
+            <language>java</language>
+            <instantiationStrategy>per-lookup</instantiationStrategy>
+            <threadSafe>true</threadSafe>
+            <parameters>
+                <parameter>
+                    <name>project</name>
+                    <type>org.apache.maven.project.MavenProject</type>
+                    <required>true</required>
+                    <editable>false</editable>
+                    <description>The Maven project</description>
+                </parameter>
+            </parameters>
+            <configuration>
+                <project implementation="org.apache.maven.project.MavenProject" default-value="${project}"/>
+            </configuration>
+        </mojo>
+    </mojos>
+</plugin>

--- a/plugins/hkj-maven-plugin/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/plugins/hkj-maven-plugin/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+org.higherkindedj.maven.HKJLifecycleParticipant

--- a/plugins/hkj-maven-plugin/src/test/java/org/higherkindedj/maven/HKJConfigurationTest.java
+++ b/plugins/hkj-maven-plugin/src/test/java/org/higherkindedj/maven/HKJConfigurationTest.java
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HKJConfiguration")
+class HKJConfigurationTest {
+
+  private MavenProject project;
+  private Plugin plugin;
+
+  @BeforeEach
+  void setUp() {
+    project = new MavenProject();
+    project.setVersion("1.0.0");
+    plugin = new Plugin();
+    plugin.setGroupId("io.github.higher-kinded-j");
+    plugin.setArtifactId("hkj-maven-plugin");
+  }
+
+  @Nested
+  @DisplayName("default configuration")
+  class DefaultConfiguration {
+
+    @Test
+    @DisplayName("uses project version when no version specified")
+    void usesProjectVersion_whenNoVersionSpecified() {
+      HKJConfiguration config = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(config.version()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    @DisplayName("preview defaults to true")
+    void previewDefaultsToTrue() {
+      HKJConfiguration config = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(config.preview()).isTrue();
+    }
+
+    @Test
+    @DisplayName("spring defaults to false")
+    void springDefaultsToFalse() {
+      HKJConfiguration config = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(config.spring()).isFalse();
+    }
+
+    @Test
+    @DisplayName("pathTypeMismatch defaults to true")
+    void pathTypeMismatchDefaultsToTrue() {
+      HKJConfiguration config = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(config.pathTypeMismatch()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("custom configuration")
+  class CustomConfiguration {
+
+    @Test
+    @DisplayName("reads custom version")
+    void readsCustomVersion() {
+      Xpp3Dom config = new Xpp3Dom("configuration");
+      addChild(config, "version", "0.3.7-SNAPSHOT");
+      plugin.setConfiguration(config);
+
+      HKJConfiguration result = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(result.version()).isEqualTo("0.3.7-SNAPSHOT");
+    }
+
+    @Test
+    @DisplayName("reads preview disabled")
+    void readsPreviewDisabled() {
+      Xpp3Dom config = new Xpp3Dom("configuration");
+      addChild(config, "preview", "false");
+      plugin.setConfiguration(config);
+
+      HKJConfiguration result = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(result.preview()).isFalse();
+    }
+
+    @Test
+    @DisplayName("reads spring enabled")
+    void readsSpringEnabled() {
+      Xpp3Dom config = new Xpp3Dom("configuration");
+      addChild(config, "spring", "true");
+      plugin.setConfiguration(config);
+
+      HKJConfiguration result = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(result.spring()).isTrue();
+    }
+
+    @Test
+    @DisplayName("reads pathTypeMismatch disabled")
+    void readsPathTypeMismatchDisabled() {
+      Xpp3Dom config = new Xpp3Dom("configuration");
+      addChild(config, "pathTypeMismatch", "false");
+      plugin.setConfiguration(config);
+
+      HKJConfiguration result = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(result.pathTypeMismatch()).isFalse();
+    }
+
+    @Test
+    @DisplayName("handles blank values as defaults")
+    void handlesBlankValuesAsDefaults() {
+      Xpp3Dom config = new Xpp3Dom("configuration");
+      addChild(config, "version", "   ");
+      addChild(config, "preview", "");
+      plugin.setConfiguration(config);
+
+      HKJConfiguration result = HKJConfiguration.fromPlugin(plugin, project);
+
+      assertThat(result.version()).isEqualTo("1.0.0");
+      assertThat(result.preview()).isTrue();
+    }
+  }
+
+  private void addChild(Xpp3Dom parent, String name, String value) {
+    Xpp3Dom child = new Xpp3Dom(name);
+    child.setValue(value);
+    parent.addChild(child);
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,8 +15,17 @@ include(
     "hkj-processor-plugins",
     "hkj-benchmarks",
     "hkj-openrewrite",
+    "hkj-checker",
+    "hkj-bom",
+    // Plugin modules (under plugins/ directory)
+    "hkj-gradle-plugin",
+    "hkj-maven-plugin",
     // Spring Boot integration modules
     "hkj-spring:autoconfigure",
     "hkj-spring:starter",
     "hkj-spring:example"
 )
+
+// Remap plugin modules to plugins/ subdirectory
+project(":hkj-gradle-plugin").projectDir = file("plugins/hkj-gradle-plugin")
+project(":hkj-maven-plugin").projectDir = file("plugins/hkj-maven-plugin")


### PR DESCRIPTION
## Description

This PR introduces comprehensive build tooling for Higher-Kinded-J projects:

1. **Gradle Plugin** (`hkj-gradle-plugin`): A single-line plugin that automatically configures HKJ dependencies, Java preview features, annotation processors, and compile-time checks. Replaces multi-block manual configuration.

2. **Maven Plugin** (`hkj-maven-plugin`): Maven equivalent providing the same automatic configuration through a lifecycle participant and diagnostics mojo.

3. **Compile-Time Checker** (`hkj-checker`): A javac compiler plugin that detects Path type mismatches at compile time. Prevents runtime `IllegalArgumentException` errors by catching cases where different Path types are mixed in chains (e.g., `MaybePath` chained with `IOPath`).

4. **Bill of Materials** (`hkj-bom`): A Maven platform module for centralized dependency version management.

5. **Documentation**: New tooling guide chapters covering plugin setup, compile-time checks, and diagnostics.

### Key Features

- **Gradle Plugin DSL**: Simple configuration block with sensible defaults
  ```gradle
  plugins {
      id("io.github.higher-kinded-j.hkj") version "0.3.7"
  }
  ```

- **Automatic Configuration**: Adds dependencies, enables preview features, configures annotation processors, and registers diagnostics task

- **Compile-Time Safety**: Detects Path type mismatches in `via()`, `flatMap()`, `then()`, `zipWith()`, `recoverWith()`, and `orElse()` methods

- **Diagnostics Task**: Both plugins provide `hkjDiagnostics`/`hkj:diagnostics` to inspect configuration

- **No False Positives**: Checker silently skips unresolvable types to avoid spurious errors

### Testing

- Comprehensive unit tests for plugin configuration and extension DSL
- Functional tests for Gradle plugin using Gradle TestKit
- Property-based tests for Path type registry invariants
- Compiler tests using compile-testing library for checker validation
- Test data files covering correct usage and various mismatch scenarios

### Documentation Updates

- Updated README with plugin-based setup instructions
- New quickstart guide section for Gradle plugin
- Three new tooling chapters: intro, gradle_plugin, compile_checks, diagnostics
- Updated CONTRIBUTING.md with plugin development instructions

Fixes #403 


## Type of change

- [x] New feature (build plugins and compile-time checker)
- [x] Documentation update (tooling guides and README)
- [x] Test addition (comprehensive test coverage for new modules)

## How Has This Been Tested?

- `./gradlew test` passes locally with all new unit and functional tests
- Gradle TestKit functional tests verify plugin behavior in realistic build scenarios
- Compiler tests validate checker detection of Path type mismatches
- Property-based tests ensure Path type registry invariants hold across all combinations
- Existing tests updated to use Awaitility for more reliable async test timing

## Checklist:

- [x] My code follows the style guidelines of this project (Google Java Style Guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md, new tooling guides)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works (unit, functional, property-based, compiler tests)
- [x] New and existing unit tests pass locally with my changes (`./gradlew test`)
- [x] GitHub Actions CI build passes with my changes

## Additional Comments

The compile-time checker follows a "no false positives" policy: if a type cannot be resolved during compilation, the check is silently skipped rather than reporting an error. This ensures the checker integrates smoothly with complex build environments while still catching the common case of explicit Path type mismatches.

The Gradle plugin is the recommended approach for new projects; the Maven plugin provides equivalent functionality for Maven-based builds.

