### PR TITLE
Fix Javadoc formatting and improve build configuration

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/PathVia.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/PathVia.java
@@ -40,6 +40,7 @@ import java.lang.annotation.Target;
  * <p>The processor automatically maps the return type to the appropriate Path type:
  *
  * <table border="1">
+ *   <caption>Return type to Path type mapping</caption>
  *   <tr><th>Method Return Type</th><th>Generated Path Type</th></tr>
  *   <tr><td>{@code Optional<T>}</td><td>{@code OptionalPath<T>}</td></tr>
  *   <tr><td>{@code Maybe<T>}</td><td>{@code MaybePath<T>}</td></tr>

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateFocus.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateFocus.java
@@ -55,9 +55,8 @@ import java.lang.annotation.Target;
  * <p>By default, the generated class is placed in the same package as the annotated record. Use the
  * {@link #targetPackage()} element to specify a different package for the generated class.
  *
- * @see org.higherkindedj.optics.focus.FocusPath
- * @see org.higherkindedj.optics.focus.AffinePath
- * @see org.higherkindedj.optics.focus.TraversalPath
+ * @see GenerateFocus#generateNavigators()
+ * @see GenerateFocus#maxNavigatorDepth()
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/OpticsSpec.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/OpticsSpec.java
@@ -9,7 +9,7 @@ package org.higherkindedj.optics.annotations;
  * will analyse abstract methods and generate implementations based on their return types and
  * annotations.
  *
- * <h3>Generated Class Naming</h3>
+ * <h2>Generated Class Naming</h2>
  *
  * <p>The generated class name is derived from the spec interface name:
  *
@@ -22,7 +22,7 @@ package org.higherkindedj.optics.annotations;
  * <p><strong>Recommended convention:</strong> Name your spec interface with a "Spec" suffix for
  * cleaner generated class names.
  *
- * <h3>Method Annotations</h3>
+ * <h2>Method Annotations</h2>
  *
  * <p>Abstract methods must return an optic type ({@code Lens}, {@code Prism}, {@code Traversal},
  * etc.) and be annotated with a copy strategy or matching annotation:

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/TraverseField.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/TraverseField.java
@@ -70,7 +70,7 @@ public @interface TraverseField {
    * <p>This should be a static field or method call that returns a {@code Traverse<F>} instance for
    * the Kind's witness type.
    *
-   * <h3>Examples</h3>
+   * <p><strong>Examples:</strong>
    *
    * <ul>
    *   <li>Enum singleton: {@code "com.example.TreeTraverse.INSTANCE"}

--- a/hkj-core/build.gradle.kts
+++ b/hkj-core/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
   `java-library`
@@ -114,7 +115,7 @@ mavenPublishing {
     // - `JavadocJar.Javadoc()` to publish standard javadocs
     javadocJar = JavadocJar.Javadoc(),
     // whether to publish a sources jar
-    sourcesJar = true,
+    sourcesJar = SourcesJar.Sources(),
   ))
 
   coordinates(


### PR DESCRIPTION
## Description

This PR addresses several documentation and build configuration improvements:

1. **Javadoc fixes in annotations:**
   - Updated `@see` references in `GenerateFocus` to point to relevant annotation methods instead of external classes
   - Fixed heading levels in `OpticsSpec` from `<h3>` to `<h2>` for proper document hierarchy
   - Fixed heading format in `TraverseField` from `<h3>` to `<p><strong>` for consistency
   - Added missing `<caption>` element to table in `PathVia` for accessibility compliance

2. **Build configuration improvement:**
   - Updated `sourcesJar` configuration in `build.gradle.kts` to use explicit `SourcesJar.Sources()` instead of boolean value for better type safety and clarity

These changes improve documentation quality, ensure Javadoc compliance, and enhance build configuration clarity.

## Type of change

- [x] Documentation update
- [x] Refactoring/Code cleanup

## How Has This Been Tested?

- Javadoc generation should complete without warnings
- Build configuration changes are syntactic improvements with no functional impact

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (Javadoc)
- [x] My changes generate no new warnings
- [x] The GitHub Actions CI build should pass with these changes

## Additional Comments

These are minor documentation and configuration improvements that enhance code quality and maintainability without affecting functionality.

https://claude.ai/code/session_01ApHJ8JyXtxwY6auvwxgX5K