### PR TITLE
Document SNAPSHOT repository setup for Gradle plugin users

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,3 +80,13 @@ jobs:
           echo "Publishing version ${{ steps.versioner.outputs.version }} to Central Portal"
           ./gradlew publishToMavenCentral -PprojectVersion=${{ steps.versioner.outputs.version }}
         shell: bash
+
+      - name: Publish Gradle Plugin to Plugin Portal
+        if: steps.versioner.outputs.is_snapshot == 'false'
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: |
+          echo "Publishing plugin version ${{ steps.versioner.outputs.version }} to Gradle Plugin Portal"
+          ./gradlew :hkj-gradle-plugin:publishPlugins -PprojectVersion=${{ steps.versioner.outputs.version }}
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -269,6 +269,27 @@ plugins {
 
 This single line configures dependencies, preview features, annotation processors, and compile-time Path type checking automatically.
 
+For **SNAPSHOT** versions, add the Sonatype snapshots repository to both `pluginManagement` (in `settings.gradle.kts`) and `repositories` (in `build.gradle.kts`):
+
+```gradle
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+```
+
+```gradle
+// build.gradle.kts
+repositories {
+    mavenCentral()
+    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+}
+```
+
 ### Maven -- With HKJ Plugin (Recommended)
 
 ```xml
@@ -306,7 +327,7 @@ See the **[Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ google-java-format = "1.32.0"
 
 # Plugins
 maven-publish = "0.33.0"
+plugin-publish = "1.3.1"
 spotless = "8.1.0"
 openrewrite = "7.21.0"
 jmh-plugin = "0.7.3"
@@ -116,6 +117,7 @@ jooq = { module = "org.jooq:jooq", version.ref = "jooq" }
 
 [plugins]
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 openrewrite = { id = "org.openrewrite.rewrite", version.ref = "openrewrite" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmh-plugin" }

--- a/hkj-book/src/quickstart.md
+++ b/hkj-book/src/quickstart.md
@@ -29,6 +29,33 @@ plugins {
 
 This single line configures dependencies, preview features, annotation processors, and compile-time Path type checking automatically. See the [Gradle Plugin](tooling/gradle_plugin.md) documentation for the full DSL reference.
 
+For **SNAPSHOT** versions of the plugin, add the Sonatype snapshots repository to your `settings.gradle.kts`:
+
+```gradle
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+```
+
+You also need the snapshots repository in your project's `repositories` block so the plugin can resolve HKJ library dependencies:
+
+```gradle
+// build.gradle.kts
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+```
+
 ### Manual Setup
 
 If you prefer to configure dependencies yourself:
@@ -70,7 +97,7 @@ For SNAPSHOTS, add the Sonatype snapshots repository:
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 ```

--- a/hkj-book/src/tooling/gradle_plugin.md
+++ b/hkj-book/src/tooling/gradle_plugin.md
@@ -55,6 +55,39 @@ plugins {
 
 That is it. The plugin handles dependencies, preview flags, compile-time checks, and Javadoc configuration automatically.
 
+### Using SNAPSHOT Versions
+
+SNAPSHOT versions of the plugin are published to the Sonatype snapshots repository. Add it to `pluginManagement` in your `settings.gradle.kts`:
+
+```gradle
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+```
+
+You also need the same repository in your project's `repositories` block so the plugin can resolve HKJ library dependencies:
+
+```gradle
+// build.gradle.kts
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+```
+
+~~~admonish note
+Release versions are published to both Maven Central and the [Gradle Plugin Portal](https://plugins.gradle.org), so no extra repository configuration is needed for releases.
+~~~
+
 ---
 
 ## Extension DSL Reference
@@ -63,7 +96,7 @@ The plugin creates an `hkj` extension block with these options:
 
 ```gradle
 hkj {
-    version = "0.3.7-SNAPSHOT"       // HKJ library version (default: project version)
+    version = "0.3.7-SNAPSHOT"       // HKJ library version (default: plugin version)
     preview = true           // add --enable-preview flags (default: true)
     spring = false           // add hkj-spring-boot-starter (default: false)
     checks {
@@ -76,7 +109,7 @@ hkj {
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `version` | Project version | Version of HKJ libraries to use |
+| `version` | Plugin version | Version of HKJ libraries to use |
 | `preview` | `true` | Adds `--enable-preview` to compile, test, exec, and javadoc tasks |
 | `spring` | `false` | Adds `hkj-spring-boot-starter` to implementation dependencies |
 | `checks.pathTypeMismatch` | `true` | Enables compile-time Path type mismatch detection |
@@ -111,7 +144,7 @@ This adds `hkj-spring-boot-starter` to the `implementation` configuration, which
 
 ## Version Management
 
-By default, the plugin uses your project's version for HKJ dependencies. Override this to pin a specific version:
+By default, the plugin uses its own published version for HKJ dependencies. Override this to pin a different version:
 
 ```gradle
 hkj {
@@ -190,7 +223,7 @@ The plugin automatically adds `hkj-core`, annotation processors, compile-time ch
 
 ```xml
 <configuration>
-    <version>0.3.7-SNAPSHOT</version>   <!-- HKJ library version (default: project version) -->
+    <version>0.3.7-SNAPSHOT</version>   <!-- HKJ library version (default: plugin version) -->
     <preview>true</preview>              <!-- add --enable-preview flags (default: true) -->
     <spring>false</spring>               <!-- add hkj-spring-boot-starter (default: false) -->
     <pathTypeMismatch>true</pathTypeMismatch>  <!-- enable compile-time checks (default: true) -->

--- a/plugins/hkj-gradle-plugin/build.gradle.kts
+++ b/plugins/hkj-gradle-plugin/build.gradle.kts
@@ -1,15 +1,19 @@
 plugins {
     `java-gradle-plugin`
     id("com.vanniktech.maven.publish")
+    alias(libs.plugins.plugin.publish)
 }
 
 gradlePlugin {
+    website.set("https://github.com/higher-kinded-j/higher-kinded-j")
+    vcsUrl.set("https://github.com/higher-kinded-j/higher-kinded-j")
     plugins {
         create("hkj") {
             id = "io.github.higher-kinded-j.hkj"
             implementationClass = "org.higherkindedj.gradle.HKJPlugin"
             displayName = "Higher-Kinded-J Plugin"
             description = "Configures HKJ dependencies, preview features, and compile-time checks"
+            tags.set(listOf("higher-kinded-types", "functional-programming", "java"))
         }
     }
 }
@@ -24,6 +28,23 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+}
+
+// Generate version.properties so the plugin knows its own version at runtime
+val generateVersionProperties = tasks.register("generateVersionProperties") {
+    val outputDir = layout.buildDirectory.dir("generated/resources/hkj")
+    val versionValue = project.version.toString()
+    inputs.property("version", versionValue)
+    outputs.dir(outputDir)
+    doLast {
+        val dir = outputDir.get().asFile
+        dir.mkdirs()
+        dir.resolve("hkj-version.properties").writeText("version=$versionValue\n")
+    }
+}
+
+sourceSets.main {
+    resources.srcDir(generateVersionProperties)
 }
 
 // Central configuration for publishing

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJChecksExtension.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJChecksExtension.java
@@ -7,6 +7,13 @@ import org.gradle.api.provider.Property;
 /** Configuration for HKJ compile-time checks. */
 public abstract class HKJChecksExtension {
 
-  /** Enable Path type mismatch detection. Defaults to true. */
+  /** Creates a new checks extension instance. */
+  public HKJChecksExtension() {}
+
+  /**
+   * Enable Path type mismatch detection. Defaults to true.
+   *
+   * @return the path type mismatch check property
+   */
   public abstract Property<Boolean> getPathTypeMismatch();
 }

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJExtension.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJExtension.java
@@ -25,26 +25,51 @@ public abstract class HKJExtension {
 
   private final HKJChecksExtension checks;
 
+  /**
+   * Creates the extension.
+   *
+   * @param objects the Gradle object factory for creating nested extensions
+   */
   @Inject
   public HKJExtension(ObjectFactory objects) {
     this.checks = objects.newInstance(HKJChecksExtension.class);
   }
 
-  /** HKJ library version. Defaults to the plugin version. */
+  /**
+   * HKJ library version. Defaults to the plugin version.
+   *
+   * @return the version property
+   */
   public abstract Property<String> getVersion();
 
-  /** Whether to add --enable-preview flags. Defaults to true. */
+  /**
+   * Whether to add --enable-preview flags. Defaults to true.
+   *
+   * @return the preview property
+   */
   public abstract Property<Boolean> getPreview();
 
-  /** Whether to add hkj-spring-boot-starter. Defaults to false. */
+  /**
+   * Whether to add hkj-spring-boot-starter. Defaults to false.
+   *
+   * @return the spring integration property
+   */
   public abstract Property<Boolean> getSpring();
 
-  /** Compile-time check configuration. */
+  /**
+   * Compile-time check configuration.
+   *
+   * @return the checks extension
+   */
   public HKJChecksExtension getChecks() {
     return checks;
   }
 
-  /** Configures compile-time checks. */
+  /**
+   * Configures compile-time checks.
+   *
+   * @param action the configuration action
+   */
   public void checks(Action<? super HKJChecksExtension> action) {
     action.execute(checks);
   }

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJPlugin.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJPlugin.java
@@ -2,8 +2,11 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.gradle;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -30,6 +33,9 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions;
  */
 public class HKJPlugin implements Plugin<Project> {
 
+  /** Creates a new HKJ plugin instance. */
+  public HKJPlugin() {}
+
   private static final String GROUP_ID = "io.github.higher-kinded-j";
   private static final String EXTENSION_NAME = "hkj";
 
@@ -39,8 +45,8 @@ public class HKJPlugin implements Plugin<Project> {
 
     HKJExtension extension = project.getExtensions().create(EXTENSION_NAME, HKJExtension.class);
 
-    // Set defaults
-    extension.getVersion().convention(project.provider(() -> project.getVersion().toString()));
+    // Set defaults - use the plugin's own published version, not the consuming project's version
+    extension.getVersion().convention(readPluginVersion());
     extension.getPreview().convention(true);
     extension.getSpring().convention(false);
     extension.getChecks().getPathTypeMismatch().convention(true);
@@ -71,9 +77,25 @@ public class HKJPlugin implements Plugin<Project> {
           .withType(JavaCompile.class)
           .configureEach(
               task -> {
-                if (!task.getOptions().getCompilerArgs().contains("-Xplugin:HKJChecker")) {
-                  task.getOptions().getCompilerArgs().add("-Xplugin:HKJChecker");
+                List<String> args = task.getOptions().getCompilerArgs();
+                if (!args.contains("-Xplugin:HKJChecker")) {
+                  args.add("-Xplugin:HKJChecker");
                 }
+                // The checker accesses jdk.compiler internals at compile time
+                task.getOptions().setFork(true);
+                task.getOptions()
+                    .getForkOptions()
+                    .getJvmArgs()
+                    .addAll(
+                        List.of(
+                            "--add-exports",
+                            "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                            "--add-exports",
+                            "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                            "--add-exports",
+                            "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                            "--add-exports",
+                            "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"));
               });
     }
 
@@ -123,6 +145,24 @@ public class HKJPlugin implements Plugin<Project> {
                   (StandardJavadocDocletOptions) task.getOptions();
               options.addBooleanOption("-enable-preview", true);
             });
+  }
+
+  private static String readPluginVersion() {
+    Properties props = new Properties();
+    try (InputStream in = HKJPlugin.class.getResourceAsStream("/hkj-version.properties")) {
+      if (in != null) {
+        props.load(in);
+        String version = props.getProperty("version");
+        if (version != null && !version.trim().isEmpty()) {
+          return version.trim();
+        }
+      }
+    } catch (IOException e) {
+      // fall through
+    }
+    throw new IllegalStateException(
+        "Could not determine HKJ plugin version. "
+            + "Please set hkj.version explicitly in your build script.");
   }
 
   private void registerDiagnosticsTask(Project project, HKJExtension extension) {

--- a/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginTest.java
+++ b/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginTest.java
@@ -127,6 +127,23 @@ class HKJPluginTest {
     }
 
     @Test
+    @DisplayName("enables forked compilation with --add-exports for checker")
+    void plugin_addsForkOptionsForChecker_whenChecksEnabled() {
+      applyPlugin();
+      evaluateProject();
+
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task -> {
+                assertThat(task.getOptions().isFork()).isTrue();
+                assertThat(task.getOptions().getForkOptions().getJvmArgs())
+                    .contains("--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED");
+              });
+    }
+
+    @Test
     @DisplayName("registers hkjDiagnostics task in help group")
     void plugin_registersHKJDiagnosticsTask() {
       applyPlugin();


### PR DESCRIPTION
Users of the HKJ Gradle plugin with SNAPSHOT versions need the Sonatype snapshots repository in both pluginManagement (settings.gradle.kts) and project repositories (build.gradle.kts). This was only documented for the manual setup path previously.

Also update version default references from "project version" to "plugin version" to reflect the fix in HKJPlugin.

Add Gradle Plugin Portal publishing for hkj-gradle-plugin

Configure com.gradle.plugin-publish so the plugin is discoverable on the Gradle Plugin Portal (plugins.gradle.org) without requiring users to add custom Maven repositories to pluginManagement.

- Add plugin-publish plugin to version catalog and plugin build
- Add website, vcsUrl, and tags metadata for Portal listing
- Add publishPlugins step to CI workflow (release versions only, the Portal does not support snapshots)

Requires GRADLE_PUBLISH_KEY and GRADLE_PUBLISH_SECRET secrets to be configured in the GitHub repository settings.

Fix plugin version default to use plugin's own version, not consuming project's

The HKJ Gradle plugin was defaulting its dependency version to project.getVersion() which resolves to the *client* project's version (e.g. 1.0-SNAPSHOT) instead of the HKJ library version. This caused dependency resolution failures when the client project version didn't match any published HKJ artifact.

Now generates hkj-version.properties at build time containing the plugin's published version, and reads it at runtime as the default.

