### PR TITLE
Add Fold.plus() for combining multiple folds + benchmark quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       #    This will compile, run tests (triggering jacocoTestReport via finalizedBy)
       #    and generate the XML report needed by Codecov.
       - name: Build with Gradle & Generate JaCoCo Report
-        run: ./gradlew build
+        run: ./gradlew build -x :hkj-benchmarks:test -x :hkj-benchmarks:jmhClasses
 
       # 5. Upload the generated JaCoCo XML report to Codecov
       - name: Upload coverage reports to Codecov

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,73 @@
+# Plan: Release Quality Gate & Benchmark Documentation
+
+## Summary
+
+Four changes addressing observability, correctness, and release readiness:
+
+1. **Benchmark tests FAIL instead of skip** when results are missing
+2. **`releaseReadiness` Gradle task** — single-command quality gate ordered fast to slow
+3. **Pitest uses full profile** in the release task
+4. **Improve hkj-book benchmarks.md** — add section documenting what assertion tests validate and the release quality gate
+5. **`get()` prefix match fix** for parameterized benchmarks (regression from previous params fix)
+
+---
+
+## 1. BenchmarkAssertionsTest: fail instead of skip
+
+**File:** `hkj-benchmarks/src/test/java/.../BenchmarkAssertionsTest.java`
+
+- Change `assumeThat` to `assertThat` in `assumeResultsAvailable()` and `assumeBenchmarkPresent()`
+- Rename to `assertResultsAvailable()` and `assertBenchmarkPresent()`
+- Change all individual `assumeThat(result).isPresent()` to `assertThat(result).as("...").isPresent()`
+- Remove the `assumeThat` import; update class javadoc
+- Fix `get()` to fall back to prefix match for benchmarks with `@Param` annotations
+
+**Rationale:** Running `:hkj-benchmarks:test` without `:hkj-benchmarks:jmh` first should fail loudly, not silently skip everything and report green.
+
+---
+
+## 2. `releaseReadiness` Gradle task
+
+**File:** `build.gradle.kts` (root)
+
+Register a new `releaseReadiness` task in the `verification` group. Ordered fast to slow:
+
+1. `spotlessCheck` — code formatting (seconds)
+2. `build` — compile + all unit tests + jacoco (minutes)
+3. `:hkj-benchmarks:jmh` — JMH benchmarks (minutes)
+4. `:hkj-benchmarks:test` — benchmark assertion tests (seconds, must follow jmh)
+5. Pitest with full profile (slowest) — via `Exec` task calling `./gradlew :hkj-processor:pitest -Ppitest.profile=full`
+
+Use `mustRunAfter` chains to enforce the ordering. The `doLast` block prints a summary with paths to all generated reports.
+
+The pitest step uses an `Exec` task (same pattern as `longBenchmark`) because the `-Ppitest.profile=full` property must be set at Gradle invocation time for the conditional logic in `hkj-processor/build.gradle.kts` to resolve correctly.
+
+---
+
+## 3. Update hkj-book benchmarks.md
+
+**File:** `hkj-book/src/benchmarks.md`
+
+Add two new sections after "Running Benchmarks":
+
+### "Benchmark Assertion Tests" section
+- What the 18 test groups validate (table with group name → what it checks)
+- How to run: `./gradlew :hkj-benchmarks:jmh` then `./gradlew :hkj-benchmarks:test`
+- That tests **fail** (not skip) if benchmarks haven't been run — this is intentional
+- Link to the assertion test source for reference
+
+### "Release Quality Gate" section
+- The `releaseReadiness` command
+- What it runs and in what order (fast → slow)
+- That pitest uses the full (STRONGER mutators) profile
+- Report locations for each tool
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `hkj-benchmarks/src/test/java/.../BenchmarkAssertionsTest.java` | `assume` → `assert`, `get()` prefix match |
+| `build.gradle.kts` (root) | Add `releaseReadiness` task with pitest full profile |
+| `hkj-book/src/benchmarks.md` | Add assertion tests + release quality gate sections |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,3 +132,68 @@ tasks.register("benchmarkValidation") {
         println("\nRun './gradlew :hkj-benchmarks:benchmarkSummary' for a quick results overview.")
     }
 }
+
+/**
+ * Release readiness quality gate.
+ *
+ * Runs all verification steps from fastest to slowest, failing fast
+ * on the cheapest checks first:
+ *
+ * 1. spotlessCheck       — code formatting (seconds)
+ * 2. build               — compile + unit tests + JaCoCo (minutes)
+ * 3. jmh                 — JMH benchmarks (minutes)
+ * 4. benchmark tests     — benchmark assertion tests (seconds, requires jmh)
+ * 5. pitest (full)       — mutation testing with STRONGER mutators (slowest)
+ *
+ * Usage: ./gradlew releaseReadiness
+ *
+ * This is the essential quality gate before any release. All steps must pass.
+ */
+tasks.register("releaseReadiness") {
+    group = "verification"
+    description = "Release quality gate: spotless, build, benchmarks, benchmark assertions, pitest (full profile)"
+
+    dependsOn("spotlessCheck")
+    dependsOn("build")
+    dependsOn(":hkj-benchmarks:jmh")
+    dependsOn(":hkj-benchmarks:test")
+    dependsOn("pitestFull")
+
+    // Enforce fast-to-slow ordering
+    tasks.findByPath("build")?.mustRunAfter("spotlessCheck")
+    tasks.findByPath(":hkj-benchmarks:jmh")?.mustRunAfter("build")
+    tasks.findByPath(":hkj-benchmarks:test")?.mustRunAfter(":hkj-benchmarks:jmh")
+
+    doLast {
+        println("\n" + "=".repeat(70))
+        println("  RELEASE READINESS — ALL CHECKS PASSED")
+        println("=".repeat(70))
+        println("\nAll quality gates passed (fast to slow):")
+        println("  1. Spotless           — code formatting")
+        println("  2. Build              — compile + unit tests + JaCoCo")
+        println("  3. JMH Benchmarks     — performance benchmarks")
+        println("  4. Benchmark Tests    — performance assertions")
+        println("  5. Pitest (full)      — mutation testing (STRONGER mutators)")
+        println("\nReports:")
+        println("  - JaCoCo:     hkj-core/build/reports/jacoco/test/html/index.html")
+        println("  - JMH JSON:   hkj-benchmarks/build/reports/jmh/results.json")
+        println("  - JMH Human:  hkj-benchmarks/build/reports/jmh/human.txt")
+        println("  - Pitest:     hkj-processor/build/reports/pitest/index.html")
+    }
+}
+
+tasks.register<Exec>("pitestFull") {
+    group = "verification"
+    description = "Run pitest with full profile (STRONGER mutators, all CPU cores)"
+    workingDir = rootProject.projectDir
+    commandLine(
+        if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew",
+        ":hkj-processor:pitest",
+        "-Ppitest.profile=full"
+    )
+    // Pitest is the slowest step — run it after everything else
+    mustRunAfter(":hkj-benchmarks:test")
+    doFirst {
+        println("\nRunning pitest with FULL profile (STRONGER mutators, all CPU cores)")
+    }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/Fold.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/Fold.java
@@ -378,6 +378,100 @@ public interface Fold<S, A> extends Optic<S, S, A, A> {
   }
 
   /**
+   * Combines this fold with another fold of the same type, producing a fold that returns results
+   * from both.
+   *
+   * <p>The combined fold first extracts all parts focused by {@code this} fold, then all parts
+   * focused by the {@code other} fold. Elements from this fold appear before elements from the
+   * other fold in all operations ({@link #getAll}, {@link #foldMap}, etc.).
+   *
+   * <p>Together with {@link #empty()}, this operation forms a monoid on folds:
+   *
+   * <ul>
+   *   <li><b>Left identity:</b> {@code Fold.empty().plus(fold)} behaves like {@code fold}
+   *   <li><b>Right identity:</b> {@code fold.plus(Fold.empty())} behaves like {@code fold}
+   *   <li><b>Associativity:</b> {@code a.plus(b).plus(c)} behaves like {@code a.plus(b.plus(c))}
+   * </ul>
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * record Person(String firstName, String lastName) {}
+   *
+   * Fold<Person, String> firstNameFold = Lens.of(Person::firstName, ...).asFold();
+   * Fold<Person, String> lastNameFold  = Lens.of(Person::lastName, ...).asFold();
+   *
+   * Fold<Person, String> allNames = firstNameFold.plus(lastNameFold);
+   * allNames.getAll(new Person("Alice", "Smith"));
+   * // Returns: ["Alice", "Smith"]
+   * }</pre>
+   *
+   * @param other The fold to combine with this fold.
+   * @return A new fold that focuses on all parts from both folds.
+   */
+  default Fold<S, A> plus(Fold<S, A> other) {
+    Fold<S, A> self = this;
+    return new Fold<>() {
+      @Override
+      public <M> M foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f, S source) {
+        return monoid.combine(self.foldMap(monoid, f, source), other.foldMap(monoid, f, source));
+      }
+    };
+  }
+
+  /**
+   * Returns a fold that focuses on no elements, serving as the identity element for {@link #plus}.
+   *
+   * <p>For any fold {@code f}:
+   *
+   * <ul>
+   *   <li>{@code Fold.empty().plus(f).getAll(s)} equals {@code f.getAll(s)}
+   *   <li>{@code f.plus(Fold.empty()).getAll(s)} equals {@code f.getAll(s)}
+   * </ul>
+   *
+   * @param <S> The type of the whole structure.
+   * @param <A> The type of the focused parts.
+   * @return A fold that always returns the monoid identity value.
+   */
+  static <S, A> Fold<S, A> empty() {
+    return new Fold<>() {
+      @Override
+      public <M> M foldMap(Monoid<M> monoid, Function<? super A, ? extends M> f, S source) {
+        return monoid.empty();
+      }
+    };
+  }
+
+  /**
+   * Combines multiple folds into a single fold that returns results from all of them.
+   *
+   * <p>This is a convenience method equivalent to chaining {@link #plus} calls: {@code Fold.sum(a,
+   * b, c)} behaves like {@code a.plus(b).plus(c)}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Fold<Config, String> combined = Fold.sum(
+   *     hostFold, portFold, userFold
+   * );
+   * }</pre>
+   *
+   * @param first The first fold (required).
+   * @param rest Additional folds to combine.
+   * @param <S> The type of the whole structure.
+   * @param <A> The type of the focused parts.
+   * @return A fold that focuses on all parts from all provided folds.
+   */
+  @SafeVarargs
+  static <S, A> Fold<S, A> sum(Fold<S, A> first, Fold<S, A>... rest) {
+    Fold<S, A> result = first;
+    for (Fold<S, A> fold : rest) {
+      result = result.plus(fold);
+    }
+    return result;
+  }
+
+  /**
    * Creates a {@code Fold} from a function that extracts a list of focused parts.
    *
    * <p>Example:

--- a/hkj-benchmarks/build.gradle.kts
+++ b/hkj-benchmarks/build.gradle.kts
@@ -100,7 +100,7 @@ tasks {
     description = "Run benchmarks with large chain/recursion depths for stress testing"
     workingDir = rootProject.projectDir
     commandLine(
-      "./gradlew",
+      if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew",
       ":hkj-benchmarks:jmh",
       "-PbenchmarkMode=long"
     )

--- a/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/FoldPlusBenchmark.java
+++ b/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/FoldPlusBenchmark.java
@@ -1,0 +1,169 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.optics.Fold;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * JMH benchmarks for Fold.plus(), Fold.empty(), and Fold.sum() combination operations.
+ *
+ * <p>These benchmarks measure:
+ *
+ * <ul>
+ *   <li>Throughput of getAll on a single fold vs combined folds
+ *   <li>Overhead of plus(2), plus(5), and sum(5) combinations
+ *   <li>Comparison with manual Stream.concat alternative
+ *   <li>Scaling with different collection sizes
+ * </ul>
+ *
+ * <p>Expected results:
+ *
+ * <ul>
+ *   <li>Single fold should be the baseline (fastest)
+ *   <li>plus(2) should have roughly 2x the cost of a single fold
+ *   <li>plus(5) and sum(5) should be comparable to each other
+ *   <li>Manual Stream.concat should be slightly faster due to fewer abstraction layers
+ * </ul>
+ *
+ * <p>Run with: {@code ./gradlew :hkj-benchmarks:jmh -Pincludes=".*FoldPlusBenchmark.*"}
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class FoldPlusBenchmark {
+
+  record Item(String name, int price) {}
+
+  record Container(
+      List<Item> itemsA,
+      List<Item> itemsB,
+      List<Item> itemsC,
+      List<Item> itemsD,
+      List<Item> itemsE) {}
+
+  @Param({"10", "100", "1000"})
+  private int collectionSize;
+
+  private Container container;
+  private Fold<Container, Item> foldA;
+  private Fold<Container, Item> foldB;
+  private Fold<Container, Item> foldC;
+  private Fold<Container, Item> foldD;
+  private Fold<Container, Item> foldE;
+  private Fold<Container, Item> plusTwo;
+  private Fold<Container, Item> plusFive;
+  private Fold<Container, Item> sumFive;
+
+  private static final Monoid<Integer> SUM_MONOID =
+      new Monoid<>() {
+        @Override
+        public Integer empty() {
+          return 0;
+        }
+
+        @Override
+        public Integer combine(Integer a, Integer b) {
+          return a + b;
+        }
+      };
+
+  @Setup
+  public void setup() {
+    List<Item> items = new ArrayList<>(collectionSize);
+    for (int i = 0; i < collectionSize; i++) {
+      items.add(new Item("item" + i, i * 10));
+    }
+
+    container =
+        new Container(
+            List.copyOf(items),
+            List.copyOf(items),
+            List.copyOf(items),
+            List.copyOf(items),
+            List.copyOf(items));
+
+    foldA = Fold.of(Container::itemsA);
+    foldB = Fold.of(Container::itemsB);
+    foldC = Fold.of(Container::itemsC);
+    foldD = Fold.of(Container::itemsD);
+    foldE = Fold.of(Container::itemsE);
+
+    plusTwo = foldA.plus(foldB);
+    plusFive = foldA.plus(foldB).plus(foldC).plus(foldD).plus(foldE);
+    sumFive = Fold.sum(foldA, foldB, foldC, foldD, foldE);
+  }
+
+  /** Baseline: single fold getAll. */
+  @Benchmark
+  public List<Item> singleFoldGetAll() {
+    return foldA.getAll(container);
+  }
+
+  /** Two folds combined with plus, getAll. */
+  @Benchmark
+  public List<Item> plusTwoGetAll() {
+    return plusTwo.getAll(container);
+  }
+
+  /** Five folds combined with chained plus, getAll. */
+  @Benchmark
+  public List<Item> plusFiveGetAll() {
+    return plusFive.getAll(container);
+  }
+
+  /** Five folds combined with Fold.sum(), getAll. */
+  @Benchmark
+  public List<Item> sumFiveGetAll() {
+    return sumFive.getAll(container);
+  }
+
+  /** Manual alternative: Stream.concat for two lists. */
+  @Benchmark
+  public List<Item> manualConcatTwo() {
+    return Stream.concat(container.itemsA().stream(), container.itemsB().stream()).toList();
+  }
+
+  /** Manual alternative: Stream.of + flatMap for five lists. */
+  @Benchmark
+  public List<Item> manualConcatFive() {
+    return Stream.of(
+            container.itemsA(),
+            container.itemsB(),
+            container.itemsC(),
+            container.itemsD(),
+            container.itemsE())
+        .flatMap(List::stream)
+        .toList();
+  }
+
+  /** Baseline: single fold foldMap with sum monoid. */
+  @Benchmark
+  public int singleFoldFoldMap() {
+    return foldA.foldMap(SUM_MONOID, Item::price, container);
+  }
+
+  /** Two folds combined, foldMap with sum monoid. */
+  @Benchmark
+  public int plusTwoFoldMap() {
+    return plusTwo.foldMap(SUM_MONOID, Item::price, container);
+  }
+
+  /** Five folds combined, foldMap with sum monoid. */
+  @Benchmark
+  public int plusFiveFoldMap() {
+    return plusFive.foldMap(SUM_MONOID, Item::price, container);
+  }
+}

--- a/hkj-benchmarks/src/test/java/org/higherkindedj/benchmarks/BenchmarkAssertionsTest.java
+++ b/hkj-benchmarks/src/test/java/org/higherkindedj/benchmarks/BenchmarkAssertionsTest.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.benchmarks;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -35,7 +34,8 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Then run these tests: {@code ./gradlew :hkj-benchmarks:test}
  *
