### PR TITLE
Fix hkj-checker javadoc task failing due to missing --add-exports flags

### DIFF
--- a/hkj-checker/build.gradle.kts
+++ b/hkj-checker/build.gradle.kts
@@ -42,10 +42,12 @@ tasks.named<JavaCompile>("compileTestJava") {
 tasks.withType<Javadoc>().configureEach {
     options {
         this as org.gradle.external.javadoc.StandardJavadocDocletOptions
-        addBooleanOption("-add-exports=jdk.compiler/com.sun.tools.javac.api=org.higherkindedj.checker", true)
-        addBooleanOption("-add-exports=jdk.compiler/com.sun.tools.javac.code=org.higherkindedj.checker", true)
-        addBooleanOption("-add-exports=jdk.compiler/com.sun.tools.javac.tree=org.higherkindedj.checker", true)
-        addBooleanOption("-add-exports=jdk.compiler/com.sun.tools.javac.util=org.higherkindedj.checker", true)
+        listOf(
+            "jdk.compiler/com.sun.tools.javac.api=org.higherkindedj.checker",
+            "jdk.compiler/com.sun.tools.javac.code=org.higherkindedj.checker",
+            "jdk.compiler/com.sun.tools.javac.tree=org.higherkindedj.checker",
+            "jdk.compiler/com.sun.tools.javac.util=org.higherkindedj.checker"
+        ).forEach { addBooleanOption("-add-exports=$it", true) }
     }
 }
 


### PR DESCRIPTION
The javadoc task needs the same jdk.compiler --add-exports as compilation since PathTypeMismatchChecker uses com.sun.tools.javac internal APIs. Uses addBooleanOption to pass each export as a unique flag.

## Description

Please include a summary of the change and which issue is fixed or feature is added. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue number) / Relates to # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring/Code cleanup
- [ ] Test addition/update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] `./gradlew test` passes locally
- [ ] New unit tests added/updated
- [ ] Relevant examples in `MonadSimulation.java` or `OrderWorkflowRunner.java` updated/tested (if applicable)


## Checklist:

- [ ] My code follows the style guidelines of this project (Standard Google Java Conventions)[**See Google Java Style Guide**](https://google.github.io/styleguide/javaguide.html)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g., README.md, Javadoc)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`./gradlew test`)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)
- [ ] I have checked that the GitHub Actions CI build passes with my changes

## Additional Comments (Optional)

Add any other comments here.