### PR TITLE
Add mapT method to all monad transformers with custom assertions

### DIFF
--- a/hkj-book/src/transformers/archetypes.md
+++ b/hkj-book/src/transformers/archetypes.md
@@ -181,19 +181,19 @@ A REST API receives a request body with multiple fields. Each field has its own 
 
 <pre style="line-height:1.5;font-size:0.95em">
     <span style="color:#4CAF50">validateName ════●═══╗</span>
-                        ║
+    <span style="color:#4CAF50">                     ║</span>
     <span style="color:#4CAF50">validateEmail ═══●═══╬═══ zipWith3Accum ═══●═══▶  Registration</span>
-                        ║
+    <span style="color:#4CAF50">                     ║</span>
     <span style="color:#4CAF50">validateAge ════●════╝</span>
 
     If any fail, errors <b>accumulate</b> (not short-circuit):
 
     <span style="color:#F44336">validateName ────●───╗</span>
     <span style="color:#F44336">  "Name too short"   ║</span>
-                        <span style="color:#F44336">╠═══ zipWith3Accum ═══●═══▶  List[err1, err2]</span>
+    <span style="color:#F44336">                     ╠═══ zipWith3Accum ═══●═══▶  List[err1, err2]</span>
     <span style="color:#F44336">validateEmail ───●───╝</span>
-    <span style="color:#F44336">  "Invalid email"</span>
-                        ║
+    <span style="color:#F44336">  "Invalid email"</span><span style="color:#4CAF50">    ║</span>
+    <span style="color:#4CAF50">                     ║</span>
     <span style="color:#4CAF50">validateAge ════●════╝</span>
     <span style="color:#4CAF50">  (valid, but still</span>
     <span style="color:#4CAF50">   collected with errors)</span>
@@ -314,7 +314,7 @@ Financial regulations require every step in a transaction to produce an audit en
 <pre style="line-height:1.5;font-size:0.95em">
     <span style="color:#4CAF50"><b>Value</b>   ═══●══════════════●══════════════●═══▶  TransferResult</span>
     <span style="color:#4CAF50">         debit          credit         map</span>
-              │                │
+              │               │
               ▼ <i>siding</i>        ▼ <i>siding</i>
     <span style="color:#FFB300"><b>Log</b>     ──●──────────────●──────────────────▶  [DEBIT, CREDIT]</span>
     <span style="color:#FFB300">       [DEBIT ...]    [CREDIT ...]</span>

--- a/hkj-book/src/transformers/eithert_transformer.md
+++ b/hkj-book/src/transformers/eithert_transformer.md
@@ -162,6 +162,43 @@ EitherT<F, L, R> concrete = EITHER_T.narrow(kind);
 
 ---
 
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of an `EitherT` without touching the inner `Either` at all. Imagine you have built a pipeline over `CompletableFuture` but now want to continue in a synchronous `Optional` context — or you want to apply a cross-cutting concern (logging, retry) at the monad level.
+
+`mapT` does exactly this. It applies a function to the wrapped `Kind<F, Either<L, R>>` and produces a new `EitherT<G, L, R>`:
+
+```
+  EitherT< F , L, R >  ── mapT(f) ──>  EitherT< G , L, R >
+       │                                      │
+  ┌────┴────┐                            ┌────┴────┐
+  │    F    │     f: F[...] -> G[...]    │    G    │
+  │ ┌─────┐ │         ====>              │ ┌─────┐ │
+  │ │ E   │ │   inner Either untouched   │ │ E   │ │
+  │ │ L|R │ │                            │ │ L|R │ │
+  │ └─────┘ │                            │ └─────┘ │
+  └─────────┘                            └─────────┘
+```
+
+```java
+// Switch from Future to Optional after awaiting a result
+EitherT<CompletableFutureKind.Witness, Error, Data> futureET = ...;
+
+EitherT<OptionalKind.Witness, Error, Data> optionalET =
+    futureET.mapT(futureKind -> {
+      Either<Error, Data> awaited = FUTURE.join(futureKind);
+      return OPTIONAL.widen(Optional.of(awaited));
+    });
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* inside the `Either` (the `R` in `Right(R)`).
+`mapT` transforms the *outer monad* wrapping the `Either` — the `F` in `F<Either<L, R>>`.
+They operate at different levels of the transformer stack.
+~~~
+
+---
+
 ## Creating EitherT Instances
 
 ~~~admonish title="Creating _EitherT_ Instances"

--- a/hkj-book/src/transformers/maybet_transformer.md
+++ b/hkj-book/src/transformers/maybet_transformer.md
@@ -147,6 +147,43 @@ MaybeT<F, A> concrete = MAYBE_T.narrow(kind);
 
 ---
 
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of a `MaybeT` without touching the inner `Maybe` at all. Perhaps you have an `IO`-based pipeline but want to switch to a `Task` for structured concurrency, or you want to collapse two layers of optionality by moving from `Optional<Maybe<A>>` to `Id<Maybe<A>>`.
+
+`mapT` applies a function to the wrapped `Kind<F, Maybe<A>>` and produces a new `MaybeT<G, A>`:
+
+```
+  MaybeT< F , A >  ── mapT(f) ──>  MaybeT< G , A >
+       │                                  │
+  ┌────┴────┐                        ┌────┴────┐
+  │    F    │   f: F[...] -> G[...]  │    G    │
+  │ ┌─────┐ │        ====>           │ ┌─────┐ │
+  │ │Maybe│ │  inner Maybe sealed    │ │Maybe│ │
+  │ │  A  │ │                        │ │  A  │ │
+  │ └─────┘ │                        │ └─────┘ │
+  └─────────┘                        └─────────┘
+```
+
+```java
+// Collapse Optional<Maybe<A>> into Id<Maybe<A>>
+MaybeT<OptionalKind.Witness, String> optMt = MaybeT.just(optMonad, "Hello");
+
+MaybeT<IdKind.Witness, String> idMt =
+    optMt.mapT(optKind -> {
+      Optional<Maybe<String>> opt = OPTIONAL.narrow(optKind);
+      return ID.widen(Id.of(opt.orElse(Maybe.nothing())));
+    });
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* inside the `Maybe` (the `A` in `Just(A)`).
+`mapT` transforms the *outer monad* wrapping the `Maybe` — the `F` in `F<Maybe<A>>`.
+They operate at different levels of the transformer stack.
+~~~
+
+---
+
 ## Creating MaybeT Instances
 
 ~~~admonish title="Creating _MaybeT_ Instances"

--- a/hkj-book/src/transformers/optionalt_transformer.md
+++ b/hkj-book/src/transformers/optionalt_transformer.md
@@ -148,6 +148,43 @@ OptionalT<F, A> concrete = OPTIONAL_T.narrow(kind);
 
 ---
 
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of an `OptionalT` without touching the inner `Optional`. Perhaps you have awaited an async result and want to continue in a synchronous context, or you want to apply a natural transformation to switch effect types.
+
+`mapT` applies a function to the wrapped `Kind<F, Optional<A>>` and produces a new `OptionalT<G, A>`:
+
+```
+  OptionalT< F , A >  ── mapT(f) ──>  OptionalT< G , A >
+       │                                     │
+  ┌────┴────┐                           ┌────┴────┐
+  │    F    │   f: F[...] -> G[...]     │    G    │
+  │ ┌─────┐ │         ====>             │ ┌─────┐ │
+  │ │Opt  │ │  inner Optional sealed    │ │Opt  │ │
+  │ │  A  │ │                           │ │  A  │ │
+  │ └─────┘ │                           │ └─────┘ │
+  └─────────┘                           └─────────┘
+```
+
+```java
+// Switch from Future to Optional after awaiting an async result
+OptionalT<CompletableFutureKind.Witness, String> asyncOt = ...;
+
+OptionalT<OptionalKind.Witness, String> syncOt =
+    asyncOt.mapT(futureKind -> {
+      Optional<String> awaited = FUTURE.narrow(futureKind).join();
+      return OPTIONAL.widen(Optional.of(awaited));
+    });
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* inside the `Optional` (the `A` in `Optional.of(A)`).
+`mapT` transforms the *outer monad* wrapping the `Optional` — the `F` in `F<Optional<A>>`.
+They operate at different levels of the transformer stack.
+~~~
+
+---
+
 ## Creating OptionalT Instances
 
 ~~~admonish title="Creating _OptionalT_ Instances"

--- a/hkj-book/src/transformers/readert_transformer.md
+++ b/hkj-book/src/transformers/readert_transformer.md
@@ -156,6 +156,37 @@ ReaderT<F, R, A> concrete = READER_T.narrow(kind);
 
 ---
 
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of a `ReaderT` without altering the environment-threading logic. Perhaps you want to switch from `Optional` to `Id` (collapsing optionality with a default), or apply a natural transformation to move between effect types.
+
+Because `ReaderT` wraps a function rather than a value, `mapT` composes the transformation function after each result of `run`:
+
+```
+  env ──> run() ──> Kind<F, A> ──> f ──> Kind<G, A>
+   │                                          │
+   └──── combined into new ReaderT<G, R, A> ──┘
+```
+
+```java
+// Switch from Optional to Id, providing a default for empty results
+ReaderT<OptionalKind.Witness, Config, String> optReader = ...;
+
+ReaderT<IdKind.Witness, Config, String> idReader =
+    optReader.mapT(optKind -> {
+      Optional<String> opt = OPTIONAL.narrow(optKind);
+      return ID.widen(Id.of(opt.orElse("default")));
+    });
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* produced by the reader (the `A` in `Kind<F, A>`).
+`mapT` transforms the *outer monad* that wraps each result — the `F` in `R -> F<A>`.
+The environment-threading is completely unaffected.
+~~~
+
+---
+
 ## Creating ReaderT Instances
 
 ~~~admonish title="Creating _ReaderT_ Instances"

