### PR TITLE
Auto-publish snapshots on merge to main and add snapshot badge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: Publish Higher-Kinded-J package to Maven Central
 
 on:
   push:
-    tags: # Trigger publishing only when a tag is pushed (e.g., 'v1.0.0')
+    branches: [ "main" ] # Auto-publish snapshot on merge to main
+    tags: # Publish release when a version tag is pushed (e.g., 'v1.0.0')
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
@@ -19,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history and tags for version derivation
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5
@@ -37,10 +40,28 @@ jobs:
           VERSION=""
           IS_SNAPSHOT=""
           if [[ "${{ github.event_name }}" == "push" && "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
+            # --- Release: triggered by version tag ---
             VERSION="${{ github.ref_name }}" # e.g., v0.1.3
             VERSION="${VERSION#v}"          # Remove 'v' prefix -> 0.1.3
             IS_SNAPSHOT="false"
             echo "Version from tag: $VERSION"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # --- Snapshot: triggered by merge to main ---
+            # Derive snapshot version from latest release tag: v0.4.0 -> 0.4.1-SNAPSHOT
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "")
+            if [[ -n "$LATEST_TAG" ]]; then
+              TAG_VERSION="${LATEST_TAG#v}" # e.g., 0.4.0
+              MAJOR=$(echo "$TAG_VERSION" | cut -d. -f1)
+              MINOR=$(echo "$TAG_VERSION" | cut -d. -f2)
+              PATCH=$(echo "$TAG_VERSION" | cut -d. -f3)
+              NEXT_PATCH=$((PATCH + 1))
+              VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
+              echo "Snapshot version derived from tag $LATEST_TAG: $VERSION"
+            else
+              VERSION="0.0.1-SNAPSHOT"
+              echo "No release tags found, using default snapshot: $VERSION"
+            fi
+            IS_SNAPSHOT="true"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${{ github.event.inputs.version }}"
             if [[ "$VERSION" == *"-SNAPSHOT" ]]; then
@@ -50,7 +71,7 @@ jobs:
             fi
             echo "Version from input: $VERSION"
           else
-            # Default to a SNAPSHOT version based on commit if needed, or fail
+            # Default fallback
             VERSION="0.0.0-SNAPSHOT-$(git rev-parse --short HEAD)"
             IS_SNAPSHOT="true"
             echo "Default SNAPSHOT version: $VERSION"
@@ -60,12 +81,23 @@ jobs:
             echo "Error: Version could not be determined."
             exit 1
           fi
-          
-          # Corrected way to set outputs
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "is_snapshot=$IS_SNAPSHOT" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      - name: Log publish details
+        run: |
+          echo "============================================================"
+          echo "  PUBLISHING HIGHER-KINDED-J"
+          echo "============================================================"
+          echo "  Version:     ${{ steps.versioner.outputs.version }}"
+          echo "  Is Snapshot: ${{ steps.versioner.outputs.is_snapshot }}"
+          echo "  Trigger:     ${{ github.event_name }}"
+          echo "  Ref:         ${{ github.ref }}"
+          echo "  Commit:      ${{ github.sha }}"
+          echo "============================================================"
+        shell: bash
 
       - name: Publish to Central Portal
         env:
@@ -79,6 +111,42 @@ jobs:
         run: |
           echo "Publishing version ${{ steps.versioner.outputs.version }} to Central Portal"
           ./gradlew publishToMavenCentral -PprojectVersion=${{ steps.versioner.outputs.version }}
+        shell: bash
+
+      - name: Log publish result
+        run: |
+          VERSION="${{ steps.versioner.outputs.version }}"
+          IS_SNAPSHOT="${{ steps.versioner.outputs.is_snapshot }}"
+          echo "============================================================"
+          echo "  PUBLISH COMPLETE"
+          echo "============================================================"
+          echo "  Published version: $VERSION"
+          echo ""
+          echo "  Artifacts published to Maven Central:"
+          echo "    - io.github.higher-kinded-j:hkj-core:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-api:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-annotations:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-processor:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-processor-plugins:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-bom:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-gradle-plugin:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-maven-plugin:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-openrewrite:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-checker:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-spring-autoconfigure:$VERSION"
+          echo "    - io.github.higher-kinded-j:hkj-spring-starter:$VERSION"
+          echo ""
+          if [[ "$IS_SNAPSHOT" == "true" ]]; then
+            echo "  Repository: Maven Central Snapshots"
+            echo "  URL: https://central.sonatype.com/repository/maven-snapshots/io/github/higher-kinded-j/"
+            echo ""
+            echo "  Note: Gradle Plugin Portal does not accept snapshots."
+            echo "  The Gradle plugin is available from Maven Central Snapshots."
+          else
+            echo "  Repository: Maven Central"
+            echo "  URL: https://central.sonatype.com/artifact/io.github.higher-kinded-j/hkj-core"
+          fi
+          echo "============================================================"
         shell: bash
 
       - name: Publish Gradle Plugin to Plugin Portal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 <div align="center">
   <a href="https://github.com/higher-kinded-j/higher-kinded-j"><img src="https://img.shields.io/badge/code-blue?logo=github" alt="GitHub Repository"></a>
   <a href="https://codecov.io/gh/higher-kinded-j/higher-kinded-j"><img src="https://img.shields.io/codecov/c/github/higher-kinded-j/higher-kinded-j?token=VR0K0ZEDHD" alt="Codecov Coverage"></a>
-  <a href="https://central.sonatype.com/artifact/io.github.higher-kinded-j/hkj-core"><img src="https://img.shields.io/maven-central/v/io.github.higher-kinded-j/hkj-core" alt="Maven Central"></a>
+  <a href="https://central.sonatype.com/artifact/io.github.higher-kinded-j/hkj-core"><img src="https://img.shields.io/maven-central/v/io.github.higher-kinded-j/hkj-core?versionPrefix=&label=maven-central" alt="Maven Central"></a>
+  <a href="https://central.sonatype.com/repository/maven-snapshots/io/github/higher-kinded-j/hkj-core/"><img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fgithub%2Fhigher-kinded-j%2Fhkj-core%2Fmaven-metadata.xml&versionPrefix=&label=snapshot&color=green" alt="Latest Snapshot"></a>
   <a href="https://github.com/higher-kinded-j/higher-kinded-j/discussions"><img src="https://img.shields.io/github/discussions/higher-kinded-j/higher-kinded-j" alt="GitHub Discussions"></a>
   <a href="https://techhub.social/@ultramagnetic"><img src="https://img.shields.io/mastodon/follow/109367467120571209?domain=techhub.social&style=plastic&logoSize=auto" alt="Follow on Mastodon"></a>
 </div>
@@ -289,7 +290,7 @@ For **SNAPSHOT** versions, add the Sonatype snapshots repository to both `plugin
 // settings.gradle.kts
 pluginManagement {
     repositories {
-        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
         gradlePluginPortal()
         mavenCentral()
     }
@@ -300,7 +301,7 @@ pluginManagement {
 // build.gradle.kts
 repositories {
     mavenCentral()
-    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 ```
 
@@ -341,7 +342,7 @@ See the **[Quickstart Guide](https://higher-kinded-j.github.io/latest/quickstart
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 ```

--- a/hkj-book/src/home.md
+++ b/hkj-book/src/home.md
@@ -8,7 +8,8 @@
 <div style="text-align: center;">
   <a href="https://github.com/higher-kinded-j/higher-kinded-j"><img src="https://img.shields.io/badge/code-blue?logo=github" alt="Static Badge"></a>
   <a href="https://codecov.io/gh/higher-kinded-j/higher-kinded-j"><img src="https://img.shields.io/codecov/c/github/higher-kinded-j/higher-kinded-j?token=VR0K0ZEDHD" alt="Codecov"></a>
-  <a href="https://central.sonatype.com/artifact/io.github.higher-kinded-j/hkj-core"><img src="https://img.shields.io/maven-central/v/io.github.higher-kinded-j/hkj-core" alt="Maven Central Version"></a>
+  <a href="https://central.sonatype.com/artifact/io.github.higher-kinded-j/hkj-core"><img src="https://img.shields.io/maven-central/v/io.github.higher-kinded-j/hkj-core?versionPrefix=&label=maven-central" alt="Maven Central Version"></a>
+  <a href="https://central.sonatype.com/repository/maven-snapshots/io/github/higher-kinded-j/hkj-core/"><img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fgithub%2Fhigher-kinded-j%2Fhkj-core%2Fmaven-metadata.xml&versionPrefix=&label=snapshot&color=green" alt="Latest Snapshot"></a>
   <a href="https://github.com/higher-kinded-j/higher-kinded-j/discussions"><img src="https://img.shields.io/github/discussions/higher-kinded-j/higher-kinded-j" alt="GitHub Discussions"></a>
   <a href="https://techhub.social/@ultramagnetic"><img src="https://img.shields.io/mastodon/follow/109367467120571209?domain=techhub.social&style=plastic&logoSize=auto" alt="Mastodon Follow"></a>
 </div>

--- a/hkj-book/src/quickstart.md
+++ b/hkj-book/src/quickstart.md
@@ -36,7 +36,7 @@ For **SNAPSHOT** versions of the plugin, add the Sonatype snapshots repository t
 pluginManagement {
     repositories {
         maven {
-            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
         gradlePluginPortal()
         mavenCentral()
@@ -51,7 +51,7 @@ You also need the snapshots repository in your project's `repositories` block so
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 ```
@@ -97,7 +97,7 @@ For SNAPSHOTS, add the Sonatype snapshots repository:
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 ```

--- a/hkj-book/src/tooling/gradle_plugin.md
+++ b/hkj-book/src/tooling/gradle_plugin.md
@@ -64,7 +64,7 @@ SNAPSHOT versions of the plugin are published to the Sonatype snapshots reposito
 pluginManagement {
     repositories {
         maven {
-            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
         gradlePluginPortal()
         mavenCentral()
@@ -79,7 +79,7 @@ You also need the same repository in your project's `repositories` block so the 
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 ```


### PR DESCRIPTION
- Trigger publish workflow on push to main, deriving snapshot version from the latest release tag (e.g. v0.4.0 → 0.4.1-SNAPSHOT)
- Add green snapshot version badge (shields.io maven-metadata/v) to README.md and hkj-book home page, alongside the Maven Central badge
- Remove v prefix from both version badges to match Maven/Gradle coords
- Replace all defunct s01.oss.sonatype.org URLs with the new central.sonatype.com/repository/maven-snapshots across all docs
- Add detailed artifact listing to publish workflow logs

