### PR TITLE
Honor @ResponseStatus on hkj-spring Effect Path return value handlers

### DIFF
--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandler.java
@@ -129,6 +129,9 @@ public class CompletableFuturePathReturnValueHandler
           }
         });
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Execute the CompletableFuture asynchronously
     path.run()
         .whenComplete(
@@ -138,7 +141,7 @@ public class CompletableFuturePathReturnValueHandler
                   log.error("CompletableFuturePath failed", throwable);
                   writeFailureResponse(throwable, response);
                 } else {
-                  writeSuccessResponse(result, response);
+                  writeSuccessResponse(result, response, successStatus);
                 }
                 deferredResult.setResult(null);
               } catch (Exception e) {
@@ -215,12 +218,15 @@ public class CompletableFuturePathReturnValueHandler
    *
    * @param value the result value
    * @param response the HTTP response
+   * @param status the HTTP status code to set
    */
-  private void writeSuccessResponse(Object value, HttpServletResponse response) {
+  private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandler.java
@@ -34,7 +34,9 @@ import tools.jackson.databind.json.JsonMapper;
  * <p>Conversion rules:
  *
  * <ul>
- *   <li>{@code Right<A>} → HTTP 200 OK with value as JSON body
+ *   <li>{@code Right<A>} → HTTP 200 OK with value as JSON body (or the status declared by {@link
+ *       org.springframework.web.bind.annotation.ResponseStatus @ResponseStatus} on the handler
+ *       method/class)
  *   <li>{@code Left<E>} → HTTP 4xx/5xx with error as JSON body
  * </ul>
  *
@@ -110,6 +112,9 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
       return;
     }
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Fold to HTTP response
     either.fold(
         error -> {
@@ -117,7 +122,7 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
           return null;
         },
         value -> {
-          writeSuccessResponse(value, response);
+          writeSuccessResponse(value, response, successStatus);
           return null;
         });
   }
@@ -162,12 +167,15 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
    *
    * @param value the success value
    * @param response the HTTP response
+   * @param status the HTTP status code to set
    */
-  private void writeSuccessResponse(Object value, HttpServletResponse response) {
+  private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandler.java
@@ -111,11 +111,14 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
       }
     }
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Interpret the program via the boundary
     Try<?> result = boundary.runSafe(freePath.toFree());
     result.fold(
         value -> {
-          writeSuccessResponse(value, response);
+          writeSuccessResponse(value, response, successStatus);
           return null;
         },
         throwable -> {
@@ -152,11 +155,13 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
     }
   }
 
