### PR TITLE
Fix #490: hkj.web.either.default-error-status now binds and takes effect

### DIFF
--- a/hkj-spring/CONFIGURATION.md
+++ b/hkj-spring/CONFIGURATION.md
@@ -155,20 +155,34 @@ hkj:
     vstream-path-enabled: false  # Disable VStreamPath handler
 ```
 
-### `hkj.web.default-error-status`
+### `hkj.web.either.default-error-status` (alias: `hkj.web.default-error-status`)
 
-Default HTTP status code for Left/Invalid values when the error type is unknown.
+Default HTTP status code returned by the `EitherPathReturnValueHandler` for `Left` values whose
+simple class name matches none of the built-in `ErrorStatusCodeMapper` heuristics (`NotFound`,
+`Validation`/`Invalid`, `Forbidden`/`Authorization`, `Authentication`/`Unauthorized`).
 
 - **Type:** `int`
 - **Default:** `400`
 - **Valid values:** Any HTTP status code (100-599)
 - **Effect:** Used when error class name does not match any known patterns
 
-**Example:**
+The nested form `hkj.web.either.default-error-status` is the preferred path. The flat legacy
+form `hkj.web.default-error-status` is retained as an alias and binds to the same underlying
+value.
+
+**Example (preferred nested form):**
 ```yaml
 hkj:
   web:
