### PR TITLE
Upgrade dependencies and improve OpenRewrite configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,17 +18,8 @@ repositories {
 }
 // OpenRewrite configuration for the root project
 rewrite {
-    activeRecipe("org.openrewrite.java.ShortenFullyQualifiedTypeReferences")
+    activeRecipe("com.higherkindedj.ShortenFullyQualifiedTypeReferencesJavaOnly")
     failOnDryRunResults = true  // CI enforcement
-
-    // Only parse Java source files, exclude build scripts and other non-Java files
-    exclusion(
-        "**/*.kts",
-        "**/*.kt",
-        "**/*.gradle",
-        "**/build/**",
-        "**/.gradle/**"
-    )
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
 # Core dependencies
 jspecify = "1.0.0"
-javapoet = "0.7.0"
+javapoet = "0.12.0"
 autoservice = "1.1.1"
-palantir-java-format = "2.69.0"
+palantir-java-format = "2.89.0"
 
 # Testing
-junit = "6.0.2"
-assertj = "3.27.6"
+junit = "6.0.3"
+assertj = "3.27.7"
 awaitility = "4.3.0"
 jqwik = "1.9.3"
 archunit = "1.4.1"
-compile-testing = "0.21.0"
-truth = "1.4.4"
+compile-testing = "0.23.0"
+truth = "1.4.5"
 
 # Benchmarking
 jmh = "1.37"
@@ -24,24 +24,24 @@ spring-boot = "4.0.3"
 spring-dependency-management = "1.1.7"
 
 # Jackson 3.x (group ID changed from com.fasterxml.jackson to tools.jackson in Spring Boot 4)
-jackson = "3.0.0"
+jackson = "3.1.0"
 
 # JOOQ - Database access library (for spec interface examples)
-jooq = "3.19.18"
+jooq = "3.20.11"
 
 # Maven Plugin API (for hkj-maven-plugin)
-maven-plugin-api = "3.9.9"
-maven-core = "3.9.9"
-maven-plugin-annotations = "3.13.1"
+maven-plugin-api = "3.9.14"
+maven-core = "3.9.14"
+maven-plugin-annotations = "3.15.2"
 
 # Code quality
-google-java-format = "1.32.0"
+google-java-format = "1.35.0"
 
 # Plugins
-maven-publish = "0.33.0"
+maven-publish = "0.36.0"
 plugin-publish = "1.3.1"
-spotless = "8.1.0"
-openrewrite = "7.21.0"
+spotless = "8.3.0"
+openrewrite = "7.28.1"
 jmh-plugin = "0.7.3"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/hkj-benchmarks/build.gradle.kts
+++ b/hkj-benchmarks/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)
   testImplementation(libs.assertj.core)
-  testImplementation("com.google.code.gson:gson:2.11.0")
+  testImplementation("com.google.code.gson:gson:2.13.2")
   testRuntimeOnly(libs.junit.platform.launcher)
 }
 