-  private void writeSuccessResponse(Object value, HttpServletResponse response) {
+  private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandler.java
@@ -96,12 +96,15 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
       return;
     }
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Execute the deferred IO at the edge and convert result to HTTP response
     ioPath
         .runSafe()
         .fold(
             value -> {
-              writeSuccessResponse(value, response);
+              writeSuccessResponse(value, response, successStatus);
               return null;
             },
             throwable -> {
@@ -149,12 +152,15 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
    *
    * @param value the result of successful IO execution
    * @param response the HTTP response
+   * @param status the HTTP status code to set
    */
-  private void writeSuccessResponse(Object value, HttpServletResponse response) {
+  private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandler.java
@@ -25,7 +25,9 @@ import tools.jackson.databind.json.JsonMapper;
  * <p>Conversion rules:
  *
  * <ul>
- *   <li>{@code Just<A>} → HTTP 200 OK with value as JSON body
+ *   <li>{@code Just<A>} → HTTP 200 OK with value as JSON body (or the status declared by {@link
+ *       org.springframework.web.bind.annotation.ResponseStatus @ResponseStatus} on the handler
+ *       method/class)
  *   <li>{@code Nothing} → HTTP 404 Not Found (configurable)
  * </ul>
  *
@@ -81,7 +83,9 @@ public class MaybePathReturnValueHandler implements HandlerMethodReturnValueHand
     // Extract underlying Maybe and convert to HTTP response
     var maybe = path.run();
     if (maybe.isJust()) {
-      writeJustResponse(maybe.get(), response);
+      int successStatus =
+          SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+      writeJustResponse(maybe.get(), response, successStatus);
     } else {
       writeNothingResponse(response);
     }
@@ -109,12 +113,15 @@ public class MaybePathReturnValueHandler implements HandlerMethodReturnValueHand
    *
    * @param value the value
    * @param response the HTTP response
+   * @param status the HTTP status code to set
    */
-  private void writeJustResponse(Object value, HttpServletResponse response) {
+  private void writeJustResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/SuccessStatusResolver.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/SuccessStatusResolver.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import java.lang.reflect.Method;
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Utility class for resolving the success HTTP status code for a controller method.
+ *
+ * <p>Honors Spring's {@link ResponseStatus} annotation when declared on the handler method or on
+ * its containing controller class (including meta-annotated usages, e.g. a custom
+ * {@code @CreatedStatus} annotation that is itself annotated with {@code @ResponseStatus}).
+ *
+ * <p>Precedence:
+ *
+ * <ol>
+ *   <li>{@code @ResponseStatus} on the handler method
+ *   <li>{@code @ResponseStatus} on the containing controller class
+ *   <li>The supplied fallback status (typically {@link HttpStatus#OK})
+ * </ol>
+ *
+ * <p>This allows controllers to use canonical REST semantics with Effect Path return types:
+ *
+ * <pre>{@code
+ * @PostMapping
+ * @ResponseStatus(HttpStatus.CREATED)
+ * public EitherPath<DomainError, User> createUser(...) { ... }
+ *
+ * @DeleteMapping("/{id}")
+ * @ResponseStatus(HttpStatus.NO_CONTENT)
+ * public MaybePath<Void> deleteUser(...) { ... }
+ * }</pre>
+ */
+public final class SuccessStatusResolver {
+
+  private SuccessStatusResolver() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  /**
+   * Resolves the success HTTP status code for the given return type.
+   *
+   * @param returnType the method parameter describing the controller method's return type (may be
+   *     null, in which case {@code defaultStatus} is returned)
+   * @param defaultStatus the status code to use when no {@code @ResponseStatus} annotation is
+   *     present on the method or its declaring class
+   * @return the resolved HTTP status code
+   */
+  public static int resolveSuccessStatus(@Nullable MethodParameter returnType, int defaultStatus) {
+    if (returnType == null) {
+      return defaultStatus;
+    }
+
+    Method method = returnType.getMethod();
+    ResponseStatus annotation = null;
+    if (method != null) {
+      annotation = AnnotatedElementUtils.findMergedAnnotation(method, ResponseStatus.class);
+    }
+    if (annotation == null) {
+      Class<?> containingClass = returnType.getContainingClass();
+      if (containingClass != null) {
+        annotation =
+            AnnotatedElementUtils.findMergedAnnotation(containingClass, ResponseStatus.class);
+      }
+    }
+
+    if (annotation != null) {
+      return annotation.code().value();
+    }
+    return defaultStatus;
+  }
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandler.java
@@ -89,11 +89,14 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
       return;
     }
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Extract underlying Try and convert to HTTP response
     path.run()
         .fold(
             value -> {
-              writeSuccessResponse(value, response);
+              writeSuccessResponse(value, response, successStatus);
               return null;
             },
             throwable -> {
@@ -141,12 +144,15 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
    *
    * @param value the success value
    * @param response the HTTP response
+   * @param status the HTTP status code to set
    */
-  private void writeSuccessResponse(Object value, HttpServletResponse response) {
+  private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VStreamPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VStreamPathReturnValueHandler.java
@@ -154,6 +154,9 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
           }
         });
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Execute the VStream on a virtual thread, pulling elements and writing SSE events
     Thread.ofVirtual()
         .name("hkj-vstream-handler")
@@ -161,7 +164,18 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
             () -> {
               AtomicLong elementCount = new AtomicLong(0);
               try {
-                response.setStatus(HttpStatus.OK.value());
+                response.setStatus(successStatus);
+
+                // 204 No Content must not have a body — skip SSE headers and stream execution
+                if (successStatus == HttpStatus.NO_CONTENT.value()) {
+                  if (metricsService != null) {
+                    metricsService.recordVStreamSuccess();
+                    metricsService.recordVStreamElements(0);
+                  }
+                  deferredResult.setResult(null);
+                  return;
+                }
+
                 response.setContentType(MediaType.TEXT_EVENT_STREAM_VALUE);
                 response.setCharacterEncoding("UTF-8");
                 response.setHeader("Cache-Control", "no-cache");

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandler.java
@@ -148,6 +148,9 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
           }
         });
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Execute the VTask asynchronously on a virtual thread
     long startTime = System.currentTimeMillis();
     vtaskPath
@@ -169,7 +172,7 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
                     metricsService.recordVTaskSuccess();
                     metricsService.recordVTaskDuration(durationMillis);
                   }
-                  writeSuccessResponse(result, response);
+                  writeSuccessResponse(result, response, successStatus);
                 }
                 deferredResult.setResult(null);
               } catch (Exception e) {
@@ -226,11 +229,13 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
     }
   }
 
-  private void writeSuccessResponse(Object value, HttpServletResponse response) {
+  private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandler.java
@@ -116,6 +116,9 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
       return;
     }
 
+    int successStatus =
+        SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
     // Fold to HTTP response
     validated.fold(
         errors -> {
@@ -123,7 +126,7 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
           return null;
         },
         value -> {
-          writeValidResponse(value, response);
+          writeValidResponse(value, response, successStatus);
           return null;
         });
   }
