### PR TITLE
Add nested container widening for Focus DSL code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ bin/
 /.idea/
 
 
-hkj-core/.jqwik-database
+**/.jqwik-database
 
 /hkj-book/mdbook-admonish.css
 /hkj-book/src/CODE_OF_CONDUCT.md

--- a/hkj-book/src/optics/copy_strategies.md
+++ b/hkj-book/src/optics/copy_strategies.md
@@ -496,7 +496,7 @@ The `.toLens()` method converts a Focus path into a composable optic, which we c
                                    │
                                    ▼
                ┌───────────────────────────────────────┐
-               │ Does it have toBuilder().build()?    │
+               │ Does it have toBuilder().build()?     │
                └───────────────────────────────────────┘
                       │ YES                    │ NO
                       ▼                        ▼
@@ -505,10 +505,10 @@ The `.toLens()` method converts a Focus path into a composable optic, which we c
             │                  │    └───────────────────────┘
             │ JOOQ, Lombok,    │           │ YES       │ NO
             │ Immutables,      │           ▼           ▼
-            │ AutoValue        │    ┌──────────┐  ┌─────────────────────┐
-            └──────────────────┘    │ @Wither  │  │ Does it have an     │
+            │ AutoValue        │    ┌──────────┐  ┌──────────────────────┐
+            └──────────────────┘    │ @Wither  │  │ Does it have an      │
                                     │          │  │ all-args constructor?│
-                                    │LocalDate,│  └─────────────────────┘
+                                    │LocalDate,│  └──────────────────────┘
                                     │java.time │       │ YES       │ NO
                                     └──────────┘       ▼           ▼
                                              ┌───────────────┐ ┌──────────────┐

--- a/hkj-book/src/optics/focus_containers.md
+++ b/hkj-book/src/optics/focus_containers.md
@@ -8,7 +8,7 @@
 ~~~
 
 ~~~admonish title="Hands On Practice"
-[Tutorial20_ContainerNavigation.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial20_ContainerNavigation.java) (4 exercises, ~12 minutes)
+[Tutorial20_ContainerNavigation.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial20_ContainerNavigation.java) (4 exercises, ~10 minutes)
 ~~~
 
 ---
@@ -89,6 +89,8 @@ Every container type holds its values in one of two ways: it either wraps *at mo
 - **Zero or more** (e.g., `Map<K, V>`, `T[]`) produces a `TraversalPath`; there may be many values to iterate over.
 
 The `TraversableGenerator` SPI lets any container type participate in this path widening. When `@GenerateFocus` encounters a registered container field, it generates the correct `AffinePath` or `TraversalPath` automatically, with no manual composition needed.