--- a/hkj-book/src/transformers/statet_transformer.md
+++ b/hkj-book/src/transformers/statet_transformer.md
@@ -208,6 +208,42 @@ Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, String> combined =
 
 ---
 
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of a `StateT` without touching the state-threading logic. Perhaps you want to switch from `Optional` to `Id` (guaranteeing a result with a default), or apply a natural transformation to move between effect types.
+
+Because `StateT` stores its `Monad<F>` instance internally, switching from `F` to `G` requires supplying a new `Monad<G>`. This is the one transformer where `mapT` takes an extra parameter:
+
+```
+  state ──> runStateTFn() ──> Kind<F, StateTuple<S, A>> ──> f ──> Kind<G, StateTuple<S, A>>
+    │                                                                        │
+    └──── combined into new StateT<S, G, A> with monadG ────────────────────┘
+```
+
+```java
+// Switch from Optional to Id, providing a default for empty results
+StateT<Integer, OptionalKind.Witness, String> optStateT = ...;
+Monad<IdKind.Witness> idMonad = IdMonad.instance();
+
+StateT<Integer, IdKind.Witness, String> idStateT =
+    optStateT.mapT(idMonad, optKind -> {
+      Optional<StateTuple<Integer, String>> opt = OPTIONAL.narrow(optKind);
+      return ID.widen(Id.of(opt.orElse(StateTuple.of(0, "default"))));
+    });
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* produced by the state computation (the `A` in `StateTuple<S, A>`).
+`mapT` transforms the *outer monad* wrapping each state transition — the `F` in `S -> F<StateTuple<S, A>>`.
+The state-threading is completely unaffected.
+~~~
+
+~~~admonish warning title="StateT requires a new Monad instance"
+Unlike the other five transformers, `StateT.mapT` takes `Monad<G> monadG` as its first parameter. This is because `StateT` stores the monad instance for internal sequencing — when you switch monads, the new `StateT` needs the new monad to continue operating correctly.
+~~~
+
+---
+
 ## State-Specific Operations
 
 Common state operations can be constructed using `StateT.create`:

--- a/hkj-book/src/transformers/writert_transformer.md
+++ b/hkj-book/src/transformers/writert_transformer.md
@@ -183,6 +183,44 @@ Without a `Monoid`, WriterT cannot combine the output from `flatMap` chains. The
 
 ---
 
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of a `WriterT` without touching the accumulated output. Perhaps you want to wrap an `Id`-based writer into an `Optional` context for a downstream API, or switch effect types via a natural transformation.
+
+`mapT` applies a function to the wrapped `Kind<F, Pair<A, W>>` and produces a new `WriterT<G, W, A>`:
+
+```
+  WriterT< F , W, A >  ── mapT(f) ──>  WriterT< G , W, A >
+       │                                      │
+  ┌────┴────┐                            ┌────┴────┐
+  │    F    │     f: F[...] -> G[...]    │    G    │
+  │ ┌─────┐ │          ====>             │ ┌─────┐ │
+  │ │Pair │ │   inner Pair untouched     │ │Pair │ │
+  │ │ A,W │ │                            │ │ A,W │ │
+  │ └─────┘ │                            │ └─────┘ │
+  └─────────┘                            └─────────┘
+```
+
+```java
+// Switch from Id to Optional — wrapping a pure writer into an optional context
+WriterT<IdKind.Witness, List<String>, String> idWriter =
+    WriterT.writer(idMonad, "result", List.of("step 1", "step 2"));
+
+WriterT<OptionalKind.Witness, List<String>, String> optWriter =
+    idWriter.mapT(idKind -> {
+      Pair<String, List<String>> pair = ID.unwrap(idKind);
+      return OPTIONAL.widen(Optional.of(pair));
+    });
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* inside the `Pair` (the `A` in `Pair<A, W>`).
+`mapT` transforms the *outer monad* wrapping the `Pair` — the `F` in `F<Pair<A, W>>`.
+The accumulated output `W` is completely unaffected.
+~~~
+
+---
+
 ## Creating WriterT Instances
 
 ```java

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherT.java
@@ -4,6 +4,7 @@ package org.higherkindedj.hkt.either_t;
 
 import static org.higherkindedj.hkt.util.validation.Operation.*;
 
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.TypeArity;
@@ -137,6 +138,36 @@ public record EitherT<F extends WitnessArity<TypeArity.Unary>, L, R>(Kind<F, Eit
     Validation.kind().requireNonNull(fr, LIFT_F, "source Kind");
     Kind<F, Either<L, R>> mapped = outerMonad.map(Either::right, fr);
     return new EitherT<>(mapped);
+  }
+
+  /**
+   * Transforms the outer monad layer of this {@code EitherT} by applying the given function to the
+   * underlying {@code Kind<F, Either<L, R>>}, producing a new {@code EitherT<G, L, R>} wrapping the
+   * result. The inner {@link Either} value is left untouched — only the surrounding monadic context
+   * changes.
+   *
+   * <p>This is useful for applying cross-cutting concerns (logging, retry, timeout) at the monad
+   * level, or for switching between monadic contexts via a natural transformation.
+   *
+   * <p><b>Example — switching from IO to Task via a natural transformation:</b>
+   *
+   * <pre>{@code
+   * EitherT<IOKind.Witness, String, Integer> ioResult = ...;
+   * Natural<IOKind.Witness, TaskKind.Witness> ioToTask = ...;
+   *
+   * EitherT<TaskKind.Witness, String, Integer> taskResult = ioResult.mapT(ioToTask::apply);
+   * }</pre>
+   *
+   * @param f The function to apply to the underlying {@code Kind<F, Either<L, R>>}. Must not be
+   *     null.
+   * @param <G> The witness type of the target outer monad.
+   * @return A new {@code EitherT<G, L, R>} wrapping the transformed monadic value.
+   * @throws NullPointerException if {@code f} is null.
+   */
+  public <G extends WitnessArity<TypeArity.Unary>> EitherT<G, L, R> mapT(
+      Function<Kind<F, Either<L, R>>, Kind<G, Either<L, R>>> f) {
+    Validation.function().require(f, "f", MAP_T);
+    return EitherT.fromKind(f.apply(this.value()));
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeT.java
@@ -4,6 +4,7 @@ package org.higherkindedj.hkt.maybe_t;
 
 import static org.higherkindedj.hkt.util.validation.Operation.*;
 
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.TypeArity;
@@ -128,6 +129,34 @@ public record MaybeT<F extends WitnessArity<TypeArity.Unary>, A>(Kind<F, Maybe<A
     Validation.kind().requireNonNull(fa, LIFT_F, "source Kind");
     Kind<F, Maybe<A>> mapped = outerMonad.map(Maybe::fromNullable, fa);
     return new MaybeT<>(mapped);
+  }
+
+  /**
+   * Transforms the outer monad layer of this {@code MaybeT} by applying the given function to the
+   * underlying {@code Kind<F, Maybe<A>>}, producing a new {@code MaybeT<G, A>} wrapping the result.
+   * The inner {@link Maybe} value is left untouched — only the surrounding monadic context changes.
+   *
+   * <p>This is useful for applying cross-cutting concerns (logging, retry, timeout) at the monad
+   * level, or for switching between monadic contexts via a natural transformation.
+   *
+   * <p><b>Example — switching from IO to Task via a natural transformation:</b>
+   *
+   * <pre>{@code
+   * MaybeT<IOKind.Witness, String> ioResult = ...;
+   * Natural<IOKind.Witness, TaskKind.Witness> ioToTask = ...;
+   *
+   * MaybeT<TaskKind.Witness, String> taskResult = ioResult.mapT(ioToTask::apply);
+   * }</pre>
+   *
+   * @param f The function to apply to the underlying {@code Kind<F, Maybe<A>>}. Must not be null.
+   * @param <G> The witness type of the target outer monad.
+   * @return A new {@code MaybeT<G, A>} wrapping the transformed monadic value.
+   * @throws NullPointerException if {@code f} is null.
+   */
+  public <G extends WitnessArity<TypeArity.Unary>> MaybeT<G, A> mapT(
+      Function<Kind<F, Maybe<A>>, Kind<G, Maybe<A>>> f) {
+    Validation.function().require(f, "f", MAP_T);
+    return MaybeT.fromKind(f.apply(this.value()));
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalT.java
@@ -5,6 +5,7 @@ package org.higherkindedj.hkt.optional_t;
 import static org.higherkindedj.hkt.util.validation.Operation.*;
 
 import java.util.Optional;
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.TypeArity;
@@ -133,6 +134,36 @@ public record OptionalT<F extends WitnessArity<TypeArity.Unary>, A>(Kind<F, Opti
     Validation.kind().requireNonNull(fa, LIFT_F, "source Kind");
     Kind<F, Optional<A>> mapped = outerMonad.map(Optional::ofNullable, fa);
     return new OptionalT<>(mapped);
+  }
+
+  /**
+   * Transforms the outer monad layer of this {@code OptionalT} by applying the given function to
+   * the underlying {@code Kind<F, Optional<A>>}, producing a new {@code OptionalT<G, A>} wrapping
+   * the result. The inner {@link Optional} value is left untouched — only the surrounding monadic
+   * context changes.
+   *
+   * <p>This is useful for applying cross-cutting concerns (logging, retry, timeout) at the monad
+   * level, or for switching between monadic contexts via a natural transformation.
+   *
+   * <p><b>Example — switching from IO to Task via a natural transformation:</b>
+   *
+   * <pre>{@code
+   * OptionalT<IOKind.Witness, String> ioResult = ...;
+   * Natural<IOKind.Witness, TaskKind.Witness> ioToTask = ...;
+   *
+   * OptionalT<TaskKind.Witness, String> taskResult = ioResult.mapT(ioToTask::apply);
+   * }</pre>
+   *
+   * @param f The function to apply to the underlying {@code Kind<F, Optional<A>>}. Must not be
+   *     null.
+   * @param <G> The witness type of the target outer monad.
+   * @return A new {@code OptionalT<G, A>} wrapping the transformed monadic value.
+   * @throws NullPointerException if {@code f} is null.
+   */
+  public <G extends WitnessArity<TypeArity.Unary>> OptionalT<G, A> mapT(
+      Function<Kind<F, Optional<A>>, Kind<G, Optional<A>>> f) {
+    Validation.function().require(f, "f", MAP_T);
+    return OptionalT.fromKind(f.apply(this.value()));
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderT.java
@@ -126,6 +126,42 @@ public record ReaderT<F extends WitnessArity<TypeArity.Unary>, R_ENV, A>(
   }
 
   /**
+   * Transforms the outer monad layer of this {@code ReaderT} by applying the given function to the
+   * result of each invocation of the underlying {@code run} function, producing a new {@code
+   * ReaderT<G, R_ENV, A>}. The environment handling is left untouched — only the monadic context of
+   * each computed result changes.
+   *
+   * <p>Because {@code ReaderT} wraps a function rather than a value, {@code mapT} composes {@code
+   * f} after the result of {@code run}:
+   *
+   * <pre>
+   * env ──&gt; run() ──&gt; Kind&lt;F, A&gt; ──&gt; f ──&gt; Kind&lt;G, A&gt;
+   * </pre>
+   *
+   * <p>This is useful for applying cross-cutting concerns (logging, retry, timeout) at the monad
+   * level, or for switching between monadic contexts via a natural transformation.
+   *
+   * <p><b>Example — switching from IO to Task via a natural transformation:</b>
+   *
+   * <pre>{@code
+   * ReaderT<IOKind.Witness, Config, String> ioReader = ...;
+   * Natural<IOKind.Witness, TaskKind.Witness> ioToTask = ...;
+   *
+   * ReaderT<TaskKind.Witness, Config, String> taskReader = ioReader.mapT(ioToTask::apply);
+   * }</pre>
+   *
+   * @param f The function to apply to each computed {@code Kind<F, A>}. Must not be null.
+   * @param <G> The witness type of the target outer monad.
+   * @return A new {@code ReaderT<G, R_ENV, A>} that applies {@code f} after each run.
+   * @throws NullPointerException if {@code f} is null.
+   */
+  public <G extends WitnessArity<TypeArity.Unary>> ReaderT<G, R_ENV, A> mapT(
+      Function<Kind<F, A>, Kind<G, A>> f) {
+    Validation.function().require(f, "f", MAP_T);
+    return ReaderT.of(env -> f.apply(this.run().apply(env)));
+  }
+
+  /**
    * Accesses the underlying function {@code R_ENV -> Kind<F, A>} of this {@link ReaderT}.
    *
    * @return The function {@code R_ENV -> Kind<F, A>}. Never null.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateT.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.hkt.state_t;
 
 import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
+import static org.higherkindedj.hkt.util.validation.Operation.MAP_T;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
@@ -82,6 +83,43 @@ public record StateT<S, F extends WitnessArity<TypeArity.Unary>, A>(
    */
   public Kind<F, A> evalStateT(S initialState) {
     return this.monadF.map(StateTuple::value, runStateT(initialState));
+  }
+
+  /**
+   * Transforms the outer monad layer of this {@code StateT} by applying the given function to the
+   * result of each state transition, producing a new {@code StateT<S, G, A>} that uses {@code
+   * monadG} for sequencing. The state-threading logic is left untouched — only the monadic context
+   * of each computed {@link StateTuple} changes.
+   *
+   * <p>Because {@code StateT} stores its {@link Monad} instance internally, switching from {@code
+   * F} to {@code G} requires a new {@code Monad<G>} to be supplied.
+   *
+   * <p>This is useful for applying cross-cutting concerns (logging, retry, timeout) at the monad
+   * level, or for switching between monadic contexts via a natural transformation.
+   *
+   * <p><b>Example — switching from IO to Task via a natural transformation:</b>
+   *
+   * <pre>{@code
+   * StateT<Integer, IOKind.Witness, String> ioState = ...;
+   * Natural<IOKind.Witness, TaskKind.Witness> ioToTask = ...;
+   * Monad<TaskKind.Witness> taskMonad = ...;
+   *
+   * StateT<Integer, TaskKind.Witness, String> taskState =
+   *     ioState.mapT(taskMonad, ioToTask::apply);
+   * }</pre>
+   *
+   * @param monadG The {@link Monad} instance for the target monad {@code G}. Must not be null.
+   * @param f The function to apply to each computed {@code Kind<F, StateTuple<S, A>>}. Must not be
+   *     null.
+   * @param <G> The witness type of the target outer monad.
+   * @return A new {@code StateT<S, G, A>} that applies {@code f} after each state transition.
+   * @throws NullPointerException if {@code monadG} or {@code f} is null.
+   */
+  public <G extends WitnessArity<TypeArity.Unary>> StateT<S, G, A> mapT(
+      Monad<G> monadG, Function<Kind<F, StateTuple<S, A>>, Kind<G, StateTuple<S, A>>> f) {
+    Validation.transformer().requireOuterMonad(monadG, STATE_T_CLASS, MAP_T);
+    Validation.function().require(f, "f", MAP_T);
+    return StateT.create(s -> f.apply(this.runStateTFn().apply(s)), monadG);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
@@ -84,7 +84,8 @@ public enum Operation {
   MAP_ELEVENTH("mapEleventh"),
   MAP_TWELFTH("mapTwelfth"),
   MAP_ERROR("mapError"),
-  MAP_WRITTEN("mapWritten");
+  MAP_WRITTEN("mapWritten"),
+  MAP_T("mapT");
 
   Operation(String label) {
     this.label = label;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer_t/WriterT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer_t/WriterT.java
@@ -4,6 +4,7 @@ package org.higherkindedj.hkt.writer_t;
 
 import static org.higherkindedj.hkt.util.validation.Operation.*;
 
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.Monoid;
@@ -116,6 +117,35 @@ public record WriterT<F extends WitnessArity<TypeArity.Unary>, W, A>(Kind<F, Pai
     Validation.function().require(monoid, "monoid", LIFT_F);
     Validation.kind().requireNonNull(fa, LIFT_F, "source Kind");
     return new WriterT<>(monad.map(a -> Pair.of(a, monoid.empty()), fa));
+  }
+
+  /**
+   * Transforms the outer monad layer of this {@code WriterT} by applying the given function to the
+   * underlying {@code Kind<F, Pair<A, W>>}, producing a new {@code WriterT<G, W, A>} wrapping the
+   * result. The inner {@link Pair} of value and accumulated output is left untouched — only the
+   * surrounding monadic context changes.
+   *
+   * <p>This is useful for applying cross-cutting concerns (logging, retry, timeout) at the monad
+   * level, or for switching between monadic contexts via a natural transformation.
+   *
+   * <p><b>Example — switching from IO to Task via a natural transformation:</b>
+   *
+   * <pre>{@code
+   * WriterT<IOKind.Witness, String, Integer> ioResult = ...;
+   * Natural<IOKind.Witness, TaskKind.Witness> ioToTask = ...;
+   *
+   * WriterT<TaskKind.Witness, String, Integer> taskResult = ioResult.mapT(ioToTask::apply);
+   * }</pre>
+   *
+   * @param f The function to apply to the underlying {@code Kind<F, Pair<A, W>>}. Must not be null.
+   * @param <G> The witness type of the target outer monad.
+   * @return A new {@code WriterT<G, W, A>} wrapping the transformed monadic value.
+   * @throws NullPointerException if {@code f} is null.
+   */
+  public <G extends WitnessArity<TypeArity.Unary>> WriterT<G, W, A> mapT(
+      Function<Kind<F, Pair<A, W>>, Kind<G, Pair<A, W>>> f) {
+    Validation.function().require(f, "f", MAP_T);
+    return WriterT.fromKind(f.apply(this.run()));
   }
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/TransformerConsistencyRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/TransformerConsistencyRules.java
@@ -50,7 +50,7 @@ class TransformerConsistencyRules {
   @DisplayName("Transformer monad classes should have lift method")
   void transformer_monads_should_have_lift_method() {
     classes()
-        .that(isTransformerType())
+        .that(isTransformerTypeWithDirectLiftF())
         .and()
         .areNotInterfaces()
         .and()
@@ -113,6 +113,26 @@ class TransformerConsistencyRules {
   }
 
   /**
+   * Transformer types should have a mapT method.
+   *
+   * <p>The mapT method allows transforming the outer monad layer of a transformer without
+   * unwrapping the inner value. This is a standard operation for monad transformers.
+   */
+  @Test
+  @DisplayName("Transformer types should have mapT method")
+  void transformer_types_should_have_mapT_method() {
+    classes()
+        .that(isTransformerType())
+        .and()
+        .areNotInterfaces()
+        .and()
+        .haveSimpleNameNotEndingWith("package-info")
+        .should(haveMethodNamed("mapT"))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
    * Transformer Kind interfaces should follow naming convention.
    *
    * <p>Each transformer should have a Kind interface (e.g., EitherTKind, MaybeTKind).
@@ -147,19 +167,40 @@ class TransformerConsistencyRules {
   }
 
   /**
-   * Custom predicate that matches transformer types (EitherT, MaybeT, OptionalT, ReaderT).
+   * Custom predicate matching transformer types that declare {@code liftF} directly. StateT is
+   * excluded because it provides {@code liftF} through {@link StateTKindHelper} instead.
    *
    * @return the described predicate
    */
-  private static DescribedPredicate<JavaClass> isTransformerType() {
+  private static DescribedPredicate<JavaClass> isTransformerTypeWithDirectLiftF() {
     return DescribedPredicate.describe(
-        "is a transformer type (EitherT, MaybeT, OptionalT, ReaderT)",
+        "is a transformer type with direct liftF (EitherT, MaybeT, OptionalT, ReaderT, WriterT)",
         javaClass -> {
           String name = javaClass.getSimpleName();
           return name.equals("EitherT")
               || name.equals("MaybeT")
               || name.equals("OptionalT")
-              || name.equals("ReaderT");
+              || name.equals("ReaderT")
+              || name.equals("WriterT");
+        });
+  }
+
+  /**
+   * Custom predicate that matches all transformer types.
+   *
+   * @return the described predicate
+   */
+  private static DescribedPredicate<JavaClass> isTransformerType() {
+    return DescribedPredicate.describe(
+        "is a transformer type (EitherT, MaybeT, OptionalT, ReaderT, StateT, WriterT)",
+        javaClass -> {
+          String name = javaClass.getSimpleName();
+          return name.equals("EitherT")
+              || name.equals("MaybeT")
+              || name.equals("OptionalT")
+              || name.equals("ReaderT")
+              || name.equals("StateT")
+              || name.equals("WriterT");
         });
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/either_t/EitherTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/either_t/EitherTTest.java
@@ -3,12 +3,17 @@
 package org.higherkindedj.hkt.either_t;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
 import java.util.Optional;
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
 import org.higherkindedj.hkt.test.api.CoreTypeTest;
@@ -293,6 +298,59 @@ class EitherTTest {
       EitherT<OptionalKind.Witness, String, String> lifted = EitherT.liftF(outerMonad, liftedValue);
       assertThat(lifted).isNotNull();
       assertThat(lifted.value()).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("mapT")
+  class MapTTests {
+
+    @Test
+    @DisplayName("mapT with identity should return equivalent EitherT")
+    void mapT_identity() {
+      EitherT<OptionalKind.Witness, String, String> et = EitherT.right(outerMonad, rightValue);
+      EitherT<OptionalKind.Witness, String, String> result = et.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(Either.right(rightValue));
+    }
+
+    @Test
+    @DisplayName("mapT should transform outer monad to a different type")
+    void mapT_crossMonad() {
+      EitherT<OptionalKind.Witness, String, String> et = EitherT.right(outerMonad, rightValue);
+
+      // Transform Optional to Id via natural transformation
+      EitherT<IdKind.Witness, String, String> result =
+          et.mapT(
+              optKind -> {
+                Optional<Either<String, String>> opt = OPTIONAL.narrow(optKind);
+                return IdKindHelper.ID.widen(Id.of(opt.orElse(Either.left("empty"))));
+              });
+
+      Id<Either<String, String>> id = IdKindHelper.ID.narrow(result.value());
+      assertThat(id.value()).isEqualTo(Either.right(rightValue));
+    }
+
+    @Test
+    @DisplayName("mapT should preserve left values")
+    void mapT_preservesLeft() {
+      EitherT<OptionalKind.Witness, String, String> et = EitherT.left(outerMonad, leftValue);
+      EitherT<OptionalKind.Witness, String, String> result = et.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(Either.left(leftValue));
+    }
+
+    @Test
+    @DisplayName("mapT should preserve empty outer monad")
+    void mapT_preservesEmpty() {
+      EitherT<OptionalKind.Witness, String, String> et = EitherT.fromKind(wrappedEmpty);
+      EitherT<OptionalKind.Witness, String, String> result = et.mapT(Function.identity());
+      assertThat(unwrapT(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapT should reject null function")
+    void mapT_rejectsNull() {
+      EitherT<OptionalKind.Witness, String, String> et = EitherT.right(outerMonad, rightValue);
+      assertThatThrownBy(() -> et.mapT(null)).isInstanceOf(NullPointerException.class);
     }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/maybe_t/MaybeTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/maybe_t/MaybeTTest.java
@@ -3,11 +3,16 @@
 package org.higherkindedj.hkt.maybe_t;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
 import java.util.Optional;
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
@@ -341,6 +346,59 @@ class MaybeTTest {
       MaybeT<OptionalKind.Witness, String> step2 = MaybeT.fromKind(kind2);
 
       assertThat(unwrapT(step2)).isPresent().contains(Maybe.just("test"));
+    }
+  }
+
+  @Nested
+  @DisplayName("mapT")
+  class MapTTests {
+
+    @Test
+    @DisplayName("mapT with identity should return equivalent MaybeT")
+    void mapT_identity() {
+      MaybeT<OptionalKind.Witness, String> mt = MaybeT.just(outerMonad, justValue);
+      MaybeT<OptionalKind.Witness, String> result = mt.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(Maybe.just(justValue));
+    }
+
+    @Test
+    @DisplayName("mapT should transform outer monad to a different type")
+    void mapT_crossMonad() {
+      MaybeT<OptionalKind.Witness, String> mt = MaybeT.just(outerMonad, justValue);
+
+      MaybeT<IdKind.Witness, String> result =
+          mt.mapT(
+              optKind -> {
+                Optional<Maybe<String>> opt = OPTIONAL.narrow(optKind);
+                return IdKindHelper.ID.widen(Id.of(opt.orElse(Maybe.nothing())));
+              });
+
+      Id<Maybe<String>> id = IdKindHelper.ID.narrow(result.value());
+      assertThat(id.value()).isEqualTo(Maybe.just(justValue));
+    }
+
+    @Test
+    @DisplayName("mapT should preserve Nothing")
+    void mapT_preservesNothing() {
+      MaybeT<OptionalKind.Witness, String> mt = MaybeT.nothing(outerMonad);
+      MaybeT<OptionalKind.Witness, String> result = mt.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(Maybe.nothing());
+    }
+
+    @Test
+    @DisplayName("mapT should preserve empty outer monad")
+    void mapT_preservesEmpty() {
+      Kind<OptionalKind.Witness, Maybe<String>> empty = OPTIONAL.widen(Optional.empty());
+      MaybeT<OptionalKind.Witness, String> mt = MaybeT.fromKind(empty);
+      MaybeT<OptionalKind.Witness, String> result = mt.mapT(Function.identity());
+      assertThat(unwrapT(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapT should reject null function")
+    void mapT_rejectsNull() {
+      MaybeT<OptionalKind.Witness, String> mt = MaybeT.just(outerMonad, justValue);
+      assertThatThrownBy(() -> mt.mapT(null)).isInstanceOf(NullPointerException.class);
     }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/optional_t/OptionalTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/optional_t/OptionalTTest.java
@@ -4,11 +4,16 @@ package org.higherkindedj.hkt.optional_t;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
 import java.util.Optional;
+import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
 import org.junit.jupiter.api.BeforeEach;
@@ -207,6 +212,59 @@ class OptionalTTest {
 
       assertThat(otOuterEmpty.toString()).startsWith("OptionalT[value=").endsWith("]");
       assertThat(otOuterEmpty.toString()).contains("Optional.empty");
+    }
+  }
+
+  @Nested
+  @DisplayName("mapT")
+  class MapTTests {
+
+    @Test
+    @DisplayName("mapT with identity should return equivalent OptionalT")
+    void mapT_identity() {
+      OptionalT<OptionalKind.Witness, String> ot = OptionalT.some(outerMonad, presentValue);
+      OptionalT<OptionalKind.Witness, String> result = ot.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(Optional.of(presentValue));
+    }
+
+    @Test
+    @DisplayName("mapT should transform outer monad to a different type")
+    void mapT_crossMonad() {
+      OptionalT<OptionalKind.Witness, String> ot = OptionalT.some(outerMonad, presentValue);
+
+      OptionalT<IdKind.Witness, String> result =
+          ot.mapT(
+              optKind -> {
+                Optional<Optional<String>> opt = OPTIONAL.narrow(optKind);
+                return IdKindHelper.ID.widen(Id.of(opt.orElse(Optional.empty())));
+              });
+
+      Id<Optional<String>> id = IdKindHelper.ID.narrow(result.value());
+      assertThat(id.value()).isPresent().contains(presentValue);
+    }
+
+    @Test
+    @DisplayName("mapT should preserve None (empty inner)")
+    void mapT_preservesNone() {
+      OptionalT<OptionalKind.Witness, String> ot = OptionalT.none(outerMonad);
+      OptionalT<OptionalKind.Witness, String> result = ot.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("mapT should preserve empty outer monad")
+    void mapT_preservesEmptyOuter() {
+      Kind<OptionalKind.Witness, Optional<String>> outerEmpty = OPTIONAL.widen(Optional.empty());
+      OptionalT<OptionalKind.Witness, String> ot = OptionalT.fromKind(outerEmpty);
+      OptionalT<OptionalKind.Witness, String> result = ot.mapT(Function.identity());
+      assertThat(unwrapT(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapT should reject null function")
+    void mapT_rejectsNull() {
+      OptionalT<OptionalKind.Witness, String> ot = OptionalT.some(outerMonad, presentValue);
+      assertThatThrownBy(() -> ot.mapT(null)).isInstanceOf(NullPointerException.class);
     }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/reader_t/ReaderTAssert.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/reader_t/ReaderTAssert.java
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.reader_t;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.assertj.core.api.AbstractAssert;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+
+/**
+ * Custom AssertJ assertion for ReaderT transformer types.
+ *
+ * <p>Provides fluent assertions for ReaderT values wrapped in Kind. Because ReaderT wraps a
+ * function from an environment to a monadic result, assertions require running the reader with a
+ * specific environment before inspecting the result.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Assert that running with an environment produces the expected value
+ * assertThatReaderT(result, this::unwrapToOptional)
+ *     .whenRunWith("test-env")
+ *     .hasValue("expected");
+ *
+ * // Assert that the outer monad is empty after running
+ * assertThatReaderT(result, this::unwrapToOptional)
+ *     .whenRunWith("test-env")
+ *     .isEmpty();
+ * }</pre>
+ *
+ * @param <F> the witness type of the outer monad
+ * @param <R_ENV> the environment type
+ * @param <A> the value type
+ */
+public class ReaderTAssert {
+
+  /**
+   * Entry point for ReaderT assertions when the outer monad unwraps to Optional.
+   *
+   * @param <F> the witness type of the outer monad
+   * @param <R_ENV> the environment type
+   * @param <A> the value type
+   * @param actual the ReaderT Kind to assert on
+   * @param outerUnwrapper function to unwrap outer monad to Optional
+   * @return a new {@link ReaderTOptionalAssert} instance
+   */
+  public static <F extends WitnessArity<TypeArity.Unary>, R_ENV, A>
+      ReaderTOptionalAssert<F, R_ENV, A> assertThatReaderT(
+          Kind<ReaderTKind.Witness<F, R_ENV>, A> actual,
+          Function<Kind<F, A>, Optional<A>> outerUnwrapper) {
+    return new ReaderTOptionalAssert<>(actual, outerUnwrapper);
+  }
+
+  /**
+   * Specialised assertion class for ReaderT with Optional-based unwrapping.
+   *
+   * <p>Provides a two-phase assertion model: first run the reader with an environment via {@link
+   * #whenRunWith(Object)}, then assert on the resulting value.
+   *
+   * @param <F> the witness type of the outer monad
+   * @param <R_ENV> the environment type
+   * @param <A> the value type
+   */
+  public static class ReaderTOptionalAssert<F extends WitnessArity<TypeArity.Unary>, R_ENV, A>
+      extends AbstractAssert<
+          ReaderTOptionalAssert<F, R_ENV, A>, Kind<ReaderTKind.Witness<F, R_ENV>, A>> {
+
+    private final Function<Kind<F, A>, Optional<A>> outerUnwrapper;
+
+    protected ReaderTOptionalAssert(
+        Kind<ReaderTKind.Witness<F, R_ENV>, A> actual,
+        Function<Kind<F, A>, Optional<A>> outerUnwrapper) {
+      super(actual, ReaderTOptionalAssert.class);
+      this.outerUnwrapper = outerUnwrapper;
+    }
+
+    /**
+     * Runs the ReaderT with the given environment and returns a result assertion for the computed
+     * value.
+     *
+     * @param env the environment to run the reader with
+     * @return a {@link ReaderTResultAssert} for asserting on the result
+     */
+    public ReaderTResultAssert<F, R_ENV, A> whenRunWith(R_ENV env) {
+      isNotNull();
+      var readerT = ReaderTKindHelper.READER_T.narrow(actual);
+      Kind<F, A> result = readerT.run().apply(env);
+      Optional<A> unwrapped = outerUnwrapper.apply(result);
+      return new ReaderTResultAssert<>(unwrapped, env);
+    }
+
+    /**
+     * Verifies that this ReaderT is equal to another ReaderT by comparing results for a given
+     * environment.
+     *
+     * @param other the other ReaderT to compare with
+     * @param env the environment to run both readers with
+     * @return this assertion object for chaining
+     * @throws AssertionError if the results are not equal
+     */
+    public ReaderTOptionalAssert<F, R_ENV, A> isEqualToReaderT(
+        Kind<ReaderTKind.Witness<F, R_ENV>, A> other, R_ENV env) {
+      isNotNull();
+      var thisReaderT = ReaderTKindHelper.READER_T.narrow(actual);
+      Optional<A> thisResult = outerUnwrapper.apply(thisReaderT.run().apply(env));
+
+      if (other == null) {
+        failWithMessage("Expected ReaderT to compare with but was null");
+        return this;
+      }
+
+      var otherReaderT = ReaderTKindHelper.READER_T.narrow(other);
+      Optional<A> otherResult = outerUnwrapper.apply(otherReaderT.run().apply(env));
+
+      if (!thisResult.equals(otherResult)) {
+        failWithMessage(
+            "Expected ReaderT to be equal to <%s> but was <%s> for environment <%s>",
+            otherResult, thisResult, env);
+      }
+      return this;
+    }
+  }
+
+  /**
+   * Assertion class for the result of running a ReaderT with a specific environment.
+   *
+   * @param <F> the witness type of the outer monad
+   * @param <R_ENV> the environment type
+   * @param <A> the value type
+   */
+  public static class ReaderTResultAssert<F extends WitnessArity<TypeArity.Unary>, R_ENV, A> {
+
+    private final Optional<A> result;
+    private final R_ENV environment;
+
+    protected ReaderTResultAssert(Optional<A> result, R_ENV environment) {
+      this.result = result;
+      this.environment = environment;
+    }
+
+    /**
+     * Verifies that the result is empty (outer monad was empty).
+     *
+     * @return this assertion object for chaining
+     * @throws AssertionError if the result is present
+     */
+    public ReaderTResultAssert<F, R_ENV, A> isEmpty() {
+      if (result.isPresent()) {
+        failWithMessage(
+            "Expected result to be empty for environment <%s> but was present with: <%s>",
+            environment, result.get());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result is present (not empty).
+     *
+     * @return this assertion object for chaining
+     * @throws AssertionError if the result is empty
+     */
+    public ReaderTResultAssert<F, R_ENV, A> isPresent() {
+      if (result.isEmpty()) {
+        failWithMessage(
+            "Expected result to be present for environment <%s> but was empty", environment);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result contains a value equal to the expected value.
+     *
+     * @param expected the expected value
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or value does not match
+     */
+    public ReaderTResultAssert<F, R_ENV, A> hasValue(A expected) {
+      isPresent();
+      A actual = result.get();
+      if (!Objects.equals(actual, expected)) {
+        failWithMessage(
+            "Expected value to be <%s> for environment <%s> but was <%s>",
+            expected, environment, actual);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result value satisfies the given requirements.
+     *
+     * @param requirements the consumer to apply to the value
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or requirements not satisfied
+     */
+    public ReaderTResultAssert<F, R_ENV, A> satisfiesValue(Consumer<? super A> requirements) {
+      isPresent();
+      A value = result.get();
+      try {
+        requirements.accept(value);
+      } catch (AssertionError e) {
+        failWithMessage(
+            "Value did not satisfy requirements for environment <%s>: %s",
+            environment, e.getMessage());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result value matches the given predicate.
+     *
+     * @param predicate the predicate to test
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or predicate fails
+     */
+    public ReaderTResultAssert<F, R_ENV, A> valueMatches(Predicate<? super A> predicate) {
+      isPresent();
+      A value = result.get();
+      if (!predicate.test(value)) {
+        failWithMessage(
+            "Value <%s> did not match predicate for environment <%s>", value, environment);
+      }
+      return this;
+    }
+
+    private void failWithMessage(String message, Object... args) {
+      throw new AssertionError(String.format(message, args));
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/reader_t/ReaderTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/reader_t/ReaderTTest.java
@@ -3,12 +3,16 @@
 package org.higherkindedj.hkt.reader_t;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
 import java.util.Optional;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
 import org.higherkindedj.hkt.test.api.CoreTypeTest;
@@ -306,6 +310,73 @@ class ReaderTTest {
           OPTIONAL.narrow(outerMonad.map(String::length, runFunc.apply(environment)));
 
       assertThat(result).isPresent().contains(environment.length());
+    }
+  }
+
+  @Nested
+  @DisplayName("mapT")
+  class MapTTests {
+
+    @Test
+    @DisplayName("mapT with identity should return equivalent ReaderT")
+    void mapT_identity() {
+      ReaderT<OptionalKind.Witness, String, Integer> rt =
+          ReaderT.reader(outerMonad, simpleFunction);
+      ReaderT<OptionalKind.Witness, String, Integer> result = rt.mapT(Function.identity());
+      assertThat(unwrapT(result)).isPresent().contains(environment.length());
+    }
+
+    @Test
+    @DisplayName("mapT should transform outer monad to a different type")
+    void mapT_crossMonad() {
+      ReaderT<OptionalKind.Witness, String, Integer> rt =
+          ReaderT.reader(outerMonad, simpleFunction);
+
+      ReaderT<IdKind.Witness, String, Integer> result =
+          rt.mapT(
+              optKind -> {
+                Optional<Integer> opt = OPTIONAL.narrow(optKind);
+                return IdKindHelper.ID.widen(Id.of(opt.orElse(-1)));
+              });
+
+      // Run the transformed reader with the environment
+      Kind<IdKind.Witness, Integer> idResult = result.run().apply(environment);
+      Id<Integer> id = IdKindHelper.ID.narrow(idResult);
+      assertThat(id.value()).isEqualTo(environment.length());
+    }
+
+    @Test
+    @DisplayName("mapT should thread environment correctly after transformation")
+    void mapT_threadsEnvironment() {
+      ReaderT<OptionalKind.Witness, String, Integer> rt =
+          ReaderT.reader(outerMonad, simpleFunction);
+      ReaderT<OptionalKind.Witness, String, Integer> result = rt.mapT(Function.identity());
+
+      // Verify with different environments
+      Optional<Integer> result1 = OPTIONAL.narrow(result.run().apply(environment));
+      Optional<Integer> result2 = OPTIONAL.narrow(result.run().apply(otherEnvironment));
+
+      assertThat(result1).isPresent().contains(environment.length());
+      assertThat(result2).isPresent().contains(otherEnvironment.length());
+    }
+
+    @Test
+    @DisplayName("mapT should preserve empty outer monad")
+    void mapT_preservesEmpty() {
+      ReaderT<OptionalKind.Witness, String, Integer> rt =
+          ReaderT.of(env -> OPTIONAL.widen(Optional.empty()));
+      ReaderT<OptionalKind.Witness, String, Integer> result = rt.mapT(Function.identity());
+
+      Optional<Integer> unwrapped = OPTIONAL.narrow(result.run().apply(environment));
+      assertThat(unwrapped).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapT should reject null function")
+    void mapT_rejectsNull() {
+      ReaderT<OptionalKind.Witness, String, Integer> rt =
+          ReaderT.reader(outerMonad, simpleFunction);
+      assertThatThrownBy(() -> rt.mapT(null)).isInstanceOf(NullPointerException.class);
     }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTAssert.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTAssert.java
@@ -1,0 +1,313 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.state_t;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.assertj.core.api.AbstractAssert;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.state.StateTuple;
+
+/**
+ * Custom AssertJ assertion for StateT transformer types.
+ *
+ * <p>Provides fluent assertions for StateT values wrapped in Kind. Because StateT wraps a function
+ * from an initial state to a monadic result containing both a value and a final state, assertions
+ * require running the computation with a specific initial state before inspecting the result.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Assert that running with an initial state produces the expected value and final state
+ * assertThatStateT(result, this::unwrapToOptional)
+ *     .whenRunWith(0)
+ *     .hasValue("expected")
+ *     .hasFinalState(42);
+ *
+ * // Assert both value and state together
+ * assertThatStateT(result, this::unwrapToOptional)
+ *     .whenRunWith(0)
+ *     .hasResult("expected", 42);
+ *
+ * // Assert that the outer monad is empty after running
+ * assertThatStateT(result, this::unwrapToOptional)
+ *     .whenRunWith(0)
+ *     .isEmpty();
+ * }</pre>
+ */
+public class StateTAssert {
+
+  /**
+   * Entry point for StateT assertions when the outer monad unwraps to Optional.
+   *
+   * @param <S> the state type
+   * @param <F> the witness type of the outer monad
+   * @param <A> the value type
+   * @param actual the StateT Kind to assert on
+   * @param outerUnwrapper function to unwrap outer monad to Optional
+   * @return a new {@link StateTOptionalAssert} instance
+   */
+  public static <S, F extends WitnessArity<TypeArity.Unary>, A>
+      StateTOptionalAssert<S, F, A> assertThatStateT(
+          Kind<StateTKind.Witness<S, F>, A> actual,
+          Function<Kind<F, StateTuple<S, A>>, Optional<StateTuple<S, A>>> outerUnwrapper) {
+    return new StateTOptionalAssert<>(actual, outerUnwrapper);
+  }
+
+  /**
+   * Specialised assertion class for StateT with Optional-based unwrapping.
+   *
+   * <p>Provides a two-phase assertion model: first run the state computation with an initial state
+   * via {@link #whenRunWith(Object)}, then assert on the resulting value and final state.
+   *
+   * @param <S> the state type
+   * @param <F> the witness type of the outer monad
+   * @param <A> the value type
+   */
+  public static class StateTOptionalAssert<S, F extends WitnessArity<TypeArity.Unary>, A>
+      extends AbstractAssert<StateTOptionalAssert<S, F, A>, Kind<StateTKind.Witness<S, F>, A>> {
+
+    private final Function<Kind<F, StateTuple<S, A>>, Optional<StateTuple<S, A>>> outerUnwrapper;
+
+    protected StateTOptionalAssert(
+        Kind<StateTKind.Witness<S, F>, A> actual,
+        Function<Kind<F, StateTuple<S, A>>, Optional<StateTuple<S, A>>> outerUnwrapper) {
+      super(actual, StateTOptionalAssert.class);
+      this.outerUnwrapper = outerUnwrapper;
+    }
+
+    /**
+     * Runs the StateT computation with the given initial state and returns a result assertion for
+     * the computed value and final state.
+     *
+     * @param initialState the initial state to run the computation with
+     * @return a {@link StateTResultAssert} for asserting on the result
+     */
+    public StateTResultAssert<S, F, A> whenRunWith(S initialState) {
+      isNotNull();
+      var stateT = StateTKindHelper.STATE_T.narrow(actual);
+      Kind<F, StateTuple<S, A>> result = stateT.runStateT(initialState);
+      Optional<StateTuple<S, A>> unwrapped = outerUnwrapper.apply(result);
+      return new StateTResultAssert<>(unwrapped, initialState);
+    }
+
+    /**
+     * Verifies that this StateT is equal to another StateT by comparing results for a given initial
+     * state.
+     *
+     * @param other the other StateT to compare with
+     * @param initialState the initial state to run both computations with
+     * @return this assertion object for chaining
+     * @throws AssertionError if the results are not equal
+     */
+    public StateTOptionalAssert<S, F, A> isEqualToStateT(
+        Kind<StateTKind.Witness<S, F>, A> other, S initialState) {
+      isNotNull();
+      var thisStateT = StateTKindHelper.STATE_T.narrow(actual);
+      Optional<StateTuple<S, A>> thisResult =
+          outerUnwrapper.apply(thisStateT.runStateT(initialState));
+
+      if (other == null) {
+        failWithMessage("Expected StateT to compare with but was null");
+        return this;
+      }
+
+      var otherStateT = StateTKindHelper.STATE_T.narrow(other);
+      Optional<StateTuple<S, A>> otherResult =
+          outerUnwrapper.apply(otherStateT.runStateT(initialState));
+
+      if (!thisResult.equals(otherResult)) {
+        failWithMessage(
+            "Expected StateT to be equal to <%s> but was <%s> for initial state <%s>",
+            otherResult, thisResult, initialState);
+      }
+      return this;
+    }
+  }
+
+  /**
+   * Assertion class for the result of running a StateT computation with a specific initial state.
+   *
+   * @param <S> the state type
+   * @param <F> the witness type of the outer monad
+   * @param <A> the value type
+   */
+  public static class StateTResultAssert<S, F extends WitnessArity<TypeArity.Unary>, A> {
+
+    private final Optional<StateTuple<S, A>> result;
+    private final S initialState;
+
+    protected StateTResultAssert(Optional<StateTuple<S, A>> result, S initialState) {
+      this.result = result;
+      this.initialState = initialState;
+    }
+
+    /**
+     * Verifies that the result is empty (outer monad was empty).
+     *
+     * @return this assertion object for chaining
+     * @throws AssertionError if the result is present
+     */
+    public StateTResultAssert<S, F, A> isEmpty() {
+      if (result.isPresent()) {
+        failWithMessage(
+            "Expected result to be empty for initial state <%s> but was present with: <%s>",
+            initialState, result.get());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result is present (not empty).
+     *
+     * @return this assertion object for chaining
+     * @throws AssertionError if the result is empty
+     */
+    public StateTResultAssert<S, F, A> isPresent() {
+      if (result.isEmpty()) {
+        failWithMessage(
+            "Expected result to be present for initial state <%s> but was empty", initialState);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result contains a value equal to the expected value.
+     *
+     * @param expected the expected value
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or value does not match
+     */
+    public StateTResultAssert<S, F, A> hasValue(A expected) {
+      isPresent();
+      A actual = result.get().value();
+      if (!Objects.equals(actual, expected)) {
+        failWithMessage(
+            "Expected value to be <%s> for initial state <%s> but was <%s>",
+            expected, initialState, actual);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result contains a final state equal to the expected state.
+     *
+     * @param expected the expected final state
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or final state does not match
+     */
+    public StateTResultAssert<S, F, A> hasFinalState(S expected) {
+      isPresent();
+      S actual = result.get().state();
+      if (!Objects.equals(actual, expected)) {
+        failWithMessage(
+            "Expected final state to be <%s> for initial state <%s> but was <%s>",
+            expected, initialState, actual);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the result contains both the expected value and final state.
+     *
+     * @param expectedValue the expected value
+     * @param expectedState the expected final state
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or either component does not match
+     */
+    public StateTResultAssert<S, F, A> hasResult(A expectedValue, S expectedState) {
+      isPresent();
+      StateTuple<S, A> tuple = result.get();
+      if (!Objects.equals(tuple.value(), expectedValue)
+          || !Objects.equals(tuple.state(), expectedState)) {
+        failWithMessage(
+            "Expected result (%s, %s) for initial state <%s> but was (%s, %s)",
+            expectedValue, expectedState, initialState, tuple.value(), tuple.state());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the value satisfies the given requirements.
+     *
+     * @param requirements the consumer to apply to the value
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or requirements not satisfied
+     */
+    public StateTResultAssert<S, F, A> satisfiesValue(Consumer<? super A> requirements) {
+      isPresent();
+      A value = result.get().value();
+      try {
+        requirements.accept(value);
+      } catch (AssertionError e) {
+        failWithMessage(
+            "Value did not satisfy requirements for initial state <%s>: %s",
+            initialState, e.getMessage());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the final state satisfies the given requirements.
+     *
+     * @param requirements the consumer to apply to the final state
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or requirements not satisfied
+     */
+    public StateTResultAssert<S, F, A> satisfiesFinalState(Consumer<? super S> requirements) {
+      isPresent();
+      S state = result.get().state();
+      try {
+        requirements.accept(state);
+      } catch (AssertionError e) {
+        failWithMessage(
+            "Final state did not satisfy requirements for initial state <%s>: %s",
+            initialState, e.getMessage());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the value matches the given predicate.
+     *
+     * @param predicate the predicate to test
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or predicate fails
+     */
+    public StateTResultAssert<S, F, A> valueMatches(Predicate<? super A> predicate) {
+      isPresent();
+      A value = result.get().value();
+      if (!predicate.test(value)) {
+        failWithMessage(
+            "Value <%s> did not match predicate for initial state <%s>", value, initialState);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the final state matches the given predicate.
+     *
+     * @param predicate the predicate to test
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or predicate fails
+     */
+    public StateTResultAssert<S, F, A> finalStateMatches(Predicate<? super S> predicate) {
+      isPresent();
+      S state = result.get().state();
+      if (!predicate.test(state)) {
+        failWithMessage(
+            "Final state <%s> did not match predicate for initial state <%s>", state, initialState);
+      }
+      return this;
+    }
+
+    private void failWithMessage(String message, Object... args) {
+      throw new AssertionError(String.format(message, args));
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTTest.java
@@ -3,12 +3,17 @@
 package org.higherkindedj.hkt.state_t;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
 import java.util.Optional;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
+import org.higherkindedj.hkt.id.IdMonad;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
 import org.higherkindedj.hkt.state.StateTuple;
@@ -376,6 +381,99 @@ class StateTTest {
       String str = st.toString();
       // At minimum the toString should be stable and not throw
       assertThat(str).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("mapT")
+  class MapTTests {
+
+    @Test
+    @DisplayName("mapT with identity should return equivalent StateT")
+    void mapT_identity() {
+      Function<String, Kind<OptionalKind.Witness, StateTuple<String, Integer>>> runFn =
+          s -> outerMonad.of(StateTuple.of(updatedState, initialValue));
+      StateT<String, OptionalKind.Witness, Integer> st = StateT.create(runFn, outerMonad);
+
+      StateT<String, OptionalKind.Witness, Integer> result =
+          st.mapT(outerMonad, Function.identity());
+
+      Optional<StateTuple<String, Integer>> unwrapped = unwrapT(result);
+      assertThat(unwrapped).isPresent();
+      assertThat(unwrapped.get().value()).isEqualTo(initialValue);
+      assertThat(unwrapped.get().state()).isEqualTo(updatedState);
+    }
+
+    @Test
+    @DisplayName("mapT should transform outer monad to a different type")
+    void mapT_crossMonad() {
+      Function<String, Kind<OptionalKind.Witness, StateTuple<String, Integer>>> runFn =
+          s -> outerMonad.of(StateTuple.of(s + "_done", 99));
+      StateT<String, OptionalKind.Witness, Integer> st = StateT.create(runFn, outerMonad);
+
+      Monad<IdKind.Witness> idMonad = IdMonad.instance();
+      StateT<String, IdKind.Witness, Integer> result =
+          st.mapT(
+              idMonad,
+              optKind -> {
+                Optional<StateTuple<String, Integer>> opt = OPTIONAL.narrow(optKind);
+                return IdKindHelper.ID.widen(Id.of(opt.orElse(StateTuple.of("empty", -1))));
+              });
+
+      // Run the transformed StateT with Id monad
+      Kind<IdKind.Witness, StateTuple<String, Integer>> idResult = result.runStateT(initialState);
+      Id<StateTuple<String, Integer>> id = IdKindHelper.ID.narrow(idResult);
+      assertThat(id.value().value()).isEqualTo(99);
+      assertThat(id.value().state()).isEqualTo("initial_done");
+    }
+
+    @Test
+    @DisplayName("mapT should preserve state threading")
+    void mapT_preservesStateThreading() {
+      Function<String, Kind<OptionalKind.Witness, StateTuple<String, Integer>>> runFn =
+          s -> outerMonad.of(StateTuple.of(s.toUpperCase(), s.length()));
+      StateT<String, OptionalKind.Witness, Integer> st = StateT.create(runFn, outerMonad);
+
+      StateT<String, OptionalKind.Witness, Integer> result =
+          st.mapT(outerMonad, Function.identity());
+
+      Optional<StateTuple<String, Integer>> unwrapped = unwrapT(result);
+      assertThat(unwrapped).isPresent();
+      assertThat(unwrapped.get().state()).isEqualTo("INITIAL");
+      assertThat(unwrapped.get().value()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("mapT should preserve empty outer monad")
+    void mapT_preservesEmpty() {
+      Function<String, Kind<OptionalKind.Witness, StateTuple<String, Integer>>> emptyFn =
+          s -> OPTIONAL.widen(Optional.empty());
+      StateT<String, OptionalKind.Witness, Integer> st = StateT.create(emptyFn, outerMonad);
+
+      StateT<String, OptionalKind.Witness, Integer> result =
+          st.mapT(outerMonad, Function.identity());
+
+      Optional<StateTuple<String, Integer>> unwrapped = unwrapT(result);
+      assertThat(unwrapped).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapT should reject null function")
+    void mapT_rejectsNullFunction() {
+      Function<String, Kind<OptionalKind.Witness, StateTuple<String, Integer>>> runFn =
+          s -> outerMonad.of(StateTuple.of(updatedState, initialValue));
+      StateT<String, OptionalKind.Witness, Integer> st = StateT.create(runFn, outerMonad);
+      assertThatThrownBy(() -> st.mapT(outerMonad, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("mapT should reject null monad")
+    void mapT_rejectsNullMonad() {
+      Function<String, Kind<OptionalKind.Witness, StateTuple<String, Integer>>> runFn =
+          s -> outerMonad.of(StateTuple.of(updatedState, initialValue));
+      StateT<String, OptionalKind.Witness, Integer> st = StateT.create(runFn, outerMonad);
+      assertThatThrownBy(() -> st.mapT(null, Function.identity()))
+          .isInstanceOf(NullPointerException.class);
     }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/writer_t/WriterTAssert.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/writer_t/WriterTAssert.java
@@ -1,0 +1,249 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.writer_t;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.assertj.core.api.AbstractAssert;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Pair;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+
+/**
+ * Custom AssertJ assertion for WriterT transformer types.
+ *
+ * <p>Provides fluent assertions for WriterT values wrapped in Kind, handling both the outer monad
+ * layer and the inner Pair layer.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Assert that result is present with expected value and output
+ * assertThatWriterT(result, this::unwrapToOptional)
+ *     .isPresent()
+ *     .hasValue("expected")
+ *     .hasOutput("log entry");
+ *
+ * // Assert both components together
+ * assertThatWriterT(result, this::unwrapToOptional)
+ *     .hasPair("expected", "log entry");
+ *
+ * // Assert that outer monad is empty
+ * assertThatWriterT(result, this::unwrapToOptional).isEmpty();
+ * }</pre>
+ */
+public class WriterTAssert {
+
+  /**
+   * Entry point for WriterT assertions when the outer monad unwraps to Optional.
+   *
+   * @param <F> the witness type of the outer monad
+   * @param <W> the output/log type
+   * @param <A> the value type
+   * @param actual the WriterT Kind to assert on
+   * @param outerUnwrapper function to unwrap outer monad to Optional
+   * @return a new {@link WriterTOptionalAssert} instance
+   */
+  public static <F extends WitnessArity<TypeArity.Unary>, W, A>
+      WriterTOptionalAssert<F, W, A> assertThatWriterT(
+          Kind<WriterTKind.Witness<F, W>, A> actual,
+          Function<Kind<F, Pair<A, W>>, Optional<Pair<A, W>>> outerUnwrapper) {
+    return new WriterTOptionalAssert<>(actual, outerUnwrapper);
+  }
+
+  /**
+   * Specialised assertion class for WriterT with Optional-based unwrapping.
+   *
+   * <p>Provides convenient methods for asserting on Optional&lt;Pair&lt;A, W&gt;&gt; structures.
+   *
+   * @param <F> the witness type of the outer monad
+   * @param <W> the output/log type
+   * @param <A> the value type
+   */
+  public static class WriterTOptionalAssert<F extends WitnessArity<TypeArity.Unary>, W, A>
+      extends AbstractAssert<WriterTOptionalAssert<F, W, A>, Kind<WriterTKind.Witness<F, W>, A>> {
+
+    private final Function<Kind<F, Pair<A, W>>, Optional<Pair<A, W>>> outerUnwrapper;
+
+    protected WriterTOptionalAssert(
+        Kind<WriterTKind.Witness<F, W>, A> actual,
+        Function<Kind<F, Pair<A, W>>, Optional<Pair<A, W>>> outerUnwrapper) {
+      super(actual, WriterTOptionalAssert.class);
+      this.outerUnwrapper = outerUnwrapper;
+    }
+
+    private Optional<Pair<A, W>> unwrap() {
+      if (actual == null) return Optional.empty();
+      var writerT = WriterTKindHelper.WRITER_T.narrow(actual);
+      Kind<F, Pair<A, W>> outerKind = writerT.run();
+      return outerUnwrapper.apply(outerKind);
+    }
+
+    /**
+     * Verifies that the outer monad is empty.
+     *
+     * @return this assertion object for chaining
+     * @throws AssertionError if the outer monad is not empty
+     */
+    public WriterTOptionalAssert<F, W, A> isEmpty() {
+      isNotNull();
+      Optional<Pair<A, W>> unwrapped = unwrap();
+      if (unwrapped.isPresent()) {
+        failWithMessage(
+            "Expected outer monad to be empty but was present with: <%s>", unwrapped.get());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the outer monad is present (not empty).
+     *
+     * @return this assertion object for chaining
+     * @throws AssertionError if the outer monad is empty
+     */
+    public WriterTOptionalAssert<F, W, A> isPresent() {
+      isNotNull();
+      Optional<Pair<A, W>> unwrapped = unwrap();
+      if (unwrapped.isEmpty()) {
+        failWithMessage("Expected outer monad to be present but was empty");
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the WriterT contains a value equal to the expected value.
+     *
+     * @param expected the expected value (first component of the Pair)
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or value does not match
+     */
+    public WriterTOptionalAssert<F, W, A> hasValue(A expected) {
+      isPresent();
+      A actual = unwrap().get().first();
+      if (!Objects.equals(actual, expected)) {
+        failWithMessage("Expected value to be <%s> but was <%s>", expected, actual);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the WriterT contains output equal to the expected output.
+     *
+     * @param expected the expected output (second component of the Pair)
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or output does not match
+     */
+    public WriterTOptionalAssert<F, W, A> hasOutput(W expected) {
+      isPresent();
+      W actual = unwrap().get().second();
+      if (!Objects.equals(actual, expected)) {
+        failWithMessage("Expected output to be <%s> but was <%s>", expected, actual);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the WriterT contains both the expected value and output.
+     *
+     * @param expectedValue the expected value (first component)
+     * @param expectedOutput the expected output (second component)
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or either component does not match
+     */
+    public WriterTOptionalAssert<F, W, A> hasPair(A expectedValue, W expectedOutput) {
+      isPresent();
+      Pair<A, W> pair = unwrap().get();
+      if (!Objects.equals(pair.first(), expectedValue)
+          || !Objects.equals(pair.second(), expectedOutput)) {
+        failWithMessage(
+            "Expected Pair<%s, %s> but was Pair<%s, %s>",
+            expectedValue, expectedOutput, pair.first(), pair.second());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the value satisfies the given requirements.
+     *
+     * @param requirements the consumer to apply to the value
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or requirements not satisfied
+     */
+    public WriterTOptionalAssert<F, W, A> satisfiesValue(Consumer<? super A> requirements) {
+      isPresent();
+      A value = unwrap().get().first();
+      try {
+        requirements.accept(value);
+      } catch (AssertionError e) {
+        failWithMessage("Value did not satisfy requirements: %s", e.getMessage());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the output satisfies the given requirements.
+     *
+     * @param requirements the consumer to apply to the output
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or requirements not satisfied
+     */
+    public WriterTOptionalAssert<F, W, A> satisfiesOutput(Consumer<? super W> requirements) {
+      isPresent();
+      W output = unwrap().get().second();
+      try {
+        requirements.accept(output);
+      } catch (AssertionError e) {
+        failWithMessage("Output did not satisfy requirements: %s", e.getMessage());
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that the output matches the given predicate.
+     *
+     * @param predicate the predicate to test
+     * @return this assertion object for chaining
+     * @throws AssertionError if not present or predicate fails
+     */
+    public WriterTOptionalAssert<F, W, A> outputMatches(Predicate<? super W> predicate) {
+      isPresent();
+      W output = unwrap().get().second();
+      if (!predicate.test(output)) {
+        failWithMessage("Output <%s> did not match predicate", output);
+      }
+      return this;
+    }
+
+    /**
+     * Verifies that this WriterT is equal to another WriterT by comparing unwrapped values.
+     *
+     * @param other the other WriterT to compare with
+     * @return this assertion object for chaining
+     * @throws AssertionError if the WriterT values are not equal
+     */
+    public WriterTOptionalAssert<F, W, A> isEqualToWriterT(
+        Kind<WriterTKind.Witness<F, W>, A> other) {
+      isNotNull();
+      Optional<Pair<A, W>> thisUnwrapped = unwrap();
+
+      if (other == null) {
+        failWithMessage("Expected WriterT to compare with but was null");
+        return this;
+      }
+
+      var otherWriterT = WriterTKindHelper.WRITER_T.narrow(other);
+      Kind<F, Pair<A, W>> otherOuterKind = otherWriterT.run();
+      Optional<Pair<A, W>> otherUnwrapped = outerUnwrapper.apply(otherOuterKind);
+
+      if (!thisUnwrapped.equals(otherUnwrapped)) {
+        failWithMessage(
+            "Expected WriterT to be equal to <%s> but was <%s>", otherUnwrapped, thisUnwrapped);
+      }
+      return this;
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/writer_t/WriterTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/writer_t/WriterTTest.java
@@ -1,0 +1,213 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.writer_t;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.Pair;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WriterT Core Type Tests")
+class WriterTTest {
+
+  private static final Monoid<String> STRING_MONOID =
+      new Monoid<>() {
+        @Override
+        public String empty() {
+          return "";
+        }
+
+        @Override
+        public String combine(String a, String b) {
+          return a + b;
+        }
+      };
+
+  private Monad<OptionalKind.Witness> outerMonad;
+
+  private final Integer testValue = 42;
+  private final String testOutput = "log entry";
+
+  @BeforeEach
+  void setUp() {
+    outerMonad = OptionalMonad.INSTANCE;
+  }
+
+  private <A> Optional<Pair<A, String>> unwrapT(WriterT<OptionalKind.Witness, String, A> writerT) {
+    Kind<OptionalKind.Witness, Pair<A, String>> outerKind = writerT.run();
+    return OPTIONAL.narrow(outerKind);
+  }
+
+  @Nested
+  @DisplayName("Factory Methods")
+  class FactoryMethodTests {
+
+    @Test
+    @DisplayName("of should create WriterT with value and empty output")
+    void of_createsWithEmptyOutput() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.of(outerMonad, STRING_MONOID, testValue);
+      Optional<Pair<Integer, String>> result = unwrapT(wt);
+      assertThat(result).isPresent();
+      assertThat(result.get().first()).isEqualTo(testValue);
+      assertThat(result.get().second()).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("writer should create WriterT with explicit value and output")
+    void writer_createsWithValueAndOutput() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.writer(outerMonad, testValue, testOutput);
+      Optional<Pair<Integer, String>> result = unwrapT(wt);
+      assertThat(result).isPresent();
+      assertThat(result.get().first()).isEqualTo(testValue);
+      assertThat(result.get().second()).isEqualTo(testOutput);
+    }
+
+    @Test
+    @DisplayName("fromKind should wrap existing Kind<F, Pair<A, W>>")
+    void fromKind_wrapsExisting() {
+      Kind<OptionalKind.Witness, Pair<Integer, String>> wrapped =
+          OPTIONAL.widen(Optional.of(Pair.of(testValue, testOutput)));
+      WriterT<OptionalKind.Witness, String, Integer> wt = WriterT.fromKind(wrapped);
+      Optional<Pair<Integer, String>> result = unwrapT(wt);
+      assertThat(result).isPresent();
+      assertThat(result.get()).isEqualTo(Pair.of(testValue, testOutput));
+    }
+
+    @Test
+    @DisplayName("liftF should lift monadic value with empty output")
+    void liftF_liftsWithEmptyOutput() {
+      Kind<OptionalKind.Witness, Integer> fa = outerMonad.of(testValue);
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.liftF(outerMonad, STRING_MONOID, fa);
+      Optional<Pair<Integer, String>> result = unwrapT(wt);
+      assertThat(result).isPresent();
+      assertThat(result.get().first()).isEqualTo(testValue);
+      assertThat(result.get().second()).isEqualTo("");
+    }
+  }
+
+  @Nested
+  @DisplayName("Object Methods")
+  class ObjectMethodTests {
+
+    @Test
+    @DisplayName("equals should compare based on wrapped value")
+    void equals_comparesWrappedValue() {
+      Kind<OptionalKind.Witness, Pair<Integer, String>> wrapped1 =
+          OPTIONAL.widen(Optional.of(Pair.of(testValue, testOutput)));
+      Kind<OptionalKind.Witness, Pair<Integer, String>> wrapped2 =
+          OPTIONAL.widen(Optional.of(Pair.of(testValue, testOutput)));
+      Kind<OptionalKind.Witness, Pair<Integer, String>> wrapped3 =
+          OPTIONAL.widen(Optional.of(Pair.of(99, "other")));
+
+      WriterT<OptionalKind.Witness, String, Integer> wt1 = WriterT.fromKind(wrapped1);
+      WriterT<OptionalKind.Witness, String, Integer> wt2 = WriterT.fromKind(wrapped2);
+      WriterT<OptionalKind.Witness, String, Integer> wt3 = WriterT.fromKind(wrapped3);
+
+      assertThat(wt1).isEqualTo(wt2);
+      assertThat(wt1).isNotEqualTo(wt3);
+      assertThat(wt1).isNotEqualTo(null);
+    }
+
+    @Test
+    @DisplayName("hashCode should be consistent with equals")
+    void hashCode_consistentWithEquals() {
+      Kind<OptionalKind.Witness, Pair<Integer, String>> wrapped1 =
+          OPTIONAL.widen(Optional.of(Pair.of(testValue, testOutput)));
+      Kind<OptionalKind.Witness, Pair<Integer, String>> wrapped2 =
+          OPTIONAL.widen(Optional.of(Pair.of(testValue, testOutput)));
+
+      WriterT<OptionalKind.Witness, String, Integer> wt1 = WriterT.fromKind(wrapped1);
+      WriterT<OptionalKind.Witness, String, Integer> wt2 = WriterT.fromKind(wrapped2);
+
+      assertThat(wt1.hashCode()).isEqualTo(wt2.hashCode());
+    }
+
+    @Test
+    @DisplayName("toString should represent the structure")
+    void toString_representsStructure() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.writer(outerMonad, testValue, testOutput);
+      assertThat(wt.toString()).startsWith("WriterT[run=").endsWith("]");
+    }
+  }
+
+  @Nested
+  @DisplayName("mapT")
+  class MapTTests {
+
+    @Test
+    @DisplayName("mapT with identity should return equivalent WriterT")
+    void mapT_identity() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.writer(outerMonad, testValue, testOutput);
+      WriterT<OptionalKind.Witness, String, Integer> result = wt.mapT(Function.identity());
+      Optional<Pair<Integer, String>> unwrapped = unwrapT(result);
+      assertThat(unwrapped).isPresent();
+      assertThat(unwrapped.get()).isEqualTo(Pair.of(testValue, testOutput));
+    }
+
+    @Test
+    @DisplayName("mapT should transform outer monad to a different type")
+    void mapT_crossMonad() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.writer(outerMonad, testValue, testOutput);
+
+      WriterT<IdKind.Witness, String, Integer> result =
+          wt.mapT(
+              optKind -> {
+                Optional<Pair<Integer, String>> opt = OPTIONAL.narrow(optKind);
+                return IdKindHelper.ID.widen(Id.of(opt.orElse(Pair.of(-1, "empty"))));
+              });
+
+      Id<Pair<Integer, String>> id = IdKindHelper.ID.narrow(result.run());
+      assertThat(id.value()).isEqualTo(Pair.of(testValue, testOutput));
+    }
+
+    @Test
+    @DisplayName("mapT should preserve accumulated output")
+    void mapT_preservesOutput() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.writer(outerMonad, testValue, "accumulated log");
+      WriterT<OptionalKind.Witness, String, Integer> result = wt.mapT(Function.identity());
+      Optional<Pair<Integer, String>> unwrapped = unwrapT(result);
+      assertThat(unwrapped).isPresent();
+      assertThat(unwrapped.get().second()).isEqualTo("accumulated log");
+    }
+
+    @Test
+    @DisplayName("mapT should preserve empty outer monad")
+    void mapT_preservesEmpty() {
+      Kind<OptionalKind.Witness, Pair<Integer, String>> empty = OPTIONAL.widen(Optional.empty());
+      WriterT<OptionalKind.Witness, String, Integer> wt = WriterT.fromKind(empty);
+      WriterT<OptionalKind.Witness, String, Integer> result = wt.mapT(Function.identity());
+      Optional<Pair<Integer, String>> unwrapped = unwrapT(result);
+      assertThat(unwrapped).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mapT should reject null function")
+    void mapT_rejectsNull() {
+      WriterT<OptionalKind.Witness, String, Integer> wt =
+          WriterT.writer(outerMonad, testValue, testOutput);
+      assertThatThrownBy(() -> wt.mapT(null)).isInstanceOf(NullPointerException.class);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java
@@ -5,6 +5,7 @@ package org.higherkindedj.example.basic.either_t;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
@@ -15,6 +16,8 @@ import org.higherkindedj.hkt.either_t.EitherTKind;
 import org.higherkindedj.hkt.either_t.EitherTMonad;
 import org.higherkindedj.hkt.future.CompletableFutureKind;
 import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
 
 public class EitherTExample {
 
@@ -156,8 +159,40 @@ public class EitherTExample {
     // Expected: Left(DomainError[message=Input empty])
   }
 
+  // --- mapT: Switching the outer monad ---
+  //
+  // mapT lets you swap the outer monad without touching the inner Either.
+  // Here we convert a Future-based EitherT into an Optional-based one —
+  // useful when you have already awaited a result and want to continue
+  // in a synchronous context.
+
+  public void mapTExample() {
+    System.out.println("\n--- 4. Using mapT to switch from Future to Optional ---");
+
+    // Start with an async result
+    Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>> futureResult =
+        runWorkflow("Data");
+
+    EitherT<CompletableFutureKind.Witness, DomainError, ProcessedData> futureET =
+        EitherT.fromKind(futureResult);
+
+    // Use mapT to await the future and move into Optional
+    EitherT<OptionalKind.Witness, DomainError, ProcessedData> optionalET =
+        futureET.mapT(
+            futureKind -> {
+              Either<DomainError, ProcessedData> awaited = FUTURE.join(futureKind);
+              return OptionalKindHelper.OPTIONAL.widen(Optional.of(awaited));
+            });
+
+    // Now we can work synchronously with the Optional-based transformer
+    Optional<Either<DomainError, ProcessedData>> result =
+        OptionalKindHelper.OPTIONAL.narrow(optionalET.value());
+    System.out.println("Synchronous result: " + result);
+  }
+
   public static void main(String[] args) {
     EitherTExample example = new EitherTExample();
     example.asyncWorkflowErrorHandlingExample();
+    example.mapTExample();
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/maybe_t/MaybeTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/maybe_t/MaybeTExample.java
@@ -15,6 +15,9 @@ import org.higherkindedj.hkt.MonadError;
 import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.future.CompletableFutureKind;
 import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.hkt.maybe_t.MaybeT;
 import org.higherkindedj.hkt.maybe_t.MaybeTKind;
@@ -30,8 +33,33 @@ public class MaybeTExample {
   public static void main(String[] args) {
     MaybeTExample example = new MaybeTExample();
     example.createExample();
+    example.mapTExample();
     MaybeTAsyncExample asyncExample = new MaybeTAsyncExample();
     asyncExample.asyncExample();
+  }
+
+  // --- mapT: Switching the outer monad ---
+  //
+  // mapT lets you swap the outer monad without unwrapping the inner Maybe.
+  // Here we convert an Optional-based MaybeT into an Id-based one —
+  // collapsing the two layers of optionality into a single Maybe.
+
+  public void mapTExample() {
+    System.out.println("\n--- mapT: Optional -> Id ---");
+    OptionalMonad optMonad = OptionalMonad.INSTANCE;
+
+    MaybeT<OptionalKind.Witness, String> mt = MaybeT.just(optMonad, "Hello");
+
+    // Use mapT to collapse Optional<Maybe<A>> into Id<Maybe<A>>
+    MaybeT<IdKind.Witness, String> idMt =
+        mt.mapT(
+            optKind -> {
+              Optional<Maybe<String>> opt = OPTIONAL.narrow(optKind);
+              return IdKindHelper.ID.widen(Id.of(opt.orElse(Maybe.nothing())));
+            });
+
+    Id<Maybe<String>> result = IdKindHelper.ID.narrow(idMt.value());
+    System.out.println("Result: " + result.value()); // Just(Hello)
   }
 
   public void createExample() {

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.example.basic.optional_t;
 
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 import static org.higherkindedj.hkt.optional_t.OptionalTKindHelper.OPTIONAL_T;
 
 import java.util.Optional;
@@ -15,6 +16,7 @@ import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.future.CompletableFutureKind;
 import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional_t.OptionalT;
 import org.higherkindedj.hkt.optional_t.OptionalTKind;
 import org.higherkindedj.hkt.optional_t.OptionalTMonad;
@@ -64,6 +66,19 @@ public class OptionalTExample {
     Kind<CompletableFutureKind.Witness, Optional<String>> wrappedFVO = ot1.value();
     CompletableFuture<Optional<String>> futureOptional = FUTURE.narrow(wrappedFVO);
     futureOptional.thenAccept(optStr -> System.out.println("ot1 result: " + optStr));
+
+    // --- mapT: Switching from Future to Optional ---
+    // mapT swaps the outer monad without touching the inner Optional.
+    // Here we await the async result and move into a synchronous context.
+    OptionalT<OptionalKind.Witness, String> syncOt =
+        ot2.mapT(
+            futureKind -> {
+              Optional<String> awaited = FUTURE.narrow(futureKind).join();
+              return OPTIONAL.widen(Optional.of(awaited));
+            });
+
+    Optional<Optional<String>> syncResult = OPTIONAL.narrow(syncOt.value());
+    System.out.println("mapT result (Future -> Optional): " + syncResult);
   }
 
   public static class OptionalTAsyncExample {

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTExample.java
@@ -8,6 +8,9 @@ import static org.higherkindedj.hkt.reader_t.ReaderTKindHelper.READER_T;
 import java.util.Optional;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
 import org.higherkindedj.hkt.reader_t.ReaderT;
@@ -79,5 +82,19 @@ public class ReaderTExample {
     //        (ReaderTKind<OptionalKind.Witness, Config, String>) READER_T.widen(rt1);
     var kindRt1 = READER_T.widen(rt1);
     ReaderT<OptionalKind.Witness, Config, String> unwrappedRt1 = READER_T.narrow(kindRt1);
+
+    // --- mapT: Switching from Optional to Id ---
+    // mapT composes a function after each run result, changing the outer monad.
+    // Here we collapse Optional into Id, providing a default for empty results.
+    ReaderT<IdKind.Witness, Config, String> idRt =
+        rt1.mapT(
+            optKind -> {
+              Optional<String> opt = OPTIONAL.narrow(optKind);
+              return IdKindHelper.ID.widen(Id.of(opt.orElse("default")));
+            });
+
+    Kind<IdKind.Witness, String> idResult = idRt.run().apply(testConfig);
+    Id<String> id = IdKindHelper.ID.narrow(idResult);
+    System.out.println("mapT result (Optional -> Id): " + id.value());
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTExample.java
@@ -136,6 +136,8 @@ public class StateTExample {
     // Output: true
     System.out.println(
         "Is empty from small initial (state 5 for combined): " + combinedEmptyResult.isEmpty());
+
+    mapTExample();
   }
 
   public static <S, F extends WitnessArity<TypeArity.Unary>> Kind<StateTKind.Witness<S, F>, S> get(

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTExample.java
@@ -11,11 +11,15 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.TypeArity;
 import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdKindHelper;
+import org.higherkindedj.hkt.id.IdMonad;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.optional.OptionalMonad;
 import org.higherkindedj.hkt.state.StateTuple;
 import org.higherkindedj.hkt.state_t.StateT;
-import org.higherkindedj.hkt.state_t.StateTKind; // For StateTKind.Witness
+import org.higherkindedj.hkt.state_t.StateTKind;
 import org.higherkindedj.hkt.state_t.StateTMonad;
 
 public class StateTExample {
@@ -160,5 +164,35 @@ public class StateTExample {
       Kind<StateTKind.Witness<S, F>, A> gets(Function<S, A> f, Monad<F> monadF) {
     Function<S, Kind<F, StateTuple<S, A>>> runFn = s -> monadF.of(StateTuple.of(s, f.apply(s)));
     return StateT.create(runFn, monadF);
+  }
+
+  // --- mapT: Switching from Optional to Id ---
+  //
+  // mapT swaps the outer monad without touching the state-threading logic.
+  // StateT uniquely requires a new Monad instance because it stores its monad
+  // for internal sequencing.
+
+  public static void mapTExample() {
+    OptionalMonad optionalMonad = OptionalMonad.INSTANCE;
+    Monad<IdKind.Witness> idMonad = IdMonad.instance();
+
+    StateT<Integer, OptionalKind.Witness, String> optionalStateT =
+        StateT.create(
+            s -> OPTIONAL.widen(Optional.of(StateTuple.of(s + 1, "count=" + s))), optionalMonad);
+
+    // Use mapT to switch from Optional to Id, providing a default for empty results
+    StateT<Integer, IdKind.Witness, String> idStateT =
+        optionalStateT.mapT(
+            idMonad,
+            optKind -> {
+              Optional<StateTuple<Integer, String>> opt = OPTIONAL.narrow(optKind);
+              return IdKindHelper.ID.widen(Id.of(opt.orElse(StateTuple.of(0, "empty"))));
+            });
+
+    // Run with Id monad — no optionality, guaranteed result
+    Kind<IdKind.Witness, StateTuple<Integer, String>> result = idStateT.runStateT(10);
+    Id<StateTuple<Integer, String>> id = IdKindHelper.ID.narrow(result);
+    System.out.println("\nmapT result (Optional -> Id): " + id.value());
+    // StateTuple[state=11, value=count=10]
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer_t/WriterTExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer_t/WriterTExample.java
@@ -2,9 +2,11 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.example.basic.writer_t;
 
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 import static org.higherkindedj.hkt.writer_t.WriterTKindHelper.WRITER_T;
 
 import java.util.List;
+import java.util.Optional;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Monoids;
 import org.higherkindedj.hkt.Pair;
@@ -12,6 +14,7 @@ import org.higherkindedj.hkt.expression.For;
 import org.higherkindedj.hkt.id.IdKind;
 import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.id.IdMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.writer_t.WriterT;
 import org.higherkindedj.hkt.writer_t.WriterTKind;
 import org.higherkindedj.hkt.writer_t.WriterTMonad;
@@ -98,6 +101,8 @@ public class WriterTExample {
     var resultPair = unwrap(result);
     System.out.println("Final value: " + resultPair.first());
     System.out.println("Diagnostics: " + resultPair.second());
+
+    mapTExample();
   }
 
   /** A multi-step computation that accumulates diagnostic output. */
@@ -109,6 +114,31 @@ public class WriterTExample {
         .let(t -> t._2() + 10)
         .from(t -> w.tell(List.of("Added 10: " + t._4())))
         .yield((_, doubled, _, plusTen, _) -> plusTen);
+  }
+
+  // --- Example 5: Using mapT to switch from Id to Optional ---
+  //
+  // mapT swaps the outer monad without touching the accumulated log.
+  // Here we wrap an Id-based WriterT into an Optional context — useful
+  // when a downstream API expects optional semantics.
+
+  void mapTExample() {
+    var idMonad = IdMonad.instance();
+
+    WriterT<IdKind.Witness, List<String>, String> idWriter =
+        WriterT.writer(idMonad, "result", List.of("step 1", "step 2"));
+
+    WriterT<OptionalKind.Witness, List<String>, String> optWriter =
+        idWriter.mapT(
+            idKind -> {
+              Pair<String, List<String>> pair = IdKindHelper.ID.unwrap(idKind);
+              return OPTIONAL.widen(Optional.of(pair));
+            });
+
+    Optional<Pair<String, List<String>>> result = OPTIONAL.narrow(optWriter.run());
+    System.out.println("\n--- mapT: Id -> Optional ---");
+    System.out.println("Result: " + result);
+    // Optional[Pair[first=result, second=[step 1, step 2]]]
   }
 
   /** Helper to unwrap a WriterT over Id to its Pair. */


### PR DESCRIPTION
## Description

This PR adds the `mapT` method to all monad transformer types (StateT, ReaderT, WriterT, EitherT, MaybeT, OptionalT) and introduces comprehensive custom AssertJ assertions for testing transformers.

The `mapT` method enables transforming the outer monad layer of a transformer without unwrapping the inner value. This is a standard operation for monad transformers that allows switching between different effect types or applying natural transformations at the monad level.

Additionally, three new assertion classes are introduced:
- `StateTAssert`: Fluent assertions for StateT with support for running computations with initial state
- `ReaderTAssert`: Fluent assertions for ReaderT with support for running readers with environments
- `WriterTAssert`: Fluent assertions for WriterT with support for inspecting values and outputs

These assertions follow the AssertJ pattern and provide a two-phase model where applicable (run computation, then assert on results).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/update
- [x] Documentation update

## How Has This Been Tested?

- Added comprehensive unit tests for `mapT` in all transformer test classes (StateTTest, ReaderTTest, EitherTTest, MaybeT, OptionalTTest)
- Added new test classes for custom assertions (WriterTTest with assertion examples)
- Updated architecture consistency rules to enforce `mapT` presence on transformer types
- All existing tests pass with the new changes
- Examples updated to demonstrate `mapT` usage across different transformers

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (transformer markdown files updated with mapT examples)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked that the GitHub Actions CI build passes with my changes

## Additional Comments

The `mapT` implementation varies slightly by transformer type:
- **StateT**: Requires passing a new `Monad<G>` instance since it stores the monad internally
- **ReaderT, WriterT, EitherT, MaybeT, OptionalT**: Take only the transformation function since they don't store monad instances

All transformers now have consistent `mapT` support, enabling flexible composition and effect type switching across the entire transformer hierarchy.
Fixes #444 