-    default-error-status: 500  # Use 500 for unknown errors
+    either:
+      default-error-status: 500  # Use 500 for unmatched Left values
+```
+
+**Example (legacy flat form, still supported):**
+```yaml
+hkj:
+  web:
+    default-error-status: 500
 ```
 
 ### `hkj.web.maybe-nothing-status`

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjProperties.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjProperties.java
@@ -227,10 +227,13 @@ public class HkjProperties {
     private boolean freePathEnabled = true;
 
     /**
-     * Default HTTP status code for Left values when error type is unknown. Default: 400 (Bad
-     * Request)
+     * EitherPath-specific configuration, including default error status for Left values.
+     *
+     * <p>Bound from {@code hkj.web.either.*} properties. The flat {@code
+     * hkj.web.default-error-status} property is preserved as a backward-compatible alias; see
+     * {@link #getDefaultErrorStatus()}.
      */
-    private int defaultErrorStatus = 400;
+    private Either either = new Either();
 
     /** HTTP status code for MaybePath Nothing values. Default: 404 (Not Found) */
     private int maybeNothingStatus = 404;
@@ -412,21 +415,50 @@ public class HkjProperties {
     }
 
     /**
-     * Returns the default error HTTP status code.
+     * Returns the default error HTTP status code for Left values whose class name matches none of
+     * the {@code ErrorStatusCodeMapper} heuristics.
+     *
+     * <p>Reads from the nested {@link Either#getDefaultErrorStatus()}. Both {@code
+     * hkj.web.default-error-status} (flat, legacy) and {@code hkj.web.either.default-error-status}
+     * (nested, preferred) are bound to the same underlying value.
      *
      * @return the default error HTTP status code
      */
     public int getDefaultErrorStatus() {
-      return defaultErrorStatus;
+      return either.getDefaultErrorStatus();
     }
 
     /**
-     * Sets the default error HTTP status code.
+     * Sets the default error HTTP status code. Delegates to {@link
+     * Either#setDefaultErrorStatus(int)} so that both {@code hkj.web.default-error-status} and
+     * {@code hkj.web.either.default-error-status} converge on the same value.
      *
      * @param defaultErrorStatus the default error HTTP status code
      */
     public void setDefaultErrorStatus(int defaultErrorStatus) {
-      this.defaultErrorStatus = defaultErrorStatus;
+      this.either.setDefaultErrorStatus(defaultErrorStatus);
+    }
+
+    /**
+     * Returns the nested EitherPath configuration.
+     *
+     * @return the EitherPath configuration
+     */
+    public Either getEither() {
+      return either;
+    }
+
+    /**
+     * Sets the nested EitherPath configuration. A {@code null} argument is ignored so that the
+     * {@link #getDefaultErrorStatus()} / {@link #setDefaultErrorStatus(int)} delegation cannot
+     * produce a {@link NullPointerException}.
+     *
+     * @param either the EitherPath configuration; ignored if {@code null}
+     */
+    public void setEither(Either either) {
+      if (either != null) {
+        this.either = either;
+      }
     }
 
     /**
@@ -751,6 +783,51 @@ public class HkjProperties {
      */
     public void setErrorStatusMappings(Map<String, Integer> errorStatusMappings) {
       this.errorStatusMappings = errorStatusMappings;
+    }
+
+    /**
+     * EitherPath-specific configuration properties.
+     *
+     * <p>Bound from {@code hkj.web.either.*}. Example:
+     *
+     * <pre>
+     * hkj:
+     *   web:
+     *     either:
+     *       default-error-status: 500
+     * </pre>
+     *
+     * <p>The legacy flat property {@code hkj.web.default-error-status} is bound to the same
+     * underlying value via {@link Web#setDefaultErrorStatus(int)}, so either form works.
+     */
+    public static class Either {
+      /**
+       * Default HTTP status code for Left values when the error type's simple class name matches
+       * none of the {@code ErrorStatusCodeMapper} heuristics (NotFound, Validation/Invalid,
+       * Forbidden/Authorization, Authentication/Unauthorized). Default: 400 (Bad Request).
+       */
+      private int defaultErrorStatus = 400;
+
+      /** Creates a new Either configuration with default values. */
+      public Either() {}
+
+      /**
+       * Returns the default error HTTP status code for unmatched Left values.
+       *
+       * @return the default error HTTP status code
+       */
+      public int getDefaultErrorStatus() {
+        return defaultErrorStatus;
+      }
+
+      /**
+       * Sets the default error HTTP status code for unmatched Left values.
+       *
+       * @param defaultErrorStatus the default error HTTP status code
+       */
+      public void setDefaultErrorStatus(int defaultErrorStatus) {
+        this.defaultErrorStatus = defaultErrorStatus;
+      }
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjPropertiesEitherTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjPropertiesEitherTest.java
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.higherkindedj.spring.autoconfigure.HkjProperties.Web;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the nested {@link HkjProperties.Web.Either} configuration and its interaction with
+ * the legacy flat {@code Web} accessors introduced to fix issue #490.
+ *
+ * <p>These tests drive the POJO directly (no Spring context) to guarantee every added accessor is
+ * exercised and covered, independent of the binder's behaviour.
+ */
+@DisplayName("HkjProperties.Web.Either (issue #490)")
+class HkjPropertiesEitherTest {
+
+  @Nested
+  @DisplayName("Either POJO accessors")
+  class EitherPojoAccessors {
+
+    @Test
+    @DisplayName("Default constructor yields default status 400")
+    void defaultStatusIs400() {
+      Web.Either either = new Web.Either();
+      assertThat(either.getDefaultErrorStatus()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("setDefaultErrorStatus updates the field")
+    void setDefaultErrorStatusUpdatesField() {
+      Web.Either either = new Web.Either();
+      either.setDefaultErrorStatus(500);
+      assertThat(either.getDefaultErrorStatus()).isEqualTo(500);
+    }
+  }
+
+  @Nested
+  @DisplayName("Web accessors delegate to nested Either")
+  class WebDelegation {
+
+    @Test
+    @DisplayName("getEither returns the eagerly-created Either instance")
+    void getEitherReturnsNonNull() {
+      Web web = new Web();
+      assertThat(web.getEither()).isNotNull();
+      assertThat(web.getEither().getDefaultErrorStatus()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("setEither replaces the nested instance and drives getDefaultErrorStatus")
+    void setEitherReplacesInstance() {
+      Web web = new Web();
+      Web.Either replacement = new Web.Either();
+      replacement.setDefaultErrorStatus(503);
+
+      web.setEither(replacement);
+
+      assertThat(web.getEither()).isSameAs(replacement);
+      // Delegation: flat accessor now sees the replacement's value.
+      assertThat(web.getDefaultErrorStatus()).isEqualTo(503);
+    }
+
+    @Test
+    @DisplayName("setEither(null) is ignored so delegation never NPEs")
+    void setEitherNullIsIgnored() {
+      Web web = new Web();
+      Web.Either original = web.getEither();
+
+      web.setEither(null);
+
+      // The existing instance is preserved.
+      assertThat(web.getEither()).isSameAs(original);
+      // And the delegating accessors still return the default without error.
+      assertThat(web.getDefaultErrorStatus()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("Web.getDefaultErrorStatus reads from the nested Either")
+    void flatGetterDelegatesToEither() {
+      Web web = new Web();
+      web.getEither().setDefaultErrorStatus(418);
+      assertThat(web.getDefaultErrorStatus()).isEqualTo(418);
+    }
+
+    @Test
+    @DisplayName("Web.setDefaultErrorStatus writes through to the nested Either")
+    void flatSetterDelegatesToEither() {
+      Web web = new Web();
+      web.setDefaultErrorStatus(422);
+      assertThat(web.getEither().getDefaultErrorStatus()).isEqualTo(422);
+      // And the round-trip via the flat accessor agrees.
+      assertThat(web.getDefaultErrorStatus()).isEqualTo(422);
+    }
+
+    @Test
+    @DisplayName("Writes via nested and flat accessors converge on a single value")
+    void convergesOnSingleValue() {
+      Web web = new Web();
+
+      web.setDefaultErrorStatus(500); // flat path
+      assertThat(web.getEither().getDefaultErrorStatus()).isEqualTo(500);
+
+      web.getEither().setDefaultErrorStatus(501); // nested path
+      assertThat(web.getDefaultErrorStatus()).isEqualTo(501);
+    }
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfigurationTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfigurationTest.java
@@ -207,6 +207,40 @@ class HkjWebMvcAutoConfigurationTest {
     }
 
     @Test
+    @DisplayName("Should bind nested hkj.web.either.default-error-status (issue #490)")
+    void shouldBindNestedEitherDefaultErrorStatus() {
+      contextRunner
+          .withPropertyValues("hkj.web.either.default-error-status=500")
+          .run(
+              context -> {
+                HkjProperties properties = context.getBean(HkjProperties.class);
+
+                // Nested accessor returns the configured value
+                assertThat(properties.getWeb().getEither().getDefaultErrorStatus()).isEqualTo(500);
+
+                // Legacy flat accessor resolves to the same value
+                assertThat(properties.getWeb().getDefaultErrorStatus()).isEqualTo(500);
+              });
+    }
+
+    @Test
+    @DisplayName("Legacy flat path should still bind and be visible on nested accessor")
+    void legacyFlatPathShouldBindToNestedAccessor() {
+      contextRunner
+          .withPropertyValues("hkj.web.default-error-status=422")
+          .run(
+              context -> {
+                HkjProperties properties = context.getBean(HkjProperties.class);
+
+                // Legacy flat path still works
+                assertThat(properties.getWeb().getDefaultErrorStatus()).isEqualTo(422);
+
+                // And is visible through the nested accessor since both share the same field
+                assertThat(properties.getWeb().getEither().getDefaultErrorStatus()).isEqualTo(422);
+              });
+    }
+
+    @Test
     @DisplayName("Should load error status mappings")
     void shouldLoadErrorStatusMappings() {
       contextRunner

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
@@ -224,6 +224,24 @@ class EitherPathReturnValueHandlerTest {
 
       verify(response).setStatus(500);
     }
+
+    @Test
+    @DisplayName(
+        "Should route non-heuristic-matching domain errors to the custom default (issue #490)")
+    void shouldRouteUnmatchedDomainErrorsToConfiguredDefault() throws Exception {
+      // Reproduces the scenario from issue #490: a record whose simple name contains none
+      // of the heuristic substrings (NotFound / Validation / Invalid / Forbidden /
+      // Authorization / Authentication / Unauthorized) must fall through to the configured
+      // default status — 500 here — not the hardcoded 400 default.
+      EitherPathReturnValueHandler customHandler =
+          new EitherPathReturnValueHandler(jsonMapper, 500);
+      DuplicateError error = new DuplicateError("x");
+      EitherPath<DuplicateError, TestUser> path = Path.left(error);
+
+      customHandler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).setStatus(500);
+    }
   }
 
   @Nested
@@ -318,6 +336,9 @@ class EitherPathReturnValueHandlerTest {
   record TestAuthorizationError(String message) {}
 
   record TestAuthenticationError(String message) {}
+
+  /** A domain error whose simple name matches no heuristic substring (issue #490). */
+  record DuplicateError(String id) {}
 
   @SuppressWarnings("unused")
   static class SampleController {

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/EitherDefaultErrorStatusController.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/EitherDefaultErrorStatusController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Test controller for verifying that the {@code hkj.web.either.default-error-status} property
- * governs the HTTP status of {@code Left} values whose class name matches none of the
- * {@code ErrorStatusCodeMapper} heuristics.
+ * governs the HTTP status of {@code Left} values whose class name matches none of the {@code
+ * ErrorStatusCodeMapper} heuristics.
  *
  * <p>Uses a sealed domain-error hierarchy with three variants:
  *

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/EitherDefaultErrorStatusController.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/EitherDefaultErrorStatusController.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example.controller;
+
+import org.higherkindedj.hkt.either.Either;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Test controller for verifying that the {@code hkj.web.either.default-error-status} property
+ * governs the HTTP status of {@code Left} values whose class name matches none of the
+ * {@code ErrorStatusCodeMapper} heuristics.
+ *
+ * <p>Uses a sealed domain-error hierarchy with three variants:
+ *
+ * <ul>
+ *   <li>{@code NotFoundErr} — matches the {@code NotFound} heuristic → 404
+ *   <li>{@code Dup} — matches no heuristic → configured default
+ *   <li>{@code Pers} — matches no heuristic → configured default
+ * </ul>
+ *
+ * <p>Exists as a top-level class (rather than a nested static class inside the test) because
+ * {@code @WebMvcTest} requires the controller to be independently resolvable by Spring's bean
+ * registration machinery.
+ *
+ * @see org.higherkindedj.spring.example.EitherDefaultErrorStatusSliceTest
+ */
+@RestController
+@RequestMapping("/api/either-status")
+public class EitherDefaultErrorStatusController {
+
+  /** Creates an EitherDefaultErrorStatusController. */
+  public EitherDefaultErrorStatusController() {}
+
+  /** Sealed domain error hierarchy with variants that do and do not match heuristics. */
+  public sealed interface DomainError
+      permits DomainError.NotFoundErr, DomainError.Dup, DomainError.Pers {
+    record NotFoundErr(String id) implements DomainError {}
+
+    record Dup(String id) implements DomainError {}
+
+    record Pers(String op) implements DomainError {}
+  }
+
+  /**
+   * Returns a Left(NotFoundErr) — the heuristic should map this to 404.
+   *
+   * @return Either with a NotFoundErr left value
+   */
+  @GetMapping("/not-found")
+  public Either<DomainError, String> notFound() {
+    return Either.left(new DomainError.NotFoundErr("x"));
+  }
+
+  /**
+   * Returns a Left(Dup) — no heuristic match, should fall back to configured default.
+   *
+   * @return Either with a Dup left value
+   */
+  @GetMapping("/duplicate")
+  public Either<DomainError, String> duplicate() {
+    return Either.left(new DomainError.Dup("x"));
+  }
+
+  /**
+   * Returns a Left(Pers) — no heuristic match, should fall back to configured default.
+   *
+   * @return Either with a Pers left value
+   */
+  @GetMapping("/persistence")
+  public Either<DomainError, String> persistence() {
+    return Either.left(new DomainError.Pers("save"));
+  }
+}

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/EitherDefaultErrorStatusSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/EitherDefaultErrorStatusSliceTest.java
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.higherkindedj.spring.autoconfigure.HkjAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjJacksonAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjWebMvcAutoConfiguration;
+import org.higherkindedj.spring.example.controller.EitherDefaultErrorStatusController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * End-to-end slice test reproducing the exact scenario from issue #490.
+ *
+ * <p>The {@link EitherDefaultErrorStatusController} returns {@code Either<DomainError, ?>} from
+ * three endpoints. With {@code hkj.web.either.default-error-status=500} configured:
+ *
+ * <ul>
+ *   <li>{@code /api/either-status/not-found} hits the {@code NotFound} heuristic → 404
+ *   <li>{@code /api/either-status/duplicate} matches no heuristic → must fall back to the
+ *       configured 500 (not the hardcoded 400 observed before the fix)
+ *   <li>{@code /api/either-status/persistence} matches no heuristic → must fall back to the
+ *       configured 500
+ * </ul>
+ *
+ * <p>Lives in the example module because {@code @WebMvcTest} requires a {@code
+ * @SpringBootApplication} for context bootstrapping, and {@link HkjSpringExampleApplication}
+ * provides one.
+ *
+ * <p>Property-level binding coverage for both the nested {@code hkj.web.either.default-error-
+ * status} and the legacy flat {@code hkj.web.default-error-status} lives in {@code
+ * HkjWebMvcAutoConfigurationTest} / {@code HkjPropertiesEitherTest} in the autoconfigure module;
+ * this class focuses on the full MVC round-trip for the specific bug reproduction.
+ */
+@WebMvcTest(EitherDefaultErrorStatusController.class)
+@ImportAutoConfiguration({
+  HkjAutoConfiguration.class,
+  HkjJacksonAutoConfiguration.class,
+  HkjWebMvcAutoConfiguration.class
+})
+@TestPropertySource(properties = "hkj.web.either.default-error-status=500")
+@DisplayName("Either default-error-status end-to-end (issue #490)")
+class EitherDefaultErrorStatusSliceTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("/api/either-status/not-found → 404 via NotFound heuristic")
+  void notFoundHitsHeuristic() throws Exception {
+    mockMvc
+        .perform(get("/api/either-status/not-found"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.id").value("x"));
+  }
+
+  @Test
+  @DisplayName("/api/either-status/duplicate → 500 via configured default (no heuristic match)")
+  void duplicateFallsBackToConfiguredDefault() throws Exception {
+    mockMvc
+        .perform(get("/api/either-status/duplicate"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.id").value("x"));
+  }
+
+  @Test
+  @DisplayName(
+      "/api/either-status/persistence → 500 via configured default (no heuristic match)")
+  void persistenceFallsBackToConfiguredDefault() throws Exception {
+    mockMvc
+        .perform(get("/api/either-status/persistence"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.op").value("save"));
+  }
+}

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/EitherDefaultErrorStatusSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/EitherDefaultErrorStatusSliceTest.java
@@ -32,8 +32,8 @@ import org.springframework.test.web.servlet.MockMvc;
  *       configured 500
  * </ul>
  *
- * <p>Lives in the example module because {@code @WebMvcTest} requires a {@code
- * @SpringBootApplication} for context bootstrapping, and {@link HkjSpringExampleApplication}
+ * <p>Lives in the example module because {@code @WebMvcTest} requires a
+ * {@code @SpringBootApplication} for context bootstrapping, and {@link HkjSpringExampleApplication}
  * provides one.
  *
  * <p>Property-level binding coverage for both the nested {@code hkj.web.either.default-error-
@@ -74,8 +74,7 @@ class EitherDefaultErrorStatusSliceTest {
   }
 
   @Test
-  @DisplayName(
-      "/api/either-status/persistence → 500 via configured default (no heuristic match)")
+  @DisplayName("/api/either-status/persistence → 500 via configured default (no heuristic match)")
   void persistenceFallsBackToConfiguredDefault() throws Exception {
     mockMvc
         .perform(get("/api/either-status/persistence"))

--- a/plugins/hkj-maven-plugin/src/test/java/org/higherkindedj/maven/HKJLifecycleParticipantTest.java
+++ b/plugins/hkj-maven-plugin/src/test/java/org/higherkindedj/maven/HKJLifecycleParticipantTest.java
@@ -4,6 +4,7 @@ package org.higherkindedj.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
@@ -85,7 +86,7 @@ class HKJLifecycleParticipantTest {
     if (child == null) {
       return List.of();
     }
-    return java.util.Arrays.stream(child.getChildren("path"))
+    return Arrays.stream(child.getChildren("path"))
         .map(p -> p.getChild("artifactId").getValue())
         .toList();
   }
@@ -95,7 +96,7 @@ class HKJLifecycleParticipantTest {
     if (child == null) {
       return List.of();
     }
-    return java.util.Arrays.stream(child.getChildren("arg")).map(Xpp3Dom::getValue).toList();
+    return Arrays.stream(child.getChildren("arg")).map(Xpp3Dom::getValue).toList();
   }
 
   @Nested


### PR DESCRIPTION
The property documented at `hkj.web.either.default-error-status` had no matching field on `HkjProperties.Web`, so Spring silently dropped the configured value. Every `Left` whose class name matched none of the `ErrorStatusCodeMapper` heuristics (NotFound / Validation / Invalid / Forbidden / Authorization / Authentication / Unauthorized) fell back to the field-default `400` instead of the user-configured status.

The handler (`EitherPathReturnValueHandler`) and the mapper (`ErrorStatusCodeMapper`) were already correct — the bug was the missing binding target.

Changes:

* `HkjProperties.Web` gains a nested `Either` config class carrying `defaultErrorStatus` (default 400). The preferred property path is now `hkj.web.either.default-error-status`.
* The legacy flat path `hkj.web.default-error-status` is preserved as a backward-compatible alias: `Web.getDefaultErrorStatus()` and `Web.setDefaultErrorStatus()` now delegate through the nested `Either`, so existing callers (auto-config, actuator, tests) continue to work unchanged and both property forms converge on the same value.
* `CONFIGURATION.md` documents the preferred nested form and notes the alias.

Tests:

* `HkjPropertiesEitherTest` — direct POJO coverage for every new accessor (constructor, `get/setEither`, `Either.get/setDefaultErrorStatus`, flat-accessor delegation, convergence of both paths on a single field).
* `HkjWebMvcAutoConfigurationTest` — two new context tests: the nested path binds, the flat path still binds.
* `EitherPathReturnValueHandlerTest` — regression test reproducing the issue scenario (a record whose simple name matches no heuristic substring routes to the configured default, not hardcoded 400).
* `EitherPathDefaultErrorStatusSliceTest` (example module) — end-to-end `@WebMvcTest` slice reproducing the bug report: a controller with /bug490/not-found, /bug490/duplicate, /bug490/persistence endpoints asserts 404 / 500 / 500 with `hkj.web.either.default-error-status=500` configured.


Fixes #490 
