### PR TITLE
Add HTTP header injection and error status mapping strategy

### DIFF
--- a/.claude/skills/hkj-spring/SKILL.md
+++ b/.claude/skills/hkj-spring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hkj-spring
-description: "HKJ Spring Boot integration: hkj-spring-boot-starter, Either/Validated as REST responses, Jackson 3.x serialization, auto-configuration, EitherHttpMessageConverter, functional error handling in @RestController, domain error to HTTP status mapping"
+description: "Higher-Kinded-J Spring Boot integration (hkj-spring-boot-starter). Use PROACTIVELY whenever the working file or task involves: (1) a Spring controller method (@RestController / @GetMapping / @PostMapping / @PutMapping / @DeleteMapping) that returns Either, Validated, EitherPath, MaybePath, ValidationPath, TryPath, IOPath, CompletableFuturePath, VTaskPath, VStreamPath, or FreePath; (2) a sealed interface or sealed hierarchy named DomainError / *Error / *Failure used as the Left of an Either; (3) Jackson 3.x / tools.jackson serialization of HKJ types; (4) any application.yml / application.properties key under hkj.web.*, hkj.json.*, hkj.validation.*, hkj.async.*, hkj.virtual-threads.*, hkj.actuator.*, hkj.security.*, or hkj.effect-boundary.*; (5) mapping a domain error to an HTTP status code, including 4xx/5xx codes outside the heuristic table (409 Conflict, 422 Unprocessable Entity, 429 Too Many Requests, 503 Service Unavailable); (6) ErrorStatusCodeStrategy, ErrorStatusCodeMapper, DefaultErrorStatusCodeStrategy, or HttpHeaderCarrier (Retry-After, WWW-Authenticate, Location); (7) @WebMvcTest slices that need HkjAutoConfiguration / HkjJacksonAutoConfiguration / HkjWebMvcAutoConfiguration imported; (8) EffectBoundary, @Interpreter, @EnableEffectBoundary, @EffectTest, or returning FreePath from a controller; (9) auto-configuration questions about the starter."
 ---
 
 # Higher-Kinded-J Spring Boot Integration
@@ -83,40 +83,105 @@ The starter auto-configures everything: response conversion, JSON serialization,
 
 ## HTTP Status Code Mapping
 
-The starter maps `Left` error values to HTTP status codes using the `ErrorStatusCodeMapper` utility (final class, class-name heuristics, not user-implementable):
+The starter resolves the status for a `Left` error value in this order:
 
-| Error class name contains... | HTTP status |
-|------------------------------|-------------|
-| `NotFound` | 404 |
-| `Validation` or `Invalid` | 400 |
-| `Authorization` or `Forbidden` | 403 |
-| `Authentication` or `Unauthorized` | 401 |
-| (default) | configured default (500) |
+1. **Explicit mapping** by simple (or fully-qualified) class name from `hkj.web.error-status-mappings`
+2. **Token heuristic** on the simple class name (CamelCase split, lower-cased, whole-token match)
+3. **Configured default** (`hkj.web.either.default-error-status`, alias `hkj.web.default-error-status`)
 
-### Design Your Error Class Names to Match
+| Token(s) present in the simple class name | HTTP status |
+|-------------------------------------------|-------------|
+| `not` adjacent to `found`                 | 404 |
+| `validation` or `invalid`                 | 400 |
+| `authorization` or `forbidden`            | 403 |
+| `authentication` or `unauthorized`        | 401 |
+| (no match)                                | configured default |
 
-Because the mapper uses heuristics on class names, name your sealed error variants to trigger the right status code:
+### Explicit Mappings (covers 409, 422, 429, 503, …)
 
-```java
-public sealed interface DomainError {
-    record UserNotFound(String id) implements DomainError {}        // -> 404
-    record ValidationFailed(List<String> errors) implements DomainError {}  // -> 400
-    record ForbiddenAction(String reason) implements DomainError {} // -> 403
-    record UnauthorizedAccess(String reason) implements DomainError {} // -> 401
-    record DuplicateResource(String id) implements DomainError {}   // -> default (500)
-}
-```
-
-### Overriding the Default Status
-
-Configure the default status for unmatched errors in `application.yml`:
+For status codes the heuristics do not produce, add entries to `hkj.web.error-status-mappings`:
 
 ```yaml
 hkj:
   web:
     either:
       default-error-status: 500
+    error-status-mappings:
+      MfaAlreadyEnrolledError: 409   # Conflict
+      PaymentDeclinedError: 422      # Unprocessable Entity
+      MfaThrottledError: 429         # Too Many Requests
+      ScheduledMaintenanceError: 503 # Service Unavailable
 ```
+
+Mapping by fully-qualified class name is also supported, useful when two error classes share a
+simple name across packages.
+
+### Custom Strategy Bean (field-dependent status)
+
+When the status depends on the error's field values, register an `ErrorStatusCodeStrategy`
+bean. It replaces the default via `@ConditionalOnMissingBean`:
+
+```java
+@Bean
+ErrorStatusCodeStrategy errorStatusCodeStrategy() {
+    return (error, defaultStatus) -> switch (error) {
+        case MfaThrottledError t when t.retryAfter() > 60 -> 503;
+        case MfaThrottledError ignored -> 429;
+        default -> ErrorStatusCodeMapper.determineStatusCode(error, defaultStatus);
+    };
+}
+```
+
+### Designing Error Class Names
+
+If you can pick the names, choose ones that trip the heuristics so you avoid configuration:
+
+```java
+public sealed interface DomainError {
+    record UserNotFound(String id) implements DomainError {}              // -> 404
+    record ValidationFailed(List<String> errors) implements DomainError {} // -> 400
+    record ForbiddenAction(String reason) implements DomainError {}      // -> 403
+    record UnauthorizedAccess(String reason) implements DomainError {}   // -> 401
+    record DuplicateResource(String id) implements DomainError {}        // -> default
+}
+```
+
+If the desired status is 409, 422, 429, 503, or anything else outside the heuristics, prefer
+an explicit mapping over renaming the variant — names should describe the domain, not the HTTP
+table.
+
+### Response Header Injection (Retry-After, WWW-Authenticate, …)
+
+Error payloads can surface response headers by implementing `HttpHeaderCarrier`:
+
+```java
+public record MfaThrottledError(int retryAfterSeconds) implements DomainError, HttpHeaderCarrier {
+    @Override public Map<String, String> headers() {
+        return Map.of("Retry-After", Integer.toString(retryAfterSeconds));
+    }
+}
+```
+
+Honoured by `EitherPath`, `TryPath`, `ValidationPath`, `IOPath`, `CompletableFuturePath`,
+`VTaskPath`, and `FreePath` handlers. Headers are added (not set), so multi-valued headers
+like `WWW-Authenticate` and `Set-Cookie` accumulate as separate header lines, matching the
+HTTP grammar; upstream headers from filters or interceptors are preserved. For single-valued
+headers like `Retry-After`, the carrier should ensure the value appears at most once across
+all payload elements. **Not** honoured by `VStreamPath` (SSE: headers commit before the
+first event, set them via a filter / controller advice instead).
+
+### Known Limits (so you don't fight the framework)
+
+- The strategy bean is process-wide. For per-request behaviour, inspect request context inside
+  the implementation.
+- `MaybePath`'s `Nothing` carries no payload, so it cannot implement `HttpHeaderCarrier`. Wrap
+  the result in `EitherPath<DomainError, T>` if you need headers or per-class status.
+- `@ResponseStatus` on the handler method governs success values only; error status always
+  comes from the strategy.
+
+For the canonical end-to-end fixture (one endpoint per heuristic + every override + a header
+case), see `hkj-spring/example/.../ErrorStatusFixtureController.java` and the matching
+`ErrorStatusFixtureSliceTest`.
 
 ---
 