--- a/hkj-openrewrite/build.gradle.kts
+++ b/hkj-openrewrite/build.gradle.kts
@@ -7,13 +7,13 @@ plugins {
 
 dependencies {
     // OpenRewrite core dependencies
-    compileOnly("org.openrewrite:rewrite-java:8.70.2")
-    compileOnly("org.openrewrite:rewrite-core:8.70.2")
+    compileOnly("org.openrewrite:rewrite-java:8.75.5")
+    compileOnly("org.openrewrite:rewrite-core:8.75.5")
 
     // Required for recipe testing
-    testImplementation("org.openrewrite:rewrite-java:8.70.2")
-    testImplementation("org.openrewrite:rewrite-test:8.70.2")
-    testImplementation("org.openrewrite:rewrite-java-25:8.70.2")
+    testImplementation("org.openrewrite:rewrite-java:8.75.5")
+    testImplementation("org.openrewrite:rewrite-test:8.75.5")
+    testImplementation("org.openrewrite:rewrite-java-25:8.75.5")
 
     // Testing dependencies
     testImplementation(platform(libs.junit.bom))

--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -115,7 +115,7 @@ mavenPublishing {
 //
 // Fine-tuning individual settings (these override the profile):
 //   -Ppitest.threads=N         Override thread count
-//   -Ppitest.mutators=GROUP    Override mutator group (DEFAULT, STRONGER, ALL)
+//   -Ppitest.mutators=GROUP    Override mutator group (DEFAULTS, STRONGER, ALL)
 //   -Ppitest.heap=SIZE         Override per-fork heap (e.g. 768m, 1g)
 //
 // Reports: hkj-processor/build/reports/pitest/
@@ -126,7 +126,7 @@ val isFull = pitestProfile == "full"
 
 val cpuCount = Runtime.getRuntime().availableProcessors()
 val profileThreads = if (isFull) cpuCount else maxOf(1, cpuCount / 2)
-val profileMutators = if (isFull) "STRONGER" else "DEFAULT"
+val profileMutators = if (isFull) "STRONGER" else "DEFAULTS"
 val profileHeap = if (isFull) "1g" else "512m"
 
 // Allow per-setting overrides via project properties
@@ -135,8 +135,8 @@ val effectiveMutators = (project.findProperty("pitest.mutators") as String?) ?: 
 val effectiveHeap = (project.findProperty("pitest.heap") as String?) ?: profileHeap
 
 pitest {
-    // Use PIT version 1.22.0 as specified in project requirements
-    pitestVersion.set("1.22.0")
+    // Use PIT version 1.22.1 as specified in project requirements
+    pitestVersion.set("1.22.1")
 
     // Target classes for mutation
     targetClasses.set(setOf(
@@ -149,7 +149,7 @@ pitest {
         "org.higherkindedj.optics.processing.*Tests"
     ))
 
-    // Mutator group: DEFAULT (conservative) or STRONGER (full)
+    // Mutator group: DEFAULTS (conservative) or STRONGER (full)
     mutators.set(setOf(effectiveMutators))
 
     // Output formats
@@ -170,6 +170,15 @@ pitest {
 
     // Heap per forked JVM
     jvmArgs.set(listOf("-Xmx${effectiveHeap}"))
+
+    // Timeout: allow more time for mutated code (PIT default can be too tight)
+    timeoutConstInMillis.set(8000)
+    timeoutFactor.set("1.5".toBigDecimal())
+
+    // Exclude slow golden file tests from mutation runs to avoid minion timeouts
+    excludedTestClasses.set(setOf(
+        "org.higherkindedj.optics.processing.ForComprehensionGoldenFileTest"
+    ))
 
     // Exclude test infrastructure from mutation
     excludedClasses.set(setOf(

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/VirtualThreadUserService.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/VirtualThreadUserService.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.spring.example.service;
 
 import java.time.Duration;
+import java.util.List;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.VStreamPath;
 import org.higherkindedj.hkt.effect.VTaskPath;
@@ -129,7 +130,7 @@ public class VirtualThreadUserService {
    */
   public VStreamPath<User> streamAllUsers() {
     return Path.vstream(
-        VStream.fromList(userService.findAll().fold(err -> java.util.List.of(), users -> users))
+        VStream.fromList(userService.findAll().fold(err -> List.of(), users -> users))
             .map(
                 user -> {
                   // Simulate per-element processing delay

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,12 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.higherkindedj.ShortenFullyQualifiedTypeReferencesJavaOnly
+displayName: Shorten fully qualified type references (Java files only)
+description: >
+  Wraps ShortenFullyQualifiedTypeReferences with a precondition that limits
+  it to Java source files, preventing modifications to Kotlin build scripts.
+preconditions:
+  - org.openrewrite.FindSourceFiles:
+      filePattern: "**/*.java"
+recipeList:
+  - org.openrewrite.java.ShortenFullyQualifiedTypeReferences


### PR DESCRIPTION
## Description

This PR updates multiple dependencies to their latest versions and improves the OpenRewrite configuration to prevent unintended modifications to Kotlin build scripts.

### Key Changes:

1. **Dependency Updates**: Updated core and testing dependencies including:
   - JavaPoet: 0.7.0 → 0.12.0
   - Palantir Java Format: 2.69.0 → 2.89.0
   - Jackson: 3.0.0 → 3.1.0
   - JOOQ: 3.19.18 → 3.20.11
   - Maven plugins: 3.9.9 → 3.9.14 (API/Core), 3.13.1 → 3.15.2 (Annotations)
   - Google Java Format: 1.32.0 → 1.35.0
   - Spotless: 8.1.0 → 8.3.0
   - OpenRewrite: 7.21.0 → 7.28.1
   - Gradle: 9.2.1 → 9.4.0
   - Testing libraries (JUnit, AssertJ, Compile Testing, Truth)

2. **OpenRewrite Configuration**: 
   - Created new `rewrite.yml` with a custom recipe `ShortenFullyQualifiedTypeReferencesJavaOnly` that wraps the standard OpenRewrite recipe with a precondition limiting it to `**/*.java` files only
   - Updated root `build.gradle.kts` to use the new custom recipe instead of the standard one
   - Removed manual exclusion patterns from the root build script, delegating file filtering to the recipe precondition

3. **PIT Mutation Testing**:
   - Updated PIT version: 1.22.0 → 1.22.1
   - Fixed mutator group naming: `DEFAULT` → `DEFAULTS` (aligns with PIT 1.22.1 API)
   - Added timeout configuration for mutation testing to prevent minion timeouts
   - Excluded slow golden file tests from mutation runs

4. **Code Cleanup**:
   - Applied OpenRewrite's `ShortenFullyQualifiedTypeReferences` to shorten `java.util.List` to `List` in `VirtualThreadUserService.java`
   - Updated Gson dependency: 2.11.0 → 2.13.2

Relates to ongoing maintenance and stability improvements.

## Type of change

- [x] Refactoring/Code cleanup
- [x] Dependency updates

## How Has This Been Tested?

- OpenRewrite configuration changes ensure Java files are properly formatted while Kotlin build scripts remain untouched
- PIT mutation testing configuration updates align with version 1.22.1 requirements
- Dependency updates are compatible with existing codebase

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] The GitHub Actions CI build should pass with these changes

## Additional Comments

The OpenRewrite configuration improvement addresses a potential issue where the standard `ShortenFullyQualifiedTypeReferences` recipe could inadvertently modify Kotlin build scripts. The new custom recipe with file pattern precondition ensures the transformation only applies to Java source files.

Fixes #351 