+
+Nested container patterns such as `Optional<List<String>>` or `Either<E, Map<K, V>>` are also detected automatically. The processor generates composed widening chains (e.g., `.some().each()`) and selects the correct return type using the widening lattice. See [Nested Container Widening](focus_navigation.md#nested-container-widening) for details.
 
 ### How It Works
 
@@ -241,7 +243,7 @@ module com.example.optics {
 Once registered, any `@GenerateFocus` record with a `Result<E, A>` field will automatically generate an `AffinePath` that calls `.some(ResultAffines.success())`.
 
 ~~~admonish info title="Hands-On Learning"
-Practice container type navigation in [Tutorial 20: Custom Container Navigation](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial20_ContainerNavigation.java) (4 exercises, ~12 minutes).
+Practice container type navigation in [Tutorial 20: Custom Container Navigation](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial20_ContainerNavigation.java) (4 exercises, ~10 minutes).
 ~~~
 
 ~~~admonish tip title="See Also"

--- a/hkj-book/src/optics/focus_dsl.md
+++ b/hkj-book/src/optics/focus_dsl.md
@@ -215,9 +215,9 @@ Department modified = employeesPath.modifyAll(e -> promote(e), department);
 
 ~~~admonish tip title="See Also"
 1. [Navigation and Composition](focus_navigation.md) - Collection navigation, `.via()` composition, and generated navigators
-2. [Type Class and Effect Integration](focus_effects.md) - `modifyF([spi_widening_roadmap.md](../../../../../../../home/magnus/Documents/Higher-Kinded-J%20Ideas/focus-spi-widening/spi_widening_roadmap.md))`, `foldMap()`, `traverseOver()`, sum types, and Effect path bridging
+2. [Type Class and Effect Integration](focus_effects.md) - `modifyF()` `foldMap()`, `traverseOver()`, sum types, and Effect path bridging
 3. [Custom Containers and Code Generation](focus_containers.md) - Generated class structure, SPI container types, and registration
-4. [Focus DSL Reference](focus_reference.md) - Decision guide, c[spi_widening_roadmap.md](../../../../../../../home/magnus/Documents/Higher-Kinded-J%20Ideas/focus-spi-widening/spi_widening_roadmap.md)ommon patterns, performance, pitfalls, and FAQ
+4. [Focus DSL Reference](focus_reference.md) - Decision guide, common patterns, performance, pitfalls, and FAQ
 ~~~
 
 ---

--- a/hkj-book/src/optics/focus_navigation.md
+++ b/hkj-book/src/optics/focus_navigation.md
@@ -10,7 +10,8 @@
 ~~~
 
 ~~~admonish title="Hands On Practice"
-[Tutorial12_FocusDSL.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial12_FocusDSL.java) | [Tutorial19_NavigatorGeneration.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial19_NavigatorGeneration.java)
+- [Tutorial12_FocusDSL.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial12_FocusDSL.java) 
+- [Tutorial19_NavigatorGeneration.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial19_NavigatorGeneration.java)
 ~~~
 
 ~~~admonish title="Example Code"
@@ -407,6 +408,50 @@ TraversalPath<Company, String> metadataValues =
 
 ~~~admonish note title="Custom Generators"
 If you write a custom `TraversableGenerator` for your own container type, override `getCardinality()` to return `ZERO_OR_ONE` for optional-like types. The default is `ZERO_OR_MORE`, which is correct for collection-like types. See [Traversal Generator Plugins](../tooling/generator_plugins.md) for details.
+~~~
+
+### Nested Container Widening
+
+Fields with nested container types are automatically detected and generate composed widening chains. Previously, only the outermost container was widened; the inner container required manual navigation.
+
+| Field Type | Generated Chain | Return Type |
+|-----------|----------------|-------------|
+| `Optional<List<String>>` | `.some().each()` | `TraversalPath` |
+| `List<Optional<String>>` | `.each().some()` | `TraversalPath` |
+| `Optional<Optional<String>>` | `.some().some()` | `AffinePath` |
+| `List<List<String>>` | `.each().each()` | `TraversalPath` |
+| `Either<E, Map<K, V>>` | `.some(Affines.eitherRight()).each(EachInstances.mapValuesEach())` | `TraversalPath` |
+| `Optional<Either<E, String>>` | `.some().some(Affines.eitherRight())` | `AffinePath` |
+
+The widening lattice composes across nesting levels:
+
+- **Focus + Affine = Affine** (e.g., a plain field containing an Optional)
+- **Focus + Traversal = Traversal** (e.g., a plain field containing a List)
+- **Affine + Traversal = Traversal** (e.g., `Optional<List<...>>`)
+- **Traversal + anything = Traversal** (e.g., `List<Optional<...>>`, `List<List<...>>`)
+
+```java
+@GenerateFocus
+record Config(
+    String name,
+    Optional<List<String>> tags,           // TraversalPath via .some().each()
+    List<Optional<String>> items,          // TraversalPath via .each().some()
+    Optional<Optional<String>> nested,     // AffinePath via .some().some()
+    Either<String, List<Integer>> data     // TraversalPath via .some(eitherRight()).each()
+) {}
+
+// Usage
+TraversalPath<Config, String> allTags = ConfigFocus.tags();
+List<String> tagValues = allTags.getAll(config);
+
+AffinePath<Config, String> nestedOpt = ConfigFocus.nested();
+Optional<String> innerValue = nestedOpt.getOptional(config);
+```
+
+Nesting is detected up to three levels deep. For deeper nesting, use manual `.via()` composition on the generated path.
+
+~~~admonish note title="Navigator Path Kind Propagation"
+Navigators also correctly compose path kinds for nested containers. If a field is `Optional<List<Address>>` and `Address` is a navigable type, the navigator will use `TraversalPath` (the composed result of Affine + Traversal) for all navigation methods on the inner `Address` fields.
 ~~~
 
 ### Controlling Navigator Generation

--- a/hkj-book/src/optics/focus_reference.md
+++ b/hkj-book/src/optics/focus_reference.md
@@ -43,8 +43,6 @@ Company result = OpticInterpreters.direct().run(program);
 
 - **Navigating deeply nested structures** with many levels
 - **IDE autocomplete is important** for discoverability
-- **Teaching or onboarding** developers new to optics
-- **Prototyping** before optimising for performance
 
 ```java
 // Focus DSL - clear intent, discoverable

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -412,6 +412,13 @@ public class FocusProcessor extends AbstractProcessor {
         methodBuilder.addStatement(
             "return " + baseLens + ".each(" + resolvedExpr + ")", args.toArray());
       }
+      case NESTED -> {
+        // Nested container type: composed widening chain
+        List<Object> args =
+            new ArrayList<>(List.of(FOCUS_PATH_CLASS, Lens.class, recordTypeName, recordTypeName));
+        String chainExpr = buildWideningChainExpression(pathTypeInfo.wideningChain(), args);
+        methodBuilder.addStatement("return " + baseLens + chainExpr, args.toArray());
+      }
       default ->
           methodBuilder.addStatement(
               "return " + baseLens, FOCUS_PATH_CLASS, Lens.class, recordTypeName, recordTypeName);
@@ -441,6 +448,79 @@ public class FocusProcessor extends AbstractProcessor {
         ".<%s, %s>traverseOver(%s)", witnessType, elementType, kindInfo.traverseExpression());
   }
 
+  /**
+   * Builds the chained widening expression for a nested container.
+   *
+   * <p>For example, {@code Optional<List<String>>} produces {@code .some().each()}, and {@code
+   * Either<E, Map<K, V>>} produces {@code
+   * .some(Affines.eitherRight()).each(EachInstances.mapValuesEach())}.
+   *
+   * @param chain the list of widening steps
+   * @param args the mutable list of JavaPoet arguments (for SPI import resolution)
+   * @return the chained expression string
+   */
+  private String buildWideningChainExpression(List<WideningStep> chain, List<Object> args) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < chain.size(); i++) {
+      WideningStep step = chain.get(i);
+      // Check if the next step requires argument type matching (SPI with parameters).
+      // If so, the current no-arg step needs a type witness to help Java's type inference.
+      boolean nextStepNeedsTypeWitness =
+          i + 1 < chain.size() && isParameterisedStep(chain.get(i + 1));
+      switch (step.type()) {
+        case OPTIONAL -> {
+          if (nextStepNeedsTypeWitness && step.innerTypeMirror() != null) {
+            sb.append(".<$T>some()");
+            args.add(TypeName.get(step.innerTypeMirror()));
+          } else {
+            sb.append(".some()");
+          }
+        }
+        case COLLECTION -> {
+          if (nextStepNeedsTypeWitness && step.innerTypeMirror() != null) {
+            sb.append(".<$T>each()");
+            args.add(TypeName.get(step.innerTypeMirror()));
+          } else {
+            sb.append(".each()");
+          }
+        }
+        case NULLABLE -> sb.append(".nullable()");
+        case SPI_ZERO_OR_ONE -> {
+          TraversableGenerator gen = step.spiGenerator();
+          String opticExpr = gen.generateOpticExpression();
+          String resolvedExpr =
+              OpticExpressionResolver.resolve(opticExpr, gen.getRequiredImports(), args);
+          sb.append(".some(").append(resolvedExpr).append(")");
+        }
+        case SPI_ZERO_OR_MORE -> {
+          TraversableGenerator gen = step.spiGenerator();
+          String opticExpr = gen.generateOpticExpression();
+          String resolvedExpr =
+              OpticExpressionResolver.resolve(opticExpr, gen.getRequiredImports(), args);
+          sb.append(".each(").append(resolvedExpr).append(")");
+        }
+        case KIND_EXACTLY_ONE, KIND_ZERO_OR_ONE -> {
+          KindFieldInfo kindInfo = step.kindInfo();
+          sb.append(buildTraverseOverCall(kindInfo)).append(".headOption()");
+        }
+        case KIND_ZERO_OR_MORE -> {
+          KindFieldInfo kindInfo = step.kindInfo();
+          sb.append(buildTraverseOverCall(kindInfo));
+        }
+        default -> {
+          // NONE or NESTED should not appear in a chain
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  /** Returns true if this widening step requires argument type matching (has parameters). */
+  private static boolean isParameterisedStep(WideningStep step) {
+    return step.type() == WideningType.SPI_ZERO_OR_ONE
+        || step.type() == WideningType.SPI_ZERO_OR_MORE;
+  }
+
   /** Represents the type of path widening to apply. */
   private enum WideningType {
     /** No widening - standard FocusPath. */
@@ -460,20 +540,40 @@ public class FocusProcessor extends AbstractProcessor {
     /** SPI-registered zero-or-one type - AffinePath via .some(affine). */
     SPI_ZERO_OR_ONE,
     /** SPI-registered zero-or-more type - TraversalPath via .each(each). */
-    SPI_ZERO_OR_MORE
+    SPI_ZERO_OR_MORE,
+    /** Nested container type - composed widening chain. */
+    NESTED
   }
+
+  /**
+   * Represents a single widening step in a nested container chain.
+   *
+   * @param type the widening type for this step
+   * @param kindInfo Kind field info if this step is a Kind type (may be null)
+   * @param spiGenerator SPI generator if this step is an SPI type (may be null)
+   * @param innerTypeMirror the type produced by unwrapping this container (may be null)
+   */
+  private record WideningStep(
+      WideningType type,
+      KindFieldInfo kindInfo,
+      TraversableGenerator spiGenerator,
+      TypeMirror innerTypeMirror) {}
+
+  /** Maximum recursion depth for nested container analysis. */
+  private static final int MAX_NESTING_DEPTH = 3;
 
   /** Holds information about path type analysis. */
   private record PathTypeInfo(
       ClassName pathClass,
       TypeName innerType,
       WideningType wideningType,
+      List<WideningStep> wideningChain,
       KindFieldInfo kindInfo,
       TraversableGenerator spiGenerator) {
 
     /** Creates a PathTypeInfo without Kind info or SPI generator. */
     static PathTypeInfo of(ClassName pathClass, TypeName innerType, WideningType wideningType) {
-      return new PathTypeInfo(pathClass, innerType, wideningType, null, null);
+      return new PathTypeInfo(pathClass, innerType, wideningType, List.of(), null, null);
     }
 
     /** Creates a PathTypeInfo for a Kind field. */
@@ -484,7 +584,8 @@ public class FocusProcessor extends AbstractProcessor {
             case ZERO_OR_ONE -> WideningType.KIND_ZERO_OR_ONE;
             case ZERO_OR_MORE -> WideningType.KIND_ZERO_OR_MORE;
           };
-      return new PathTypeInfo(pathClass, kindInfo.elementType(), widening, kindInfo, null);
+      return new PathTypeInfo(
+          pathClass, kindInfo.elementType(), widening, List.of(), kindInfo, null);
     }
 
     /** Creates a PathTypeInfo for an SPI-detected field. */
@@ -493,7 +594,13 @@ public class FocusProcessor extends AbstractProcessor {
         TypeName innerType,
         WideningType wideningType,
         TraversableGenerator generator) {
-      return new PathTypeInfo(pathClass, innerType, wideningType, null, generator);
+      return new PathTypeInfo(pathClass, innerType, wideningType, List.of(), null, generator);
+    }
+
+    /** Creates a PathTypeInfo for a nested container with a widening chain. */
+    static PathTypeInfo forNested(
+        ClassName pathClass, TypeName innerType, List<WideningStep> chain) {
+      return new PathTypeInfo(pathClass, innerType, WideningType.NESTED, chain, null, null);
     }
   }
 
@@ -518,12 +625,30 @@ public class FocusProcessor extends AbstractProcessor {
 
     // Check for Optional types (takes precedence over @Nullable)
     if (OPTIONAL_TYPES.contains(qualifiedName)) {
+      TypeMirror innerTypeMirror = getFirstTypeArgument(declaredType);
+      Optional<PathTypeInfo> nested =
+          analyseNestedContainer(
+              new WideningStep(WideningType.OPTIONAL, null, null, innerTypeMirror),
+              innerTypeMirror,
+              widenCollections);
+      if (nested.isPresent()) {
+        return nested.get();
+      }
       TypeName innerType = extractTypeArgument(declaredType);
       return PathTypeInfo.of(AFFINE_PATH_CLASS, innerType, WideningType.OPTIONAL);
     }
 
     // Check for Collection types (takes precedence over @Nullable)
     if (COLLECTION_TYPES.contains(qualifiedName)) {
+      TypeMirror innerTypeMirror = getFirstTypeArgument(declaredType);
+      Optional<PathTypeInfo> nested =
+          analyseNestedContainer(
+              new WideningStep(WideningType.COLLECTION, null, null, innerTypeMirror),
+              innerTypeMirror,
+              widenCollections);
+      if (nested.isPresent()) {
+        return nested.get();
+      }
       TypeName innerType = extractTypeArgument(declaredType);
       return PathTypeInfo.of(TRAVERSAL_PATH_CLASS, innerType, WideningType.COLLECTION);
     }
@@ -549,32 +674,19 @@ public class FocusProcessor extends AbstractProcessor {
     // otherwise they remain FocusPath for backwards compatibility.
     // Generators are pre-sorted by priority descending; highest-priority match wins.
     // Only equal-priority conflicts emit a warning.
-    TraversableGenerator matchedGenerator = null;
-    for (TraversableGenerator generator : traversableGenerators) {
-      if (generator.supports(type)) {
-        if (matchedGenerator != null && matchedGenerator.priority() == generator.priority()) {
-          processingEnv
-              .getMessager()
-              .printMessage(
-                  Diagnostic.Kind.WARNING,
-                  "Multiple TraversableGenerator SPI providers with equal priority ("
-                      + generator.priority()
-                      + ") support type "
-                      + type
-                      + ": "
-                      + matchedGenerator.getClass().getName()
-                      + " and "
-                      + generator.getClass().getName()
-                      + ". Using the first match.",
-                  component);
-        } else if (matchedGenerator == null) {
-          matchedGenerator = generator;
-        }
-        // If matchedGenerator has higher priority, skip silently
-      }
-    }
+    TraversableGenerator matchedGenerator = findSpiGenerator(type, component);
     if (matchedGenerator != null && matchedGenerator.getCardinality() == Cardinality.ZERO_OR_ONE) {
       int typeArgIndex = matchedGenerator.getFocusTypeArgumentIndex();
+      TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, typeArgIndex);
+      Optional<PathTypeInfo> nested =
+          analyseNestedContainer(
+              new WideningStep(
+                  WideningType.SPI_ZERO_OR_ONE, null, matchedGenerator, innerTypeMirror),
+              innerTypeMirror,
+              widenCollections);
+      if (nested.isPresent()) {
+        return nested.get();
+      }
       TypeName innerType = extractTypeArgumentAt(declaredType, typeArgIndex);
       return PathTypeInfo.forSpi(
           AFFINE_PATH_CLASS, innerType, WideningType.SPI_ZERO_OR_ONE, matchedGenerator);
@@ -585,6 +697,16 @@ public class FocusProcessor extends AbstractProcessor {
         && matchedGenerator != null
         && matchedGenerator.getCardinality() == Cardinality.ZERO_OR_MORE) {
       int typeArgIndex = matchedGenerator.getFocusTypeArgumentIndex();
+      TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, typeArgIndex);
+      Optional<PathTypeInfo> nested =
+          analyseNestedContainer(
+              new WideningStep(
+                  WideningType.SPI_ZERO_OR_MORE, null, matchedGenerator, innerTypeMirror),
+              innerTypeMirror,
+              widenCollections);
+      if (nested.isPresent()) {
+        return nested.get();
+      }
       TypeName innerType = extractTypeArgumentAt(declaredType, typeArgIndex);
       return PathTypeInfo.forSpi(
           TRAVERSAL_PATH_CLASS, innerType, WideningType.SPI_ZERO_OR_MORE, matchedGenerator);
@@ -596,6 +718,206 @@ public class FocusProcessor extends AbstractProcessor {
     }
 
     return PathTypeInfo.of(FOCUS_PATH_CLASS, null, WideningType.NONE);
+  }
+
+  /**
+   * Finds the highest-priority SPI generator that supports the given type.
+   *
+   * @param type the type to check
+   * @param component the record component for diagnostic messages (may be null)
+   * @return the matched generator, or null if none found
+   */
+  private TraversableGenerator findSpiGenerator(TypeMirror type, Element component) {
+    TraversableGenerator matchedGenerator = null;
+    for (TraversableGenerator generator : traversableGenerators) {
+      if (generator.supports(type)) {
+        if (matchedGenerator != null && matchedGenerator.priority() == generator.priority()) {
+          if (component != null) {
+            processingEnv
+                .getMessager()
+                .printMessage(
+                    Diagnostic.Kind.WARNING,
+                    "Multiple TraversableGenerator SPI providers with equal priority ("
+                        + generator.priority()
+                        + ") support type "
+                        + type
+                        + ": "
+                        + matchedGenerator.getClass().getName()
+                        + " and "
+                        + generator.getClass().getName()
+                        + ". Using the first match.",
+                    component);
+          }
+        } else if (matchedGenerator == null) {
+          matchedGenerator = generator;
+        }
+      }
+    }
+    return matchedGenerator;
+  }
+
+  /**
+   * Analyses whether an inner type contains nested containers and, if so, builds the full widening
+   * chain starting with the given outer step.
+   *
+   * @param outerStep the widening step for the outermost container
+   * @param innerTypeMirror the inner type to check for further nesting
+   * @param widenCollections whether to widen ZERO_OR_MORE SPI types
+   * @return a PathTypeInfo for the nested chain, or empty if no nesting was found
+   */
+  private Optional<PathTypeInfo> analyseNestedContainer(
+      WideningStep outerStep, TypeMirror innerTypeMirror, boolean widenCollections) {
+    if (innerTypeMirror == null) {
+      return Optional.empty();
+    }
+    List<WideningStep> innerChain = analyseNestedType(innerTypeMirror, widenCollections, 1);
+    if (innerChain.isEmpty()) {
+      return Optional.empty();
+    }
+    List<WideningStep> fullChain = new ArrayList<>();
+    fullChain.add(outerStep);
+    fullChain.addAll(innerChain);
+    TypeName deepInnerType = resolveDeepInnerType(innerTypeMirror, innerChain);
+    ClassName pathClass = computeComposedPathClass(fullChain);
+    return Optional.of(PathTypeInfo.forNested(pathClass, deepInnerType, fullChain));
+  }
+
+  /**
+   * Recursively analyses a type to detect nested container patterns. Returns a list of widening
+   * steps for the inner containers, or an empty list if the type is not a recognised container.
+   *
+   * @param type the type to analyse
+   * @param widenCollections whether to widen ZERO_OR_MORE SPI types
+   * @param depth current recursion depth
+   * @return list of widening steps for nested containers
+   */
+  private List<WideningStep> analyseNestedType(
+      TypeMirror type, boolean widenCollections, int depth) {
+    if (depth >= MAX_NESTING_DEPTH || type.getKind() != TypeKind.DECLARED) {
+      return List.of();
+    }
+
+    DeclaredType declaredType = (DeclaredType) type;
+    TypeElement typeElement = (TypeElement) declaredType.asElement();
+    String qualifiedName = typeElement.getQualifiedName().toString();
+
+    // Check for Optional types
+    if (OPTIONAL_TYPES.contains(qualifiedName)) {
+      List<WideningStep> steps = new ArrayList<>();
+      TypeMirror innerTypeMirror = getFirstTypeArgument(declaredType);
+      steps.add(new WideningStep(WideningType.OPTIONAL, null, null, innerTypeMirror));
+      if (innerTypeMirror != null) {
+        steps.addAll(analyseNestedType(innerTypeMirror, widenCollections, depth + 1));
+      }
+      return steps;
+    }
+
+    // Check for Collection types
+    if (COLLECTION_TYPES.contains(qualifiedName)) {
+      List<WideningStep> steps = new ArrayList<>();
+      TypeMirror innerTypeMirror = getFirstTypeArgument(declaredType);
+      steps.add(new WideningStep(WideningType.COLLECTION, null, null, innerTypeMirror));
+      if (innerTypeMirror != null) {
+        steps.addAll(analyseNestedType(innerTypeMirror, widenCollections, depth + 1));
+      }
+      return steps;
+    }
+
+    // Check for SPI types
+    TraversableGenerator gen = findSpiGenerator(type, null);
+    if (gen != null && gen.getCardinality() == Cardinality.ZERO_OR_ONE) {
+      List<WideningStep> steps = new ArrayList<>();
+      TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, gen.getFocusTypeArgumentIndex());
+      steps.add(new WideningStep(WideningType.SPI_ZERO_OR_ONE, null, gen, innerTypeMirror));
+      if (innerTypeMirror != null) {
+        steps.addAll(analyseNestedType(innerTypeMirror, widenCollections, depth + 1));
+      }
+      return steps;
+    }
+    if (widenCollections && gen != null && gen.getCardinality() == Cardinality.ZERO_OR_MORE) {
+      List<WideningStep> steps = new ArrayList<>();
+      TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, gen.getFocusTypeArgumentIndex());
+      steps.add(new WideningStep(WideningType.SPI_ZERO_OR_MORE, null, gen, innerTypeMirror));
+      if (innerTypeMirror != null) {
+        steps.addAll(analyseNestedType(innerTypeMirror, widenCollections, depth + 1));
+      }
+      return steps;
+    }
+
+    return List.of();
+  }
+
+  /**
+   * Computes the final path class by composing the widening lattice across a chain.
+   *
+   * <p>The widening lattice: Focus + Affine = Affine, Focus + Traversal = Traversal, Affine +
+   * Traversal = Traversal.
+   */
+  private ClassName computeComposedPathClass(List<WideningStep> chain) {
+    boolean hasTraversal = false;
+    boolean hasAffine = false;
+    for (WideningStep step : chain) {
+      switch (step.type()) {
+        case COLLECTION, KIND_ZERO_OR_MORE, SPI_ZERO_OR_MORE -> hasTraversal = true;
+        case OPTIONAL, NULLABLE, KIND_ZERO_OR_ONE, KIND_EXACTLY_ONE, SPI_ZERO_OR_ONE ->
+            hasAffine = true;
+        default -> {}
+      }
+    }
+    if (hasTraversal) return TRAVERSAL_PATH_CLASS;
+    if (hasAffine) return AFFINE_PATH_CLASS;
+    return FOCUS_PATH_CLASS;
+  }
+
+  /**
+   * Resolves the deepest inner type by walking through the nested container chain.
+   *
+   * @param typeMirror the type at the current nesting level
+   * @param chain the remaining widening steps
+   * @return the innermost type name
+   */
+  private TypeName resolveDeepInnerType(TypeMirror typeMirror, List<WideningStep> chain) {
+    if (chain.isEmpty() || typeMirror.getKind() != TypeKind.DECLARED) {
+      return TypeName.get(typeMirror).box();
+    }
+
+    DeclaredType declaredType = (DeclaredType) typeMirror;
+    WideningStep step = chain.getFirst();
+
+    int typeArgIndex = 0;
+    if (step.spiGenerator() != null) {
+      typeArgIndex = step.spiGenerator().getFocusTypeArgumentIndex();
+    }
+
+    TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, typeArgIndex);
+    if (innerTypeMirror == null) {
+      return ClassName.get(Object.class);
+    }
+
+    if (chain.size() == 1) {
+      // Resolve wildcard bounds on the innermost type
+      TypeMirror resolved = ProcessorUtils.resolveWildcard(innerTypeMirror);
+      return resolved != null ? TypeName.get(resolved).box() : ClassName.get(Object.class);
+    }
+
+    return resolveDeepInnerType(innerTypeMirror, chain.subList(1, chain.size()));
+  }
+
+  /** Gets the first type argument of a declared type, or null if none. */
+  private TypeMirror getFirstTypeArgument(DeclaredType declaredType) {
+    return getTypeArgumentAt(declaredType, 0);
+  }
+
+  /** Gets the type argument at the given index, or null if out of bounds. */
+  private TypeMirror getTypeArgumentAt(DeclaredType declaredType, int index) {
+    List<? extends TypeMirror> args = declaredType.getTypeArguments();
+    if (args.isEmpty() || index >= args.size()) {
+      return null;
+    }
+    TypeMirror arg = args.get(index);
+    // Resolve wildcard bounds
+    TypeMirror resolved = ProcessorUtils.resolveWildcard(arg);
+    return resolved != null ? resolved : null;
   }
 
   /** Extracts the first type argument from a parameterised type. */
@@ -620,19 +942,33 @@ public class FocusProcessor extends AbstractProcessor {
 
   /** Gets the path class description for Javadoc. */
   private String getPathDescription(PathTypeInfo info) {
+    if (info.wideningType == WideningType.NESTED) {
+      ClassName pathClass = info.pathClass();
+      if (pathClass.equals(TRAVERSAL_PATH_CLASS)) return "TraversalPath";
+      if (pathClass.equals(AFFINE_PATH_CLASS)) return "AffinePath";
+      return "FocusPath";
+    }
     return switch (info.wideningType) {
       case OPTIONAL, NULLABLE, KIND_ZERO_OR_ONE, KIND_EXACTLY_ONE, SPI_ZERO_OR_ONE -> "AffinePath";
       case COLLECTION, KIND_ZERO_OR_MORE, SPI_ZERO_OR_MORE -> "TraversalPath";
       case NONE -> "FocusPath";
+      case NESTED -> "FocusPath"; // handled above, unreachable
     };
   }
 
   /** Gets the appropriate get method name for Javadoc examples. */
   private String getPathGetMethod(PathTypeInfo info) {
+    if (info.wideningType == WideningType.NESTED) {
+      ClassName pathClass = info.pathClass();
+      if (pathClass.equals(TRAVERSAL_PATH_CLASS)) return "getAll";
+      if (pathClass.equals(AFFINE_PATH_CLASS)) return "getOptional";
+      return "get";
+    }
     return switch (info.wideningType) {
       case OPTIONAL, NULLABLE, KIND_ZERO_OR_ONE, KIND_EXACTLY_ONE, SPI_ZERO_OR_ONE -> "getOptional";
       case COLLECTION, KIND_ZERO_OR_MORE, SPI_ZERO_OR_MORE -> "getAll";
       case NONE -> "get";
+      case NESTED -> "get"; // handled above, unreachable
     };
   }
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -147,7 +147,9 @@ public class NavigatorClassGenerator {
   }
 
   /**
-   * Determines what path kind a field type introduces, considering annotations.
+   * Determines what path kind a field type introduces, considering annotations. Recursively
+   * composes path kinds for nested container types (e.g., Optional&lt;List&lt;String&gt;&gt;
+   * produces TRAVERSAL).
    *
    * @param component the record component (may be null for nested navigation)
    * @param type the field type to analyse
@@ -159,7 +161,21 @@ public class NavigatorClassGenerator {
       return PathKind.AFFINE;
     }
 
-    if (type.getKind() != TypeKind.DECLARED) {
+    return getFieldPathKindRecursive(type, 0);
+  }
+
+  /** Maximum recursion depth for nested container path kind analysis. */
+  private static final int MAX_NAVIGATOR_NESTING_DEPTH = 3;
+
+  /**
+   * Recursively determines the composed path kind for a type, accounting for nested containers.
+   *
+   * @param type the type to analyse
+   * @param depth current recursion depth
+   * @return the composed path kind
+   */
+  private PathKind getFieldPathKindRecursive(TypeMirror type, int depth) {
+    if (depth >= MAX_NAVIGATOR_NESTING_DEPTH || type.getKind() != TypeKind.DECLARED) {
       return PathKind.FOCUS;
     }
 
@@ -168,10 +184,12 @@ public class NavigatorClassGenerator {
     String qualifiedName = typeElement.getQualifiedName().toString();
 
     if (OPTIONAL_TYPES.contains(qualifiedName)) {
-      return PathKind.AFFINE;
+      PathKind innerKind = getInnerPathKind(declaredType, 0, depth);
+      return PathKind.AFFINE.widen(innerKind);
     }
     if (COLLECTION_TYPES.contains(qualifiedName)) {
-      return PathKind.TRAVERSAL;
+      PathKind innerKind = getInnerPathKind(declaredType, 0, depth);
+      return PathKind.TRAVERSAL.widen(innerKind);
     }
 
     // Check for subtypes of Collection
@@ -179,7 +197,8 @@ public class NavigatorClassGenerator {
       if (iface.getKind() == TypeKind.DECLARED) {
         TypeElement ifaceElement = (TypeElement) ((DeclaredType) iface).asElement();
         if (COLLECTION_TYPES.contains(ifaceElement.getQualifiedName().toString())) {
-          return PathKind.TRAVERSAL;
+          PathKind innerKind = getInnerPathKind(declaredType, 0, depth);
+          return PathKind.TRAVERSAL.widen(innerKind);
         }
       }
     }
@@ -190,38 +209,41 @@ public class NavigatorClassGenerator {
     }
 
     // Consult TraversableGenerator SPI for additional container types.
-    // Generators are pre-sorted by priority descending; highest-priority match wins.
-    // Only equal-priority conflicts emit a warning.
-    TraversableGenerator matched = null;
-    for (TraversableGenerator generator : traversableGenerators) {
-      if (generator.supports(type)) {
-        if (matched != null && matched.priority() == generator.priority()) {
-          processingEnv
-              .getMessager()
-              .printMessage(
-                  Diagnostic.Kind.WARNING,
-                  "Multiple TraversableGenerator SPI providers with equal priority ("
-                      + generator.priority()
-                      + ") support type "
-                      + type
-                      + ": "
-                      + matched.getClass().getName()
-                      + " and "
-                      + generator.getClass().getName()
-                      + ". Using the first match.");
-        } else if (matched == null) {
-          matched = generator;
-        }
-      }
-    }
+    TraversableGenerator matched = findSpiGenerator(type);
     if (matched != null) {
-      return switch (matched.getCardinality()) {
-        case ZERO_OR_ONE -> PathKind.AFFINE;
-        case ZERO_OR_MORE -> PathKind.TRAVERSAL;
-      };
+      PathKind spiKind =
+          switch (matched.getCardinality()) {
+            case ZERO_OR_ONE -> PathKind.AFFINE;
+            case ZERO_OR_MORE -> PathKind.TRAVERSAL;
+          };
+      PathKind innerKind =
+          getInnerPathKind(declaredType, matched.getFocusTypeArgumentIndex(), depth);
+      return spiKind.widen(innerKind);
     }
 
     return PathKind.FOCUS;
+  }
+
+  /**
+   * Gets the composed path kind of the inner type argument at the given index.
+   *
+   * @param declaredType the outer container type
+   * @param typeArgIndex the index of the type argument to check
+   * @param currentDepth the current recursion depth
+   * @return the path kind of the inner type, or FOCUS if not a container
+   */
+  private PathKind getInnerPathKind(DeclaredType declaredType, int typeArgIndex, int currentDepth) {
+    List<? extends TypeMirror> args = declaredType.getTypeArguments();
+    if (args.isEmpty() || typeArgIndex >= args.size()) {
+      return PathKind.FOCUS;
+    }
+    TypeMirror innerType = args.get(typeArgIndex);
+    // Resolve wildcards
+    TypeMirror resolved = ProcessorUtils.resolveWildcard(innerType);
+    if (resolved == null) {
+      return PathKind.FOCUS;
+    }
+    return getFieldPathKindRecursive(resolved, currentDepth + 1);
   }
 
   /**
@@ -1041,14 +1063,37 @@ public class NavigatorClassGenerator {
     return (TypeElement) declaredType.asElement();
   }
 
-  /** Finds the SPI generator for a type and returns it, or null if none matches. */
+  /**
+   * Finds the highest-priority SPI generator that supports the given type. Emits a warning if
+   * multiple generators with equal priority match.
+   *
+   * @param type the type to check
+   * @return the matched generator, or null if none found
+   */
   private TraversableGenerator findSpiGenerator(TypeMirror type) {
+    TraversableGenerator matched = null;
     for (TraversableGenerator generator : traversableGenerators) {
       if (generator.supports(type)) {
-        return generator;
+        if (matched != null && matched.priority() == generator.priority()) {
+          processingEnv
+              .getMessager()
+              .printMessage(
+                  Diagnostic.Kind.WARNING,
+                  "Multiple TraversableGenerator SPI providers with equal priority ("
+                      + generator.priority()
+                      + ") support type "
+                      + type
+                      + ": "
+                      + matched.getClass().getName()
+                      + " and "
+                      + generator.getClass().getName()
+                      + ". Using the first match.");
+        } else if (matched == null) {
+          matched = generator;
+        }
       }
     }
-    return null;
+    return matched;
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNestedContainerTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNestedContainerTest.java
@@ -1,0 +1,536 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for nested container widening: automatic detection of nested container patterns and
+ * generation of composed widening chains.
+ *
+ * <p>Covers patterns such as:
+ *
+ * <ul>
+ *   <li>{@code Optional<List<String>>} produces {@code .some().each()} returning TraversalPath
+ *   <li>{@code List<Optional<String>>} produces {@code .each().some()} returning TraversalPath
+ *   <li>{@code Optional<Optional<String>>} produces {@code .some().some()} returning AffinePath
+ *   <li>{@code List<List<String>>} produces {@code .each().each()} returning TraversalPath
+ * </ul>
+ */
+@DisplayName("Nested Container Widening")
+public class FocusProcessorNestedContainerTest {
+
+  @Nested
+  @DisplayName("Two-Level Nesting")
+  class TwoLevelNesting {
+
+    @Test
+    @DisplayName("Optional<List<String>> should produce .some().each() returning TraversalPath")
+    void optionalOfListShouldProduceSomeThenEach() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, Optional<List<String>> tags) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> tags() {
+              return FocusPath.of(Lens.of(Config::tags, (source, newValue) -> new Config(source.name(), newValue))).some().each();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName("List<Optional<String>> should produce .each().some() returning TraversalPath")
+    void listOfOptionalShouldProduceEachThenSome() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, List<Optional<String>> items) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> items() {
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).each().some();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName("Optional<Optional<String>> should produce .some().some() returning AffinePath")
+    void optionalOfOptionalShouldProduceSomeThenSome() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+
+              @GenerateFocus
+              public record Config(String name, Optional<Optional<String>> nested) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static AffinePath<Config, String> nested() {
+              return FocusPath.of(Lens.of(Config::nested, (source, newValue) -> new Config(source.name(), newValue))).some().some();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName("List<List<String>> should produce .each().each() returning TraversalPath")
+    void listOfListShouldProduceEachThenEach() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, List<List<String>> matrix) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> matrix() {
+              return FocusPath.of(Lens.of(Config::matrix, (source, newValue) -> new Config(source.name(), newValue))).each().each();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName("Set<Optional<String>> should produce .each().some() returning TraversalPath")
+    void setOfOptionalShouldProduceEachThenSome() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+              import java.util.Set;
+
+              @GenerateFocus
+              public record Config(String name, Set<Optional<String>> items) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> items() {
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).each().some();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+  }
+
+  @Nested
+  @DisplayName("Three-Level Nesting")
+  class ThreeLevelNesting {
+
+    @Test
+    @DisplayName(
+        "Optional<List<Optional<String>>> should produce .some().each().some() returning"
+            + " TraversalPath")
+    void optionalOfListOfOptionalShouldProduceThreeLevelChain() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, Optional<List<Optional<String>>> deep) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> deep() {
+              return FocusPath.of(Lens.of(Config::deep, (source, newValue) -> new Config(source.name(), newValue))).some().each().some();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName(
+        "List<List<List<String>>> should produce .each().each().each() returning TraversalPath")
+    void listOfListOfListShouldProduceThreeLevelChain() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, List<List<List<String>>> cube) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> cube() {
+              return FocusPath.of(Lens.of(Config::cube, (source, newValue) -> new Config(source.name(), newValue))).each().each().each();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+  }
+
+  @Nested
+  @DisplayName("Non-Nested Types Unchanged")
+  class NonNestedRegression {
+
+    @Test
+    @DisplayName("Simple Optional<String> should still produce .some() returning AffinePath")
+    void simpleOptionalShouldBeUnchanged() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+
+              @GenerateFocus
+              public record Config(String name, Optional<String> email) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static AffinePath<Config, String> email() {
+              return FocusPath.of(Lens.of(Config::email, (source, newValue) -> new Config(source.name(), newValue))).some();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName("Simple List<String> should still produce .each() returning TraversalPath")
+    void simpleListShouldBeUnchanged() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, List<String> items) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, String> items() {
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).each();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName("Plain String field should remain FocusPath")
+    void plainFieldShouldBeUnchanged() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Config(String name) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static FocusPath<Config, String> name() {
+              return FocusPath.of(Lens.of(Config::name, (source, newValue) -> new Config(newValue)));
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+  }
+
+  @Nested
+  @DisplayName("SPI Container Nesting")
+  class SpiContainerNesting {
+
+    @Test
+    @DisplayName(
+        "Optional<Either<String, Integer>> should produce"
+            + " .<Either<String, Integer>>some().some(Affines.eitherRight()) returning AffinePath")
+    void optionalOfEitherShouldProduceSomeThenSpiSome() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.higherkindedj.hkt.either.Either;
+              import java.util.Optional;
+
+              @GenerateFocus
+              public record Config(String name, Optional<Either<String, Integer>> result) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static AffinePath<Config, Integer> result() {
+              return FocusPath.of(Lens.of(Config::result, (source, newValue) -> new Config(source.name(), newValue))).<Either<String, Integer>>some().some(Affines.eitherRight());
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName(
+        "List<Either<String, Integer>> should produce"
+            + " .<Either<String, Integer>>each().some(Affines.eitherRight()) returning TraversalPath")
+    void listOfEitherShouldProduceEachThenSpiSome() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.higherkindedj.hkt.either.Either;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, List<Either<String, Integer>> results) {}
+              """);
+
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, Integer> results() {
+              return FocusPath.of(Lens.of(Config::results, (source, newValue) -> new Config(source.name(), newValue))).<Either<String, Integer>>each().some(Affines.eitherRight());
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+
+    @Test
+    @DisplayName(
+        "Either<String, List<Integer>> with widenCollections should produce"
+            + " .some(eitherRight()).each() returning TraversalPath")
+    void eitherOfListShouldProduceSpiSomeThenEach() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.higherkindedj.hkt.either.Either;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(String name, Either<String, List<Integer>> items) {}
+              """);
+
+      // Either<String, List<Integer>>:
+      // The outer Either is an SPI ZERO_OR_ONE type (focuses on R = List<Integer>)
+      // The inner List<Integer> is a COLLECTION type
+      // Chain: .some(Affines.eitherRight()).each() → TraversalPath
+      final String expectedMethod =
+          """
+          public static TraversalPath<Config, Integer> items() {
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).some(Affines.eitherRight()).each();
+          }
+          """;
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedMethod);
+    }
+  }
+
+  @Nested
+  @DisplayName("Widening Lattice Composition")
+  class WideningLattice {
+
+    @Test
+    @DisplayName("Affine + Affine = Affine (Optional<Optional<String>>)")
+    void affinePlusAffineShouldBeAffine() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+
+              @GenerateFocus
+              public record Config(Optional<Optional<String>> value) {}
+              """);
+
+      // AffinePath because Affine + Affine = Affine
+      final String expectedReturn = "public static AffinePath<Config, String> value()";
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedReturn);
+    }
+
+    @Test
+    @DisplayName("Affine + Traversal = Traversal (Optional<List<String>>)")
+    void affinePlusTraversalShouldBeTraversal() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(Optional<List<String>> value) {}
+              """);
+
+      // TraversalPath because Affine + Traversal = Traversal
+      final String expectedReturn = "public static TraversalPath<Config, String> value()";
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedReturn);
+    }
+
+    @Test
+    @DisplayName("Traversal + Affine = Traversal (List<Optional<String>>)")
+    void traversalPlusAffineShouldBeTraversal() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.Optional;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(List<Optional<String>> value) {}
+              """);
+
+      // TraversalPath because Traversal + Affine = Traversal
+      final String expectedReturn = "public static TraversalPath<Config, String> value()";
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedReturn);
+    }
+
+    @Test
+    @DisplayName("Traversal + Traversal = Traversal (List<List<String>>)")
+    void traversalPlusTraversalShouldBeTraversal() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Config",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import java.util.List;
+
+              @GenerateFocus
+              public record Config(List<List<String>> value) {}
+              """);
+
+      // TraversalPath because Traversal + Traversal = Traversal
+      final String expectedReturn = "public static TraversalPath<Config, String> value()";
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedReturn);
+    }
+  }
+}


### PR DESCRIPTION
- Support nested container widening in Navigator/Focus code generation so types like Optional<List<String>> resolve traversals correctly
- Fix type inference failure in nested SPI container widening
- Restore equal-priority SPI generator warning in NavigatorClassGenerator
Fixes #433 