- * <p>These tests use assumptions, so they skip gracefully if benchmark results don't exist.
+ * <p>These tests <strong>fail</strong> if benchmark results are not available. Run benchmarks
+ * before running these tests. This is intentional — silent skips hide missing quality gates.
  */
 @DisplayName("Benchmark Assertions")
 class BenchmarkAssertionsTest {
@@ -73,13 +73,48 @@ class BenchmarkAssertionsTest {
 
   private static Optional<BenchmarkResult> get(String benchmarkClass, String method) {
     String fullName = "org.higherkindedj.benchmarks." + benchmarkClass + "." + method;
-    return Optional.ofNullable(results.get(fullName));
+    // Try exact match first (non-parameterized benchmarks)
+    BenchmarkResult exact = results.get(fullName);
+    if (exact != null) {
+      return Optional.of(exact);
+    }
+    // Fall back to prefix match for benchmarks that have @Param annotations
+    // but the caller doesn't care about specific param values
+    return results.entrySet().stream()
+        .filter(e -> e.getKey().startsWith(fullName + ":"))
+        .map(Map.Entry::getValue)
+        .findFirst();
   }
 
-  private static void assumeResultsAvailable() {
-    assumeThat(resultsAvailable)
+  /**
+   * Lookup a parameterized benchmark result. JMH encodes params as {@code
+   * ClassName.method:param=value} or with multiple params separated by commas.
+   */
+  private static Optional<BenchmarkResult> getParam(
+      String benchmarkClass, String method, String params) {
+    String base = "org.higherkindedj.benchmarks." + benchmarkClass + "." + method;
+    // Try colon-separated (standard JMH format)
+    Optional<BenchmarkResult> result = Optional.ofNullable(results.get(base + ":" + params));
+    if (result.isEmpty()) {
+      // Try dot-separated fallback
+      result = Optional.ofNullable(results.get(base + "." + params));
+    }
+    return result;
+  }
+
+  private static boolean anyResultsFor(String benchmarkClass) {
+    String prefix = "org.higherkindedj.benchmarks." + benchmarkClass + ".";
+    return results.keySet().stream().anyMatch(k -> k.startsWith(prefix));
+  }
+
+  private static void assertResultsAvailable() {
+    assertThat(resultsAvailable)
         .as("Benchmark results available (run ./gradlew :hkj-benchmarks:jmh first)")
         .isTrue();
+  }
+
+  private static void assertBenchmarkPresent(String benchmarkClass) {
+    assertThat(anyResultsFor(benchmarkClass)).as(benchmarkClass + " results available").isTrue();
   }
 
   // ========================================================================
@@ -93,7 +128,7 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("All benchmarks should have positive throughput")
     void allBenchmarksShouldHavePositiveThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       results
           .values()
@@ -108,7 +143,7 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("All benchmarks should have reasonable error margins (<50% of score)")
     void allBenchmarksShouldHaveReasonableErrorMargins() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       results
           .values()
@@ -139,10 +174,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("VTask.succeed should have measurable throughput")
     void succeedShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var succeed = get("VTaskBenchmark", "constructSucceed");
-      assumeThat(succeed).isPresent();
+      assertThat(succeed).isPresent();
 
       // Sanity check: succeed should have positive throughput
       assertThat(succeed.get().score)
@@ -153,10 +188,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("VTask.of should have measurable throughput")
     void ofShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var of = get("VTaskBenchmark", "constructOf");
-      assumeThat(of).isPresent();
+      assertThat(of).isPresent();
 
       // Sanity check: of should have positive throughput
       assertThat(of.get().score).as("VTask.of should have positive throughput").isGreaterThan(0.0);
@@ -165,10 +200,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("Map construction should have measurable throughput")
     void mapConstructionShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var construction = get("VTaskBenchmark", "mapConstruction");
-      assumeThat(construction).isPresent();
+      assertThat(construction).isPresent();
 
       assertThat(construction.get().score)
           .as("Map construction should have positive throughput")
@@ -187,10 +222,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("Par.zip should have measurable throughput")
     void zipShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var zip = get("VTaskParBenchmark", "zipTwoTasks");
-      assumeThat(zip).isPresent();
+      assertThat(zip).isPresent();
 
       // Zip involves StructuredTaskScope overhead, sanity check for positive throughput
       assertThat(zip.get().score).as("Par.zip should have positive throughput").isGreaterThan(0.0);
@@ -199,10 +234,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("Par.map2 should have measurable throughput")
     void map2ShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var map2 = get("VTaskParBenchmark", "map2Tasks");
-      assumeThat(map2).isPresent();
+      assertThat(map2).isPresent();
 
       // Sanity check for positive throughput
       assertThat(map2.get().score)
@@ -222,10 +257,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("VTask construction should have measurable throughput")
     void vtaskConstructionShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var vtask = get("VTaskVsIOBenchmark", "vtask_construction");
-      assumeThat(vtask).isPresent();
+      assertThat(vtask).isPresent();
 
       assertThat(vtask.get().score)
           .as("VTask construction should have positive throughput")
@@ -235,10 +270,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("IO construction should have measurable throughput")
     void ioConstructionShouldHaveMeasurableThroughput() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var io = get("VTaskVsIOBenchmark", "io_construction");
-      assumeThat(io).isPresent();
+      assertThat(io).isPresent();
 
       assertThat(io.get().score)
           .as("IO construction should have positive throughput")
@@ -257,10 +292,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("Maybe operations should have measurable throughput")
     void maybeConstructionShouldBeFast() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var just = get("MaybeBenchmark", "constructJust");
-      assumeThat(just).isPresent();
+      assertThat(just).isPresent();
 
       // Sanity check: construction should have positive throughput
       assertThat(just.get().score)
@@ -271,10 +306,10 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("Either operations should have measurable throughput")
     void eitherConstructionShouldBeFast() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var right = get("EitherBenchmark", "constructRight");
-      assumeThat(right).isPresent();
+      assertThat(right).isPresent();
 
       // Sanity check: construction should have positive throughput
       assertThat(right.get().score)
@@ -285,16 +320,795 @@ class BenchmarkAssertionsTest {
     @Test
     @DisplayName("Trampoline should handle deep recursion efficiently")
     void trampolineShouldHandleDeepRecursion() {
-      assumeResultsAvailable();
+      assertResultsAvailable();
 
       var factorial = get("TrampolineBenchmark", "factorialTrampoline");
-      assumeThat(factorial).isPresent();
+      assertThat(factorial).isPresent();
 
       // Deep recursion should complete without stack overflow - sanity check
       // Threshold lowered from 0.1 to accommodate slower environments
       assertThat(factorial.get().score)
           .as("Trampoline factorial should have positive throughput")
           .isGreaterThan(0.05);
+    }
+  }
+
+  // ========================================================================
+  // Fold Plus Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("Fold Plus Performance")
+  class FoldPlusPerformance {
+
+    @Test
+    @DisplayName("Single fold should have measurable throughput")
+    void singleFoldShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FoldPlusBenchmark");
+
+      var single = getParam("FoldPlusBenchmark", "singleFoldGetAll", "collectionSize=100");
+      assertThat(single).isPresent();
+
+      assertThat(single.get().score)
+          .as("Single fold getAll should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Fold.sum should perform comparably to chained plus")
+    void sumShouldPerformComparablyToChainedPlus() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FoldPlusBenchmark");
+
+      var plusFive = getParam("FoldPlusBenchmark", "plusFiveGetAll", "collectionSize=100");
+      var sumFive = getParam("FoldPlusBenchmark", "sumFiveGetAll", "collectionSize=100");
+      assertThat(plusFive).isPresent();
+      assertThat(sumFive).isPresent();
+
+      double ratio = sumFive.get().score / plusFive.get().score;
+      assertThat(ratio)
+          .as("Fold.sum(5) vs chained plus(5) ratio should be reasonable (was %.2f)", ratio)
+          .isBetween(0.3, 3.0);
+    }
+
+    @Test
+    @DisplayName("Plus overhead should be bounded relative to manual concat")
+    void plusOverheadShouldBeBounded() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FoldPlusBenchmark");
+
+      var plusTwo = getParam("FoldPlusBenchmark", "plusTwoGetAll", "collectionSize=100");
+      var manualTwo = getParam("FoldPlusBenchmark", "manualConcatTwo", "collectionSize=100");
+      assertThat(plusTwo).isPresent();
+      assertThat(manualTwo).isPresent();
+
+      double ratio = manualTwo.get().score / plusTwo.get().score;
+      assertThat(ratio)
+          .as("Manual concat vs plus(2) ratio should be <10x overhead (was %.2f)", ratio)
+          .isLessThan(10.0);
+    }
+
+    @Test
+    @DisplayName("foldMap should have measurable throughput on combined folds")
+    void foldMapShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FoldPlusBenchmark");
+
+      var foldMap = getParam("FoldPlusBenchmark", "plusFiveFoldMap", "collectionSize=100");
+      assertThat(foldMap).isPresent();
+
+      assertThat(foldMap.get().score)
+          .as("plusFive foldMap should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // Abstraction Overhead
+  // ========================================================================
+
+  @Nested
+  @DisplayName("Abstraction Overhead")
+  class AbstractionOverhead {
+
+    @Test
+    @DisplayName("Raw Java should be faster than IO/VTask wrappers")
+    void rawJavaShouldBeFasterThanWrappers() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("AbstractionOverheadBenchmark");
+
+      var rawJava = get("AbstractionOverheadBenchmark", "rawJava_simple");
+      var io = get("AbstractionOverheadBenchmark", "io_simple");
+      var vtask = get("AbstractionOverheadBenchmark", "vtask_simple");
+      assertThat(rawJava).isPresent();
+      assertThat(io).isPresent();
+      assertThat(vtask).isPresent();
+
+      assertThat(rawJava.get().score)
+          .as("Raw Java should have higher throughput than IO")
+          .isGreaterThan(io.get().score);
+      assertThat(rawJava.get().score)
+          .as("Raw Java should have higher throughput than VTask")
+          .isGreaterThan(vtask.get().score);
+    }
+
+    @Test
+    @DisplayName("Chain operations should have measurable throughput")
+    void chainOperationsShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("AbstractionOverheadBenchmark");
+
+      var rawChain = get("AbstractionOverheadBenchmark", "rawJava_chain");
+      var ioChain = get("AbstractionOverheadBenchmark", "io_chain");
+      var vtaskChain = get("AbstractionOverheadBenchmark", "vtask_chain");
+      assertThat(rawChain).isPresent();
+      assertThat(ioChain).isPresent();
+      assertThat(vtaskChain).isPresent();
+
+      assertThat(rawChain.get().score)
+          .as("Raw Java chain should have positive throughput")
+          .isGreaterThan(0.0);
+      assertThat(ioChain.get().score)
+          .as("IO chain should have positive throughput")
+          .isGreaterThan(0.0);
+      assertThat(vtaskChain.get().score)
+          .as("VTask chain should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("VTaskPath overhead should be bounded relative to VTask")
+    void vtaskPathOverheadShouldBeBounded() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("AbstractionOverheadBenchmark");
+
+      var vtask = get("AbstractionOverheadBenchmark", "vtask_simple");
+      var vtaskPath = get("AbstractionOverheadBenchmark", "vtaskPath_simple");
+      assertThat(vtask).isPresent();
+      assertThat(vtaskPath).isPresent();
+
+      // VTaskPath wraps VTask; overhead should be bounded
+      double ratio = vtask.get().score / vtaskPath.get().score;
+      assertThat(ratio)
+          .as("VTaskPath overhead vs VTask should be <50x (was %.2f)", ratio)
+          .isLessThan(50.0);
+    }
+  }
+
+  // ========================================================================
+  // Concurrency Scaling
+  // ========================================================================
+
+  @Nested
+  @DisplayName("Concurrency Scaling")
+  class ConcurrencyScaling {
+
+    @Test
+    @DisplayName("VTask single thread should have measurable throughput")
+    void vtaskSingleThreadShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ConcurrencyScalingBenchmark");
+
+      var single = get("ConcurrencyScalingBenchmark", "vtask_singleThread");
+      assertThat(single).isPresent();
+
+      assertThat(single.get().score)
+          .as("VTask single thread should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("IO single thread should have measurable throughput")
+    void ioSingleThreadShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ConcurrencyScalingBenchmark");
+
+      var single = get("ConcurrencyScalingBenchmark", "io_singleThread");
+      assertThat(single).isPresent();
+
+      assertThat(single.get().score)
+          .as("IO single thread should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Multi-threaded benchmarks should have positive throughput")
+    void multiThreadedShouldHavePositiveThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ConcurrencyScalingBenchmark");
+
+      var vtaskMax = get("ConcurrencyScalingBenchmark", "vtask_maxThreads");
+      var ioMax = get("ConcurrencyScalingBenchmark", "io_maxThreads");
+      assertThat(vtaskMax).isPresent();
+      assertThat(ioMax).isPresent();
+
+      assertThat(vtaskMax.get().score)
+          .as("VTask max threads should have positive throughput")
+          .isGreaterThan(0.0);
+      assertThat(ioMax.get().score)
+          .as("IO max threads should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // IO Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("IO Performance")
+  class IOPerformance {
+
+    @Test
+    @DisplayName("IO construction should be faster than execution")
+    void constructionShouldBeFasterThanExecution() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("IOBenchmark");
+
+      var construct = getParam("IOBenchmark", "constructSimple", "chainDepth=50");
+      var run = getParam("IOBenchmark", "runSimple", "chainDepth=50");
+      assertThat(construct).isPresent();
+      assertThat(run).isPresent();
+
+      // With short JMH runs (1 iteration, 200ms), JIT warmup can invert this relationship.
+      // Allow construction to be at least 20% of execution throughput as a sanity check.
+      assertThat(construct.get().score)
+          .as("IO construction should be comparable to or faster than execution")
+          .isGreaterThan(run.get().score * 0.2);
+    }
+
+    @Test
+    @DisplayName("IO deep recursion should complete (stack safe)")
+    void deepRecursionShouldComplete() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("IOBenchmark");
+
+      var deep = getParam("IOBenchmark", "deepRecursion", "chainDepth=50");
+      assertThat(deep).isPresent();
+
+      assertThat(deep.get().score)
+          .as("IO deep recursion should have positive throughput (stack safe)")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("IO map construction should be lazy (faster than execution)")
+    void mapConstructionShouldBeLazy() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("IOBenchmark");
+
+      var construct = getParam("IOBenchmark", "mapConstruction", "chainDepth=50");
+      var execute = getParam("IOBenchmark", "mapExecution", "chainDepth=50");
+      assertThat(construct).isPresent();
+      assertThat(execute).isPresent();
+
+      // With short JMH runs (1 iteration, 200ms), JIT warmup can invert this relationship.
+      // Allow construction to be at least 20% of execution throughput as a sanity check.
+      assertThat(construct.get().score)
+          .as("IO map construction should be comparable to or faster than execution (lazy)")
+          .isGreaterThan(execute.get().score * 0.2);
+    }
+  }
+
+  // ========================================================================
+  // IOPath Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("IOPath Performance")
+  class IOPathPerformance {
+
+    @Test
+    @DisplayName("IOPath construction should have measurable throughput")
+    void constructionShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("IOPathBenchmark");
+
+      var pure = getParam("IOPathBenchmark", "constructPure", "chainDepth=50");
+      assertThat(pure).isPresent();
+
+      assertThat(pure.get().score)
+          .as("IOPath pure construction should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("IOPath construction should be faster than execution")
+    void constructionShouldBeFasterThanExecution() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("IOPathBenchmark");
+
+      var construct = getParam("IOPathBenchmark", "mapConstruction", "chainDepth=50");
+      var execute = getParam("IOPathBenchmark", "mapExecution", "chainDepth=50");
+      assertThat(construct).isPresent();
+      assertThat(execute).isPresent();
+
+      // With short JMH runs (1 iteration, 200ms), JIT warmup can invert this relationship.
+      // Allow construction to be at least 20% of execution throughput as a sanity check.
+      assertThat(construct.get().score)
+          .as("IOPath map construction should be comparable to or faster than execution")
+          .isGreaterThan(execute.get().score * 0.2);
+    }
+
+    @Test
+    @DisplayName("IOPath error handling should have measurable throughput")
+    void errorHandlingShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("IOPathBenchmark");
+
+      var handleError = getParam("IOPathBenchmark", "handleErrorNoError", "chainDepth=50");
+      assertThat(handleError).isPresent();
+
+      assertThat(handleError.get().score)
+          .as("IOPath handleError should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // VTaskPath Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("VTaskPath Performance")
+  class VTaskPathPerformance {
+
+    @Test
+    @DisplayName("VTaskPath construction should have measurable throughput")
+    void constructionShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskPathBenchmark");
+
+      var pure = getParam("VTaskPathBenchmark", "constructPure", "chainDepth=50");
+      assertThat(pure).isPresent();
+
+      assertThat(pure.get().score)
+          .as("VTaskPath pure construction should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("VTaskPath construction should be faster than execution")
+    void constructionShouldBeFasterThanExecution() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskPathBenchmark");
+
+      var construct = getParam("VTaskPathBenchmark", "mapConstruction", "chainDepth=50");
+      var execute = getParam("VTaskPathBenchmark", "mapExecution", "chainDepth=50");
+      assertThat(construct).isPresent();
+      assertThat(execute).isPresent();
+
+      // With short JMH runs (1 iteration, 200ms), JIT warmup can invert this relationship.
+      // Allow construction to be at least 20% of execution throughput as a sanity check.
+      assertThat(construct.get().score)
+          .as("VTaskPath map construction should be comparable to or faster than execution")
+          .isGreaterThan(execute.get().score * 0.2);
+    }
+
+    @Test
+    @DisplayName("VTaskPath timeout construction should have measurable throughput")
+    void timeoutShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskPathBenchmark");
+
+      var timeout = getParam("VTaskPathBenchmark", "timeoutNoTrigger", "chainDepth=50");
+      assertThat(timeout).isPresent();
+
+      assertThat(timeout.get().score)
+          .as("VTaskPath timeout (not triggered) should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // VTaskPath vs IOPath Comparison
+  // ========================================================================
+
+  @Nested
+  @DisplayName("VTaskPath vs IOPath")
+  class VTaskPathVsIOPath {
+
+    @Test
+    @DisplayName("Both paths should have measurable simple execution throughput")
+    void bothPathsShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskPathVsIOPathBenchmark");
+
+      var ioPath =
+          getParam("VTaskPathVsIOPathBenchmark", "ioPath_simpleExecution", "chainDepth=50");
+      var vtaskPath =
+          getParam("VTaskPathVsIOPathBenchmark", "vtaskPath_simpleExecution", "chainDepth=50");
+      assertThat(ioPath).isPresent();
+      assertThat(vtaskPath).isPresent();
+
+      assertThat(ioPath.get().score)
+          .as("IOPath simple execution should have positive throughput")
+          .isGreaterThan(0.0);
+      assertThat(vtaskPath.get().score)
+          .as("VTaskPath simple execution should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Construction costs should be comparable between paths")
+    void constructionCostsShouldBeComparable() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskPathVsIOPathBenchmark");
+
+      var ioConstruct =
+          getParam("VTaskPathVsIOPathBenchmark", "ioPath_construction", "chainDepth=50");
+      var vtaskConstruct =
+          getParam("VTaskPathVsIOPathBenchmark", "vtaskPath_construction", "chainDepth=50");
+      assertThat(ioConstruct).isPresent();
+      assertThat(vtaskConstruct).isPresent();
+
+      // Construction costs should be within 20x of each other
+      double ratio = ioConstruct.get().score / vtaskConstruct.get().score;
+      assertThat(ratio)
+          .as("IOPath vs VTaskPath construction ratio should be bounded (was %.2f)", ratio)
+          .isBetween(0.05, 20.0);
+    }
+
+    @Test
+    @DisplayName("toIOPath conversion should have measurable throughput")
+    void toIOPathConversionShouldWork() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskPathVsIOPathBenchmark");
+
+      var conversion =
+          getParam(
+              "VTaskPathVsIOPathBenchmark", "vtaskPath_toIOPath_simpleExecution", "chainDepth=50");
+      assertThat(conversion).isPresent();
+
+      assertThat(conversion.get().score)
+          .as("VTaskPath toIOPath conversion should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // ForPath VTask Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("ForPath VTask Performance")
+  class ForPathVTaskPerformance {
+
+    @Test
+    @DisplayName("ForPath comprehension should have measurable throughput")
+    void forPathShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ForPathVTaskBenchmark");
+
+      var twoStep = getParam("ForPathVTaskBenchmark", "forPath_twoStep", "chainDepth=50");
+      assertThat(twoStep).isPresent();
+
+      assertThat(twoStep.get().score)
+          .as("ForPath two-step should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("ForPath overhead should be bounded vs direct chaining")
+    void forPathOverheadShouldBeBounded() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ForPathVTaskBenchmark");
+
+      var direct = getParam("ForPathVTaskBenchmark", "direct_threeStepChain", "chainDepth=50");
+      var forPath =
+          getParam("ForPathVTaskBenchmark", "forPath_threeStepEquivalent", "chainDepth=50");
+      assertThat(direct).isPresent();
+      assertThat(forPath).isPresent();
+
+      // ForPath overhead vs direct should be bounded
+      double ratio = direct.get().score / forPath.get().score;
+      assertThat(ratio)
+          .as("Direct vs ForPath ratio should be <20x (was %.2f)", ratio)
+          .isLessThan(20.0);
+    }
+
+    @Test
+    @DisplayName("ForPath parallel composition should have measurable throughput")
+    void parallelCompositionShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ForPathVTaskBenchmark");
+
+      var par2 = getParam("ForPathVTaskBenchmark", "forPath_par2", "chainDepth=50");
+      assertThat(par2).isPresent();
+
+      assertThat(par2.get().score)
+          .as("ForPath par(2) should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // Scope and Resource Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("Scope and Resource Performance")
+  class ScopePerformance {
+
+    @Test
+    @DisplayName("Scope.allSucceed should have measurable throughput")
+    void allSucceedShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ScopeBenchmark");
+
+      var allSucceed = getParam("ScopeBenchmark", "scope_allSucceed", "taskCount=10");
+      assertThat(allSucceed).isPresent();
+
+      assertThat(allSucceed.get().score)
+          .as("Scope.allSucceed should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Resource usage should have measurable throughput")
+    void resourceUsageShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ScopeBenchmark");
+
+      var resource = getParam("ScopeBenchmark", "resource_simple_use", "taskCount=10");
+      assertThat(resource).isPresent();
+
+      assertThat(resource.get().score)
+          .as("Resource simple use should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Par.all should have measurable throughput for comparison")
+    void parAllShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("ScopeBenchmark");
+
+      var parAll = getParam("ScopeBenchmark", "par_all_direct", "taskCount=10");
+      assertThat(parAll).isPresent();
+
+      assertThat(parAll.get().score)
+          .as("Par.all direct should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // Memory Footprint
+  // ========================================================================
+
+  @Nested
+  @DisplayName("Memory Footprint")
+  class MemoryFootprint {
+
+    @Test
+    @DisplayName("VTask bulk construction should have measurable throughput")
+    void vtaskBulkConstructionShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("MemoryFootprintBenchmark");
+
+      var vtask = getParam("MemoryFootprintBenchmark", "vtask_constructMany", "count=1000");
+      assertThat(vtask).isPresent();
+
+      assertThat(vtask.get().score)
+          .as("VTask bulk construction should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("IO bulk construction should have measurable throughput")
+    void ioBulkConstructionShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("MemoryFootprintBenchmark");
+
+      var io = getParam("MemoryFootprintBenchmark", "io_constructMany", "count=1000");
+      assertThat(io).isPresent();
+
+      assertThat(io.get().score)
+          .as("IO bulk construction should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("CompletableFuture baseline should have measurable throughput")
+    void completableFutureBaselineShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("MemoryFootprintBenchmark");
+
+      var cf =
+          getParam("MemoryFootprintBenchmark", "completableFuture_constructMany", "count=1000");
+      assertThat(cf).isPresent();
+
+      assertThat(cf.get().score)
+          .as("CompletableFuture bulk construction should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // VStream Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("VStream Performance")
+  class VStreamPerformance {
+
+    @Test
+    @DisplayName("VStream map should have measurable throughput")
+    void mapShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VStreamBenchmark");
+
+      var map = getParam("VStreamBenchmark", "mapExecution", "chainDepth=50,streamSize=50");
+      if (map.isEmpty()) {
+        map = getParam("VStreamBenchmark", "mapExecution", "streamSize=50,chainDepth=50");
+      }
+      assertThat(map).isPresent();
+
+      assertThat(map.get().score)
+          .as("VStream map execution should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("VStream construction should be lazy (faster than execution)")
+    void constructionShouldBeLazy() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VStreamBenchmark");
+
+      var construct =
+          getParam("VStreamBenchmark", "mapConstruction", "chainDepth=50,streamSize=50");
+      if (construct.isEmpty()) {
+        construct = getParam("VStreamBenchmark", "mapConstruction", "streamSize=50,chainDepth=50");
+      }
+      var execute = getParam("VStreamBenchmark", "mapExecution", "chainDepth=50,streamSize=50");
+      if (execute.isEmpty()) {
+        execute = getParam("VStreamBenchmark", "mapExecution", "streamSize=50,chainDepth=50");
+      }
+      assertThat(construct).isPresent();
+      assertThat(execute).isPresent();
+
+      // With short JMH runs (1 iteration, 200ms), JIT warmup can invert this relationship.
+      // Allow construction to be at least 20% of execution throughput as a sanity check.
+      assertThat(construct.get().score)
+          .as("VStream map construction should be comparable to or faster than execution (lazy)")
+          .isGreaterThan(execute.get().score * 0.2);
+    }
+
+    @Test
+    @DisplayName("Java Stream baseline should have measurable throughput")
+    void javaStreamBaselineShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VStreamBenchmark");
+
+      var baseline =
+          getParam("VStreamBenchmark", "baselineJavaStreamMap", "chainDepth=50,streamSize=50");
+      if (baseline.isEmpty()) {
+        baseline =
+            getParam("VStreamBenchmark", "baselineJavaStreamMap", "streamSize=50,chainDepth=50");
+      }
+      assertThat(baseline).isPresent();
+
+      assertThat(baseline.get().score)
+          .as("Java Stream baseline should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // VTask vs Platform Threads
+  // ========================================================================
+
+  @Nested
+  @DisplayName("VTask vs Platform Threads")
+  class VTaskVsPlatformThreads {
+
+    @Test
+    @DisplayName("VTask parallel execution should have measurable throughput")
+    void vtaskParallelShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskVsPlatformThreadsBenchmark");
+
+      var vtask = getParam("VTaskVsPlatformThreadsBenchmark", "vtask_parAll", "taskCount=100");
+      assertThat(vtask).isPresent();
+
+      assertThat(vtask.get().score)
+          .as("VTask Par.all should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Platform thread pool should have measurable throughput")
+    void platformThreadsShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskVsPlatformThreadsBenchmark");
+
+      var platform =
+          getParam("VTaskVsPlatformThreadsBenchmark", "platform_invokeAll", "taskCount=100");
+      assertThat(platform).isPresent();
+
+      assertThat(platform.get().score)
+          .as("Platform thread pool should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Sequential baselines should have measurable throughput")
+    void sequentialBaselinesShouldHaveMeasurableThroughput() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("VTaskVsPlatformThreadsBenchmark");
+
+      var vtaskSeq =
+          getParam("VTaskVsPlatformThreadsBenchmark", "vtask_sequential", "taskCount=100");
+      var platformSeq =
+          getParam("VTaskVsPlatformThreadsBenchmark", "platform_sequential", "taskCount=100");
+      assertThat(vtaskSeq).isPresent();
+      assertThat(platformSeq).isPresent();
+
+      assertThat(vtaskSeq.get().score)
+          .as("VTask sequential should have positive throughput")
+          .isGreaterThan(0.0);
+      assertThat(platformSeq.get().score)
+          .as("Platform sequential should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  // ========================================================================
+  // Free Monad Performance
+  // ========================================================================
+
+  @Nested
+  @DisplayName("Free Monad Performance")
+  class FreeMonadPerformance {
+
+    @Test
+    @DisplayName("Free construction should be lazy (faster than execution)")
+    void constructionShouldBeLazy() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FreeBenchmark");
+
+      var construct = getParam("FreeBenchmark", "deepChainConstruction", "chainDepth=50");
+      var execute = getParam("FreeBenchmark", "deepChainExecution", "chainDepth=50");
+      assertThat(construct).isPresent();
+      assertThat(execute).isPresent();
+
+      // With short JMH runs (1 iteration, 200ms), JIT warmup can invert this relationship.
+      // Allow construction to be at least 20% of execution throughput as a sanity check.
+      assertThat(construct.get().score)
+          .as("Free deep chain construction should be comparable to or faster than execution")
+          .isGreaterThan(execute.get().score * 0.2);
+    }
+
+    @Test
+    @DisplayName("Free stack safety stress test should complete")
+    void stackSafetyStressTestShouldComplete() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FreeBenchmark");
+
+      var stress = getParam("FreeBenchmark", "stackSafetyStressTest", "chainDepth=50");
+      assertThat(stress).isPresent();
+
+      assertThat(stress.get().score)
+          .as("Free stack safety stress test should have positive throughput")
+          .isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("Direct composition baseline should be faster than Free interpretation")
+    void directShouldBeFasterThanFree() {
+      assertResultsAvailable();
+      assertBenchmarkPresent("FreeBenchmark");
+
+      var direct = getParam("FreeBenchmark", "directComposition", "chainDepth=50");
+      var free = getParam("FreeBenchmark", "deepChainExecution", "chainDepth=50");
+      assertThat(direct).isPresent();
+      assertThat(free).isPresent();
+
+      assertThat(direct.get().score)
+          .as("Direct composition should have higher throughput than Free interpretation")
+          .isGreaterThan(free.get().score);
     }
   }
 
@@ -318,6 +1132,17 @@ class BenchmarkAssertionsTest {
     @SuppressWarnings("unchecked")
     static BenchmarkResult fromMap(Map<String, Object> map) {
       String name = (String) map.get("benchmark");
+      // For parameterized benchmarks, JMH stores params in a separate "params" map.
+      // Append them to the name in the format JMH uses: "name:key=value,key2=value2"
+      Map<String, String> params = (Map<String, String>) map.get("params");
+      if (params != null && !params.isEmpty()) {
+        String paramStr =
+            params.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(","));
+        name = name + ":" + paramStr;
+      }
       Map<String, Object> primaryMetric = (Map<String, Object>) map.get("primaryMetric");
       double score = parseDouble(primaryMetric.get("score"));
       double scoreError = parseDouble(primaryMetric.get("scoreError"));

--- a/hkj-book/src/benchmarks.md
+++ b/hkj-book/src/benchmarks.md
@@ -197,6 +197,87 @@ VStream's pull-based model adds overhead per element compared to Java Stream's p
 
 ---
 
+## Benchmark Assertion Tests
+
+The benchmark suite includes automated assertion tests that validate performance characteristics after each benchmark run. These are not just "did it finish?" checks — they verify relative performance, overhead ratios, and sanity bounds.
+
+~~~admonish warning title="Tests Fail If Benchmarks Haven't Run"
+The assertion tests **fail** (not skip) if benchmark results are missing. This is intentional. Run `./gradlew :hkj-benchmarks:jmh` before running `./gradlew :hkj-benchmarks:test`. Silent skips hide missing quality gates.
+~~~
+
+### What the Tests Validate
+
+| Test Group | What It Checks |
+|------------|---------------|
+| **SanityChecks** | Every benchmark has positive throughput and bounded error margins |
+| **VTaskRelativePerformance** | VTask construction costs (succeed, of, map) are positive |
+| **ParCombinatorPerformance** | Par.zip and Par.map2 have positive throughput |
+| **VTaskVsIOOverhead** | Both VTask and IO construction perform within expected bounds |
+| **CoreTypePerformance** | Maybe, Either, and Trampoline operations have positive throughput |
+| **FoldPlusPerformance** | Fold combination overhead is bounded; `sum` vs `plus` parity |
+| **AbstractionOverhead** | Raw Java > IO > VTask ordering; VTaskPath wrapper overhead bounded |
+| **ConcurrencyScaling** | Single and multi-threaded VTask/IO performance is positive |
+| **IOPerformance** | IO construction vs execution ratios; deep recursion completes (stack safety) |
+| **IOPathPerformance** | IOPath construction, map pipelines, and error handling overhead |
+| **VTaskPathPerformance** | VTaskPath construction, map pipelines, and timeout overhead |
+| **VTaskPathVsIOPath** | Cross-type comparison: construction ratios and conversion costs |
+| **ForPathVTaskPerformance** | For-comprehension overhead vs direct chaining; parallel step overhead |
+| **ScopePerformance** | Scope.allSucceed, Resource bracket, and Par.all throughput |
+| **MemoryFootprint** | Bulk construction rates for VTask, IO, and CompletableFuture |
+| **VStreamPerformance** | VStream map execution, construction vs execution, Java Stream baseline |
+| **VTaskVsPlatformThreads** | VTask Par.all vs platform thread pool at scale |
+| **FreeMonadPerformance** | Free monad construction, stack safety, and interpretation overhead |
+
+### Running the Tests
+
+```bash
+# Step 1: Run benchmarks (generates results.json)
+./gradlew :hkj-benchmarks:jmh
+
+# Step 2: Run assertion tests against the results
+./gradlew :hkj-benchmarks:test
+
+# Or run both together via the benchmarkValidation task
+./gradlew benchmarkValidation
+```
+
+---
+
+## Release Quality Gate
+
+The `releaseReadiness` task is a single-command quality gate that runs every verification step, ordered from fastest to slowest so failures surface early:
+
+```bash
+./gradlew releaseReadiness
+```
+
+| Step | Task | What It Checks | Speed |
+|------|------|---------------|-------|
+| 1 | `spotlessCheck` | Code formatting (Google Java Format) | Seconds |
+| 2 | `build` | Compilation, all unit tests, JaCoCo coverage | Minutes |
+| 3 | `:hkj-benchmarks:jmh` | JMH benchmarks execute successfully | Minutes |
+| 4 | `:hkj-benchmarks:test` | Benchmark assertion tests pass | Seconds |
+| 5 | `:hkj-processor:pitest` (full) | Mutation testing with STRONGER mutators | Slowest |
+
+If any step fails, the build stops immediately. All five must pass before a release.
+
+~~~admonish info title="Pitest Full Profile"
+The release gate runs pitest with `-Ppitest.profile=full`, which uses STRONGER mutators and all available CPU cores. This is more thorough than the default conservative profile used during local development.
+~~~
+
+### Reports Generated
+
+After a successful run, reports are available at:
+
+| Tool | Location |
+|------|----------|
+| JaCoCo | `hkj-core/build/reports/jacoco/test/html/index.html` |
+| JMH (JSON) | `hkj-benchmarks/build/reports/jmh/results.json` |
+| JMH (human) | `hkj-benchmarks/build/reports/jmh/human.txt` |
+| Pitest | `hkj-processor/build/reports/pitest/index.html` |
+
+---
+
 ## When Overhead Matters (and When It Doesn't)
 
 The benchmarks consistently show that abstraction overhead is measured in **nanoseconds**. Real-world operations — database queries, HTTP calls, file reads — are measured in **milliseconds**. The overhead is three to four orders of magnitude smaller than any I/O operation.

--- a/hkj-book/src/optics/ch2_intro.md
+++ b/hkj-book/src/optics/ch2_intro.md
@@ -57,7 +57,7 @@ Both can read. Only Traversal can write. Choose based on intent.
 
 ~~~admonish info title="In This Chapter"
 - **Traversals** – Focus on zero-or-more elements within a structure. Apply the same modification to every item in a list, or extract all values matching a path.
-- **Folds** – Read-only traversal that aggregates results using a Monoid. Sum all prices, count matching elements, or check if any element satisfies a predicate.
+- **Folds** – Read-only traversal that aggregates results using a Monoid. Sum all prices, count matching elements, or check if any element satisfies a predicate. Combine multiple folds with `plus` to extract values from different paths in a single query.
 - **Getters** – A read-only Lens. When you need to extract a value but never modify it, a Getter documents that intent in the type.
 - **Setters** – A write-only optic. Modify values without reading them first, useful when the modification doesn't depend on the current value.
 - **Common Data Structures** – Ready-made traversals for Java's standard collections. Iterate over List elements, Map entries, Set members, and more.
@@ -70,7 +70,7 @@ Both can read. Only Traversal can write. Choose based on intent.
 ## Chapter Contents
 
 1. [Traversals](traversals.md) - Bulk operations on collection elements
-2. [Folds](folds.md) - Read-only queries with monoid-based aggregation
+2. [Folds](folds.md) - Read-only queries with monoid-based aggregation and multi-path combination
 3. [Getters](getters.md) - Read-only focus on single values
 4. [Setters](setters.md) - Write-only modification without reading
 5. [Common Data Structures](common_data_structure_traversals.md) - Patterns for List, Map, Set, and more

--- a/hkj-book/src/optics/composition_rules.md
+++ b/hkj-book/src/optics/composition_rules.md
@@ -256,6 +256,33 @@ public final class OrderOptics {
 
 ---
 
+## Parallel Composition with `Fold.plus()`
+
+The composition rules above describe **sequential** composition (`andThen`): navigating deeper into a structure. Higher-Kinded-J also supports **parallel** composition via `Fold.plus()`, which combines results from multiple paths at the same level.
+
+| Operation | Type | Purpose |
+|-----------|------|---------|
+| `andThen` | Sequential | Navigate deeper: `A -> B -> C` |
+| `plus` | Parallel | Combine results: `A -> B` and `A -> C` into `A -> (B + C)` |
+
+```java
+// Sequential: navigate deeper into the structure
+Fold<Customer, Item> items = ordersFold.andThen(itemsFold);
+
+// Parallel: combine results from different paths
+Fold<Person, String> allNames = firstNameFold.plus(lastNameFold);
+
+// Both together: compose then combine
+Fold<Team, String> allEmails = Fold.sum(
+    leadLens.asFold().andThen(emailLens.asFold()),
+    membersFold.andThen(emailLens.asFold())
+);
+```
+
+`plus` produces a `Fold` regardless of the input optic types, since the combined result is always read-only. Convert other optics via `asFold()` before combining.
+
+---
+
 ## Common Patterns
 
 ### Pattern 1: Optional Field Access

--- a/hkj-book/src/optics/cookbook.md
+++ b/hkj-book/src/optics/cookbook.md
@@ -477,6 +477,52 @@ List<String> nicknames = Traversals.getAll(optionalNickname, user);
 
 ---
 
+## Recipe 10b: Extracting Values from Multiple Paths
+
+### Problem
+
+You have values scattered across different fields or branches of a data structure and need to extract them all into a single collection.
+
+### Solution
+
+```java
+record Team(String name, Employee lead, List<Employee> members) {}
+record Employee(String name, String email) {}
+
+// Folds for different paths
+Fold<Team, String> leadEmail = teamLeadLens.asFold()
+    .andThen(employeeEmailLens.asFold());
+Fold<Team, String> memberEmails = Fold.<Team, Employee>of(Team::members)
+    .andThen(employeeEmailLens.asFold());
+
+// Combine with plus
+Fold<Team, String> allEmails = leadEmail.plus(memberEmails);
+
+// Or use sum for three or more paths
+Fold<Team, String> allNames = Fold.sum(
+    Fold.of(t -> List.of(t.name())),
+    teamLeadLens.asFold().andThen(employeeNameLens.asFold()),
+    Fold.<Team, Employee>of(Team::members).andThen(employeeNameLens.asFold())
+);
+
+// Usage
+Team team = new Team("Backend",
+    new Employee("Alice", "alice@co"),
+    List.of(new Employee("Bob", "bob@co")));
+
+List<String> emails = allEmails.getAll(team);
+// Result: ["alice@co", "bob@co"]
+
+List<String> names = allNames.getAll(team);
+// Result: ["Backend", "Alice", "Bob"]
+```
+
+### Why It Works
+
+`Fold.plus()` delegates `foldMap` to both constituent folds and combines results via the monoid. This means all fold operations (`getAll`, `exists`, `foldMap`, `length`, etc.) work correctly across the combined paths. The ordering is deterministic: results from the first fold appear before results from the second.
+
+---
+
 ## Focus DSL Recipes
 
 The following recipes demonstrate the Focus DSL for more ergonomic optic usage.

--- a/hkj-book/src/optics/folds.md
+++ b/hkj-book/src/optics/folds.md
@@ -10,12 +10,17 @@
 - Composing folds with other optics for deep, conditional queries
 - The difference between `getAll`, `preview`, `find`, `exists`, `all`, and `length`
 - Maybe-based extensions for functional optional handling (`previewMaybe`, `findMaybe`, `getAllMaybe`)
+- Combining multiple folds with `plus`, `empty`, and `sum` for multi-path extraction
 - When to use Fold vs Traversal vs direct field access vs Stream API
 - Building read-only data processing pipelines with clear intent
 ~~~
 
 ~~~admonish title="Example Code"
 [FoldUsageExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/FoldUsageExample.java)
+~~~
+
+~~~admonish title="Hands On Practice"
+[Tutorial18_FoldCombination.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial18_FoldCombination.java)
 ~~~
 
 In previous guides, we explored optics that allow both reading and writing: **`Lens`** for required fields, **`Prism`** for conditional variants, **`Iso`** for lossless conversions, and **`Traversal`** for bulk operations on collections.
@@ -724,6 +729,112 @@ Monoids give you:
 
 ---
 
+## Combining Folds
+
+### The Problem: Extracting Values from Multiple Paths
+
+Consider a data structure with values scattered across different fields or branches. Without fold combination, you would need to call `getAll` on each fold separately and concatenate the results manually:
+
+```java
+record Team(String name, Employee lead, List<Employee> members) {}
+record Employee(String name, String email) {}
+
+// Separate folds for different paths
+Fold<Team, String> leadEmail = teamLeadLens.asFold()
+    .andThen(employeeEmailLens.asFold());
+Fold<Team, String> memberEmails = Fold.<Team, Employee>of(Team::members)
+    .andThen(employeeEmailLens.asFold());
+
+// Manual combination - verbose and error-prone
+List<String> allEmails = new ArrayList<>();
+allEmails.addAll(leadEmail.getAll(team));
+allEmails.addAll(memberEmails.getAll(team));
+```
+
+### The Solution: `Fold.plus()`
+
+`Fold.plus()` combines two folds into one that returns results from both:
+
+```java
+// Clean, composable combination
+Fold<Team, String> allEmails = leadEmail.plus(memberEmails);
+
+// Use like any other fold
+List<String> emails = allEmails.getAll(team);
+boolean hasGmail = allEmails.exists(e -> e.endsWith("@gmail.com"), team);
+int emailCount = allEmails.length(team);
+```
+
+### The Monoid Structure
+
+Folds under `plus` form a monoid, meaning they satisfy three laws:
+
+| Law | Meaning |
+|-----|---------|
+| **Left identity** | `Fold.empty().plus(f)` behaves like `f` |
+| **Right identity** | `f.plus(Fold.empty())` behaves like `f` |
+| **Associativity** | `(a.plus(b)).plus(c)` behaves like `a.plus(b.plus(c))` |
+
+`Fold.empty()` is the identity element, a fold that focuses on nothing:
+
+```java
+Fold<Team, String> nothing = Fold.empty();
+nothing.getAll(team);    // Returns: []
+nothing.length(team);    // Returns: 0
+nothing.isEmpty(team);   // Returns: true
+```
+
+For combining three or more folds, use `Fold.sum()`:
+
+```java
+Fold<Team, String> allText = Fold.sum(
+    teamNameFold,
+    leadNameFold,
+    memberNamesFold
+);
+// Equivalent to: teamNameFold.plus(leadNameFold).plus(memberNamesFold)
+```
+
+### Combining Different Optic Types
+
+Any optic can participate in fold combination via its `asFold()` method:
+
+```java
+// Lens-derived fold (exactly one element)
+Fold<Config, String> hostFold = hostLens.asFold();
+
+// Prism-derived fold (zero or one element)
+Fold<Config, String> optionalPortFold = portPrism.asFold();
+
+// Affine-derived fold (zero or one element)
+Fold<Config, String> optionalDbFold = dbAffine.asFold();
+
+// Combine them all
+Fold<Config, String> allConfigStrings = Fold.sum(
+    hostFold, optionalPortFold, optionalDbFold
+);
+```
+
+### Ordering Guarantees
+
+Elements from the first fold always appear before elements from the second:
+
+```java
+Fold<Employee, String> nameFirst = nameLens.asFold().plus(emailLens.asFold());
+nameFirst.getAll(employee);
+// Returns: ["Alice", "alice@example.com"]
+
+Fold<Employee, String> emailFirst = emailLens.asFold().plus(nameLens.asFold());
+emailFirst.getAll(employee);
+// Returns: ["alice@example.com", "Alice"]
+```
+
+~~~admonish note title="Performance Note"
+Each constituent fold in a `plus` combination performs its own pass over the source. For most use cases this is negligible, but if you are combining many folds over very large collections, consider whether a single custom `foldMap` implementation would be more appropriate.
+~~~
+
+---
+
 ## When to Use Folds vs Other Approaches
 
 ### Use Fold When:
@@ -1234,6 +1345,12 @@ Electronics count: 4
 By adding `Fold` to your arsenal alongside `Lens`, `Prism`, `Iso`, and `Traversal`, you have complete coverage for both reading and writing immutable data structures in a type-safe, composable way.
 
 The key insight: **Folds make queries first-class citizens in your codebase**, just as valuable and well-designed as the commands that modify state.
+
+---
+
+~~~admonish info title="Hands-On Learning"
+Practice fold combination in [Tutorial 18: Fold Combination](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial18_FoldCombination.java) (8 exercises, ~10 minutes).
+~~~
 
 ---
 

--- a/hkj-core/src/test/java/org/higherkindedj/optics/FoldPlusPropertyTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/FoldPlusPropertyTest.java
@@ -1,0 +1,114 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+import net.jqwik.api.*;
+import org.higherkindedj.hkt.Monoid;
+
+/**
+ * Property-based tests for the monoid laws of {@link Fold#plus}, {@link Fold#empty}, and {@link
+ * Fold#sum}.
+ *
+ * <p>These tests verify that {@code Fold} instances combined via {@code plus} satisfy the monoid
+ * laws:
+ *
+ * <ul>
+ *   <li><b>Left identity:</b> {@code Fold.empty().plus(fold).getAll(s) == fold.getAll(s)}
+ *   <li><b>Right identity:</b> {@code fold.plus(Fold.empty()).getAll(s) == fold.getAll(s)}
+ *   <li><b>Associativity:</b> {@code (a.plus(b)).plus(c).getAll(s) == a.plus(b.plus(c)).getAll(s)}
+ * </ul>
+ *
+ * <p>Additionally tests length additivity and foldMap distributivity.
+ */
+class FoldPlusPropertyTest {
+
+  record Item(String name, int price) {}
+
+  record Order(List<Item> items) {}
+
+  private static final Monoid<Integer> SUM_MONOID =
+      new Monoid<>() {
+        @Override
+        public Integer empty() {
+          return 0;
+        }
+
+        @Override
+        public Integer combine(Integer a, Integer b) {
+          return a + b;
+        }
+      };
+
+  @Provide
+  Arbitrary<Order> orders() {
+    Arbitrary<Item> items =
+        Combinators.combine(
+                Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10),
+                Arbitraries.integers().between(1, 1000))
+            .as(Item::new);
+    return items.list().ofMinSize(0).ofMaxSize(10).map(Order::new);
+  }
+
+  @Provide
+  Arbitrary<Fold<Order, Item>> folds() {
+    return Arbitraries.of(
+        Fold.of(Order::items),
+        Fold.of(order -> order.items().isEmpty() ? List.of() : List.of(order.items().getFirst())),
+        Fold.<Order, Item>empty(),
+        Fold.of(order -> order.items().stream().filter(i -> i.price() > 500).toList()));
+  }
+
+  @Property
+  @Label("Left identity: Fold.empty().plus(fold).getAll(s) == fold.getAll(s)")
+  void leftIdentity(@ForAll("folds") Fold<Order, Item> fold, @ForAll("orders") Order order) {
+    Fold<Order, Item> combined = Fold.<Order, Item>empty().plus(fold);
+    assertThat(combined.getAll(order)).isEqualTo(fold.getAll(order));
+  }
+
+  @Property
+  @Label("Right identity: fold.plus(Fold.empty()).getAll(s) == fold.getAll(s)")
+  void rightIdentity(@ForAll("folds") Fold<Order, Item> fold, @ForAll("orders") Order order) {
+    Fold<Order, Item> combined = fold.plus(Fold.empty());
+    assertThat(combined.getAll(order)).isEqualTo(fold.getAll(order));
+  }
+
+  @Property
+  @Label("Associativity: (a.plus(b)).plus(c).getAll(s) == a.plus(b.plus(c)).getAll(s)")
+  void associativity(
+      @ForAll("folds") Fold<Order, Item> a,
+      @ForAll("folds") Fold<Order, Item> b,
+      @ForAll("folds") Fold<Order, Item> c,
+      @ForAll("orders") Order order) {
+    assertThat(a.plus(b).plus(c).getAll(order)).isEqualTo(a.plus(b.plus(c)).getAll(order));
+  }
+
+  @Property
+  @Label("Length additivity: combined.length(s) == fold1.length(s) + fold2.length(s)")
+  void lengthAdditivity(
+      @ForAll("folds") Fold<Order, Item> fold1,
+      @ForAll("folds") Fold<Order, Item> fold2,
+      @ForAll("orders") Order order) {
+    Fold<Order, Item> combined = fold1.plus(fold2);
+    assertThat(combined.length(order)).isEqualTo(fold1.length(order) + fold2.length(order));
+  }
+
+  @Property
+  @Label(
+      "foldMap distributivity: combined.foldMap(m, f, s) == m.combine(fold1.foldMap(...), fold2.foldMap(...))")
+  void foldMapDistributivity(
+      @ForAll("folds") Fold<Order, Item> fold1,
+      @ForAll("folds") Fold<Order, Item> fold2,
+      @ForAll("orders") Order order) {
+    Fold<Order, Item> combined = fold1.plus(fold2);
+    Function<Item, Integer> f = Item::price;
+
+    assertThat(combined.foldMap(SUM_MONOID, f, order))
+        .isEqualTo(
+            SUM_MONOID.combine(
+                fold1.foldMap(SUM_MONOID, f, order), fold2.foldMap(SUM_MONOID, f, order)));
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/FoldTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/FoldTest.java
@@ -728,4 +728,402 @@ class FoldTest {
       assertThat(result.get().items()).hasSize(2);
     }
   }
+
+  @Nested
+  @DisplayName("plus() - Combining Folds")
+  class PlusCombination {
+
+    @Test
+    @DisplayName("plus() should combine two folds over different fields")
+    void basicCombination() {
+      record Person(String firstName, String lastName) {}
+      Lens<Person, String> firstLens =
+          Lens.of(Person::firstName, (p, n) -> new Person(n, p.lastName()));
+      Lens<Person, String> lastLens =
+          Lens.of(Person::lastName, (p, n) -> new Person(p.firstName(), n));
+
+      Fold<Person, String> combined = firstLens.asFold().plus(lastLens.asFold());
+      Person person = new Person("Alice", "Smith");
+
+      assertThat(combined.getAll(person)).containsExactly("Alice", "Smith");
+    }
+
+    @Test
+    @DisplayName("fold.plus(Fold.empty()) should behave like fold (right identity)")
+    void rightIdentity() {
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+      Order order = new Order(List.of(new Item("Apple", 100), new Item("Banana", 50)));
+
+      Fold<Order, Item> combined = itemsFold.plus(Fold.empty());
+      assertThat(combined.getAll(order)).isEqualTo(itemsFold.getAll(order));
+    }
+
+    @Test
+    @DisplayName("Fold.empty().plus(fold) should behave like fold (left identity)")
+    void leftIdentity() {
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+      Order order = new Order(List.of(new Item("Apple", 100), new Item("Banana", 50)));
+
+      Fold<Order, Item> combined = Fold.<Order, Item>empty().plus(itemsFold);
+      assertThat(combined.getAll(order)).isEqualTo(itemsFold.getAll(order));
+    }
+
+    @Test
+    @DisplayName("plus() should be associative")
+    void associativity() {
+      record Triple(String a, String b, String c) {}
+      Fold<Triple, String> fa =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super String, ? extends M> f, Triple s) {
+              return f.apply(s.a());
+            }
+          };
+      Fold<Triple, String> fb =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super String, ? extends M> f, Triple s) {
+              return f.apply(s.b());
+            }
+          };
+      Fold<Triple, String> fc =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super String, ? extends M> f, Triple s) {
+              return f.apply(s.c());
+            }
+          };
+
+      Triple t = new Triple("x", "y", "z");
+      assertThat(fa.plus(fb).plus(fc).getAll(t)).isEqualTo(fa.plus(fb.plus(fc)).getAll(t));
+    }
+
+    @Test
+    @DisplayName("plus() should preserve ordering (first fold before second)")
+    void preservesOrdering() {
+      Fold<Order, Item> fold1 = Fold.of(order -> order.items().subList(0, 1));
+      Fold<Order, Item> fold2 = Fold.of(order -> order.items().subList(1, 2));
+
+      Order order = new Order(List.of(new Item("First", 1), new Item("Second", 2)));
+      Fold<Order, Item> combined = fold1.plus(fold2);
+
+      assertThat(combined.getAll(order)).extracting(Item::name).containsExactly("First", "Second");
+    }
+
+    @Test
+    @DisplayName("preview() on combined fold should return the first element from the first fold")
+    void previewOnCombined() {
+      record Person(String firstName, String lastName) {}
+      Lens<Person, String> firstLens =
+          Lens.of(Person::firstName, (p, n) -> new Person(n, p.lastName()));
+      Lens<Person, String> lastLens =
+          Lens.of(Person::lastName, (p, n) -> new Person(p.firstName(), n));
+
+      Fold<Person, String> combined = firstLens.asFold().plus(lastLens.asFold());
+      assertThat(combined.preview(new Person("Alice", "Smith"))).contains("Alice");
+    }
+
+    @Test
+    @DisplayName("foldMap() with sum monoid should work across combined folds")
+    void foldMapWithSumMonoid() {
+      Fold<Order, Item> fold1 = Fold.of(order -> List.of(order.items().get(0)));
+      Fold<Order, Item> fold2 = Fold.of(order -> List.of(order.items().get(1)));
+
+      Fold<Order, Item> combined = fold1.plus(fold2);
+      Order order = new Order(List.of(new Item("A", 100), new Item("B", 200)));
+
+      int total = combined.foldMap(SUM_MONOID, Item::price, order);
+      assertThat(total).isEqualTo(300);
+    }
+
+    @Test
+    @DisplayName("length() on combined fold should return sum of lengths")
+    void lengthOnCombined() {
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+      Order order = new Order(List.of(new Item("A", 1), new Item("B", 2)));
+
+      Fold<Order, Item> combined = itemsFold.plus(itemsFold);
+      assertThat(combined.length(order)).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("exists() on combined fold should check both folds")
+    void existsOnCombined() {
+      record Pair(int left, int right) {}
+      Fold<Pair, Integer> leftFold =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super Integer, ? extends M> f, Pair s) {
+              return f.apply(s.left());
+            }
+          };
+      Fold<Pair, Integer> rightFold =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super Integer, ? extends M> f, Pair s) {
+              return f.apply(s.right());
+            }
+          };
+
+      Fold<Pair, Integer> combined = leftFold.plus(rightFold);
+      Pair pair = new Pair(5, 15);
+
+      assertThat(combined.exists(x -> x > 10, pair)).isTrue();
+      assertThat(combined.exists(x -> x > 20, pair)).isFalse();
+    }
+
+    @Test
+    @DisplayName("all() on combined fold should check both folds")
+    void allOnCombined() {
+      record Pair(int left, int right) {}
+      Fold<Pair, Integer> leftFold =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super Integer, ? extends M> f, Pair s) {
+              return f.apply(s.left());
+            }
+          };
+      Fold<Pair, Integer> rightFold =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super Integer, ? extends M> f, Pair s) {
+              return f.apply(s.right());
+            }
+          };
+
+      Fold<Pair, Integer> combined = leftFold.plus(rightFold);
+      Pair pair = new Pair(5, 15);
+
+      assertThat(combined.all(x -> x > 0, pair)).isTrue();
+      assertThat(combined.all(x -> x > 10, pair)).isFalse();
+    }
+
+    @Test
+    @DisplayName("find() on combined fold should find from first fold before second")
+    void findOnCombined() {
+      record Pair(int left, int right) {}
+      Fold<Pair, Integer> leftFold =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super Integer, ? extends M> f, Pair s) {
+              return f.apply(s.left());
+            }
+          };
+      Fold<Pair, Integer> rightFold =
+          new Fold<>() {
+            @Override
+            public <M> M foldMap(Monoid<M> m, Function<? super Integer, ? extends M> f, Pair s) {
+              return f.apply(s.right());
+            }
+          };
+
+      Fold<Pair, Integer> combined = leftFold.plus(rightFold);
+      Pair pair = new Pair(5, 15);
+
+      assertThat(combined.find(x -> x > 0, pair)).contains(5);
+    }
+
+    @Test
+    @DisplayName("filtered() should work after combination")
+    void filteredOnCombined() {
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+      Fold<Order, Item> doubled = itemsFold.plus(itemsFold);
+
+      Order order = new Order(List.of(new Item("Apple", 50), new Item("Laptop", 1000)));
+
+      Fold<Order, Item> expensive = doubled.filtered(item -> item.price() > 100);
+      assertThat(expensive.getAll(order)).hasSize(2).allMatch(item -> item.name().equals("Laptop"));
+    }
+
+    @Test
+    @DisplayName("isEmpty() on combined fold should be true only when both are empty")
+    void isEmptyOnCombined() {
+      Fold<Order, Item> emptyFold = Fold.empty();
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+      Order order = new Order(List.of(new Item("A", 1)));
+
+      assertThat(emptyFold.plus(emptyFold).isEmpty(order)).isTrue();
+      assertThat(emptyFold.plus(itemsFold).isEmpty(order)).isFalse();
+      assertThat(itemsFold.plus(emptyFold).isEmpty(order)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Combining Lens.asFold() with Fold should work")
+    void lensAsFoldPlusFold() {
+      record Container(String label, List<String> tags) {}
+      Lens<Container, String> labelLens =
+          Lens.of(Container::label, (c, l) -> new Container(l, c.tags()));
+      Fold<Container, String> tagsFold = Fold.of(Container::tags);
+
+      Fold<Container, String> combined = labelLens.asFold().plus(tagsFold);
+      Container c = new Container("box", List.of("fragile", "heavy"));
+
+      assertThat(combined.getAll(c)).containsExactly("box", "fragile", "heavy");
+    }
+
+    @Test
+    @DisplayName("Combining Prism.asFold() with Fold should work")
+    void prismAsFoldPlusFold() {
+      Prism<Json, String> stringPrism =
+          Prism.of(
+              j -> j instanceof JsonString s ? Optional.of(s.value()) : Optional.empty(),
+              JsonString::new);
+      Prism<Json, Integer> numberPrism =
+          Prism.of(
+              j -> j instanceof JsonNumber n ? Optional.of(n.value()) : Optional.empty(),
+              JsonNumber::new);
+
+      // Combine string values and number values mapped to string
+      Fold<Json, String> stringFold = stringPrism.asFold();
+      Fold<Json, String> numberAsStringFold =
+          numberPrism
+              .asFold()
+              .andThen(
+                  new Fold<>() {
+                    @Override
+                    public <M> M foldMap(
+                        Monoid<M> monoid, Function<? super String, ? extends M> f, Integer source) {
+                      return f.apply(source.toString());
+                    }
+                  });
+
+      Fold<Json, String> combined = stringFold.plus(numberAsStringFold);
+      assertThat(combined.getAll(new JsonString("hello"))).containsExactly("hello");
+      assertThat(combined.getAll(new JsonNumber(42))).containsExactly("42");
+    }
+
+    @Test
+    @DisplayName("Combining Affine.asFold() with Fold should work")
+    void affineAsFoldPlusFold() {
+      record Config(Optional<String> host, Optional<String> port) {}
+      Affine<Config, String> hostAffine =
+          Affine.of(c -> c.host(), (c, h) -> new Config(Optional.of(h), c.port()));
+      Affine<Config, String> portAffine =
+          Affine.of(c -> c.port(), (c, p) -> new Config(c.host(), Optional.of(p)));
+
+      Fold<Config, String> combined = hostAffine.asFold().plus(portAffine.asFold());
+
+      Config both = new Config(Optional.of("localhost"), Optional.of("8080"));
+      assertThat(combined.getAll(both)).containsExactly("localhost", "8080");
+
+      Config hostOnly = new Config(Optional.of("localhost"), Optional.empty());
+      assertThat(combined.getAll(hostOnly)).containsExactly("localhost");
+    }
+
+    @Test
+    @DisplayName("Multiple chained plus calls should work")
+    void multipleChainedPlus() {
+      record Quad(String a, String b, String c, String d) {}
+      Function<Function<Quad, String>, Fold<Quad, String>> single =
+          getter ->
+              new Fold<>() {
+                @Override
+                public <M> M foldMap(Monoid<M> m, Function<? super String, ? extends M> f, Quad s) {
+                  return f.apply(getter.apply(s));
+                }
+              };
+
+      Fold<Quad, String> all =
+          single
+              .apply(Quad::a)
+              .plus(single.apply(Quad::b))
+              .plus(single.apply(Quad::c))
+              .plus(single.apply(Quad::d));
+
+      Quad q = new Quad("w", "x", "y", "z");
+      assertThat(all.getAll(q)).containsExactly("w", "x", "y", "z");
+    }
+
+    @Test
+    @DisplayName("Fold.empty() getAll should return empty list")
+    void emptyFoldGetAll() {
+      Fold<Order, Item> emptyFold = Fold.empty();
+      Order order = new Order(List.of(new Item("A", 1)));
+
+      assertThat(emptyFold.getAll(order)).isEmpty();
+      assertThat(emptyFold.length(order)).isEqualTo(0);
+      assertThat(emptyFold.isEmpty(order)).isTrue();
+      assertThat(emptyFold.preview(order)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Fold.sum() should combine multiple folds like chained plus")
+    void sumVarargs() {
+      record Triple(String a, String b, String c) {}
+      Function<Function<Triple, String>, Fold<Triple, String>> single =
+          getter ->
+              new Fold<>() {
+                @Override
+                public <M> M foldMap(
+                    Monoid<M> m, Function<? super String, ? extends M> f, Triple s) {
+                  return f.apply(getter.apply(s));
+                }
+              };
+
+      Fold<Triple, String> fa = single.apply(Triple::a);
+      Fold<Triple, String> fb = single.apply(Triple::b);
+      Fold<Triple, String> fc = single.apply(Triple::c);
+
+      Fold<Triple, String> summed = Fold.sum(fa, fb, fc);
+      Fold<Triple, String> chained = fa.plus(fb).plus(fc);
+
+      Triple t = new Triple("x", "y", "z");
+      assertThat(summed.getAll(t)).isEqualTo(chained.getAll(t));
+    }
+
+    @Test
+    @DisplayName("plus() with andThen should compose first then combine")
+    void plusWithAndThen() {
+      Fold<Customer, Order> ordersFold = Fold.of(Customer::orders);
+      Fold<Order, Item> itemsFold = Fold.of(Order::items);
+
+      // Two different customers' orders via different paths
+      Fold<Customer, Item> customerItems = ordersFold.andThen(itemsFold);
+
+      // Combine the names fold from items with prices fold from items
+      Fold<Customer, String> namesFold =
+          customerItems.andThen(
+              new Fold<>() {
+                @Override
+                public <M> M foldMap(Monoid<M> m, Function<? super String, ? extends M> f, Item s) {
+                  return f.apply(s.name());
+                }
+              });
+      Fold<Customer, Integer> pricesFold =
+          customerItems.andThen(
+              new Fold<>() {
+                @Override
+                public <M> M foldMap(
+                    Monoid<M> m, Function<? super Integer, ? extends M> f, Item s) {
+                  return f.apply(s.price());
+                }
+              });
+
+      Customer customer = new Customer("John", List.of(new Order(List.of(new Item("Apple", 100)))));
+
+      assertThat(namesFold.getAll(customer)).containsExactly("Apple");
+      assertThat(pricesFold.foldMap(SUM_MONOID, p -> p, customer)).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("modifyF on combined fold should sequence effects from both folds")
+    void modifyFOnCombined() {
+      Fold<Order, Item> fold1 = Fold.of(order -> List.of(order.items().get(0)));
+      Fold<Order, Item> fold2 = Fold.of(order -> List.of(order.items().get(1)));
+      Fold<Order, Item> combined = fold1.plus(fold2);
+
+      Order order = new Order(List.of(new Item("Apple", 100), new Item("Banana", 200)));
+
+      // All items pass validation
+      Function<Item, Kind<OptionalKind.Witness, Item>> validate =
+          item -> OptionalKindHelper.OPTIONAL.widen(Optional.of(item));
+
+      Kind<OptionalKind.Witness, Order> result =
+          combined.modifyF(validate, order, OptionalMonad.INSTANCE);
+
+      Optional<Order> optResult = OptionalKindHelper.OPTIONAL.narrow(result);
+      assertThat(optResult).isPresent();
+      assertThat(optResult.get()).isEqualTo(order);
+    }
+  }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/CustomerAnalyticsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/CustomerAnalyticsExample.java
@@ -67,6 +67,7 @@ public class CustomerAnalyticsExample {
     demonstrateComplexFiltering(customers);
     demonstrateFilterByWithNestedQueries(customers);
     demonstrateAggregationWithFilters(customers);
+    demonstrateCombinedFoldExtraction(customers);
     demonstrateBulkUpdates(customers);
   }
 
@@ -111,7 +112,7 @@ public class CustomerAnalyticsExample {
 
     Traversal<List<Customer>, Customer> allCustomers = Traversals.forList();
 
-    // Mark high spenders (>$1000) as VIP
+    // Mark high spenders (>£1000) as VIP
     Traversal<List<Customer>, Customer> highSpenders =
         allCustomers.filtered(c -> c.totalSpending() > 1000);
 
@@ -122,13 +123,13 @@ public class CustomerAnalyticsExample {
       System.out.println(
           "  "
               + customer.name()
-              + ": $"
+              + ": £"
               + customer.totalSpending()
               + " (VIP="
               + customer.vip()
               + ")");
     }
-    // Alice: VIP=true (>$1000), Bob: VIP=false, Charlie: VIP=true (already was + >$1000)
+    // Alice: VIP=true (>£1000), Bob: VIP=false, Charlie: VIP=true (already was + >£1000)
     // Diana: VIP=false, Eve: VIP=false
     System.out.println();
   }
@@ -163,7 +164,7 @@ public class CustomerAnalyticsExample {
 
     Traversal<List<Customer>, Customer> allCustomers = Traversals.forList();
 
-    // Find customers who: have >$500 spending AND are not VIP AND have multiple purchases
+    // Find customers who: have >£500 spending AND are not VIP AND have multiple purchases
     Traversal<List<Customer>, Customer> targetCustomers =
         allCustomers
             .filtered(c -> c.totalSpending() > 500)
@@ -172,18 +173,18 @@ public class CustomerAnalyticsExample {
 
     List<Customer> targets = Traversals.getAll(targetCustomers, customers);
 
-    System.out.println("Non-VIP customers with >$500 spending and multiple purchases:");
+    System.out.println("Non-VIP customers with >£500 spending and multiple purchases:");
     for (Customer customer : targets) {
       System.out.println(
           "  "
               + customer.name()
-              + ": $"
+              + ": £"
               + customer.totalSpending()
               + " ("
               + customer.purchases().size()
               + " purchases)");
     }
-    // Alice: $1350 (2 purchases), Eve: $680 (3 purchases)
+    // Alice: £1350 (2 purchases), Eve: £680 (3 purchases)
     System.out.println();
   }
 
@@ -193,23 +194,23 @@ public class CustomerAnalyticsExample {
     Traversal<List<Customer>, Customer> allCustomers = Traversals.forList();
     Fold<Customer, Purchase> customerPurchases = Fold.of(Customer::purchases);
 
-    // Find customers with electronics purchases over $500
+    // Find customers with electronics purchases over £500
     Traversal<List<Customer>, Customer> bigElectronicsBuyers =
         allCustomers.filterBy(
             customerPurchases, p -> p.category().equals("Electronics") && p.amount() > 500);
 
     List<Customer> result = Traversals.getAll(bigElectronicsBuyers, customers);
 
-    System.out.println("Customers with electronics purchases over $500:");
+    System.out.println("Customers with electronics purchases over £500:");
     for (Customer customer : result) {
       List<String> expensiveElectronics =
           customer.purchases().stream()
               .filter(p -> p.category().equals("Electronics") && p.amount() > 500)
-              .map(p -> p.productName() + " ($" + p.amount() + ")")
+              .map(p -> p.productName() + " (£" + p.amount() + ")")
               .toList();
       System.out.println("  " + customer.name() + ": " + expensiveElectronics);
     }
-    // Alice (Laptop $1200), Charlie (Phone $900, Tablet $600)
+    // Alice (Laptop £1200), Charlie (Phone £900, Tablet £600)
     System.out.println();
   }
 
@@ -227,7 +228,7 @@ public class CustomerAnalyticsExample {
 
     System.out.println("VIP Customer Metrics:");
     System.out.println("  Total VIP customers: " + vipCount);
-    System.out.println("  Total VIP revenue: $" + vipRevenue);
+    System.out.println("  Total VIP revenue: £" + vipRevenue);
 
     // Calculate spending from customers with >3 purchases
     Fold<List<Customer>, Customer> frequentBuyers =
@@ -239,9 +240,9 @@ public class CustomerAnalyticsExample {
 
     System.out.println("\nFrequent Buyer Metrics (3+ purchases):");
     System.out.println("  Count: " + frequentBuyerCount);
-    System.out.println("  Total revenue: $" + frequentBuyerRevenue);
+    System.out.println("  Total revenue: £" + frequentBuyerRevenue);
     if (frequentBuyerCount > 0) {
-      System.out.println("  Average spending: $" + (frequentBuyerRevenue / frequentBuyerCount));
+      System.out.println("  Average spending: £" + (frequentBuyerRevenue / frequentBuyerCount));
     }
 
     // Nested fold: sum of all electronics purchases
@@ -256,7 +257,47 @@ public class CustomerAnalyticsExample {
     }
 
     System.out.println("\nElectronics Category Metrics:");
-    System.out.println("  Total electronics spending: $" + totalElectronicsSpending);
+    System.out.println("  Total electronics spending: £" + totalElectronicsSpending);
+    System.out.println();
+  }
+
+  private static void demonstrateCombinedFoldExtraction(List<Customer> customers) {
+    System.out.println("--- Combined Fold Extraction with Fold.plus() ---");
+
+    Fold<List<Customer>, Customer> allCustomersFold = Fold.of(c -> c);
+
+    // Extract customer names
+    Fold<List<Customer>, String> namesFold =
+        allCustomersFold.andThen(Fold.of(c -> List.of(c.name())));
+
+    // Extract all product names from all customers
+    Fold<List<Customer>, String> productNamesFold =
+        allCustomersFold
+            .andThen(Fold.of(Customer::purchases))
+            .andThen(Fold.of(p -> List.of(p.productName())));
+
+    // Combine both: get all customer names AND all product names in one pass
+    Fold<List<Customer>, String> allNamesFold = namesFold.plus(productNamesFold);
+
+    System.out.println("All names (customers + products): " + allNamesFold.getAll(customers));
+    System.out.println("Total name count: " + allNamesFold.length(customers));
+
+    // Use Fold.sum() for multiple metric extractions
+    Fold<List<Customer>, Double> spendingFold =
+        allCustomersFold.andThen(Fold.of(c -> List.of(c.totalSpending())));
+
+    Fold<List<Customer>, Double> purchaseAmountsFold =
+        allCustomersFold
+            .andThen(Fold.of(Customer::purchases))
+            .andThen(Fold.of(p -> List.of(p.amount())));
+
+    // Get all monetary values across the entire dataset
+    Fold<List<Customer>, Double> allMonetaryValues = Fold.sum(spendingFold, purchaseAmountsFold);
+
+    double totalMonetary = allMonetaryValues.foldMap(Monoids.doubleAddition(), d -> d, customers);
+    System.out.println(
+        "Total monetary values (spending + purchase amounts): £"
+            + String.format("%.2f", totalMonetary));
     System.out.println();
   }
 
@@ -268,7 +309,7 @@ public class CustomerAnalyticsExample {
         Lens.of(
             Customer::totalSpending, (c, s) -> new Customer(c.name(), c.purchases(), c.vip(), s));
 
-    // Apply 10% discount to high spenders (>$1000)
+    // Apply 10% discount to high spenders (>£1000)
     Traversal<List<Customer>, Double> highSpenderSpending =
         allCustomers.filtered(c -> c.totalSpending() > 1000).andThen(spendingLens.asTraversal());
 
@@ -283,13 +324,13 @@ public class CustomerAnalyticsExample {
         System.out.println(
             "  "
                 + after.name()
-                + ": $"
+                + ": £"
                 + before.totalSpending()
-                + " -> $"
+                + " -> £"
                 + after.totalSpending()
                 + " (DISCOUNTED)");
       } else {
-        System.out.println("  " + after.name() + ": $" + after.totalSpending() + " (unchanged)");
+        System.out.println("  " + after.name() + ": £" + after.totalSpending() + " (unchanged)");
       }
     }
 
@@ -308,13 +349,13 @@ public class CustomerAnalyticsExample {
         System.out.println(
             "  "
                 + after.name()
-                + ": $"
+                + ": £"
                 + before.totalSpending()
-                + " -> $"
+                + " -> £"
                 + after.totalSpending()
                 + " (BONUS APPLIED)");
       } else {
-        System.out.println("  " + after.name() + ": $" + after.totalSpending() + " (unchanged)");
+        System.out.println("  " + after.name() + ": £" + after.totalSpending() + " (unchanged)");
       }
     }
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/FoldPlusCombinationExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/FoldPlusCombinationExample.java
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+
+/**
+ * Demonstrates {@link Fold#plus}, {@link Fold#empty}, and {@link Fold#sum} for combining multiple
+ * folds into a single query that extracts results from all constituent paths.
+ *
+ * <p>This example showcases:
+ *
+ * <ul>
+ *   <li>Combining two folds that focus on different fields of the same structure
+ *   <li>Composing a lens-derived fold with another fold via {@code plus}
+ *   <li>Using {@code Fold.sum()} to combine multiple extraction paths at once
+ *   <li>Combining folds over different branches of a sealed interface hierarchy
+ *   <li>Monoid-based aggregation across combined folds
+ * </ul>
+ */
+public class FoldPlusCombinationExample {
+
+  // --- Domain Model ---
+
+  record Department(String name, List<Team> teams) {}
+
+  record Team(String name, Employee lead, List<Employee> members) {}
+
+  record Employee(String name, String email) {}
+
+  sealed interface ContactInfo permits PhoneContact, EmailContact {}
+
+  record PhoneContact(String number) implements ContactInfo {}
+
+  record EmailContact(String address) implements ContactInfo {}
+
+  // --- Lenses (manual for this standalone example) ---
+
+  static final Lens<Department, List<Team>> deptTeamsLens =
+      Lens.of(Department::teams, (d, t) -> new Department(d.name(), t));
+
+  static final Lens<Team, Employee> teamLeadLens =
+      Lens.of(Team::lead, (t, l) -> new Team(t.name(), l, t.members()));
+
+  static final Lens<Employee, String> employeeEmailLens =
+      Lens.of(Employee::email, (e, em) -> new Employee(e.name(), em));
+
+  static final Lens<Employee, String> employeeNameLens =
+      Lens.of(Employee::name, (e, n) -> new Employee(n, e.email()));
+
+  public static void main(String[] args) {
+    System.out.println("=== Fold.plus() Combination Example ===\n");
+
+    demonstratBasicPlus();
+    demonstrateLensPlusFold();
+    demonstrateSumMultiplePaths();
+    demonstrateSealedInterfaceBranches();
+    demonstrateMonoidAggregation();
+
+    System.out.println("=== END ===");
+  }
+
+  /** Combine two folds over different fields of the same record. */
+  private static void demonstratBasicPlus() {
+    System.out.println("--- Basic plus: Combining Two Field Folds ---");
+
+    Fold<Employee, String> nameFold = employeeNameLens.asFold();
+    Fold<Employee, String> emailFold = employeeEmailLens.asFold();
+
+    // Combine: get both name and email
+    Fold<Employee, String> allStrings = nameFold.plus(emailFold);
+
+    Employee emp = new Employee("Alice", "alice@example.com");
+    System.out.println("All strings: " + allStrings.getAll(emp));
+    System.out.println("Count: " + allStrings.length(emp));
+    System.out.println("First: " + allStrings.preview(emp).orElse("none"));
+    System.out.println();
+  }
+
+  /** Combine a lens-derived fold with a list fold. */
+  private static void demonstrateLensPlusFold() {
+    System.out.println("--- Lens.asFold() + Fold: Lead and Members ---");
+
+    Fold<Team, String> leadNameFold = teamLeadLens.asFold().andThen(employeeNameLens.asFold());
+
+    Fold<Team, String> memberNamesFold =
+        Fold.<Team, Employee>of(Team::members).andThen(employeeNameLens.asFold());
+
+    // Combine: get lead name AND all member names
+    Fold<Team, String> allTeamNames = leadNameFold.plus(memberNamesFold);
+
+    Team team =
+        new Team(
+            "Platform",
+            new Employee("Alice", "alice@co"),
+            List.of(new Employee("Bob", "bob@co"), new Employee("Carol", "carol@co")));
+
+    System.out.println("All team member names: " + allTeamNames.getAll(team));
+    System.out.println("Total people: " + allTeamNames.length(team));
+    System.out.println();
+  }
+
+  /** Use Fold.sum() to combine three or more folds at once. */
+  private static void demonstrateSumMultiplePaths() {
+    System.out.println("--- Fold.sum(): Multiple Extraction Paths ---");
+
+    Department dept =
+        new Department(
+            "Engineering",
+            List.of(
+                new Team(
+                    "Backend",
+                    new Employee("Alice", "alice@co"),
+                    List.of(new Employee("Bob", "bob@co"))),
+                new Team(
+                    "Frontend",
+                    new Employee("Carol", "carol@co"),
+                    List.of(new Employee("Dave", "dave@co")))));
+
+    // Build folds to extract emails from different paths
+    Fold<Department, Team> teamsFold = Fold.of(Department::teams);
+
+    Fold<Department, String> leadEmails =
+        teamsFold.andThen(teamLeadLens.asFold()).andThen(employeeEmailLens.asFold());
+
+    Fold<Department, String> memberEmails =
+        teamsFold
+            .andThen(Fold.<Team, Employee>of(Team::members))
+            .andThen(employeeEmailLens.asFold());
+
+    // Combine using sum
+    Fold<Department, String> allEmails = Fold.sum(leadEmails, memberEmails);
+
+    System.out.println("All emails: " + allEmails.getAll(dept));
+    System.out.println("Has any @co email: " + allEmails.exists(e -> e.endsWith("@co"), dept));
+    System.out.println();
+  }
+
+  /** Combine folds over different branches of a sealed interface. */
+  private static void demonstrateSealedInterfaceBranches() {
+    System.out.println("--- Sealed Interface Branches ---");
+
+    Prism<ContactInfo, PhoneContact> phonePrism =
+        Prism.of(c -> c instanceof PhoneContact p ? Optional.of(p) : Optional.empty(), c -> c);
+    Prism<ContactInfo, EmailContact> emailPrism =
+        Prism.of(c -> c instanceof EmailContact e ? Optional.of(e) : Optional.empty(), c -> c);
+
+    // Extract the "value" from either branch
+    Fold<ContactInfo, String> phoneFold =
+        phonePrism.asFold().andThen(Fold.of(p -> List.of(p.number())));
+    Fold<ContactInfo, String> emailFold =
+        emailPrism.asFold().andThen(Fold.of(e -> List.of(e.address())));
+
+    Fold<ContactInfo, String> anyContactValue = phoneFold.plus(emailFold);
+
+    ContactInfo phone = new PhoneContact("555-1234");
+    ContactInfo email = new EmailContact("test@example.com");
+
+    System.out.println("Phone contact value: " + anyContactValue.getAll(phone));
+    System.out.println("Email contact value: " + anyContactValue.getAll(email));
+    System.out.println();
+  }
+
+  /** Demonstrate monoid-based aggregation across combined folds. */
+  private static void demonstrateMonoidAggregation() {
+    System.out.println("--- Monoid Aggregation Across Combined Folds ---");
+
+    record Product(String name, double price, double shippingCost) {}
+
+    Lens<Product, Double> priceLens =
+        Lens.of(Product::price, (p, v) -> new Product(p.name(), v, p.shippingCost()));
+    Lens<Product, Double> shippingLens =
+        Lens.of(Product::shippingCost, (p, v) -> new Product(p.name(), p.price(), v));
+
+    // Combine price and shipping cost folds
+    Fold<Product, Double> totalCostFold = priceLens.asFold().plus(shippingLens.asFold());
+
+    Monoid<Double> sumMonoid = Monoids.doubleAddition();
+
+    Product product = new Product("Laptop", 999.99, 15.00);
+
+    double totalCost = totalCostFold.foldMap(sumMonoid, d -> d, product);
+    System.out.println("Product: " + product.name());
+    System.out.println("Total cost (price + shipping): " + totalCost);
+    System.out.println("All cost components: " + totalCostFold.getAll(product));
+    System.out.println();
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/cookbook/CompositionRecipes.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/cookbook/CompositionRecipes.java
@@ -5,6 +5,7 @@ package org.higherkindedj.example.optics.cookbook;
 import java.util.List;
 import java.util.Optional;
 import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Fold;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.Prism;
 import org.higherkindedj.optics.Traversal;
@@ -59,6 +60,7 @@ public class CompositionRecipes {
     recipePrismLensComposition();
     recipeOptionalFieldAccess();
     recipeComplexComposition();
+    recipeCombiningMultipleExtractionPaths();
   }
 
   /**
@@ -213,6 +215,60 @@ public class CompositionRecipes {
 
     // Verify failures are unchanged
     System.out.println("Updated batch results: " + updated.results());
+    System.out.println();
+  }
+
+  /**
+   * Recipe: Combining Multiple Extraction Paths with Fold.plus().
+   *
+   * <p>Pattern: Extract values from different branches of a data structure and combine them into a
+   * single result set.
+   */
+  private static void recipeCombiningMultipleExtractionPaths() {
+    System.out.println("--- Recipe: Combining Multiple Extraction Paths ---");
+
+    // Two different ways to get a string value from a Result
+    Prism<Result, Success> successPrism =
+        Prism.of(r -> r instanceof Success s ? Optional.of(s) : Optional.empty(), s -> s);
+
+    Prism<Result, Failure> failurePrism =
+        Prism.of(r -> r instanceof Failure f ? Optional.of(f) : Optional.empty(), f -> f);
+
+    // Extract success values
+    Fold<Result, String> successValues =
+        successPrism.asFold().andThen(Fold.of(s -> List.of(s.value())));
+
+    // Extract failure messages
+    Fold<Result, String> failureMessages =
+        failurePrism.asFold().andThen(Fold.of(f -> List.of(f.error())));
+
+    // Combine: get ALL text from a Result regardless of variant
+    Fold<Result, String> allText = successValues.plus(failureMessages);
+
+    Result success = new Success("ok", new Metadata("api", 1L));
+    Result failure = new Failure("not found");
+
+    System.out.println("Success text: " + allText.getAll(success));
+    System.out.println("Failure text: " + allText.getAll(failure));
+
+    // Use with a batch via Fold.sum()
+    Fold<Batch, String> batchSuccesses =
+        Fold.<Batch, Result>of(Batch::results).andThen(successValues);
+    Fold<Batch, String> batchFailures =
+        Fold.<Batch, Result>of(Batch::results).andThen(failureMessages);
+
+    Fold<Batch, String> batchAllText = Fold.sum(batchSuccesses, batchFailures);
+
+    Batch batch =
+        new Batch(
+            "B1",
+            List.of(
+                new Success("result1", new Metadata("api", 1L)),
+                new Failure("error1"),
+                new Success("result2", new Metadata("db", 2L))));
+
+    System.out.println("All batch text: " + batchAllText.getAll(batch));
+    System.out.println("Total text items: " + batchAllText.length(batch));
     System.out.println();
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/README.md
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/README.md
@@ -6,7 +6,7 @@ Welcome to the Higher-Kinded-J tutorial series! These hands-on tutorials will te
 
 This tutorial series consists of three tracks:
 1. **Core Types** (10 tutorials, ~80 minutes) - Learn about Functors, Applicatives, Monads, and more
-2. **Optics** (15 tutorials, ~150 minutes) - Learn about Lenses, Prisms, Traversals, Focus DSL, and advanced patterns
+2. **Optics** (16 tutorials, ~160 minutes) - Learn about Lenses, Prisms, Traversals, Focus DSL, and advanced patterns
 3. **MTL** (1 tutorial, ~35 minutes) - Learn about MonadReader, MonadState, MonadWriter, and polymorphic functions
 
 Each tutorial contains exercises where you need to replace `___` placeholders with working code. The tests will fail until you complete the exercises correctly.
@@ -197,6 +197,15 @@ Functional list decomposition:
 - head, last, tail, init accessors
 - Stack-safe trampoline operations
 - Composing with other optics
+
+### Tutorial 18: Fold Combination (~10 minutes)
+Combining multiple folds into one:
+- `Fold.plus()` for combining two folds
+- `Fold.empty()` as the identity element
+- `Fold.sum()` for combining multiple folds at once
+- Combining Lens, Prism, and Affine folds
+- Monoid-based aggregation across combined folds
+- Combining filtered folds for categorised results
 
 ## MTL Tutorial Series
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/SOLUTIONS_REFERENCE.md
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/SOLUTIONS_REFERENCE.md
@@ -939,3 +939,45 @@ List<String> auditLog = logger.getLog();
 ValidationOpticInterpreter validator = OpticInterpreters.validation();
 List<String> issues = validator.validate(program);
 ```
+
+### Tutorial 18: Fold Combination
+
+**Exercise 1:**
+```java
+Fold<Person, String> allNames = firstNameLens.asFold().plus(lastNameLens.asFold());
+```
+
+**Exercise 2:**
+```java
+Fold<Person, String> combined = nameFold.plus(Fold.empty());
+```
+
+**Exercise 3:**
+```java
+Fold<Team, String> allNames = leadNameFold.plus(memberNamesFold);
+```
+
+**Exercise 4:**
+```java
+Fold<Shape, String> shapeDesc = circleDesc.plus(rectDesc);
+```
+
+**Exercise 5:**
+```java
+Fold<Person, String> allInfo = Fold.sum(firstFold, lastFold, ageFold);
+```
+
+**Exercise 6:**
+```java
+Fold<Team, String> extractor = Fold.sum(teamNameFold, leadFirstNameFold, leadLastNameFold, memberFirstNamesFold);
+```
+
+**Exercise 7:**
+```java
+int totalAge = leadAgeFold.plus(memberAgesFold).foldMap(sumMonoid, age -> age, team);
+```
+
+**Exercise 8:**
+```java
+Fold<Team, String> categorisedNames = seniorNames.plus(juniorNames);
+```

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial18_FoldCombination.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial18_FoldCombination.java
@@ -1,0 +1,374 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 18: Fold Combination
+ *
+ * <p>Learn how to combine multiple Fold optics using {@code plus}, {@code empty}, and {@code sum}
+ * to build queries that extract results from several different paths through a data structure.
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>{@code Fold.plus(Fold)} combines two folds into one that returns results from both
+ *   <li>{@code Fold.empty()} is the identity element (returns no results)
+ *   <li>{@code Fold.sum(first, rest...)} combines multiple folds at once
+ *   <li>Combined folds preserve ordering: results from the first fold appear first
+ *   <li>Any optic can participate via {@code asFold()} (Lens, Prism, Affine)
+ * </ul>
+ *
+ * <p>Prerequisites: Complete Tutorials 1-6 (especially Lens, Prism, and composition basics).
+ *
+ * <p>Estimated time: ~10 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial 18: Fold Combination")
+public class Tutorial18_FoldCombination {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  // --- Domain models for exercises ---
+
+  record Person(String firstName, String lastName, int age) {}
+
+  record Team(String name, Person lead, List<Person> members) {}
+
+  sealed interface Shape permits Circle, Rectangle {}
+
+  record Circle(double radius) implements Shape {}
+
+  record Rectangle(double width, double height) implements Shape {}
+
+  record Config(Optional<String> host, Optional<String> port, String name) {}
+
+  // --- Lenses ---
+
+  static final Lens<Person, String> firstNameLens =
+      Lens.of(Person::firstName, (p, n) -> new Person(n, p.lastName(), p.age()));
+
+  static final Lens<Person, String> lastNameLens =
+      Lens.of(Person::lastName, (p, n) -> new Person(p.firstName(), n, p.age()));
+
+  static final Lens<Person, Integer> ageLens =
+      Lens.of(Person::age, (p, a) -> new Person(p.firstName(), p.lastName(), a));
+
+  static final Lens<Team, Person> teamLeadLens =
+      Lens.of(Team::lead, (t, l) -> new Team(t.name(), l, t.members()));
+
+  // ===========================================================================
+  // Part 1: Basic Fold Combination
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Basic Fold Combination")
+  class BasicCombination {
+
+    /**
+     * Exercise 1: Combine two Lens-derived folds with plus
+     *
+     * <p>Use {@code Lens.asFold()} to convert lenses to folds, then combine them with {@code
+     * plus()} to get both the first name and last name from a Person.
+     *
+     * <p>Task: Create a combined fold that extracts both names.
+     */
+    @Test
+    @DisplayName("Exercise 1: Combine two field folds with plus")
+    void exercise1_combineFieldFolds() {
+      Person person = new Person("Alice", "Smith", 30);
+
+      // TODO: Create a fold that returns both firstName and lastName
+      // Hint: firstNameLens.asFold().plus(lastNameLens.asFold())
+      Fold<Person, String> allNames = answerRequired();
+
+      assertThat(allNames.getAll(person)).containsExactly("Alice", "Smith");
+      assertThat(allNames.length(person)).isEqualTo(2);
+    }
+
+    /**
+     * Exercise 2: Identity with Fold.empty()
+     *
+     * <p>{@code Fold.empty()} returns no results and serves as the identity for {@code plus()}.
+     * Combining any fold with {@code Fold.empty()} should return the same results as the original
+     * fold.
+     *
+     * <p>Task: Verify the identity property by combining a fold with Fold.empty().
+     */
+    @Test
+    @DisplayName("Exercise 2: Identity with Fold.empty()")
+    void exercise2_identityWithEmpty() {
+      Person person = new Person("Alice", "Smith", 30);
+      Fold<Person, String> nameFold = firstNameLens.asFold();
+
+      // TODO: Create a fold equivalent to nameFold by combining it with Fold.empty()
+      // Hint: nameFold.plus(Fold.empty())
+      Fold<Person, String> combined = answerRequired();
+
+      assertThat(combined.getAll(person)).isEqualTo(nameFold.getAll(person));
+      assertThat(combined.length(person)).isEqualTo(1);
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Combining Different Optic Types
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Combining Different Optic Types")
+  class DifferentOpticTypes {
+
+    /**
+     * Exercise 3: Combine a Lens fold with a list Fold
+     *
+     * <p>You can combine a fold derived from a Lens (which focuses on exactly one element) with a
+     * Fold that focuses on multiple elements from a list.
+     *
+     * <p>Task: Create a fold that returns the team lead's name followed by all member names.
+     */
+    @Test
+    @DisplayName("Exercise 3: Lens fold plus list Fold")
+    void exercise3_lensFoldPlusListFold() {
+      Team team =
+          new Team(
+              "Platform",
+              new Person("Alice", "Smith", 35),
+              List.of(new Person("Bob", "Jones", 28), new Person("Carol", "Lee", 32)));
+
+      Fold<Team, String> leadNameFold = teamLeadLens.asFold().andThen(firstNameLens.asFold());
+      Fold<Team, String> memberNamesFold =
+          Fold.<Team, Person>of(Team::members).andThen(firstNameLens.asFold());
+
+      // TODO: Combine to get the lead name followed by all member names
+      // Hint: leadNameFold.plus(memberNamesFold)
+      Fold<Team, String> allNames = answerRequired();
+
+      assertThat(allNames.getAll(team)).containsExactly("Alice", "Bob", "Carol");
+    }
+
+    /**
+     * Exercise 4: Combine folds from sealed interface branches
+     *
+     * <p>When working with sealed interfaces, you can use Prism-derived folds for each variant and
+     * combine them to extract values regardless of which variant is present.
+     *
+     * <p>Task: Create a fold that extracts a descriptive string from any Shape variant.
+     */
+    @Test
+    @DisplayName("Exercise 4: Combine folds from sealed interface branches")
+    void exercise4_sealedInterfaceBranches() {
+      Prism<Shape, Circle> circlePrism =
+          Prism.of(s -> s instanceof Circle c ? Optional.of(c) : Optional.empty(), c -> c);
+      Prism<Shape, Rectangle> rectPrism =
+          Prism.of(s -> s instanceof Rectangle r ? Optional.of(r) : Optional.empty(), r -> r);
+
+      Fold<Shape, String> circleDesc =
+          circlePrism.asFold().andThen(Fold.of(c -> List.of("circle(r=" + c.radius() + ")")));
+      Fold<Shape, String> rectDesc =
+          rectPrism
+              .asFold()
+              .andThen(Fold.of(r -> List.of("rect(" + r.width() + "x" + r.height() + ")")));
+
+      // TODO: Combine to get a description from either variant
+      // Hint: circleDesc.plus(rectDesc)
+      Fold<Shape, String> shapeDesc = answerRequired();
+
+      assertThat(shapeDesc.getAll(new Circle(5.0))).containsExactly("circle(r=5.0)");
+      assertThat(shapeDesc.getAll(new Rectangle(3.0, 4.0))).containsExactly("rect(3.0x4.0)");
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: Fold.sum() and Advanced Patterns
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: Fold.sum() and Advanced Patterns")
+  class SumAndAdvanced {
+
+    /**
+     * Exercise 5: Using Fold.sum() for multiple paths
+     *
+     * <p>{@code Fold.sum(first, rest...)} is a convenience for combining three or more folds. It
+     * behaves identically to chaining {@code plus()} calls.
+     *
+     * <p>Task: Use Fold.sum() to combine three field folds from a Person.
+     */
+    @Test
+    @DisplayName("Exercise 5: Fold.sum() for multiple paths")
+    void exercise5_foldSum() {
+      Person person = new Person("Alice", "Smith", 30);
+
+      Fold<Person, String> firstFold = firstNameLens.asFold();
+      Fold<Person, String> lastFold = lastNameLens.asFold();
+      Fold<Person, String> ageFold =
+          ageLens.asFold().andThen(Fold.of(age -> List.of(String.valueOf(age))));
+
+      // TODO: Use Fold.sum() to combine all three folds
+      // Hint: Fold.sum(firstFold, lastFold, ageFold)
+      Fold<Person, String> allInfo = answerRequired();
+
+      assertThat(allInfo.getAll(person)).containsExactly("Alice", "Smith", "30");
+    }
+
+    /**
+     * Exercise 6: Building a real-world extractor
+     *
+     * <p>Combine folds from multiple paths through a structure to build a comprehensive data
+     * extractor. This simulates extracting all relevant strings from a complex nested structure.
+     *
+     * <p>Task: Extract the team name, lead's full name, and all member first names.
+     */
+    @Test
+    @DisplayName("Exercise 6: Real-world extractor")
+    void exercise6_realWorldExtractor() {
+      Team team =
+          new Team(
+              "Backend",
+              new Person("Alice", "Smith", 35),
+              List.of(new Person("Bob", "Jones", 28), new Person("Carol", "Lee", 32)));
+
+      Fold<Team, String> teamNameFold = Fold.of(t -> List.of(t.name()));
+      Fold<Team, String> leadFirstNameFold = teamLeadLens.asFold().andThen(firstNameLens.asFold());
+      Fold<Team, String> leadLastNameFold = teamLeadLens.asFold().andThen(lastNameLens.asFold());
+      Fold<Team, String> memberFirstNamesFold =
+          Fold.<Team, Person>of(Team::members).andThen(firstNameLens.asFold());
+
+      // TODO: Use Fold.sum() to combine all four folds
+      // Hint: Fold.sum(teamNameFold, leadFirstNameFold, leadLastNameFold, memberFirstNamesFold)
+      Fold<Team, String> extractor = answerRequired();
+
+      assertThat(extractor.getAll(team))
+          .containsExactly("Backend", "Alice", "Smith", "Bob", "Carol");
+    }
+
+    /**
+     * Exercise 7: foldMap with custom monoid across combined folds
+     *
+     * <p>Combined folds work with {@code foldMap} just like regular folds. The monoid combines
+     * results from all constituent folds.
+     *
+     * <p>Task: Use foldMap with a sum monoid to add ages from both a single person fold and a list
+     * fold.
+     */
+    @Test
+    @DisplayName("Exercise 7: foldMap with custom monoid")
+    void exercise7_foldMapWithMonoid() {
+      Team team =
+          new Team(
+              "Platform",
+              new Person("Alice", "Smith", 35),
+              List.of(new Person("Bob", "Jones", 28), new Person("Carol", "Lee", 32)));
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      Fold<Team, Integer> leadAgeFold = teamLeadLens.asFold().andThen(ageLens.asFold());
+      Fold<Team, Integer> memberAgesFold =
+          Fold.<Team, Person>of(Team::members).andThen(ageLens.asFold());
+
+      // TODO: Combine the age folds and use foldMap to sum all ages
+      // Hint: Create combined fold with plus(), then call foldMap(sumMonoid, age -> age, team)
+      int totalAge = answerRequired();
+
+      assertThat(totalAge).isEqualTo(95); // 35 + 28 + 32
+    }
+
+    /**
+     * Exercise 8: Combining filtered folds
+     *
+     * <p>You can filter folds first, then combine them. This allows you to combine results from
+     * different filtered subsets.
+     *
+     * <p>Task: Combine a fold of senior members (age >= 30) with a fold of junior members (age <
+     * 30), each prefixed accordingly.
+     */
+    @Test
+    @DisplayName("Exercise 8: Combining filtered folds")
+    void exercise8_combiningFilteredFolds() {
+      Team team =
+          new Team(
+              "Platform",
+              new Person("Alice", "Smith", 35),
+              List.of(
+                  new Person("Bob", "Jones", 28),
+                  new Person("Carol", "Lee", 32),
+                  new Person("Dave", "Kim", 25)));
+
+      Fold<Team, Person> membersFold = Fold.of(Team::members);
+
+      Fold<Team, String> seniorNames =
+          membersFold
+              .filtered(p -> p.age() >= 30)
+              .andThen(firstNameLens.asFold())
+              .andThen(Fold.of(name -> List.of("Senior: " + name)));
+
+      Fold<Team, String> juniorNames =
+          membersFold
+              .filtered(p -> p.age() < 30)
+              .andThen(firstNameLens.asFold())
+              .andThen(Fold.of(name -> List.of("Junior: " + name)));
+
+      // TODO: Combine the two filtered folds
+      // Hint: seniorNames.plus(juniorNames)
+      Fold<Team, String> categorisedNames = answerRequired();
+
+      assertThat(categorisedNames.getAll(team))
+          .containsExactly("Senior: Carol", "Junior: Bob", "Junior: Dave");
+    }
+  }
+
+  /**
+   * Congratulations! You've completed Tutorial 18: Fold Combination
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How to use {@code Fold.plus()} to combine two folds into one
+   *   <li>That {@code Fold.empty()} is the identity element for {@code plus}
+   *   <li>How to use {@code Fold.sum()} for combining multiple folds at once
+   *   <li>How to combine folds from different optic types (Lens, Prism, Affine)
+   *   <li>How to combine folds across sealed interface branches
+   *   <li>That combined folds work with foldMap and custom monoids
+   *   <li>How to combine filtered folds for categorised results
+   * </ul>
+   *
+   * <p>Key Takeaways:
+   *
+   * <ul>
+   *   <li>{@code plus} forms a monoid on folds (associative with {@code empty} as identity)
+   *   <li>Results from the first fold always appear before results from the second
+   *   <li>Any optic can participate via {@code asFold()}
+   * </ul>
+   */
+  @Test
+  @DisplayName("All exercises completed")
+  void allCompleted() {
+    // This test passes when all exercises are correctly implemented
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial18_FoldCombination_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial18_FoldCombination_Solution.java
@@ -1,0 +1,243 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.optics.Fold;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 18: Fold Combination
+ *
+ * <p>These are the reference solutions for Tutorial18_FoldCombination.
+ */
+@DisplayName("Tutorial Solution: Fold Combination")
+public class Tutorial18_FoldCombination_Solution {
+
+  // --- Domain models ---
+
+  record Person(String firstName, String lastName, int age) {}
+
+  record Team(String name, Person lead, List<Person> members) {}
+
+  sealed interface Shape permits Circle, Rectangle {}
+
+  record Circle(double radius) implements Shape {}
+
+  record Rectangle(double width, double height) implements Shape {}
+
+  record Config(Optional<String> host, Optional<String> port, String name) {}
+
+  // --- Lenses ---
+
+  static final Lens<Person, String> firstNameLens =
+      Lens.of(Person::firstName, (p, n) -> new Person(n, p.lastName(), p.age()));
+
+  static final Lens<Person, String> lastNameLens =
+      Lens.of(Person::lastName, (p, n) -> new Person(p.firstName(), n, p.age()));
+
+  static final Lens<Person, Integer> ageLens =
+      Lens.of(Person::age, (p, a) -> new Person(p.firstName(), p.lastName(), a));
+
+  static final Lens<Team, Person> teamLeadLens =
+      Lens.of(Team::lead, (t, l) -> new Team(t.name(), l, t.members()));
+
+  @Nested
+  @DisplayName("Part 1: Basic Fold Combination")
+  class BasicCombination {
+
+    @Test
+    @DisplayName("Exercise 1: Combine two field folds with plus")
+    void exercise1_combineFieldFolds() {
+      Person person = new Person("Alice", "Smith", 30);
+
+      // SOLUTION: Use asFold() on each lens and combine with plus()
+      Fold<Person, String> allNames = firstNameLens.asFold().plus(lastNameLens.asFold());
+
+      assertThat(allNames.getAll(person)).containsExactly("Alice", "Smith");
+      assertThat(allNames.length(person)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Exercise 2: Identity with Fold.empty()")
+    void exercise2_identityWithEmpty() {
+      Person person = new Person("Alice", "Smith", 30);
+      Fold<Person, String> nameFold = firstNameLens.asFold();
+
+      // SOLUTION: Fold.empty() is the identity for plus()
+      Fold<Person, String> combined = nameFold.plus(Fold.empty());
+
+      assertThat(combined.getAll(person)).isEqualTo(nameFold.getAll(person));
+      assertThat(combined.length(person)).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("Part 2: Combining Different Optic Types")
+  class DifferentOpticTypes {
+
+    @Test
+    @DisplayName("Exercise 3: Lens fold plus list Fold")
+    void exercise3_lensFoldPlusListFold() {
+      Team team =
+          new Team(
+              "Platform",
+              new Person("Alice", "Smith", 35),
+              List.of(new Person("Bob", "Jones", 28), new Person("Carol", "Lee", 32)));
+
+      Fold<Team, String> leadNameFold = teamLeadLens.asFold().andThen(firstNameLens.asFold());
+      Fold<Team, String> memberNamesFold =
+          Fold.<Team, Person>of(Team::members).andThen(firstNameLens.asFold());
+
+      // SOLUTION: Combine lead name fold with member names fold
+      Fold<Team, String> allNames = leadNameFold.plus(memberNamesFold);
+
+      assertThat(allNames.getAll(team)).containsExactly("Alice", "Bob", "Carol");
+    }
+
+    @Test
+    @DisplayName("Exercise 4: Combine folds from sealed interface branches")
+    void exercise4_sealedInterfaceBranches() {
+      Prism<Shape, Circle> circlePrism =
+          Prism.of(s -> s instanceof Circle c ? Optional.of(c) : Optional.empty(), c -> c);
+      Prism<Shape, Rectangle> rectPrism =
+          Prism.of(s -> s instanceof Rectangle r ? Optional.of(r) : Optional.empty(), r -> r);
+
+      Fold<Shape, String> circleDesc =
+          circlePrism.asFold().andThen(Fold.of(c -> List.of("circle(r=" + c.radius() + ")")));
+      Fold<Shape, String> rectDesc =
+          rectPrism
+              .asFold()
+              .andThen(Fold.of(r -> List.of("rect(" + r.width() + "x" + r.height() + ")")));
+
+      // SOLUTION: Combine the two variant folds with plus()
+      Fold<Shape, String> shapeDesc = circleDesc.plus(rectDesc);
+
+      assertThat(shapeDesc.getAll(new Circle(5.0))).containsExactly("circle(r=5.0)");
+      assertThat(shapeDesc.getAll(new Rectangle(3.0, 4.0))).containsExactly("rect(3.0x4.0)");
+    }
+  }
+
+  @Nested
+  @DisplayName("Part 3: Fold.sum() and Advanced Patterns")
+  class SumAndAdvanced {
+
+    @Test
+    @DisplayName("Exercise 5: Fold.sum() for multiple paths")
+    void exercise5_foldSum() {
+      Person person = new Person("Alice", "Smith", 30);
+
+      Fold<Person, String> firstFold = firstNameLens.asFold();
+      Fold<Person, String> lastFold = lastNameLens.asFold();
+      Fold<Person, String> ageFold =
+          ageLens.asFold().andThen(Fold.of(age -> List.of(String.valueOf(age))));
+
+      // SOLUTION: Use Fold.sum() to combine all three folds
+      Fold<Person, String> allInfo = Fold.sum(firstFold, lastFold, ageFold);
+
+      assertThat(allInfo.getAll(person)).containsExactly("Alice", "Smith", "30");
+    }
+
+    @Test
+    @DisplayName("Exercise 6: Real-world extractor")
+    void exercise6_realWorldExtractor() {
+      Team team =
+          new Team(
+              "Backend",
+              new Person("Alice", "Smith", 35),
+              List.of(new Person("Bob", "Jones", 28), new Person("Carol", "Lee", 32)));
+
+      Fold<Team, String> teamNameFold = Fold.of(t -> List.of(t.name()));
+      Fold<Team, String> leadFirstNameFold = teamLeadLens.asFold().andThen(firstNameLens.asFold());
+      Fold<Team, String> leadLastNameFold = teamLeadLens.asFold().andThen(lastNameLens.asFold());
+      Fold<Team, String> memberFirstNamesFold =
+          Fold.<Team, Person>of(Team::members).andThen(firstNameLens.asFold());
+
+      // SOLUTION: Use Fold.sum() to combine all four extraction paths
+      Fold<Team, String> extractor =
+          Fold.sum(teamNameFold, leadFirstNameFold, leadLastNameFold, memberFirstNamesFold);
+
+      assertThat(extractor.getAll(team))
+          .containsExactly("Backend", "Alice", "Smith", "Bob", "Carol");
+    }
+
+    @Test
+    @DisplayName("Exercise 7: foldMap with custom monoid")
+    void exercise7_foldMapWithMonoid() {
+      Team team =
+          new Team(
+              "Platform",
+              new Person("Alice", "Smith", 35),
+              List.of(new Person("Bob", "Jones", 28), new Person("Carol", "Lee", 32)));
+
+      Monoid<Integer> sumMonoid =
+          new Monoid<>() {
+            @Override
+            public Integer empty() {
+              return 0;
+            }
+
+            @Override
+            public Integer combine(Integer a, Integer b) {
+              return a + b;
+            }
+          };
+
+      Fold<Team, Integer> leadAgeFold = teamLeadLens.asFold().andThen(ageLens.asFold());
+      Fold<Team, Integer> memberAgesFold =
+          Fold.<Team, Person>of(Team::members).andThen(ageLens.asFold());
+
+      // SOLUTION: Combine age folds and use foldMap to sum
+      int totalAge = leadAgeFold.plus(memberAgesFold).foldMap(sumMonoid, age -> age, team);
+
+      assertThat(totalAge).isEqualTo(95);
+    }
+
+    @Test
+    @DisplayName("Exercise 8: Combining filtered folds")
+    void exercise8_combiningFilteredFolds() {
+      Team team =
+          new Team(
+              "Platform",
+              new Person("Alice", "Smith", 35),
+              List.of(
+                  new Person("Bob", "Jones", 28),
+                  new Person("Carol", "Lee", 32),
+                  new Person("Dave", "Kim", 25)));
+
+      Fold<Team, Person> membersFold = Fold.of(Team::members);
+
+      Fold<Team, String> seniorNames =
+          membersFold
+              .filtered(p -> p.age() >= 30)
+              .andThen(firstNameLens.asFold())
+              .andThen(Fold.of(name -> List.of("Senior: " + name)));
+
+      Fold<Team, String> juniorNames =
+          membersFold
+              .filtered(p -> p.age() < 30)
+              .andThen(firstNameLens.asFold())
+              .andThen(Fold.of(name -> List.of("Junior: " + name)));
+
+      // SOLUTION: Combine the two filtered folds with plus()
+      Fold<Team, String> categorisedNames = seniorNames.plus(juniorNames);
+
+      assertThat(categorisedNames.getAll(team))
+          .containsExactly("Senior: Carol", "Junior: Bob", "Junior: Dave");
+    }
+  }
+
+  @Test
+  @DisplayName("All exercises completed")
+  void allCompleted() {
+    // This test passes when all exercises are correctly implemented
+  }
+}

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/VirtualThreadUserService.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/VirtualThreadUserService.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.spring.example.service;
 
 import java.time.Duration;
+import java.util.List;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.VStreamPath;
 import org.higherkindedj.hkt.effect.VTaskPath;
@@ -129,7 +130,7 @@ public class VirtualThreadUserService {
    */
   public VStreamPath<User> streamAllUsers() {
     return Path.vstream(
-        VStream.fromList(userService.findAll().fold(err -> java.util.List.of(), users -> users))
+        VStream.fromList(userService.findAll().fold(err -> List.of(), users -> users))
             .map(
                 user -> {
                   // Simulate per-element processing delay


### PR DESCRIPTION
## Description

This PR adds monoid-based fold combination operations and establishes release quality gates for benchmarks.

### Key Changes

1. **Fold Combination API** (`Fold.plus()`, `Fold.empty()`, `Fold.sum()`)
   - New `plus(Fold)` method combines two folds, returning results from both in order
   - New `empty()` static method provides the identity element
   - New `sum(Fold...)` static method combines multiple folds at once
   - Together these form a monoid on folds with left/right identity and associativity
   - Enables multi-path extraction queries without manual concatenation

2. **Benchmark Assertion Tests: Fail Instead of Skip**
   - Changed `assumeThat` to `assertThat` in benchmark result validation
   - Tests now **fail** (not skip) if benchmark results are missing
   - Prevents silent quality gate failures; forces explicit benchmark runs before test runs
   - Added `assertBenchmarkPresent()` for per-benchmark validation
   - Fixed `get()` method to support parameterized benchmarks via prefix matching

3. **Release Quality Gate Task**
   - New `releaseReadiness` Gradle task runs verification steps ordered fast-to-slow
   - Sequence: spotlessCheck → build → jmh → benchmark tests → pitest (full)
   - Single command for pre-release validation

4. **Documentation & Examples**
   - Tutorial 18: Fold Combination with 6 progressive exercises
   - Example: `FoldPlusCombinationExample.java` demonstrating real-world patterns
   - Cookbook recipe for multi-path extraction
   - Updated benchmarks.md with assertion test documentation
   - Property-based tests verifying monoid laws

5. **Benchmarks**
   - New `FoldPlusBenchmark` measuring overhead of plus(2), plus(5), sum(5)
   - Validates that combined folds scale linearly with number of constituent folds

### Motivation

- **Fold combination** addresses a common pattern: extracting values from multiple independent paths in a data structure (e.g., team lead name + all member names)
- **Benchmark quality gates** ensure performance regressions are caught before release; failing tests prevent silent skips that hide missing benchmarks
- **Release task** provides a single, ordered verification command for maintainers

### Testing

- All existing tests pass
- New unit tests in `FoldTest.java` verify basic combination, identity, associativity, and ordering
- Property-based tests in `FoldPlusPropertyTest.java` verify monoid laws
- Benchmark assertion tests validate performance characteristics
- Tutorial exercises with solutions provided

## Type of change

- [x] New feature (Fold.plus/empty/sum for fold combination)
- [x] Test addition/update (FoldTest, FoldPlusPropertyTest, BenchmarkAssertionsTest updates)
- [x] Documentation update (tutorials, examples, book chapters)
- [x] Refactoring/Code cleanup (benchmark test assertions)

## How Has This Been Tested?

- `./gradlew test` passes locally (all unit tests including new FoldTest and FoldPlusPropertyTest)
- `./gradlew :hkj-benchmarks:jmh` runs benchmarks successfully
- `./gradlew :hkj-benchmarks:test` validates benchmark results (now fails if benchmarks haven't run, as intended)
- Tutorial exercises verified with provided solutions
- Example code compiles and runs without errors

## Checklist

- [x] Code follows Google Java Style Guide conventions
- [x] Self-review completed
- [x] Hard-to-understand areas commented (monoid laws, parameterized benchmark lookup)
- [x] Documentation updated (tutorials, examples, book chapters, Javadoc)
- [x] No new warnings generated
- [x] Unit tests added for fold combination and monoid laws
- [x] All existing and new tests pass locally
- [x] GitHub Actions CI passes

## Additional Comments

The benchmark assertion test changes are intentionally strict: tests fail rather than skip when results are missing. This prevents silent quality gate failures in CI/CD pipelines. Developers must explicitly run `./gradlew :h

Fixes #415 