@@ -187,7 +252,7 @@ public class UserService {
     }
 
     public Validated<List<String>, User> validateAndCreate(UserRequest req) {
-        return Path.valid(req.name(), Semigroup.listSemigroup())
+        return Path.valid(req.name(), Semigroups.list())
             .via(name -> validateName(name))
             .zipWithAccum(
                 validateEmail(req.email()),
@@ -411,19 +476,68 @@ public FreePath<OrderEffects, OrderStatus> getStatus(@PathVariable String id) {
 
 ## Configuration
 
+The full reference lives in `hkj-spring/CONFIGURATION.md`. The headline keys:
+
 ```yaml
 # application.yml
 hkj:
   web:
+    # ---- Status codes ----
     either:
-      default-error-status: 500       # Default HTTP status for Left values
-    validated:
-      error-status: 400               # HTTP status for Invalid values
-    free-path-enabled: true           # Enable FreePath return type handling
-    free-path-failure-status: 500     # HTTP status for FreePath execution failures
-    json:
-      format: standard                # JSON serialisation format
+      default-error-status: 500             # alias: hkj.web.default-error-status
+    maybe-nothing-status: 404               # MaybePath Nothing → 404
+    try-failure-status: 500                 # TryPath Failure → 500
+    validation-invalid-status: 400          # ValidationPath Invalid → 400
+    io-failure-status: 500                  # IOPath failures → 500
+    async-failure-status: 500               # CompletableFuturePath failures → 500
+    vtask-failure-status: 500               # VTaskPath failures → 500
+    vstream-failure-status: 500             # VStreamPath failures → 500
+    free-path-failure-status: 500           # FreePath interpretation failures → 500
+
+    # ---- Per-class overrides (this is the §1 fix; takes precedence over heuristics) ----
+    error-status-mappings:
+      MfaAlreadyEnrolledError: 409
+      PaymentDeclinedError: 422
+      MfaThrottledError: 429
+      ScheduledMaintenanceError: 503
+
+    # ---- Handler toggles (all default true) ----
+    either-path-enabled: true
+    maybe-path-enabled: true
+    try-path-enabled: true
+    validation-path-enabled: true
+    io-path-enabled: true
+    completable-future-path-enabled: true
+    vtask-path-enabled: true
+    vstream-path-enabled: true
+    free-path-enabled: true
+
+    # ---- Production vs. dev: include exception details? ----
+    try-include-exception-details: false
+    io-include-exception-details: false
+    async-include-exception-details: false
+    vtask-include-exception-details: false
+    vstream-include-exception-details: false
+    free-path-include-exception-details: false
+
+  json:
+    custom-serializers-enabled: true
+    either-format: TAGGED                   # TAGGED | SIMPLE
+    validated-format: TAGGED                # TAGGED | SIMPLE
+    maybe-format: TAGGED                    # TAGGED | SIMPLE
+
+  validation:
+    enabled: true
+    accumulate-errors: true                 # true = collect all; false = fail-fast
+
+  virtual-threads:
+    default-timeout-ms: 30000
+    stream-timeout-ms: 60000
 ```
+
+For field-aware status decisions (e.g. `MfaThrottledError.retryAfter() > 60 → 503`),
+register an `ErrorStatusCodeStrategy` bean — see the [HTTP Status Code Mapping](#http-status-code-mapping)
+section above.
 
 ---
 

--- a/hkj-book/src/spring/spring_boot_integration.md
+++ b/hkj-book/src/spring/spring_boot_integration.md
@@ -175,19 +175,45 @@ public class UserController {
 - `Right(user)` → HTTP 200 with JSON: `{"id": "1", "email": "alice@example.com", ...}`
 - `Left(UserNotFoundError)` → HTTP 404 with JSON: `{"success": false, "error": {"type": "UserNotFoundError", ...}}`
 
-#### Error Type → HTTP Status Mapping {#error-type-http-status-mapping}
+#### Error Type to HTTP Status Mapping {#error-type-http-status-mapping}
 
-The framework automatically maps error types to HTTP status codes by examining class names:
+The framework resolves the status for a `Left` error in this order:
+
+1. Explicit mapping by simple (or fully-qualified) class name from `hkj.web.error-status-mappings`.
+2. Token heuristic on the simple class name (CamelCase split, lower-cased, whole-token match).
+3. Configured default (`hkj.web.either.default-error-status`, alias `hkj.web.default-error-status`).
+
+Heuristic table:
+
+| Token(s) present in the simple class name | HTTP status |
+|-------------------------------------------|-------------|
+| `not` adjacent to `found`                 | 404 |
+| `validation` or `invalid`                 | 400 |
+| `authorization` or `forbidden`            | 403 |
+| `authentication` or `unauthorized`        | 401 |
+| (no match)                                | configured default |
 
 ```java
 public sealed interface DomainError permits
-    UserNotFoundError,      // Contains "NotFound" → 404
-    ValidationError,        // Contains "Validation" → 400
-    AuthorizationError,     // Contains "Authorization" → 403
-    AuthenticationError {}  // Contains "Authentication" → 401
-
-// Custom errors default to 400 Bad Request
+    UserNotFoundError,      // -> 404 via heuristic
+    ValidationError,        // -> 400 via heuristic
+    AuthorizationError,     // -> 403 via heuristic
+    AuthenticationError {}  // -> 401 via heuristic
 ```
+
+For status codes outside the heuristic table (409 Conflict, 422 Unprocessable Entity, 429 Too Many Requests, 503 Service Unavailable), add explicit entries to `hkj.web.error-status-mappings`:
+
+```yaml
+hkj:
+  web:
+    error-status-mappings:
+      MfaAlreadyEnrolledError: 409
+      PaymentDeclinedError: 422
+      MfaThrottledError: 429
+      ScheduledMaintenanceError: 503
+```
+
+When the status depends on the error's field values (for example, `MfaThrottledError.retryAfter() > 60` should produce `503` rather than `429`), register an `ErrorStatusCodeStrategy` bean. See the [HTTP Status Codes](#http-status-codes) section below for details and the canonical end-to-end fixture.
 
 #### Composing Operations
 
@@ -447,16 +473,70 @@ All nine Effect Path handlers honour `@ResponseStatus` consistently.
 
 ### Error Status Mapping
 
-Error responses continue to flow through `ErrorStatusCodeMapper`. Register mappings for each error type, with a configurable fallback:
+Every `Left` value emitted by an `EitherPath` (or raw `Either`) handler is run through an `ErrorStatusCodeStrategy` bean. The auto-configuration registers a default strategy that combines the property-table mappings with the built-in token heuristics; adopters can replace it with their own bean for field-aware decisions.
+
+#### Property-driven mappings
+
+Add entries to `hkj.web.error-status-mappings` keyed by simple class name (or fully-qualified class name when two error types share a simple name across packages). These mappings take precedence over the heuristics:
 
 ```yaml
 hkj:
   web:
     either:
-      default-error-status: 400  # Fallback for unmapped Left error types
+      default-error-status: 500          # Fallback for unmapped Left values
+    error-status-mappings:
+      MfaAlreadyEnrolledError: 409       # Conflict
+      PaymentDeclinedError: 422          # Unprocessable Entity
+      MfaThrottledError: 429             # Too Many Requests
+      ScheduledMaintenanceError: 503     # Service Unavailable
 ```
 
-Tagged errors (those implementing the library's status-bearing error interface, or registered by type) produce their mapped status; everything else falls back to the default.
+#### Custom strategy bean
+
+When the status depends on the error's field values, register an `ErrorStatusCodeStrategy` bean. The default is annotated `@ConditionalOnMissingBean`, so a user-defined bean replaces it without further wiring:
+
+```java
+@Bean
+ErrorStatusCodeStrategy errorStatusCodeStrategy() {
+    return (error, defaultStatus) -> switch (error) {
+        case MfaThrottledError t when t.retryAfter() > 60 -> 503;
+        case MfaThrottledError ignored                   -> 429;
+        // Fall through to property mappings + heuristics for everything else
+        default -> ErrorStatusCodeMapper.determineStatusCode(error, defaultStatus);
+    };
+}
+```
+
+The strategy runs once per error response on the request thread (or the async completion thread for `CompletableFuturePath` and `VTaskPath`), so implementations should be thread-safe and side-effect-free.
+
+#### Response header injection
+
+Error payloads can surface response headers (`Retry-After`, `WWW-Authenticate`, and similar) by implementing `HttpHeaderCarrier`:
+
+```java
+public record MfaThrottledError(int retryAfterSeconds)
+        implements DomainError, HttpHeaderCarrier {
+
+    @Override
+    public Map<String, String> headers() {
+        return Map.of("Retry-After", Integer.toString(retryAfterSeconds));
+    }
+}
+```
+
+The headers are applied by the `EitherPath`, `TryPath`, `ValidationPath`, `IOPath`, `CompletableFuturePath`, `VTaskPath`, and `FreePath` return-value handlers before the JSON body is written. Internally the headers are added (not set), so multi-valued headers such as `WWW-Authenticate`, `Set-Cookie`, and `Link` accumulate as separate header lines, matching the HTTP grammar; upstream headers set by filters or interceptors are also preserved. For collection-typed payloads (such as `ValidationPath` `Invalid` values), every element that implements `HttpHeaderCarrier` contributes; values accumulate. For single-valued headers like `Retry-After`, the carrier should ensure the value appears at most once across all payload elements.
+
+`VStreamPath` does not honour `HttpHeaderCarrier`, because the response status and headers are committed before the first SSE event. Set required headers via a servlet filter or controller advice before the stream begins.
+
+~~~admonish example title="Canonical fixture"
+The example module contains a [`ErrorStatusFixtureController`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/ErrorStatusFixtureController.java) and matching [`ErrorStatusFixtureSliceTest`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/ErrorStatusFixtureSliceTest.java) that exercise every heuristic, every override, and the `Retry-After` header end-to-end. Copy them as a starting point when adding new error variants.
+~~~
+
+~~~admonish note title="Known limits"
+- The strategy bean is process-wide. For per-request behaviour, inspect the request context inside the implementation.
+- `MaybePath` `Nothing` carries no payload, so it cannot implement `HttpHeaderCarrier`. Wrap the result in `EitherPath<DomainError, T>` if you need headers or per-class status.
+- `@ResponseStatus` on the handler method governs success values only; error status always comes from the strategy.
+~~~
 
 ---
 
@@ -470,12 +550,16 @@ Configure serialisation format in `application.yml`:
 
 ```yaml
 hkj:
-  jackson:
+  json:
     custom-serializers-enabled: true  # Enable custom serialisers (default: true)
-    either-format: TAGGED             # TAGGED, UNWRAPPED, or DIRECT
-    validated-format: TAGGED          # TAGGED, UNWRAPPED, or DIRECT
-    maybe-format: TAGGED              # TAGGED, UNWRAPPED, or DIRECT
+    either-format: TAGGED             # TAGGED or SIMPLE
+    validated-format: TAGGED          # TAGGED or SIMPLE
+    maybe-format: TAGGED              # TAGGED or SIMPLE
 ```
+
+~~~admonish note title="Property prefix vs. actuator key"
+The configuration prefix is `hkj.json.*`. The actuator endpoint at `/actuator/hkj` reports the same values under the `"jackson"` key for backward compatibility with earlier releases.
+~~~
 
 ### Serialisation Formats
 
@@ -503,33 +587,11 @@ Wraps the value with metadata indicating success/failure:
 }
 ```
 
-#### UNWRAPPED
+#### SIMPLE
 
-Returns just the value or error without wrapper:
+Compact form without the discriminator metadata, suitable for clients that already infer success and failure from the HTTP status code.
 
-```json
-// Right(user)
-{
-  "id": "1",
-  "email": "alice@example.com"
-}
-
-// Left(error)
-{
-  "type": "UserNotFoundError",
-  "userId": "999"
-}
-```
-
-#### DIRECT
-
-Uses Either's default `toString()` representation (useful for debugging):
-
-```json
-"Right(value=User[id=1, email=alice@example.com])"
-```
-
-For complete serialisation details, see [hkj-spring/JACKSON_SERIALIZATION.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/JACKSON_SERIALIZATION.md).
+For complete serialisation details, including the exact field names produced for each format, see [hkj-spring/JACKSON_SERIALIZATION.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/JACKSON_SERIALIZATION.md).
 
 ---
 
@@ -1104,7 +1166,9 @@ Each functional type has a dedicated handler:
 Supporting collaborators:
 
 - **`SuccessStatusResolver`:** Reads `@ResponseStatus` on the handler method (with controller-class fallback and meta-annotation support) so each handler can override its default success status.
-- **`ErrorStatusCodeMapper`:** Configurable error-type to HTTP status mapping, falling back to `hkj.web.either.default-error-status`.
+- **`ErrorStatusCodeStrategy`:** Functional interface invoked once per error response. The default `DefaultErrorStatusCodeStrategy` consults `hkj.web.error-status-mappings` first, then falls back to `ErrorStatusCodeMapper`'s tokenised heuristics, then to `hkj.web.either.default-error-status`. Replace the bean to inject custom logic (for example, status that depends on an error's field values).
+- **`ErrorStatusCodeMapper`:** Token-aware heuristic resolver used by the default strategy. Exposed as a static helper so custom strategies can delegate to the same logic.
+- **`HttpHeaderCarrier`:** Mix-in interface that lets `Left`-side error payloads add response headers (`Retry-After`, `WWW-Authenticate`, and similar) to the outgoing response. Honoured by every error-bearing handler except `VStreamPath`.
 
 Handlers are registered automatically and integrated seamlessly with Spring's request processing lifecycle.
 
@@ -1128,9 +1192,15 @@ Yes! The integration is non-invasive. You can use `EitherPath`, `ValidationPath`
 
 Currently, the starter supports Spring Web MVC (servlet-based). For reactive-style streaming, use `VStreamPath` which provides SSE streaming on virtual threads without requiring WebFlux or Reactor dependencies.
 
-### Can I customise the error → HTTP status mapping?
+### Can I customise the error to HTTP status mapping?
 
-Yes. Implement a custom return value handler or use the configuration properties to set default status codes. See [CONFIGURATION.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/CONFIGURATION.md) for details.
+Yes, three layers of customisation are available, each more powerful than the last:
+
+1. **Property-table mappings** in `application.yml` for static, class-keyed overrides (`hkj.web.error-status-mappings.MfaThrottledError: 429`). This covers the majority of cases including the status codes the heuristic table does not produce (409, 422, 429, 503).
+2. **Custom `ErrorStatusCodeStrategy` bean** when the status depends on the error's field values, the request, or any runtime signal. Declare the bean in any `@Configuration` class; the default is annotated `@ConditionalOnMissingBean` and steps aside automatically.
+3. **`HttpHeaderCarrier` mix-in** on the error type itself for surfacing response headers like `Retry-After` alongside the status code.
+
+See [CONFIGURATION.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/CONFIGURATION.md) for the full reference and known limitations.
 
 ### How does performance compare to exceptions?
 

--- a/hkj-spring/CONFIGURATION.md
+++ b/hkj-spring/CONFIGURATION.md
@@ -12,6 +12,9 @@ This document provides a complete reference for all configuration properties ava
 6. [Virtual Thread Configuration](#virtual-thread-configuration)
 7. [Complete Example](#complete-example)
 8. [Disabling Features](#disabling-features)
+9. [Error Status Code Strategy Bean](#error-status-code-strategy-bean)
+10. [HTTP Header Injection on Errors](#http-header-injection-on-errors)
+11. [Known Limitations](#known-limitations)
 
 ## Quick Start
 
@@ -341,9 +344,11 @@ Custom mappings from error class names to HTTP status codes.
 
 - **Type:** `Map<String, Integer>`
 - **Default:** Empty map
-- **Key:** Simple class name of error (e.g., "UserNotFoundError")
-- **Value:** HTTP status code (e.g., 404)
-- **Effect:** Overrides default status code determination
+- **Key:** Simple class name of the error (e.g. `UserNotFoundError`) or its fully-qualified
+  class name (useful when two error classes share a simple name across packages).
+- **Value:** HTTP status code (e.g. 404)
+- **Effect:** Takes precedence over the heuristics. If the error matches no mapping, the
+  heuristics run; if those do not match either, the configured default applies.
 
 **Example:**
 ```yaml
@@ -354,18 +359,36 @@ hkj:
       ValidationError: 400
       AuthorizationError: 403
       AuthenticationError: 401
+      MfaAlreadyEnrolledError: 409   # Conflict
+      PaymentDeclinedError: 422      # Unprocessable Entity
+      MfaThrottledError: 429         # Too Many Requests
       ServerError: 500
 ```
 
-**Default behaviour without mappings:**
-```java
-// Built-in heuristics (case-insensitive):
-// - Contains "notfound" -> 404
-// - Contains "validation" or "invalid" -> 400
-// - Contains "authorization" or "forbidden" -> 403
-// - Contains "authentication" or "unauthorized" -> 401
-// - Default -> value of default-error-status property
-```
+**Resolution order (applied to the `Left` value of an `EitherPath` / `Either`):**
+
+1. Explicit mapping by simple class name
+2. Explicit mapping by fully-qualified class name
+3. Built-in token heuristic on the simple class name
+4. `hkj.web.either.default-error-status` (or its legacy alias `hkj.web.default-error-status`)
+
+**Built-in heuristics (token-aware, case-insensitive):**
+
+The simple class name is split on CamelCase boundaries and lower-cased; the rule fires when
+one of the listed tokens appears as a whole token (so `RevalidationError` no longer matches
+the `validation` rule).
+
+| Token(s) present                          | Status |
+| ----------------------------------------- | ------ |
+| `not` adjacent to `found`                 | 404    |
+| `validation` or `invalid`                 | 400    |
+| `authorization` or `forbidden`            | 403    |
+| `authentication` or `unauthorized`        | 401    |
+| (no match)                                | configured default |
+
+For anything beyond table lookup — for example, a status that depends on a record's field
+(`MfaThrottledError.retryAfter() ≥ 60 → 503`) — register a custom
+[`ErrorStatusCodeStrategy` bean](#error-status-code-strategy-bean).
 
 ## Validation Configuration
 
@@ -891,7 +914,75 @@ public class HkjConfig {
 }
 ```
 
+## Error Status Code Strategy Bean
+
+For status decisions that property-table mappings cannot express — for example, a status that
+depends on an error's field values — register a custom `ErrorStatusCodeStrategy` bean. The
+auto-configuration declares its default with `@ConditionalOnMissingBean`, so your bean
+replaces it without further wiring.
+
+```java
+@Bean
+ErrorStatusCodeStrategy errorStatusCodeStrategy() {
+    return (error, defaultStatus) -> switch (error) {
+        case MfaThrottledError t when t.retryAfter() > 60 -> 503; // backoff escalates to 503
+        case MfaThrottledError ignored -> 429;
+        case PaymentDeclinedError ignored -> 422;
+        // Delegate to the built-in heuristics + property mappings for everything else
+        default -> ErrorStatusCodeMapper.determineStatusCode(error, defaultStatus);
+    };
+}
+```
+
+The strategy is invoked once per error response on the request thread (or the async completion
+thread for `CompletableFuturePath` / `VTaskPath`), so implementations must be thread-safe and
+side-effect-free.
+
+## HTTP Header Injection on Errors
+
+Error payloads can surface response headers (`Retry-After`, `WWW-Authenticate`, etc.) by
+implementing `HttpHeaderCarrier`:
+
+```java
+public record MfaThrottledError(int retryAfterSeconds) implements DomainError, HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+        return Map.of("Retry-After", Integer.toString(retryAfterSeconds));
+    }
+}
+```
+
+The headers are applied by `EitherPath`, `TryPath`, `ValidationPath`, `IOPath`,
+`CompletableFuturePath`, `VTaskPath`, and `FreePath` handlers before the JSON body is written.
+Internally the headers are added (not set), so multi-valued headers such as
+`WWW-Authenticate`, `Set-Cookie`, and `Link` accumulate as separate header lines on the
+response, matching the HTTP grammar; upstream headers set by filters or interceptors are also
+preserved. For collection-typed payloads (e.g. `ValidationPath` `Invalid` values), every
+element that implements `HttpHeaderCarrier` contributes its headers. `null` keys and `null`
+values are skipped silently. For single-valued headers such as `Retry-After`, the carrier
+should ensure the value appears at most once across all payload elements.
+
+`VStreamPath` does not honour `HttpHeaderCarrier` — by the time an SSE error event is emitted,
+the response status and headers are already committed, so headers must be set before the
+stream begins.
+
+## Known Limitations
+
+These are the configuration surfaces adopters most often discover by hitting their edges. If
+any of these block you, please open an issue.
+
+| Area | Current state | Workaround |
+| ---- | ------------- | ---------- |
+| Per-class status mapping | Configurable via `hkj.web.error-status-mappings` (simple or fully-qualified class name) | Register a custom `ErrorStatusCodeStrategy` bean for field-dependent decisions |
+| Heuristic flexibility | Tokenised CamelCase match — no regex / pluggable predicate | Provide explicit mappings in `hkj.web.error-status-mappings`; they take precedence |
+| Response-header injection | Implement `HttpHeaderCarrier` on the error class | Not configurable via properties |
+| `VStreamPath` headers | Status + headers committed before the first event | Set required headers via a `WebFilter` or controller advice before the stream starts |
+| `MaybePath` Nothing payload | Single configurable status (`hkj.web.maybe-nothing-status`); no header injection — there is no error value to query | Wrap the result in `EitherPath<DomainError, T>` to gain mapping + headers |
+| Per-request strategy override | The `ErrorStatusCodeStrategy` bean is process-wide | Inspect request context inside the strategy implementation if needed |
+| `@ResponseStatus` on the handler method | Honoured for `Right` / `Valid` / success values only — error status comes from the strategy | Move per-error behaviour into mappings or a custom strategy |
+
 ## See Also
 
 - [Testing Guide](./example/TESTING.md) - How to test your configured application
+- [`ErrorStatusFixtureController`](./example/src/main/java/org/higherkindedj/spring/example/controller/ErrorStatusFixtureController.java) - Canonical `@WebMvcTest` fixture exercising every status-mapping rule
 - [Jackson Serialization](./JACKSON_SERIALIZATION.md) - Details on JSON serialization

--- a/hkj-spring/EFFECT_BOUNDARY.md
+++ b/hkj-spring/EFFECT_BOUNDARY.md
@@ -262,7 +262,7 @@ The ninth handler in the hkj-spring handler family, following the same pattern a
 2. **Looks up** the `EffectBoundary` bean from the application context
 3. **Calls** `boundary.run(program)` to interpret the Free monad program
 4. **Serialises** the result as JSON using `JsonMapper`
-5. **Maps** errors to HTTP status codes using the existing `ErrorStatusCodeMapper`
+5. **Maps** interpretation failures to the configured `hkj.web.free-path-failure-status` (default 500). If the failure value implements `HttpHeaderCarrier`, its headers are copied onto the response. `FreePath` does not currently consult `ErrorStatusCodeStrategy`, since interpretation failures are surfaced as `Throwable`s rather than typed `Left` values; route domain errors through `EitherPath` (or the inner monad of the boundary's target) when per-class status mapping is required.
 
 ### Bean Resolution Strategy
 

--- a/hkj-spring/README.md
+++ b/hkj-spring/README.md
@@ -113,6 +113,12 @@ hkj:
     vtask-failure-status: 500
     vstream-failure-status: 500
 
+    # Per-class overrides (take precedence over the heuristic table)
+    error-status-mappings:
+      MfaAlreadyEnrolledError: 409
+      PaymentDeclinedError: 422
+      MfaThrottledError: 429
+
     # Exception details (disable in production!)
     try-include-exception-details: false
     io-include-exception-details: false
@@ -144,7 +150,11 @@ hkj-spring/
 │   │   ├── VTaskPathReturnValueHandler     # Virtual thread async
 │   │   ├── VStreamPathReturnValueHandler   # Virtual thread SSE streaming
 │   │   ├── FreePathReturnValueHandler      # Effect boundary interpretation
-│   │   └── ErrorStatusCodeMapper
+│   │   ├── ErrorStatusCodeStrategy         # Pluggable error -> HTTP status resolver
+│   │   ├── DefaultErrorStatusCodeStrategy  # Mappings + heuristics, registered as default bean
+│   │   ├── ErrorStatusCodeMapper           # Token-aware heuristic helper
+│   │   ├── HttpHeaderCarrier               # Mix-in for Retry-After / WWW-Authenticate / etc.
+│   │   └── ErrorResponseHeaders            # Internal helper that copies carrier headers
 │   ├── effect/
 │   │   ├── EnableEffectBoundary            # Auto-wire interpreters
 │   │   ├── Interpreter                     # Interpreter stereotype

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfiguration.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfiguration.java
@@ -7,7 +7,9 @@ import java.util.List;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.spring.actuator.HkjMetricsService;
 import org.higherkindedj.spring.web.returnvalue.CompletableFuturePathReturnValueHandler;
+import org.higherkindedj.spring.web.returnvalue.DefaultErrorStatusCodeStrategy;
 import org.higherkindedj.spring.web.returnvalue.EitherPathReturnValueHandler;
+import org.higherkindedj.spring.web.returnvalue.ErrorStatusCodeStrategy;
 import org.higherkindedj.spring.web.returnvalue.FreePathReturnValueHandler;
 import org.higherkindedj.spring.web.returnvalue.IOPathReturnValueHandler;
 import org.higherkindedj.spring.web.returnvalue.MaybePathReturnValueHandler;
@@ -19,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcRegistrations;
 import org.springframework.context.ApplicationContext;
@@ -68,6 +71,22 @@ public class HkjWebMvcAutoConfiguration {
   public HkjWebMvcAutoConfiguration() {}
 
   /**
+   * Default {@link ErrorStatusCodeStrategy} that combines the {@code hkj.web.error-status-mappings}
+   * property table with the heuristics in {@code ErrorStatusCodeMapper}. Adopters who need
+   * field-aware mappings (e.g. {@code MfaThrottledError.retryAfter() ≥ N → 503}) can replace this
+   * by declaring their own bean of type {@link ErrorStatusCodeStrategy}; the
+   * {@code @ConditionalOnMissingBean} guard ensures the user bean wins.
+   *
+   * @param properties the HKJ configuration properties
+   * @return the default error status code strategy
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  public ErrorStatusCodeStrategy hkjErrorStatusCodeStrategy(HkjProperties properties) {
+    return new DefaultErrorStatusCodeStrategy(properties.getWeb().getErrorStatusMappings());
+  }
+
+  /**
    * Customizes the RequestMappingHandlerAdapter to add Effect Path return value handlers before
    * Spring's default handlers.
    *
@@ -95,6 +114,7 @@ public class HkjWebMvcAutoConfiguration {
       HkjProperties properties,
       JsonMapper jsonMapper,
       ApplicationContext applicationContext,
+      ErrorStatusCodeStrategy errorStatusCodeStrategy,
       @Autowired(required = false) @Nullable HkjMetricsService metricsService) {
     return new WebMvcRegistrations() {
       @Override
@@ -115,7 +135,8 @@ public class HkjWebMvcAutoConfiguration {
             // Register Path handlers in order of specificity
             if (webConfig.isEitherPathEnabled()) {
               newHandlers.add(
-                  new EitherPathReturnValueHandler(jsonMapper, webConfig.getDefaultErrorStatus()));
+                  new EitherPathReturnValueHandler(
+                      jsonMapper, webConfig.getDefaultErrorStatus(), errorStatusCodeStrategy));
             }
 
             if (webConfig.isMaybePathEnabled()) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandler.java
@@ -173,6 +173,8 @@ public class CompletableFuturePathReturnValueHandler
       // Unwrap CompletionException if present
       Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
 
+      ErrorResponseHeaders.applyTo(cause, response);
+
       Map<String, Object> errorBody;
       if (includeExceptionDetails) {
         // Include structured error with type and message for client identification

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/DefaultErrorStatusCodeStrategy.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/DefaultErrorStatusCodeStrategy.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Default {@link ErrorStatusCodeStrategy} that combines the configured {@code
+ * hkj.web.error-status-mappings} property map with the built-in heuristics in {@link
+ * ErrorStatusCodeMapper}.
+ *
+ * <p>Resolution order matches {@link ErrorStatusCodeMapper#determineStatusCode(Object, int, Map)}:
+ * explicit mapping by simple class name → explicit mapping by fully-qualified class name → token
+ * heuristic → {@code defaultStatus}.
+ */
+public final class DefaultErrorStatusCodeStrategy implements ErrorStatusCodeStrategy {
+
+  private final Map<String, Integer> errorStatusMappings;
+
+  /**
+   * Creates a strategy backed by the supplied mapping table.
+   *
+   * @param errorStatusMappings explicit overrides keyed by simple or fully-qualified class name;
+   *     {@code null} is treated as an empty map. A defensive copy is taken so subsequent mutations
+   *     of the supplied map do not affect resolution.
+   */
+  public DefaultErrorStatusCodeStrategy(@Nullable Map<String, Integer> errorStatusMappings) {
+    this.errorStatusMappings =
+        errorStatusMappings == null || errorStatusMappings.isEmpty()
+            ? Map.of()
+            : Map.copyOf(errorStatusMappings);
+  }
+
+  @Override
+  public int statusCodeFor(Object error, int defaultStatus) {
+    return ErrorStatusCodeMapper.determineStatusCode(error, defaultStatus, errorStatusMappings);
+  }
+
+  /**
+   * Returns an unmodifiable view of the mappings backing this strategy. Useful for diagnostics and
+   * tests.
+   *
+   * @return the configured mappings
+   */
+  public Map<String, Integer> mappings() {
+    return errorStatusMappings;
+  }
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandler.java
@@ -40,51 +40,54 @@ import tools.jackson.databind.json.JsonMapper;
  *   <li>{@code Left<E>} → HTTP 4xx/5xx with error as JSON body
  * </ul>
  *
- * <p>Error status codes are determined by examining the error class name:
+ * <p>Error status codes are determined by the supplied {@link ErrorStatusCodeStrategy}. By default
+ * the auto-configuration installs {@link DefaultErrorStatusCodeStrategy}, which combines explicit
+ * {@code hkj.web.error-status-mappings} entries with the heuristics in {@link
+ * ErrorStatusCodeMapper}.
  *
- * <ul>
- *   <li>Contains "notfound" → 404 Not Found
- *   <li>Contains "validation" or "invalid" → 400 Bad Request
- *   <li>Contains "authorization" or "forbidden" → 403 Forbidden
- *   <li>Contains "authentication" or "unauthorized" → 401 Unauthorized
- *   <li>Default → configurable (default 400 Bad Request)
- * </ul>
- *
- * <p>Example usage:
- *
- * <pre>{@code
- * @GetMapping("/users/{id}")
- * public Either<UserError, User> getUser(@PathVariable String id) {
- *     return userService.findById(id);
- * }
- *
- * @GetMapping("/users/{id}")
- * public EitherPath<UserError, User> getUser(@PathVariable String id) {
- *     return Path.either(userService.findById(id))
- *         .peek(user -> log.info("Found user: {}", user.id()));
- * }
- * }</pre>
+ * <p>If the {@code Left} value implements {@link HttpHeaderCarrier}, its headers are copied onto
+ * the response before the body is written — this is how throttling errors surface a {@code
+ * Retry-After} header, for example.
  *
  * @see EitherPath
  * @see Either
- * @see ErrorStatusCodeMapper
+ * @see ErrorStatusCodeStrategy
+ * @see HttpHeaderCarrier
  */
 public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHandler {
 
   private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int defaultErrorStatus;
+  private final ErrorStatusCodeStrategy errorStatusCodeStrategy;
 
   /**
-   * Creates a new EitherPathReturnValueHandler with the specified settings.
+   * Backward-compatible constructor preserved for programmatic adopters who built the handler
+   * directly without going through the auto-configuration. Equivalent to constructing with a {@link
+   * DefaultErrorStatusCodeStrategy} backed by an empty mapping table — i.e. heuristics only.
    *
    * @param jsonMapper the Jackson 3.x JsonMapper for JSON serialization
    * @param defaultErrorStatus the default HTTP status code for errors
    */
   public EitherPathReturnValueHandler(JsonMapper jsonMapper, int defaultErrorStatus) {
+    this(jsonMapper, defaultErrorStatus, new DefaultErrorStatusCodeStrategy(Map.of()));
+  }
+
+  /**
+   * Creates a new EitherPathReturnValueHandler with the specified settings.
+   *
+   * @param jsonMapper the Jackson 3.x JsonMapper for JSON serialization
+   * @param defaultErrorStatus the default HTTP status code for errors when no rule matches
+   * @param errorStatusCodeStrategy the strategy that resolves the status code for an error
+   */
+  public EitherPathReturnValueHandler(
+      JsonMapper jsonMapper,
+      int defaultErrorStatus,
+      ErrorStatusCodeStrategy errorStatusCodeStrategy) {
     this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.defaultErrorStatus = defaultErrorStatus;
+    this.errorStatusCodeStrategy = errorStatusCodeStrategy;
   }
 
   @Override
@@ -151,8 +154,9 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
    */
   private void writeErrorResponse(Object error, HttpServletResponse response) {
     try {
-      int statusCode = ErrorStatusCodeMapper.determineStatusCode(error, defaultErrorStatus);
+      int statusCode = errorStatusCodeStrategy.statusCodeFor(error, defaultErrorStatus);
       response.setStatus(statusCode);
+      ErrorResponseHeaders.applyTo(error, response);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
       Map<String, Object> errorBody = Map.of("success", false, "error", error);

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeaders.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeaders.java
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Collection;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Internal helper that copies headers from {@link HttpHeaderCarrier} error payloads onto the
+ * outgoing {@link HttpServletResponse}. Centralised so every Effect Path return-value handler
+ * applies headers identically.
+ *
+ * <p>Resolution rules:
+ *
+ * <ul>
+ *   <li>If {@code error} itself implements {@link HttpHeaderCarrier}, its headers are applied.
+ *   <li>Else if {@code error} is a {@link Collection} or array, every element that implements
+ *       {@link HttpHeaderCarrier} contributes its headers; values accumulate rather than
+ *       overwriting one another.
+ *   <li>Otherwise nothing is written.
+ * </ul>
+ *
+ * <p>Headers are applied via {@link HttpServletResponse#addHeader(String, String)}, not {@link
+ * HttpServletResponse#setHeader(String, String)}. This preserves multi-valued semantics for headers
+ * such as {@code WWW-Authenticate}, {@code Set-Cookie}, and {@code Link} (which the HTTP grammar
+ * permits to appear multiple times) and avoids overwriting headers set upstream by filters or
+ * interceptors.
+ *
+ * <p>Null keys and null values are skipped silently rather than triggering a servlet container
+ * error; the contract on {@link HttpHeaderCarrier#headers()} explicitly permits the empty or null
+ * case.
+ */
+final class ErrorResponseHeaders {
+
+  private ErrorResponseHeaders() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  /**
+   * Applies any headers the error payload wishes to surface to the response.
+   *
+   * @param error the error payload (may be {@code null})
+   * @param response the servlet response
+   */
+  static void applyTo(@Nullable Object error, HttpServletResponse response) {
+    if (error == null) {
+      return;
+    }
+    if (error instanceof HttpHeaderCarrier carrier) {
+      copy(carrier.headers(), response);
+      return;
+    }
+    if (error instanceof Collection<?> collection) {
+      for (Object element : collection) {
+        if (element instanceof HttpHeaderCarrier carrier) {
+          copy(carrier.headers(), response);
+        }
+      }
+      return;
+    }
+    if (error instanceof Object[] array) {
+      for (Object element : array) {
+        if (element instanceof HttpHeaderCarrier carrier) {
+          copy(carrier.headers(), response);
+        }
+      }
+    }
+  }
+
+  private static void copy(@Nullable Map<String, String> headers, HttpServletResponse response) {
+    if (headers == null || headers.isEmpty()) {
+      return;
+    }
+    headers.forEach(
+        (name, value) -> {
+          if (name != null && value != null) {
+            response.addHeader(name, value);
+          }
+        });
+  }
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorStatusCodeMapper.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorStatusCodeMapper.java
@@ -2,14 +2,31 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.spring.web.returnvalue;
 
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpStatus;
 
 /**
- * Utility class for mapping error types to HTTP status codes.
+ * Utility for mapping error types to HTTP status codes.
  *
- * <p>Uses simple heuristics based on error class names to determine appropriate HTTP status codes.
- * This provides a sensible default mapping for common error types without requiring explicit
- * configuration.
+ * <p>Resolution order applied by {@link #determineStatusCode(Object, int, Map)}:
+ *
+ * <ol>
+ *   <li>Explicit override from {@code errorStatusMappings} keyed by the error's simple class name
+ *       (preferred, stable across refactors of the package layout).
+ *   <li>Explicit override keyed by the error's fully-qualified class name (useful when two classes
+ *       share a simple name across packages).
+ *   <li>Built-in token-aware heuristics on the simple class name.
+ * </ol>
+ *
+ * <p>The heuristics are applied to a tokenised form of the simple class name (CamelCase split on
+ * upper-case boundaries, then lower-cased and bracketed with separators). This means {@code
+ * RevalidationError} no longer matches the {@code validation} rule, while {@code MfaNotFoundError}
+ * still matches {@code NotFound}. Adopters who need anything beyond this should configure {@link
+ * ErrorStatusCodeStrategy} as a Spring bean.
+ *
+ * @see ErrorStatusCodeStrategy
+ * @see DefaultErrorStatusCodeStrategy
  */
 public final class ErrorStatusCodeMapper {
 
@@ -18,36 +35,97 @@ public final class ErrorStatusCodeMapper {
   }
 
   /**
-   * Determines the appropriate HTTP status code based on the error type.
-   *
-   * <p>Uses simple heuristics based on the error class name:
-   *
-   * <ul>
-   *   <li>*NotFound* → 404
-   *   <li>*Validation*, *Invalid* → 400
-   *   <li>*Authorization*, *Forbidden* → 403
-   *   <li>*Authentication*, *Unauthorized* → 401
-   *   <li>default → provided default status
-   * </ul>
+   * Backward-compatible overload. Equivalent to {@link #determineStatusCode(Object, int, Map)} with
+   * an empty mapping table.
    *
    * @param error the error object
-   * @param defaultStatus the default status code to use if no pattern matches
-   * @return the HTTP status code
+   * @param defaultStatus the default status code if no rule matches
+   * @return the resolved HTTP status code
    */
   public static int determineStatusCode(Object error, int defaultStatus) {
-    String errorClassName = error.getClass().getSimpleName().toLowerCase();
+    return determineStatusCode(error, defaultStatus, Map.of());
+  }
 
-    if (errorClassName.contains("notfound")) {
+  /**
+   * Resolves the HTTP status code for an error value.
+   *
+   * @param error the error object (must not be {@code null})
+   * @param defaultStatus the default status code if no rule matches
+   * @param errorStatusMappings explicit overrides keyed by simple or fully-qualified class name;
+   *     {@code null} is treated as an empty map
+   * @return the resolved HTTP status code
+   */
+  public static int determineStatusCode(
+      Object error, int defaultStatus, @Nullable Map<String, Integer> errorStatusMappings) {
+    Class<?> klass = error.getClass();
+    if (errorStatusMappings != null && !errorStatusMappings.isEmpty()) {
+      Integer simple = errorStatusMappings.get(klass.getSimpleName());
+      if (simple != null) {
+        return simple;
+      }
+      Integer qualified = errorStatusMappings.get(klass.getName());
+      if (qualified != null) {
+        return qualified;
+      }
+    }
+    return heuristicStatus(klass.getSimpleName(), defaultStatus);
+  }
+
+  /**
+   * Returns the status code suggested by the built-in heuristics for the given simple class name,
+   * or {@code defaultStatus} if no rule matches. Exposed as a static helper so custom {@link
+   * ErrorStatusCodeStrategy} implementations can delegate to the same logic.
+   *
+   * @param simpleName the simple class name of the error
+   * @param defaultStatus the default status code if no rule matches
+   * @return the resolved HTTP status code
+   */
+  public static int heuristicStatus(String simpleName, int defaultStatus) {
+    String tokens = tokenize(simpleName);
+    if (tokens.contains("-not-found-")) {
       return HttpStatus.NOT_FOUND.value();
-    } else if (errorClassName.contains("validation") || errorClassName.contains("invalid")) {
+    }
+    if (tokens.contains("-validation-") || tokens.contains("-invalid-")) {
       return HttpStatus.BAD_REQUEST.value();
-    } else if (errorClassName.contains("authorization") || errorClassName.contains("forbidden")) {
+    }
+    if (tokens.contains("-authorization-") || tokens.contains("-forbidden-")) {
       return HttpStatus.FORBIDDEN.value();
-    } else if (errorClassName.contains("authentication")
-        || errorClassName.contains("unauthorized")) {
+    }
+    if (tokens.contains("-authentication-") || tokens.contains("-unauthorized-")) {
       return HttpStatus.UNAUTHORIZED.value();
     }
-
     return defaultStatus;
+  }
+
+  /**
+   * Tokenises a CamelCase name into {@code -lower-case-token-} form so that callers can perform
+   * word-boundary substring matches without having to roll their own scanner.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>{@code "MfaNotFoundError"} → {@code "-mfa-not-found-error-"}
+   *   <li>{@code "RevalidationError"} → {@code "-revalidation-error-"}
+   *   <li>{@code ""} → {@code "-"}
+   * </ul>
+   *
+   * @param simpleName the CamelCase name to tokenise
+   * @return the tokenised form bracketed with separators
+   */
+  static String tokenize(String simpleName) {
+    if (simpleName == null || simpleName.isEmpty()) {
+      return "-";
+    }
+    StringBuilder sb = new StringBuilder(simpleName.length() + 8);
+    sb.append('-');
+    for (int i = 0; i < simpleName.length(); i++) {
+      char c = simpleName.charAt(i);
+      if (i > 0 && Character.isUpperCase(c) && !Character.isUpperCase(simpleName.charAt(i - 1))) {
+        sb.append('-');
+      }
+      sb.append(Character.toLowerCase(c));
+    }
+    sb.append('-');
+    return sb.toString();
   }
 }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorStatusCodeStrategy.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorStatusCodeStrategy.java
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+/**
+ * Strategy for resolving the HTTP status code carried by an error value emitted from an Effect Path
+ * handler.
+ *
+ * <p>The auto-configuration registers a {@link DefaultErrorStatusCodeStrategy} bean by default,
+ * combining the {@code hkj.web.error-status-mappings} property map with the built-in heuristics in
+ * {@link ErrorStatusCodeMapper}. Adopters who need finer control — for example, mapping a single
+ * error class to different status codes based on its fields ({@code MfaThrottledError.retryAfter()
+ * ≥ N → 503}) — can replace it by declaring their own bean of this type:
+ *
+ * <pre>{@code
+ * @Bean
+ * ErrorStatusCodeStrategy errorStatusCodeStrategy() {
+ *     return (error, defaultStatus) -> switch (error) {
+ *         case MfaThrottledError t when t.retryAfter() > 60 -> 503;
+ *         case MfaThrottledError ignored -> 429;
+ *         default -> ErrorStatusCodeMapper.determineStatusCode(error, defaultStatus);
+ *     };
+ * }
+ * }</pre>
+ *
+ * <p>Implementations are invoked once per error response on the request thread (or the async
+ * completion thread for {@code CompletableFuturePath} / {@code VTaskPath}), so they should be
+ * thread-safe and side-effect-free.
+ */
+@FunctionalInterface
+public interface ErrorStatusCodeStrategy {
+
+  /**
+   * Resolves the HTTP status code for an error value.
+   *
+   * @param error the error object emitted by the handler (never {@code null})
+   * @param defaultStatus the configured default status to fall back to
+   * @return the HTTP status code to write on the response
+   */
+  int statusCodeFor(Object error, int defaultStatus);
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandler.java
@@ -131,6 +131,7 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
   private void writeFailureResponse(Throwable throwable, HttpServletResponse response) {
     try {
       response.setStatus(failureStatus);
+      ErrorResponseHeaders.applyTo(throwable, response);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
       Map<String, Object> errorBody;

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/HttpHeaderCarrier.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/HttpHeaderCarrier.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import java.util.Map;
+
+/**
+ * Mix-in implemented by error values that wish to add HTTP headers to the response written by an
+ * Effect Path return-value handler.
+ *
+ * <p>The canonical use case is rate-limit / throttling errors that need to surface a {@code
+ * Retry-After} header alongside their JSON body:
+ *
+ * <pre>{@code
+ * public record MfaThrottledError(int retryAfterSeconds) implements DomainError, HttpHeaderCarrier {
+ *     @Override
+ *     public Map<String, String> headers() {
+ *         return Map.of("Retry-After", Integer.toString(retryAfterSeconds));
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>The handler invokes {@link #headers()} after resolving the status code and before writing the
+ * JSON body. Returning {@code null} or an empty map is safe and is treated as "no headers to add".
+ * Header names and values are passed through to {@link
+ * jakarta.servlet.http.HttpServletResponse#addHeader(String, String)}, so callers are responsible
+ * for value escaping where the underlying header grammar requires it.
+ *
+ * <p>Because headers are added rather than set, multi-valued headers such as {@code
+ * WWW-Authenticate}, {@code Set-Cookie}, and {@code Link} accumulate as separate header lines on
+ * the response, matching their HTTP grammar. For single-valued headers such as {@code Retry-After},
+ * the carrier should ensure the value appears at most once across all payload elements; emitting
+ * two distinct values for a single-valued header is undefined behaviour.
+ *
+ * <p>For collection-typed error payloads (such as {@code ValidationPath} {@code Invalid} values),
+ * the handler iterates the collection and applies headers from every element that implements this
+ * interface; values accumulate.
+ *
+ * @see ErrorResponseHeaders
+ */
+public interface HttpHeaderCarrier {
+
+  /**
+   * Returns the headers to copy onto the response. May return {@code null} or an empty map.
+   *
+   * @return the headers to apply
+   */
+  Map<String, String> headers();
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandler.java
@@ -123,6 +123,7 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
   private void writeFailureResponse(Throwable throwable, HttpServletResponse response) {
     try {
       response.setStatus(failureStatus);
+      ErrorResponseHeaders.applyTo(throwable, response);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
       Map<String, Object> errorBody;

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandler.java
@@ -115,6 +115,7 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
   private void writeFailureResponse(Throwable throwable, HttpServletResponse response) {
     try {
       response.setStatus(failureStatus);
+      ErrorResponseHeaders.applyTo(throwable, response);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
       Map<String, Object> errorBody;

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandler.java
@@ -194,6 +194,8 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
       // Unwrap CompletionException if present
       Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
 
+      ErrorResponseHeaders.applyTo(cause, response);
+
       Map<String, Object> errorBody;
       if (includeExceptionDetails) {
         errorBody =

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandler.java
@@ -156,6 +156,7 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
   private void writeInvalidResponse(Object errors, HttpServletResponse response) {
     try {
       response.setStatus(invalidStatus);
+      ErrorResponseHeaders.applyTo(errors, response);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
       int errorCount = countErrors(errors);

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfigurationTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfigurationTest.java
@@ -5,7 +5,9 @@ package org.higherkindedj.spring.autoconfigure;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.higherkindedj.spring.web.returnvalue.DefaultErrorStatusCodeStrategy;
 import org.higherkindedj.spring.web.returnvalue.EitherPathReturnValueHandler;
+import org.higherkindedj.spring.web.returnvalue.ErrorStatusCodeStrategy;
 import org.higherkindedj.spring.web.returnvalue.ValidationPathReturnValueHandler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,6 +17,8 @@ import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
@@ -345,6 +349,61 @@ class HkjWebMvcAutoConfigurationTest {
             assertThat(hasEitherHandler).isTrue();
             assertThat(hasValidatedHandler).isTrue();
           });
+    }
+  }
+
+  @Nested
+  @DisplayName("ErrorStatusCodeStrategy bean wiring")
+  class ErrorStatusCodeStrategyBeanTests {
+
+    @Test
+    @DisplayName("Default DefaultErrorStatusCodeStrategy is registered when no user bean exists")
+    void defaultStrategyRegistered() {
+      contextRunner.run(
+          context -> {
+            assertThat(context).hasSingleBean(ErrorStatusCodeStrategy.class);
+            assertThat(context.getBean(ErrorStatusCodeStrategy.class))
+                .isInstanceOf(DefaultErrorStatusCodeStrategy.class);
+          });
+    }
+
+    @Test
+    @DisplayName("Default strategy is seeded from hkj.web.error-status-mappings")
+    void defaultStrategySeededFromProperties() {
+      contextRunner
+          .withPropertyValues(
+              "hkj.web.error-status-mappings.MfaAlreadyEnrolledError=409",
+              "hkj.web.error-status-mappings.MfaThrottledError=429")
+          .run(
+              context -> {
+                DefaultErrorStatusCodeStrategy strategy =
+                    context.getBean(DefaultErrorStatusCodeStrategy.class);
+                assertThat(strategy.mappings())
+                    .containsEntry("MfaAlreadyEnrolledError", 409)
+                    .containsEntry("MfaThrottledError", 429);
+              });
+    }
+
+    @Test
+    @DisplayName("User-supplied ErrorStatusCodeStrategy bean replaces the default")
+    void userStrategyReplacesDefault() {
+      contextRunner
+          .withUserConfiguration(CustomStrategyConfig.class)
+          .run(
+              context -> {
+                assertThat(context).hasSingleBean(ErrorStatusCodeStrategy.class);
+                ErrorStatusCodeStrategy strategy = context.getBean(ErrorStatusCodeStrategy.class);
+                assertThat(strategy).isNotInstanceOf(DefaultErrorStatusCodeStrategy.class);
+                assertThat(strategy.statusCodeFor(new Object(), 400)).isEqualTo(418);
+              });
+    }
+  }
+
+  @Configuration
+  static class CustomStrategyConfig {
+    @Bean
+    ErrorStatusCodeStrategy errorStatusCodeStrategy() {
+      return (error, defaultStatus) -> 418;
     }
   }
 }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandlerTest.java
@@ -7,6 +7,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.higherkindedj.hkt.effect.CompletableFuturePath;
 import org.higherkindedj.hkt.effect.Path;
@@ -295,6 +296,52 @@ class CompletableFuturePathReturnValueHandlerTest {
 
       // Handler should be created successfully
       assertThat(customTimeoutHandler).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("HttpHeaderCarrier integration")
+  class HeaderInjectionTests {
+
+    @Test
+    @DisplayName("Failure cause that implements HttpHeaderCarrier surfaces its headers")
+    void writesRetryAfter() throws Exception {
+      CompletableFuturePath<TestUser> path = Path.futureFailed(new ThrottledFailure(45));
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      await()
+          .atMost(Duration.ofSeconds(2))
+          .pollInterval(Duration.ofMillis(10))
+          .untilAsserted(() -> assertThat(mockResponse.getHeader("Retry-After")).isEqualTo("45"));
+    }
+
+    @Test
+    @DisplayName("Plain failure leaves no extra headers")
+    void noHeadersForPlainFailure() throws Exception {
+      CompletableFuturePath<TestUser> path = Path.futureFailed(new RuntimeException("boom"));
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      await()
+          .atMost(Duration.ofSeconds(2))
+          .pollInterval(Duration.ofMillis(10))
+          .untilAsserted(() -> assertThat(mockResponse.getHeader("Retry-After")).isNull());
+    }
+  }
+
+  /** Test exception that surfaces a Retry-After header via {@link HttpHeaderCarrier}. */
+  static class ThrottledFailure extends RuntimeException implements HttpHeaderCarrier {
+    private final int seconds;
+
+    ThrottledFailure(int seconds) {
+      super("throttled");
+      this.seconds = seconds;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(seconds));
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/DefaultErrorStatusCodeStrategyTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/DefaultErrorStatusCodeStrategyTest.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("DefaultErrorStatusCodeStrategy")
+class DefaultErrorStatusCodeStrategyTest {
+
+  record UserNotFoundError(String id) {}
+
+  record DuplicateError(String id) {}
+
+  @Test
+  @DisplayName("null mappings argument is treated as empty")
+  void nullMappingsTreatedAsEmpty() {
+    DefaultErrorStatusCodeStrategy strategy = new DefaultErrorStatusCodeStrategy(null);
+    assertThat(strategy.mappings()).isEmpty();
+    assertThat(strategy.statusCodeFor(new DuplicateError("x"), 418)).isEqualTo(418);
+  }
+
+  @Test
+  @DisplayName("Empty mappings falls through to heuristics")
+  void emptyFallsThroughToHeuristics() {
+    DefaultErrorStatusCodeStrategy strategy = new DefaultErrorStatusCodeStrategy(Map.of());
+    assertThat(strategy.statusCodeFor(new UserNotFoundError("x"), 500)).isEqualTo(404);
+  }
+
+  @Test
+  @DisplayName("Mapping overrides heuristic")
+  void mappingOverridesHeuristic() {
+    DefaultErrorStatusCodeStrategy strategy =
+        new DefaultErrorStatusCodeStrategy(Map.of("UserNotFoundError", 410));
+    assertThat(strategy.statusCodeFor(new UserNotFoundError("x"), 500)).isEqualTo(410);
+  }
+
+  @Test
+  @DisplayName("Constructor takes a defensive copy")
+  void defensiveCopy() {
+    Map<String, Integer> mutable = new HashMap<>();
+    mutable.put("UserNotFoundError", 410);
+    DefaultErrorStatusCodeStrategy strategy = new DefaultErrorStatusCodeStrategy(mutable);
+
+    mutable.put("UserNotFoundError", 999);
+    mutable.put("AnotherError", 500);
+
+    assertThat(strategy.statusCodeFor(new UserNotFoundError("x"), 500)).isEqualTo(410);
+    assertThat(strategy.mappings()).containsOnlyKeys("UserNotFoundError");
+  }
+
+  @Test
+  @DisplayName("mappings() view is immutable")
+  void mappingsViewImmutable() {
+    DefaultErrorStatusCodeStrategy strategy = new DefaultErrorStatusCodeStrategy(Map.of("X", 1));
+    assertThatThrownBy(() -> strategy.mappings().put("Y", 2))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  @DisplayName("Unmatched error returns supplied default")
+  void unmatchedReturnsDefault() {
+    DefaultErrorStatusCodeStrategy strategy = new DefaultErrorStatusCodeStrategy(Map.of("X", 1));
+    assertThat(strategy.statusCodeFor(new DuplicateError("x"), 422)).isEqualTo(422);
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
+import java.util.Map;
 import org.higherkindedj.hkt.effect.EitherPath;
 import org.higherkindedj.hkt.effect.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -324,6 +325,98 @@ class EitherPathReturnValueHandlerTest {
     }
   }
 
+  @Nested
+  @DisplayName("Status mapping table (issue: hkj.web.error-status-mappings was unwired)")
+  class ErrorStatusMappingTests {
+
+    @Test
+    @DisplayName("Simple-name mapping wins over heuristic and produces 409")
+    void simpleNameMappingWins() throws Exception {
+      EitherPathReturnValueHandler customHandler =
+          new EitherPathReturnValueHandler(
+              jsonMapper,
+              500,
+              new DefaultErrorStatusCodeStrategy(Map.of("MfaAlreadyEnrolledError", 409)));
+      EitherPath<MfaAlreadyEnrolledError, TestUser> path =
+          Path.left(new MfaAlreadyEnrolledError("user-1"));
+
+      customHandler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).setStatus(409);
+    }
+
+    @Test
+    @DisplayName("Mapping overrides a heuristic match (e.g. Invalid → 401 instead of 400)")
+    void mappingOverridesHeuristic() throws Exception {
+      EitherPathReturnValueHandler customHandler =
+          new EitherPathReturnValueHandler(
+              jsonMapper,
+              500,
+              new DefaultErrorStatusCodeStrategy(Map.of("MfaCodeInvalidError", 401)));
+      EitherPath<MfaCodeInvalidError, TestUser> path = Path.left(new MfaCodeInvalidError("E_BAD"));
+
+      customHandler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).setStatus(401);
+    }
+
+    @Test
+    @DisplayName("Custom strategy bean replaces default resolution entirely")
+    void customStrategyBean() throws Exception {
+      ErrorStatusCodeStrategy strategy =
+          (error, defaultStatus) ->
+              error instanceof MfaThrottledError t && t.retryAfterSeconds() > 60 ? 503 : 429;
+      EitherPathReturnValueHandler customHandler =
+          new EitherPathReturnValueHandler(jsonMapper, 500, strategy);
+
+      EitherPath<MfaThrottledError, TestUser> retryShort = Path.left(new MfaThrottledError(30));
+      customHandler.handleReturnValue(retryShort, returnType, mavContainer, webRequest);
+      verify(response).setStatus(429);
+    }
+
+    @Test
+    @DisplayName("Unmatched error with mappings + strategy still falls back to default")
+    void unmatchedFallsBack() throws Exception {
+      EitherPathReturnValueHandler customHandler =
+          new EitherPathReturnValueHandler(
+              jsonMapper, 599, new DefaultErrorStatusCodeStrategy(Map.of("Other", 999)));
+      EitherPath<DuplicateError, TestUser> path = Path.left(new DuplicateError("x"));
+
+      customHandler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).setStatus(599);
+    }
+  }
+
+  @Nested
+  @DisplayName("HttpHeaderCarrier integration (Retry-After et al.)")
+  class HeaderInjectionTests {
+
+    @Test
+    @DisplayName("Left value implementing HttpHeaderCarrier surfaces its headers")
+    void writesRetryAfterHeader() throws Exception {
+      EitherPathReturnValueHandler customHandler =
+          new EitherPathReturnValueHandler(
+              jsonMapper,
+              500,
+              new DefaultErrorStatusCodeStrategy(Map.of("MfaThrottledError", 429)));
+      EitherPath<MfaThrottledError, TestUser> path = Path.left(new MfaThrottledError(45));
+
+      customHandler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).setStatus(429);
+      verify(response).addHeader("Retry-After", "45");
+    }
+
+    @Test
+    @DisplayName("Plain Left value (no carrier) sets no extra headers")
+    void noHeadersForPlainError() throws Exception {
+      EitherPath<String, TestUser> path = Path.left("plain");
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+      verify(response, never()).addHeader(anyString(), anyString());
+    }
+  }
+
   // Test DTOs
   record TestUser(String id, String email) {}
 
@@ -339,6 +432,20 @@ class EitherPathReturnValueHandlerTest {
 
   /** A domain error whose simple name matches no heuristic substring (issue #490). */
   record DuplicateError(String id) {}
+
+  /** Conflict error with no heuristic match — relies on explicit mapping. */
+  record MfaAlreadyEnrolledError(String userId) {}
+
+  /** Heuristic match (Invalid token) but adopters may want 401 via override. */
+  record MfaCodeInvalidError(String code) {}
+
+  /** Throttling error that surfaces a Retry-After header. */
+  record MfaThrottledError(int retryAfterSeconds) implements HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(retryAfterSeconds));
+    }
+  }
 
   @SuppressWarnings("unused")
   static class SampleController {

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeadersTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeadersTest.java
@@ -1,0 +1,163 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ErrorResponseHeaders")
+class ErrorResponseHeadersTest {
+
+  @Mock private HttpServletResponse response;
+
+  record ThrottledError(int seconds) implements HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(seconds));
+    }
+  }
+
+  record AuthChallenge(String scheme) implements HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("WWW-Authenticate", scheme);
+    }
+  }
+
+  record NullHeaderError() implements HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+      return null;
+    }
+  }
+
+  record EmptyHeaderError() implements HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+      return Map.of();
+    }
+  }
+
+  record PlainError(String msg) {}
+
+  @Test
+  @DisplayName("Skips when error is null")
+  void nullErrorSkips() {
+    ErrorResponseHeaders.applyTo(null, response);
+    verifyNoInteractions(response);
+  }
+
+  @Test
+  @DisplayName("Skips when error is not a HttpHeaderCarrier or collection")
+  void plainErrorSkips() {
+    ErrorResponseHeaders.applyTo(new PlainError("x"), response);
+    verifyNoInteractions(response);
+  }
+
+  @Test
+  @DisplayName("Applies headers from a carrier error")
+  void appliesHeadersFromCarrier() {
+    ErrorResponseHeaders.applyTo(new ThrottledError(30), response);
+    verify(response).addHeader("Retry-After", "30");
+  }
+
+  @Test
+  @DisplayName("Skips silently when carrier returns null map")
+  void nullMapSkips() {
+    ErrorResponseHeaders.applyTo(new NullHeaderError(), response);
+    verify(response, never()).addHeader(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("Skips silently when carrier returns empty map")
+  void emptyMapSkips() {
+    ErrorResponseHeaders.applyTo(new EmptyHeaderError(), response);
+    verify(response, never()).addHeader(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("Skips null keys and null values without failing")
+  void skipsNullEntries() {
+    HttpHeaderCarrier carrier =
+        () -> {
+          HashMap<String, String> map = new HashMap<>();
+          map.put(null, "value");
+          map.put("Skip-Me", null);
+          map.put("Keep-Me", "x");
+          return map;
+        };
+    ErrorResponseHeaders.applyTo(carrier, response);
+    verify(response).addHeader("Keep-Me", "x");
+    verify(response, never()).addHeader(null, "value");
+    verify(response, never()).addHeader("Skip-Me", null);
+  }
+
+  @Test
+  @DisplayName("Applies headers from each carrier element of a Collection payload")
+  void collectionPayloadAppliesAll() {
+    ErrorResponseHeaders.applyTo(
+        List.of(new ThrottledError(30), new AuthChallenge("Basic")), response);
+    verify(response).addHeader("Retry-After", "30");
+    verify(response).addHeader("WWW-Authenticate", "Basic");
+  }
+
+  @Test
+  @DisplayName("Collection payload accumulates multi-valued headers across carriers")
+  void collectionAccumulatesMultiValuedHeaders() {
+    // WWW-Authenticate may carry multiple challenges; addHeader keeps both lines.
+    ErrorResponseHeaders.applyTo(
+        List.of(new AuthChallenge("Basic"), new AuthChallenge("Bearer")), response);
+    verify(response).addHeader("WWW-Authenticate", "Basic");
+    verify(response).addHeader("WWW-Authenticate", "Bearer");
+  }
+
+  @Test
+  @DisplayName("Collection payload ignores non-carrier elements")
+  void collectionPayloadIgnoresNonCarriers() {
+    ErrorResponseHeaders.applyTo(List.of(new PlainError("x"), new ThrottledError(60)), response);
+    verify(response).addHeader("Retry-After", "60");
+  }
+
+  @Test
+  @DisplayName("Array payload applies headers from each carrier element")
+  void arrayPayloadAppliesAll() {
+    Object[] errors = {new ThrottledError(30), new AuthChallenge("Bearer")};
+    ErrorResponseHeaders.applyTo(errors, response);
+    verify(response).addHeader("Retry-After", "30");
+    verify(response).addHeader("WWW-Authenticate", "Bearer");
+  }
+
+  @Test
+  @DisplayName("Array payload ignores non-carrier elements")
+  void arrayPayloadIgnoresNonCarriers() {
+    Object[] errors = {new PlainError("x"), new ThrottledError(99)};
+    ErrorResponseHeaders.applyTo(errors, response);
+    verify(response).addHeader("Retry-After", "99");
+  }
+
+  @Test
+  @DisplayName("Reflective construction throws to prevent instantiation")
+  void cannotInstantiate() throws NoSuchMethodException {
+    Constructor<ErrorResponseHeaders> ctor = ErrorResponseHeaders.class.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    assertThatThrownBy(ctor::newInstance)
+        .isInstanceOf(InvocationTargetException.class)
+        .hasCauseInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ErrorStatusCodeMapperTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ErrorStatusCodeMapperTest.java
@@ -1,0 +1,238 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ErrorStatusCodeMapper")
+class ErrorStatusCodeMapperTest {
+
+  // Test errors -- chosen to exercise every branch of tokenize() and the heuristic table.
+  record UserNotFoundError(String id) {}
+
+  record ValidationError(String msg) {}
+
+  record MfaCodeInvalidError(String msg) {}
+
+  record AuthorizationError(String msg) {}
+
+  record ForbiddenAction(String msg) {}
+
+  record AuthenticationError(String msg) {}
+
+  record UnauthorizedAccess(String msg) {}
+
+  record DuplicateError(String msg) {}
+
+  /** Single-token name to exercise the no-uppercase-boundary branch of tokenize. */
+  record nofound(String msg) {}
+
+  /** Whole-name uppercase to exercise the "no boundary inserted" branch (HTTP, FOO). */
+  record FOOError(String msg) {}
+
+  /**
+   * A token like "revalidation" must NOT match the "validation" rule under the new tokenised
+   * heuristic — this is the regression check for §2.
+   */
+  record RevalidationError(String msg) {}
+
+  @Nested
+  @DisplayName("tokenize")
+  class TokenizeTests {
+
+    @Test
+    @DisplayName("CamelCase splits at upper-case boundaries")
+    void splitsCamelCase() {
+      assertThat(ErrorStatusCodeMapper.tokenize("MfaNotFoundError"))
+          .isEqualTo("-mfa-not-found-error-");
+    }
+
+    @Test
+    @DisplayName("Single lowercase token gets bracketed")
+    void singleLowercase() {
+      assertThat(ErrorStatusCodeMapper.tokenize("nofound")).isEqualTo("-nofound-");
+    }
+
+    @Test
+    @DisplayName("Whole-uppercase name does not insert spurious boundaries")
+    void wholeUppercase() {
+      assertThat(ErrorStatusCodeMapper.tokenize("FOOError")).isEqualTo("-fooerror-");
+    }
+
+    @Test
+    @DisplayName("null input returns lone separator")
+    void nullInput() {
+      assertThat(ErrorStatusCodeMapper.tokenize(null)).isEqualTo("-");
+    }
+
+    @Test
+    @DisplayName("Empty input returns lone separator")
+    void emptyInput() {
+      assertThat(ErrorStatusCodeMapper.tokenize("")).isEqualTo("-");
+    }
+  }
+
+  @Nested
+  @DisplayName("heuristicStatus")
+  class HeuristicTests {
+
+    @Test
+    @DisplayName("Adjacent Not + Found tokens map to 404")
+    void notFound() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("UserNotFoundError", 400)).isEqualTo(404);
+    }
+
+    @Test
+    @DisplayName("Validation token maps to 400")
+    void validation() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("ValidationError", 500)).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("Invalid token maps to 400")
+    void invalid() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("MfaCodeInvalidError", 500)).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("Authorization token maps to 403")
+    void authorization() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("AuthorizationError", 500)).isEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("Forbidden token maps to 403")
+    void forbidden() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("ForbiddenAction", 500)).isEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("Authentication token maps to 401")
+    void authentication() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("AuthenticationError", 500)).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("Unauthorized token maps to 401")
+    void unauthorized() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("UnauthorizedAccess", 500)).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("Unmatched name returns the supplied default")
+    void unmatched() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("DuplicateError", 418)).isEqualTo(418);
+    }
+
+    @Test
+    @DisplayName("Revalidation does NOT match validation under tokenised matching")
+    void revalidationDoesNotMatchValidation() {
+      assertThat(ErrorStatusCodeMapper.heuristicStatus("RevalidationError", 418)).isEqualTo(418);
+    }
+  }
+
+  @Nested
+  @DisplayName("determineStatusCode (single-arg overload)")
+  class SingleArgTests {
+
+    @Test
+    @DisplayName("Defers to heuristics when no map is supplied")
+    void defersToHeuristics() {
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new UserNotFoundError("x"), 500))
+          .isEqualTo(404);
+    }
+
+    @Test
+    @DisplayName("Falls back to defaultStatus when no heuristic matches")
+    void fallsBack() {
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new DuplicateError("x"), 418))
+          .isEqualTo(418);
+    }
+  }
+
+  @Nested
+  @DisplayName("determineStatusCode (mappings overload)")
+  class MapTests {
+
+    @Test
+    @DisplayName("Simple-name mapping wins over heuristic")
+    void simpleNameMappingWins() {
+      Map<String, Integer> map = Map.of("UserNotFoundError", 410);
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new UserNotFoundError("x"), 500, map))
+          .isEqualTo(410);
+    }
+
+    @Test
+    @DisplayName("Fully-qualified-name mapping wins when simple name is absent")
+    void fqnMappingWins() {
+      Map<String, Integer> map = Map.of(UserNotFoundError.class.getName(), 451);
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new UserNotFoundError("x"), 500, map))
+          .isEqualTo(451);
+    }
+
+    @Test
+    @DisplayName("Simple-name mapping is preferred over fully-qualified-name mapping")
+    void simpleNamePreferredOverFqn() {
+      Map<String, Integer> map = new HashMap<>();
+      map.put("UserNotFoundError", 410);
+      map.put(UserNotFoundError.class.getName(), 451);
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new UserNotFoundError("x"), 500, map))
+          .isEqualTo(410);
+    }
+
+    @Test
+    @DisplayName("Empty map falls through to heuristics")
+    void emptyMapFallsThrough() {
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new ValidationError("x"), 500, Map.of()))
+          .isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("Null map is treated as empty")
+    void nullMapTreatedAsEmpty() {
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new ValidationError("x"), 500, null))
+          .isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("Map miss falls through to heuristics")
+    void mapMissFallsThrough() {
+      Map<String, Integer> map = Map.of("Other", 999);
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new ValidationError("x"), 500, map))
+          .isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("Unmatched error with non-empty map still falls back to defaultStatus")
+    void unmatchedFallsBack() {
+      Map<String, Integer> map = Map.of("Other", 999);
+      assertThat(ErrorStatusCodeMapper.determineStatusCode(new DuplicateError("x"), 418, map))
+          .isEqualTo(418);
+    }
+  }
+
+  @Nested
+  @DisplayName("Constructor visibility")
+  class ConstructorTests {
+
+    @Test
+    @DisplayName("Reflective construction throws to prevent instantiation of utility class")
+    void cannotInstantiate() throws NoSuchMethodException {
+      Constructor<ErrorStatusCodeMapper> ctor =
+          ErrorStatusCodeMapper.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      assertThatThrownBy(ctor::newInstance)
+          .isInstanceOf(InvocationTargetException.class)
+          .hasCauseInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandlerHeaderTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandlerHeaderTest.java
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+import org.higherkindedj.hkt.effect.FreePath;
+import org.higherkindedj.hkt.effect.boundary.EffectBoundary;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Targeted coverage test for the {@link HttpHeaderCarrier} integration line added to {@link
+ * FreePathReturnValueHandler#writeFailureResponse}. The handler has no general unit-test suite, so
+ * this file focuses narrowly on the failure path.
+ *
+ * <p>The simplest way to reach {@code writeFailureResponse} without standing up a real {@link
+ * EffectBoundary} interpreter is to make {@link ApplicationContext#getBean(Class)} throw — the
+ * handler catches the exception and writes a failure response. By making that exception itself a
+ * {@link HttpHeaderCarrier} we exercise the "headers applied" branch; with a plain exception we
+ * exercise the "no headers" branch.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FreePathReturnValueHandler header-carrier coverage")
+class FreePathReturnValueHandlerHeaderTest {
+
+  @Mock private HttpServletResponse response;
+
+  @Mock private NativeWebRequest webRequest;
+
+  @Mock private MethodParameter returnType;
+
+  @Mock private ModelAndViewContainer mavContainer;
+
+  @Mock private ApplicationContext applicationContext;
+
+  private FreePathReturnValueHandler handler;
+  private FreePath<MaybeKind.Witness, String> freePath;
+  private PrintWriter printWriter;
+  private StringWriter stringWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    JsonMapper jsonMapper = JsonMapper.builder().build();
+    handler = new FreePathReturnValueHandler(jsonMapper, 500, false, applicationContext);
+
+    // Any FreePath instance suffices — the boundary lookup fails before interpretation runs.
+    freePath = FreePath.pure("ignored", MaybeMonad.INSTANCE);
+    stringWriter = new StringWriter();
+    printWriter = new PrintWriter(stringWriter);
+
+    lenient().when(webRequest.getNativeResponse(HttpServletResponse.class)).thenReturn(response);
+    lenient().when(response.getWriter()).thenReturn(printWriter);
+  }
+
+  @Test
+  @DisplayName("Boundary-lookup exception that carries headers surfaces them on the response")
+  void writesRetryAfter() throws Exception {
+    when(applicationContext.getBean(EffectBoundary.class))
+        .thenThrow(new ThrottledLookupFailure(45));
+
+    handler.handleReturnValue(freePath, returnType, mavContainer, webRequest);
+
+    verify(response).addHeader("Retry-After", "45");
+    assertThat(stringWriter.toString()).contains("\"success\":false");
+  }
+
+  @Test
+  @DisplayName("Plain boundary-lookup failure adds no carrier headers")
+  void noHeadersForPlainFailure() throws Exception {
+    when(applicationContext.getBean(EffectBoundary.class))
+        .thenThrow(new NoSuchBeanDefinitionException(EffectBoundary.class));
+
+    handler.handleReturnValue(freePath, returnType, mavContainer, webRequest);
+
+    verify(response, never()).addHeader("Retry-After", "45");
+  }
+
+  /** Lookup failure that doubles as a Retry-After header carrier. */
+  static class ThrottledLookupFailure extends RuntimeException implements HttpHeaderCarrier {
+    private final int seconds;
+
+    ThrottledLookupFailure(int seconds) {
+      super("throttled");
+      this.seconds = seconds;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(seconds));
+    }
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Map;
 import org.higherkindedj.hkt.effect.IOPath;
 import org.higherkindedj.hkt.effect.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -250,6 +251,52 @@ class IOPathReturnValueHandlerTest {
       handler.handleReturnValue(path, returnType, mavContainer, webRequest);
 
       verify(mavContainer).setRequestHandled(true);
+    }
+  }
+
+  @Nested
+  @DisplayName("HttpHeaderCarrier integration")
+  class HeaderInjectionTests {
+
+    @Test
+    @DisplayName("Failure throwable that implements HttpHeaderCarrier surfaces its headers")
+    void writesRetryAfter() throws Exception {
+      IOPath<TestUser> path =
+          Path.io(
+              () -> {
+                throw new ThrottledFailure(45);
+              });
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).addHeader("Retry-After", "45");
+    }
+
+    @Test
+    @DisplayName("Plain failure sets no extra headers")
+    void noHeadersForPlainFailure() throws Exception {
+      IOPath<TestUser> path =
+          Path.io(
+              () -> {
+                throw new RuntimeException("boom");
+              });
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+      verify(response, never()).addHeader(anyString(), anyString());
+    }
+  }
+
+  /** Test exception that surfaces a Retry-After header via {@link HttpHeaderCarrier}. */
+  static class ThrottledFailure extends RuntimeException implements HttpHeaderCarrier {
+    private final int seconds;
+
+    ThrottledFailure(int seconds) {
+      super("throttled");
+      this.seconds = seconds;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(seconds));
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Map;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.TryPath;
 import org.junit.jupiter.api.BeforeEach;
@@ -220,6 +221,42 @@ class TryPathReturnValueHandlerTest {
       printWriter.flush();
       String json = stringWriter.toString();
       assertThat(json).contains("\"message\":\"No message\"");
+    }
+  }
+
+  @Nested
+  @DisplayName("HttpHeaderCarrier integration")
+  class HeaderInjectionTests {
+
+    @Test
+    @DisplayName("Failure throwable that implements HttpHeaderCarrier surfaces its headers")
+    void writesRetryAfter() throws Exception {
+      TryPath<TestUser> path = Path.failure(new ThrottledFailure(45));
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+      verify(response).addHeader("Retry-After", "45");
+    }
+
+    @Test
+    @DisplayName("Plain failure sets no extra headers")
+    void noHeadersForPlainFailure() throws Exception {
+      TryPath<TestUser> path = Path.failure(new RuntimeException("boom"));
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+      verify(response, never()).addHeader(anyString(), anyString());
+    }
+  }
+
+  /** Test exception that surfaces a Retry-After header via {@link HttpHeaderCarrier}. */
+  static class ThrottledFailure extends RuntimeException implements HttpHeaderCarrier {
+    private final int seconds;
+
+    ThrottledFailure(int seconds) {
+      super("throttled");
+      this.seconds = seconds;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(seconds));
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandlerHeaderTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandlerHeaderTest.java
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.VTaskPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.async.StandardServletAsyncWebRequest;
+import org.springframework.web.context.request.async.WebAsyncManager;
+import org.springframework.web.context.request.async.WebAsyncUtils;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Targeted coverage test for the {@link HttpHeaderCarrier} integration line added to {@link
+ * VTaskPathReturnValueHandler#writeFailureResponse}. There are no general unit tests for this
+ * handler in the suite, so this file focuses narrowly on the new branch.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VTaskPathReturnValueHandler header-carrier coverage")
+class VTaskPathReturnValueHandlerHeaderTest {
+
+  @Mock private MethodParameter returnType;
+
+  private VTaskPathReturnValueHandler handler;
+  private MockHttpServletRequest mockRequest;
+  private MockHttpServletResponse mockResponse;
+  private ServletWebRequest webRequest;
+  private ModelAndViewContainer mavContainer;
+
+  @BeforeEach
+  void setUp() {
+    JsonMapper jsonMapper = JsonMapper.builder().build();
+    handler =
+        new VTaskPathReturnValueHandler(
+            jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR.value(), false, 30000, null);
+
+    mockRequest = new MockHttpServletRequest();
+    mockRequest.setAsyncSupported(true);
+    mockResponse = new MockHttpServletResponse();
+    webRequest = new ServletWebRequest(mockRequest, mockResponse);
+    mavContainer = new ModelAndViewContainer();
+
+    WebAsyncManager asyncManager = WebAsyncUtils.getAsyncManager(webRequest);
+    asyncManager.setAsyncWebRequest(new StandardServletAsyncWebRequest(mockRequest, mockResponse));
+  }
+
+  @Test
+  @DisplayName("Failure throwable that implements HttpHeaderCarrier surfaces its headers")
+  void writesRetryAfter() throws Exception {
+    VTaskPath<String> path = Path.vtaskFail(new ThrottledFailure(45));
+
+    handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(() -> assertThat(mockResponse.getHeader("Retry-After")).isEqualTo("45"));
+  }
+
+  @Test
+  @DisplayName("Plain failure adds no carrier headers")
+  void noHeadersForPlainFailure() throws Exception {
+    VTaskPath<String> path = Path.vtaskFail(new RuntimeException("boom"));
+
+    handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(() -> assertThat(mockResponse.getHeader("Retry-After")).isNull());
+  }
+
+  /** Test exception that surfaces a Retry-After header via {@link HttpHeaderCarrier}. */
+  static class ThrottledFailure extends RuntimeException implements HttpHeaderCarrier {
+    private final int seconds;
+
+    ThrottledFailure(int seconds) {
+      super("throttled");
+      this.seconds = seconds;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("Retry-After", Integer.toString(seconds));
+    }
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandlerTest.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.Map;
 import org.higherkindedj.hkt.Semigroups;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.ValidationPath;
@@ -229,6 +230,34 @@ class ValidationPathReturnValueHandlerTest {
       printWriter.flush();
       String json = stringWriter.toString();
       assertThat(json).contains("\"errorCount\":1");
+    }
+  }
+
+  @Nested
+  @DisplayName("HttpHeaderCarrier integration")
+  class HeaderInjectionTests {
+
+    @Test
+    @DisplayName("Each carrier element of an Invalid collection contributes its headers")
+    void carriersInCollectionAccumulateHeaders() throws Exception {
+      // WWW-Authenticate is multi-valued per RFC 7235 — each challenge is a separate header line.
+      ValidationPath<List<AuthChallengeViolation>, TestUser> path =
+          Path.invalid(
+              List.of(new AuthChallengeViolation("Basic"), new AuthChallengeViolation("Bearer")),
+              Semigroups.list());
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      verify(response).addHeader("WWW-Authenticate", "Basic");
+      verify(response).addHeader("WWW-Authenticate", "Bearer");
+    }
+  }
+
+  /** Validation error that doubles as a {@code WWW-Authenticate} challenge carrier. */
+  record AuthChallengeViolation(String scheme) implements HttpHeaderCarrier {
+    @Override
+    public Map<String, String> headers() {
+      return Map.of("WWW-Authenticate", scheme);
     }
   }
 

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/ErrorStatusFixtureController.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/ErrorStatusFixtureController.java
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example.controller;
+
+import java.util.Map;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.spring.web.returnvalue.HttpHeaderCarrier;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Canonical {@code @WebMvcTest} fixture controller for asserting error → HTTP status mapping
+ * end-to-end. Adopters can copy this verbatim (or import it via {@code @ContextConfiguration}) to
+ * drive a slice test that exercises every status code their domain emits.
+ *
+ * <p>The endpoint {@code /api/error-status-fixture/{kind}} returns one variant per {@code kind},
+ * covering:
+ *
+ * <ul>
+ *   <li>Each built-in heuristic ({@code not-found}, {@code validation}, {@code invalid}, {@code
+ *       forbidden}, {@code authorization}, {@code authentication}, {@code unauthorized})
+ *   <li>Status codes that require explicit {@code hkj.web.error-status-mappings} entries ({@code
+ *       conflict} → 409, {@code unprocessable} → 422)
+ *   <li>An error that surfaces a {@code Retry-After} header via {@link HttpHeaderCarrier} ({@code
+ *       throttled})
+ *   <li>A no-match variant that should fall through to the configured default ({@code unmapped})
+ * </ul>
+ *
+ * <p>See {@code ErrorStatusFixtureSliceTest} for the matching assertions and {@code
+ * application-error-status-fixture.yml}-style property bindings.
+ */
+@RestController
+@RequestMapping("/api/error-status-fixture")
+public class ErrorStatusFixtureController {
+
+  /** Creates an ErrorStatusFixtureController. */
+  public ErrorStatusFixtureController() {}
+
+  /**
+   * Returns one error variant per {@code kind} so a single slice test can assert every
+   * status-mapping rule the project depends on.
+   *
+   * @param kind the variant to emit (see class Javadoc)
+   * @return an {@code Either} whose {@code Left} encodes the requested error variant
+   */
+  @GetMapping("/{kind}")
+  public Either<DomainError, String> raise(@PathVariable String kind) {
+    return Either.left(
+        switch (kind) {
+          case "not-found" -> new DomainError.UserNotFoundError("123");
+          case "validation" -> new DomainError.ValidationError("missing field");
+          case "invalid" -> new DomainError.MfaCodeInvalidError("E_BAD_CODE");
+          case "forbidden" -> new DomainError.ForbiddenAction("delete");
+          case "authorization" -> new DomainError.AuthorizationError("scope");
+          case "authentication" -> new DomainError.AuthenticationError("missing token");
+          case "unauthorized" -> new DomainError.UnauthorizedAccess("expired");
+          case "conflict" -> new DomainError.MfaAlreadyEnrolledError("user-1");
+          case "unprocessable" -> new DomainError.PaymentDeclinedError("insufficient funds");
+          case "throttled" -> new DomainError.MfaThrottledError(30);
+          case "unmapped" -> new DomainError.UnmappedError("opaque");
+          default -> throw new IllegalArgumentException("Unknown kind: " + kind);
+        });
+  }
+
+  /** Sealed domain-error hierarchy that exercises every supported mapping rule. */
+  public sealed interface DomainError {
+
+    /** Heuristic match → 404. */
+    record UserNotFoundError(String userId) implements DomainError {}
+
+    /** Heuristic match → 400. */
+    record ValidationError(String field) implements DomainError {}
+
+    /** Heuristic match (token "Invalid") → 400. */
+    record MfaCodeInvalidError(String code) implements DomainError {}
+
+    /** Heuristic match → 403. */
+    record ForbiddenAction(String action) implements DomainError {}
+
+    /** Heuristic match → 403. */
+    record AuthorizationError(String reason) implements DomainError {}
+
+    /** Heuristic match → 401. */
+    record AuthenticationError(String reason) implements DomainError {}
+
+    /** Heuristic match → 401. */
+    record UnauthorizedAccess(String reason) implements DomainError {}
+
+    /** Requires explicit mapping → 409. */
+    record MfaAlreadyEnrolledError(String userId) implements DomainError {}
+
+    /** Requires explicit mapping → 422. */
+    record PaymentDeclinedError(String reason) implements DomainError {}
+
+    /**
+     * Requires explicit mapping → 429 and surfaces a {@code Retry-After} header by implementing
+     * {@link HttpHeaderCarrier}.
+     */
+    record MfaThrottledError(int retryAfterSeconds) implements DomainError, HttpHeaderCarrier {
+      @Override
+      public Map<String, String> headers() {
+        return Map.of("Retry-After", Integer.toString(retryAfterSeconds));
+      }
+    }
+
+    /** No heuristic, no mapping → falls back to the configured default. */
+    record UnmappedError(String detail) implements DomainError {}
+  }
+}

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/ErrorStatusFixtureSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/ErrorStatusFixtureSliceTest.java
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.higherkindedj.spring.autoconfigure.HkjAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjJacksonAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjWebMvcAutoConfiguration;
+import org.higherkindedj.spring.example.controller.ErrorStatusFixtureController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * End-to-end slice test that exercises every error-status mapping rule the starter supports:
+ * built-in heuristics, explicit {@code hkj.web.error-status-mappings} entries, and {@link
+ * org.higherkindedj.spring.web.returnvalue.HttpHeaderCarrier} header injection.
+ *
+ * <p>This is the canonical fixture project adopters can copy when they add new {@code DomainError}
+ * variants — every variant gets one assertion and one HTTP round-trip.
+ */
+@WebMvcTest(ErrorStatusFixtureController.class)
+@ImportAutoConfiguration({
+  HkjAutoConfiguration.class,
+  HkjJacksonAutoConfiguration.class,
+  HkjWebMvcAutoConfiguration.class
+})
+@TestPropertySource(
+    properties = {
+      "hkj.web.either.default-error-status=500",
+      "hkj.web.error-status-mappings.MfaAlreadyEnrolledError=409",
+      "hkj.web.error-status-mappings.PaymentDeclinedError=422",
+      "hkj.web.error-status-mappings.MfaThrottledError=429"
+    })
+@DisplayName("Error status mapping fixture (heuristics + overrides + headers)")
+class ErrorStatusFixtureSliceTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("not-found → 404 via heuristic")
+  void notFound() throws Exception {
+    mockMvc.perform(get("/api/error-status-fixture/not-found")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("validation → 400 via heuristic")
+  void validation() throws Exception {
+    mockMvc.perform(get("/api/error-status-fixture/validation")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("invalid → 400 via heuristic (token match)")
+  void invalid() throws Exception {
+    mockMvc.perform(get("/api/error-status-fixture/invalid")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("forbidden → 403 via heuristic")
+  void forbidden() throws Exception {
+    mockMvc.perform(get("/api/error-status-fixture/forbidden")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("authorization → 403 via heuristic")
+  void authorization() throws Exception {
+    mockMvc
+        .perform(get("/api/error-status-fixture/authorization"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("authentication → 401 via heuristic")
+  void authentication() throws Exception {
+    mockMvc
+        .perform(get("/api/error-status-fixture/authentication"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("unauthorized → 401 via heuristic")
+  void unauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/error-status-fixture/unauthorized"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("conflict → 409 via explicit mapping")
+  void conflict() throws Exception {
+    mockMvc.perform(get("/api/error-status-fixture/conflict")).andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("unprocessable → 422 via explicit mapping")
+  void unprocessable() throws Exception {
+    mockMvc
+        .perform(get("/api/error-status-fixture/unprocessable"))
+        .andExpect(status().isUnprocessableEntity());
+  }
+
+  @Test
+  @DisplayName("throttled → 429 + Retry-After header via HttpHeaderCarrier")
+  void throttled() throws Exception {
+    mockMvc
+        .perform(get("/api/error-status-fixture/throttled"))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().string("Retry-After", "30"));
+  }
+
+  @Test
+  @DisplayName("unmapped → falls back to configured default 500")
+  void unmapped() throws Exception {
+    mockMvc
+        .perform(get("/api/error-status-fixture/unmapped"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.success").value(false));
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces two major enhancements to the hkj-spring error handling pipeline:

1. **HTTP Header Carrier Interface** (`HttpHeaderCarrier`): Allows error values to inject custom HTTP headers (e.g., `Retry-After`, `WWW-Authenticate`) into the response. All Effect Path return-value handlers now call `ErrorResponseHeaders.applyTo()` before writing the JSON body, enabling rate-limit and authentication errors to surface headers alongside their payloads.

2. **Error Status Code Strategy Pattern** (`ErrorStatusCodeStrategy` / `DefaultErrorStatusCodeStrategy`): Replaces the hard-coded heuristics in `ErrorStatusCodeMapper` with a pluggable strategy bean. The default implementation combines:
   - Explicit mappings from `hkj.web.error-status-mappings` (by simple or fully-qualified class name)
   - Token-aware heuristics on the simple class name (CamelCase split, whole-token matching to avoid false positives like `RevalidationError` matching `validation`)
   - Configured default status code

3. **Improved `ErrorStatusCodeMapper`**: Refactored to use a tokenized matching algorithm that splits class names on CamelCase boundaries and matches whole tokens, preventing spurious matches. Now supports explicit mapping tables and is used internally by `DefaultErrorStatusCodeStrategy`.

4. **Comprehensive Test Coverage**: Added unit tests for the new classes (`ErrorStatusCodeMapperTest`, `ErrorResponseHeadersTest`, `DefaultErrorStatusCodeStrategyTest`, `FreePathReturnValueHandlerHeaderTest`, `VTaskPathReturnValueHandlerHeaderTest`) and integration tests for all Effect Path handlers. Added `ErrorStatusFixtureController` and `ErrorStatusFixtureSliceTest` as a canonical example for adopters.

5. **Documentation Updates**: Enhanced `SKILL.md` and `CONFIGURATION.md` with detailed guidance on explicit mappings, custom strategies, and the new header carrier pattern.

## Changes

### New Files
- `HttpHeaderCarrier.java` – Mix-in interface for errors that provide HTTP headers
- `ErrorResponseHeaders.java` – Internal helper for applying headers to responses
- `ErrorStatusCodeStrategy.java` – Strategy interface for status code resolution
- `DefaultErrorStatusCodeStrategy.java` – Default implementation combining mappings + heuristics
- `ErrorStatusCodeMapperTest.java` – Comprehensive unit tests for tokenization and heuristics
- `ErrorResponseHeadersTest.java` – Tests for header carrier integration
- `DefaultErrorStatusCodeStrategyTest.java` – Tests for the default strategy
- `FreePathReturnValueHandlerHeaderTest.java` – Coverage for FreePath header injection
- `VTaskPathReturnValueHandlerHeaderTest.java` – Coverage for VTask header injection
- `ErrorStatusFixtureController.java` – Canonical example controller
- `ErrorStatusFixtureSliceTest.java` – End-to-end slice test for all mapping rules

### Modified Files
- `ErrorStatusCodeMapper.java` – Refactored to support tokenized matching and explicit mappings; now delegates to strategy pattern
- `EitherPathReturnValueHandler.java` – Updated to use `ErrorStatusCodeStrategy` bean; added header injection
- `CompletableFuturePathReturnValueHandler.java` – Added `ErrorResponseHeaders.applyTo()` call
- `VTaskPathReturnValueHandler.java` – Added `ErrorResponseHeaders.applyTo()` call
- `FreePathReturnValueHandler.java` – Added `ErrorResponseHeaders.applyTo()` call
- `IOPathReturnValueHandler.java` – Added `ErrorResponseHeaders.applyTo()` call
- `TryPathReturnValueHandler.java` – Added `ErrorResponseHeaders.applyTo()` call
- `ValidationPathReturnValueHandler.java` – Added `ErrorResponseHeaders.applyTo()` call
- `HkjWebMvcAutoConfiguration.java` – Wired `DefaultErrorStatusCodeStrategy` bean and injected into handlers
- `HkjWebMvcAutoConfigurationTest.java` – Added tests for strategy bean wiring
- `EitherPathReturnValueHandlerTest.java` – Added tests for mapping table and custom strategy
-

Fixes #498 