### PR TITLE
Add @WebMvcTest slice-test recipe for hkj-spring controllers

### DIFF
--- a/.claude/skills/hkj-spring/SKILL.md
+++ b/.claude/skills/hkj-spring/SKILL.md
@@ -261,8 +261,22 @@ Once all endpoints are migrated, remove exception handlers.
 
 ## Testing
 
+> **Heads up — `@WebMvcTest` does not load third-party auto-configurations.**
+> The hkj-spring-boot-starter registers `HkjJacksonAutoConfiguration` (for the
+> `Either` / `Validated` JSON shape) and `HkjWebMvcAutoConfiguration` (for the
+> `*ReturnValueHandler`s and HTTP status-code mapping) via
+> `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`.
+> `@WebMvcTest` slices those out, so without explicit imports MockMvc sees a
+> raw serialized `Either` and no status mapping. Add the three auto-configs
+> below to restore production behaviour inside the slice.
+
 ```java
 @WebMvcTest(UserController.class)
+@ImportAutoConfiguration({
+    HkjAutoConfiguration.class,           // binds HkjProperties
+    HkjJacksonAutoConfiguration.class,    // HkjJacksonModule → Either/Validated JSON shape
+    HkjWebMvcAutoConfiguration.class      // return-value handlers + status mapping
+})
 class UserControllerTest {
 
     @Autowired MockMvc mockMvc;
@@ -288,6 +302,10 @@ class UserControllerTest {
     }
 }
 ```
+
+For full-fidelity tests (all auto-configs, properties, filters, etc.), use
+`@SpringBootTest + @AutoConfigureMockMvc` instead. A working slice-test recipe
+lives at `hkj-spring/example/src/test/java/.../UserControllerWebMvcSliceTest.java`.
 
 ---
 

--- a/.claude/skills/hkj-spring/reference/spring-example.md
+++ b/.claude/skills/hkj-spring/reference/spring-example.md
@@ -172,8 +172,22 @@ POST /api/users
 
 ## Testing
 
+> **`@WebMvcTest` excludes third-party auto-configurations.** The
+> hkj-spring-boot-starter's auto-configs (`HkjJacksonAutoConfiguration`,
+> `HkjWebMvcAutoConfiguration`) are loaded via
+> `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`,
+> which `@WebMvcTest` intentionally trims. Without `@ImportAutoConfiguration`,
+> MockMvc will see a raw `Either` POJO with no status-code mapping and the
+> assertions below will fail. Importing the three auto-configs restores the
+> production rendering contract inside the slice.
+
 ```java
 @WebMvcTest(UserController.class)
+@ImportAutoConfiguration({
+    HkjAutoConfiguration.class,
+    HkjJacksonAutoConfiguration.class,
+    HkjWebMvcAutoConfiguration.class
+})
 class UserControllerTest {
 
     @Autowired MockMvc mockMvc;
@@ -212,6 +226,11 @@ class UserControllerTest {
     }
 }
 ```