@@ -169,12 +172,15 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
    *
    * @param value the valid value
    * @param response the HTTP response
+   * @param status the HTTP status code to set
    */
-  private void writeValidResponse(Object value, HttpServletResponse response) {
+  private void writeValidResponse(Object value, HttpServletResponse response, int status) {
     try {
-      response.setStatus(HttpStatus.OK.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectWriter.writeValue(response.getWriter(), value);
+      response.setStatus(status);
+      if (status != HttpStatus.NO_CONTENT.value()) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectWriter.writeValue(response.getWriter(), value);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to write success response", e);
     }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Method;
 import org.higherkindedj.hkt.effect.EitherPath;
 import org.higherkindedj.hkt.effect.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import tools.jackson.databind.json.JsonMapper;
@@ -249,6 +251,61 @@ class EitherPathReturnValueHandlerTest {
     }
   }
 
+  @Nested
+  @DisplayName("@ResponseStatus Tests")
+  class ResponseStatusTests {
+
+    private MethodParameter methodParamFor(String methodName) throws Exception {
+      Method method = SampleController.class.getDeclaredMethod(methodName);
+      return new MethodParameter(method, -1);
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(CREATED) on POST handler")
+    void shouldHonorCreatedStatus() throws Exception {
+      MethodParameter rt = methodParamFor("createUser");
+      TestUser user = new TestUser("1", "alice@example.com");
+      EitherPath<String, TestUser> path = Path.right(user);
+
+      handler.handleReturnValue(path, rt, mavContainer, webRequest);
+
+      verify(response).setStatus(HttpStatus.CREATED.value());
+      verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+      printWriter.flush();
+      String json = stringWriter.toString();
+      assertThat(json).contains("\"id\":\"1\"");
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(NO_CONTENT) on DELETE handler and skip body")
+    void shouldHonorNoContentStatus() throws Exception {
+      MethodParameter rt = methodParamFor("deleteUser");
+      EitherPath<String, String> path = Path.right("deleted");
+
+      handler.handleReturnValue(path, rt, mavContainer, webRequest);
+
+      verify(response).setStatus(HttpStatus.NO_CONTENT.value());
+      verify(response, never()).setContentType(anyString());
+
+      printWriter.flush();
+      assertThat(stringWriter.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should still use error status for Left values even with @ResponseStatus")
+    void shouldUseErrorStatusForLeftValues() throws Exception {
+      MethodParameter rt = methodParamFor("createUser");
+      TestUserNotFoundError error = new TestUserNotFoundError("123");
+      EitherPath<TestUserNotFoundError, TestUser> path = Path.left(error);
+
+      handler.handleReturnValue(path, rt, mavContainer, webRequest);
+
+      // Left maps to 404 via ErrorStatusCodeMapper regardless of method's @ResponseStatus
+      verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+    }
+  }
+
   // Test DTOs
   record TestUser(String id, String email) {}
 
@@ -261,4 +318,17 @@ class EitherPathReturnValueHandlerTest {
   record TestAuthorizationError(String message) {}
 
   record TestAuthenticationError(String message) {}
+
+  @SuppressWarnings("unused")
+  static class SampleController {
+    @ResponseStatus(HttpStatus.CREATED)
+    public EitherPath<String, TestUser> createUser() {
+      return Path.right(new TestUser("1", "a@b.com"));
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public EitherPath<String, String> deleteUser() {
+      return Path.right("deleted");
+    }
+  }
 }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Method;
 import org.higherkindedj.hkt.effect.MaybePath;
 import org.higherkindedj.hkt.effect.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import tools.jackson.databind.json.JsonMapper;
@@ -229,6 +231,57 @@ class MaybePathReturnValueHandlerTest {
     }
   }
 
+  @Nested
+  @DisplayName("@ResponseStatus Tests")
+  class ResponseStatusTests {
+
+    private MethodParameter methodParamFor(String methodName) throws Exception {
+      Method method = SampleController.class.getDeclaredMethod(methodName);
+      return new MethodParameter(method, -1);
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(CREATED) on POST handler")
+    void shouldHonorCreatedStatus() throws Exception {
+      MethodParameter rt = methodParamFor("createUser");
+      TestUser user = new TestUser("1", "a@b.com");
+      MaybePath<TestUser> path = Path.just(user);
+
+      handler.handleReturnValue(path, rt, mavContainer, webRequest);
+
+      verify(response).setStatus(HttpStatus.CREATED.value());
+      verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(NO_CONTENT) on DELETE handler and skip body")
+    void shouldHonorNoContentStatus() throws Exception {
+      MethodParameter rt = methodParamFor("deleteUser");
+      MaybePath<String> path = Path.just("deleted");
+
+      handler.handleReturnValue(path, rt, mavContainer, webRequest);
+
+      verify(response).setStatus(HttpStatus.NO_CONTENT.value());
+      verify(response, never()).setContentType(anyString());
+
+      printWriter.flush();
+      assertThat(stringWriter.toString()).isEmpty();
+    }
+  }
+
   // Test DTOs
   record TestUser(String id, String email) {}
+
+  @SuppressWarnings("unused")
+  static class SampleController {
+    @ResponseStatus(HttpStatus.CREATED)
+    public MaybePath<TestUser> createUser() {
+      return Path.just(new TestUser("1", "a@b.com"));
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public MaybePath<String> deleteUser() {
+      return Path.just("deleted");
+    }
+  }
 }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/SuccessStatusResolverTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/SuccessStatusResolverTest.java
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** Tests for {@link SuccessStatusResolver}. */
+@DisplayName("SuccessStatusResolver Tests")
+class SuccessStatusResolverTest {
+
+  private static MethodParameter returnTypeOf(Class<?> controller, String methodName)
+      throws NoSuchMethodException {
+    Method method = controller.getDeclaredMethod(methodName);
+    return new MethodParameter(method, -1);
+  }
+
+  @Nested
+  @DisplayName("Method-level @ResponseStatus")
+  class MethodLevel {
+
+    @Test
+    @DisplayName("Should return default status when no annotation is present")
+    void noAnnotation() throws Exception {
+      MethodParameter rt = returnTypeOf(SampleController.class, "plainGet");
+      int status = SuccessStatusResolver.resolveSuccessStatus(rt, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(CREATED) on POST handler")
+    void createdOnPost() throws Exception {
+      MethodParameter rt = returnTypeOf(SampleController.class, "createUser");
+      int status = SuccessStatusResolver.resolveSuccessStatus(rt, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(NO_CONTENT) on DELETE handler")
+    void noContentOnDelete() throws Exception {
+      MethodParameter rt = returnTypeOf(SampleController.class, "deleteUser");
+      int status = SuccessStatusResolver.resolveSuccessStatus(rt, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus(code = ACCEPTED) via code alias")
+    void acceptedViaCodeAlias() throws Exception {
+      MethodParameter rt = returnTypeOf(SampleController.class, "acceptAsync");
+      int status = SuccessStatusResolver.resolveSuccessStatus(rt, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.ACCEPTED.value());
+    }
+  }
+
+  @Nested
+  @DisplayName("Class-level @ResponseStatus")
+  class ClassLevel {
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus on controller class when method has none")
+    void classLevelApplied() throws Exception {
+      MethodParameter rt = returnTypeOf(ClassLevelController.class, "anything");
+      int status = SuccessStatusResolver.resolveSuccessStatus(rt, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.I_AM_A_TEAPOT.value());
+    }
+  }
+
+  @Nested
+  @DisplayName("Meta-annotation support")
+  class MetaAnnotation {
+
+    @Test
+    @DisplayName("Should honor @ResponseStatus when composed via meta-annotation")
+    void metaAnnotated() throws Exception {
+      MethodParameter rt = returnTypeOf(SampleController.class, "metaAnnotated");
+      int status = SuccessStatusResolver.resolveSuccessStatus(rt, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.CREATED.value());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases")
+  class EdgeCases {
+
+    @Test
+    @DisplayName("Should return default status when MethodParameter is null")
+    void nullMethodParameter() {
+      int status = SuccessStatusResolver.resolveSuccessStatus(null, HttpStatus.OK.value());
+      assertThat(status).isEqualTo(HttpStatus.OK.value());
+    }
+  }
+
+  // ---- Test fixtures ----
+
+  @SuppressWarnings("unused")
+  static class SampleController {
+    public String plainGet() {
+      return "ok";
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    public String createUser() {
+      return "created";
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUser() {}
+
+    @ResponseStatus(code = HttpStatus.ACCEPTED)
+    public String acceptAsync() {
+      return "accepted";
+    }
+
+    @Created
+    public String metaAnnotated() {
+      return "created";
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @ResponseStatus(HttpStatus.I_AM_A_TEAPOT)
+  static class ClassLevelController {
+    public String anything() {
+      return "ok";
+    }
+  }
+
+  @ResponseStatus(HttpStatus.CREATED)
+  @java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD})
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+  @interface Created {}
+}


### PR DESCRIPTION
Previously all return value handlers (EitherPath, MaybePath, TryPath, ValidationPath, IOPath, CompletableFuturePath, VTaskPath, FreePath, VStreamPath) hardcoded HttpStatus.OK for success responses, which meant POSTs could not return canonical 201 Created and DELETEs could not return 204 No Content via @ResponseStatus on the handler method.

Introduces SuccessStatusResolver which reads @ResponseStatus from the handler method, falling back to the controller class (and honoring meta-annotations). All nine handlers now use the resolved status for the success path; error paths continue to use ErrorStatusCodeMapper or their configured failure status. When the resolved status is 204 No Content the body is suppressed, matching standard REST semantics.

Fixes #486 