### PR TITLE
Fix @see javadoc tags to use string literals

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/ComposeEffects.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/ComposeEffects.java
@@ -36,8 +36,8 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * @see EffectAlgebra
- * @see org.higherkindedj.hkt.inject.Inject
- * @see org.higherkindedj.hkt.eitherf.EitherF
+ * @see "org.higherkindedj.hkt.inject.Inject"
+ * @see "org.higherkindedj.hkt.eitherf.EitherF"
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)

--- a/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/EffectAlgebra.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/EffectAlgebra.java
@@ -42,9 +42,9 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  *
- * @see org.higherkindedj.hkt.Kind
- * @see org.higherkindedj.hkt.Functor
- * @see org.higherkindedj.hkt.free.Free
+ * @see "org.higherkindedj.hkt.Kind"
+ * @see "org.higherkindedj.hkt.Functor"
+ * @see "org.higherkindedj.hkt.free.Free"
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)

--- a/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/Handles.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/Handles.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * @see EffectAlgebra
- * @see org.higherkindedj.hkt.Natural
+ * @see "org.higherkindedj.hkt.Natural"
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)


### PR DESCRIPTION
## Description

This change fixes javadoc `@see` tags in annotation classes to use string literals instead of bare class references. When `@see` tags reference classes that may not be on the compilation classpath, they should be wrapped in quotes to avoid javadoc warnings/errors.

The changes affect three annotation classes in the `hkj-annotations` module:
- `EffectAlgebra.java`: Fixed 3 `@see` tags
- `ComposeEffects.java`: Fixed 2 `@see` tags  
- `Handles.java`: Fixed 1 `@see` tag

This ensures clean javadoc generation without warnings about unresolved references.

Relates to javadoc generation quality

## Type of change

- [x] Documentation update
- [x] Refactoring/Code cleanup

## How Has This Been Tested?

- [x] `./gradlew test` passes locally
- [x] Javadoc generation completes without warnings

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (javadoc)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (`./gradlew test`)

## Additional Comments

These are purely documentation changes to javadoc comments. No functional code was modified, and no new tests are required.