+
+> If you prefer full-fidelity over slice isolation, swap the annotations for
+> `@SpringBootTest(classes = HkjSpringExampleApplication.class) +
+> @AutoConfigureMockMvc` — see `UserControllerIntegrationTest` for the full
+> pattern.
 
 ---
 

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerWebMvcSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerWebMvcSliceTest.java
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.spring.autoconfigure.HkjAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjJacksonAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjWebMvcAutoConfiguration;
+import org.higherkindedj.spring.example.domain.DomainError;
+import org.higherkindedj.spring.example.domain.User;
+import org.higherkindedj.spring.example.domain.UserNotFoundError;
+import org.higherkindedj.spring.example.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Canonical slice-test recipe for controllers that return {@code Either} / {@code Validated} /
+ * {@code *Path} types from higher-kinded-j.
+ *
+ * <p>{@code @WebMvcTest} only loads the MVC slice — third-party auto-configurations registered via
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports} are
+ * <b>not</b> picked up. Without importing them explicitly, MockMvc sees a raw POJO serialization of
+ * the {@code Either} and no status-code mapping, because:
+ *
+ * <ul>
+ *   <li>{@link HkjJacksonAutoConfiguration} (registers {@code HkjJacksonModule}) isn't loaded, so
+ *       {@code Either} / {@code Validated} serialize as their raw fields rather than the tagged
+ *       {@code {success, value}} / {@code {success, error}} shape.
+ *   <li>{@link HkjWebMvcAutoConfiguration} (registers the {@code *ReturnValueHandler}s and the
+ *       {@code ErrorStatusCodeMapper}) isn't loaded, so top-level {@code Either} values are not
+ *       unwrapped and left errors don't map to status codes like 404/400.
+ * </ul>
+ *
+ * <p>Importing all three auto-configurations below restores production behaviour inside the slice:
+ *
+ * <ul>
+ *   <li>{@link HkjAutoConfiguration} — binds {@code HkjProperties} (required by the Web MVC
+ *       auto-config).
+ *   <li>{@link HkjJacksonAutoConfiguration} — registers the Jackson module for JSON shape.
+ *   <li>{@link HkjWebMvcAutoConfiguration} — registers the return-value handlers and status-code
+ *       mapping.
+ * </ul>
+ *
+ * <p>For full-fidelity integration testing, prefer {@code @SpringBootTest + @AutoConfigureMockMvc}
+ * (see {@link UserControllerIntegrationTest}). Use this slice recipe when you want fast, focused
+ * controller tests without loading the full application context.
+ */
+@WebMvcTest(UserController.class)
+@ImportAutoConfiguration({
+  HkjAutoConfiguration.class,
+  HkjJacksonAutoConfiguration.class,
+  HkjWebMvcAutoConfiguration.class
+})
+@DisplayName("UserController @WebMvcTest slice (with hkj-spring auto-config imported)")
+class UserControllerWebMvcSliceTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private UserService userService;
+
+  @Test
+  @DisplayName("Right(User) is unwrapped to HTTP 200 with the user JSON")
+  void rightEitherUnwrappedTo200() throws Exception {
+    when(userService.findById("1"))
+        .thenReturn(Either.right(new User("1", "alice@example.com", "Alice", "Smith")));
+
+    mockMvc
+        .perform(get("/api/users/{id}", "1"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value("1"))
+        .andExpect(jsonPath("$.email").value("alice@example.com"))
+        // Top-level Either is unwrapped — the Either wrapper fields must NOT leak.
+        .andExpect(jsonPath("$.isRight").doesNotExist())
+        .andExpect(jsonPath("$.right").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("Left(UserNotFoundError) maps to HTTP 404 with tagged error JSON")
+  void leftUserNotFoundMapsTo404() throws Exception {
+    when(userService.findById("999"))
+        .thenReturn(Either.<DomainError, User>left(new UserNotFoundError("999")));
+
+    mockMvc
+        .perform(get("/api/users/{id}", "999"))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error").exists())
+        .andExpect(jsonPath("$.error.userId").value("999"));
+  }
+}


### PR DESCRIPTION
@WebMvcTest excludes third-party auto-configurations listed in META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports, so HkjJacksonAutoConfiguration (JSON shape for Either/Validated) and HkjWebMvcAutoConfiguration (*ReturnValueHandlers + status-code mapping) are not loaded in the slice. MockMvc then sees a raw serialized Either with no status mapping — assertions against the tagged JSON shape or error status codes fail.

- Add UserControllerWebMvcSliceTest: canonical recipe using @ImportAutoConfiguration({HkjAutoConfiguration, HkjJacksonAutoConfiguration, HkjWebMvcAutoConfiguration}) and @MockitoBean. Covers Right → 200 unwrap and Left(UserNotFoundError) → 404 tagged-error JSON.
- Fix misleading @WebMvcTest(UserController.class) examples in .claude/skills/hkj-spring/SKILL.md and spring-example.md reference. Add the @ImportAutoConfiguration incantation and an explanatory note; point to @SpringBootTest + @AutoConfigureMockMvc for full-fidelity tests.


Fixes #487 