### PR TITLE
Restructure of the Monad Transformers chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,13 @@ For complete documentation, see:
 
 ## Learn by Doing
 
-Twelve interactive tutorial journeys with hands-on exercises:
+Thirteen interactive tutorial journeys with hands-on exercises:
 
 | Journey | Focus | Exercises |
 |---------|-------|-----------|
 | [Core: Foundations](https://higher-kinded-j.github.io/latest/tutorials/coretypes/foundations_journey.html) | HKT simulation, Functor, Monad | 24 |
 | [Effect API](https://higher-kinded-j.github.io/latest/tutorials/effect/effect_journey.html) | Effect paths, ForPath, Contexts | 15 |
+| [Monad Transformers](https://higher-kinded-j.github.io/latest/tutorials/transformers/transformers_journey.html) | When Path isn't enough, async + absence, MTL | 28 |
 | [Concurrency: VTask](https://higher-kinded-j.github.io/latest/tutorials/concurrency/vtask_journey.html) | Virtual threads, VTaskPath, Par | 16 |
 | [Optics: Focus DSL](https://higher-kinded-j.github.io/latest/tutorials/optics/focus_dsl_journey.html) | Type-safe path navigation | 29 |
 

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -341,6 +341,69 @@ Pages in advanced topic chapters should lead with a concrete problem before intr
 
 This structure ensures readers understand *why* they need a concept before learning *how* it works. Reference material (type signatures, witness types, helper utilities) should still be present but positioned after the narrative arc, typically inside admonishments so the teaching flow is not interrupted.
 
+## Monad Transformer Pages
+
+Pages documenting individual monad transformers (e.g. `eithert_transformer.md`, `readert_transformer.md`) follow a stricter template than general advanced topics. The goal is to ensure every transformer page reads consistently and emphasises the Effect Path API as the recommended starting point.
+
+### Required Page Structure
+
+Each per-transformer page must use the following structure, in this order:
+
+1. **Title** with descriptive subtitle and optional epigraph
+2. **What You'll Learn** admonishment
+3. **See Example Code** admonishment with link to the runnable example
+4. **Path First, Stack Later** note that points readers at the equivalent Path type
+5. **The Problem** – 5 to 15 lines of imperative code demonstrating the pain
+6. **The Solution** – the same scenario expressed through the transformer, ideally with a `For` comprehension
+7. **The Railway View** – ASCII diagram showing the success and failure tracks
+8. **How It Works** – ASCII type diagram (no UML or generated SVGs) and short explanation of the type parameters
+9. **Setting Up the Monad** – constructor for the `*Monad` instance, plus a Witness/Helper note
+10. **Key Operations** – table or admonishment listing the core methods
+11. **Creating Instances** – tour of the static factory methods
+12. **Real-World Example** – one substantial worked example using `For` comprehension
+13. **Transforming the Outer Monad with `mapT`** – short section with a `mapT` example and a `mapT vs map` note
+14. **Common Mistakes** warning admonishment
+15. **See Also** admonishment with internal links
+16. **Further Reading** (optional) with external links
+17. **Navigation** (Previous/Next)
+
+### Effect Path First in Examples
+
+Code samples on transformer pages should follow this order of preference:
+
+1. **First example**: show the problem solved with the corresponding Effect Path type (e.g. `EitherPath`, `MaybePath`). This emphasises that most readers do not need the raw transformer.
+2. **Second example**: show the transformer-based solution using `For.from(...)` syntax to keep witness types localised.
+3. **Reference material**: explicit `flatMap` chains and raw `Kind<>` ceremony belong in admonishments or later sections, not in the headline example.
+
+The pattern is: *Effect Path first, transformer second, raw `Kind` only when illustrating the underlying mechanism.*
+
+### `For` Comprehension Over Raw `flatMap`
+
+Real-world examples must prefer `For.from(monad, ...)` over chained `flatMap` calls. The witness types are noisy when written inline; `For` keeps them at the top of the comprehension and lets the body read like a sequence of named bindings.
+
+When a chained `flatMap` example is genuinely useful (e.g. to show the mechanism), keep it short and place it after the `For` example, not before.
+
+### No UML or SVG Class Diagrams
+
+Per-transformer pages should not embed UML or generated SVG class diagrams. They are difficult to maintain, add little to the reader's understanding, and do not match the lightweight, code-first style of the rest of the chapter. Use the boxed ASCII type diagram (under "How It Works") and the railway diagram (under "The Railway View") instead.
+
+### Reducing `Kind` Ceremony
+
+The single biggest barrier to reading transformer pages is the volume of `EITHER_T.widen(...)`, `OPTIONAL_T.narrow(...)`, and `Kind<XKind.Witness<F, ...>, A>` annotations. Apply the following rules:
+
+- Use `var` for local variables whose type is obvious from context
+- Push `widen`/`narrow` calls into a dedicated "Working with Kind" admonishment rather than scattering them through the headline example
+- Prefer `For.from(monad, ...)` so that `Kind<>` types appear at the comprehension boundary and not inside every step
+- When a code sample demonstrates a single concept, omit unrelated ceremony
+
+### Cross-References
+
+Every transformer page should link to:
+
+- The corresponding **Effect Path type** (e.g. `EitherT` links to `EitherPath`)
+- The relevant **MTL capability** if one exists (e.g. `ReaderT` links to `MonadReader`)
+- The **Stack Archetypes** page when an archetype matches the transformer's primary use case
+
 ## Checklist for New Pages
 
 When creating a new documentation page, ensure:

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -113,6 +113,10 @@
     - [Decision Trees](optics/decision_trees.md)
 
 - [Monad Transformers & MTL](transformers/ch_intro.md)
+  - [Path or Transformer?](transformers/when_to_drop_to_transformers.md)
+  - [Quickstart](transformers/quickstart.md)
+  - [Transformers at a Glance](transformers/transformers_at_a_glance.md)
+  - [Migration Cookbook](transformers/migration_cookbook.md)
   - [Stack Archetypes](transformers/archetypes.md)
   - [Monad Transformers](transformers/transformers.md)
   - [EitherT](transformers/eithert_transformer.md)
@@ -126,6 +130,8 @@
     - [MonadState](transformers/mtl_state.md)
     - [MonadWriter](transformers/mtl_writer.md)
     - [Combining Capabilities](transformers/mtl_combining.md)
+  - [Common Compiler Errors](transformers/common_errors.md)
+  - [Capstone: A Multi-Capability Workflow](transformers/transformer_capstone.md)
 
 - [Foundations](hkts/foundations_intro.md)
   - [Higher-Kinded Types](hkts/ch_intro.md)
@@ -212,6 +218,7 @@
     - [Error Handling](tutorials/coretypes/error_handling_journey.md)
     - [Advanced](tutorials/coretypes/advanced_journey.md)
   - [Effect API](tutorials/effect/effect_journey.md)
+  - [Monad Transformers](tutorials/transformers/transformers_journey.md)
   - [Concurrency](tutorials/concurrency/ch_intro.md)
     - [VTask](tutorials/concurrency/vtask_journey.md)
     - [Scope & Resource](tutorials/concurrency/scope_resource_journey.md)

--- a/hkj-book/src/home.md
+++ b/hkj-book/src/home.md
@@ -200,7 +200,7 @@ Each Path wraps its underlying effect and provides `map`, `via`, `run`, `recover
 
 ## Learn by Doing
 
-The fastest way to master Higher-Kinded-J is through our **interactive tutorial series**. Twelve journeys guide you through hands-on exercises with immediate test feedback.
+The fastest way to master Higher-Kinded-J is through our **interactive tutorial series**. Thirteen journeys guide you through hands-on exercises with immediate test feedback.
 
 | Journey | Focus | Duration | Exercises |
 |---------|-------|----------|-----------|
@@ -208,6 +208,7 @@ The fastest way to master Higher-Kinded-J is through our **interactive tutorial 
 | **[Core: Error Handling](tutorials/coretypes/error_handling_journey.md)** | MonadError, concrete types, real-world patterns | ~30 min | 20 |
 | **[Core: Advanced](tutorials/coretypes/advanced_journey.md)** | Natural Transformations, Coyoneda, Free Applicative | ~40 min | 26 |
 | **[Effect API](tutorials/effect/effect_journey.md)** | Effect paths, ForPath, Effect Contexts | ~65 min | 15 |
+| **[Monad Transformers](tutorials/transformers/transformers_journey.md)** | When Path isn't enough, async + absence, stacking, MTL | ~90 min | 28 |
 | **[Expression: ForState](tutorials/expression/forstate_journey.md)** | Named fields, guards, pattern matching, zoom | ~25 min | 11 |
 | **[Concurrency: VTask](tutorials/concurrency/vtask_journey.md)** | Virtual threads, VTaskPath, Par combinators | ~45 min | 16 |
 | **[Concurrency: Scope & Resource](tutorials/concurrency/scope_resource_journey.md)** | Structured concurrency, resource management | ~30 min | 12 |
@@ -283,6 +284,16 @@ If you want working code immediately, start with the **[Quickstart](quickstart.m
 3. **[Optics Integration](effect/focus_integration.md):** Bridging Effect Paths with the Focus DSL
 4. **[Advanced Paths](effect/advanced_topics.md):** Free monads, effect handlers, contexts, ForPath parallelism, and resilience
 5. **[Reference](effect/capabilities.md):** Capability typeclasses, type conversions, compiler errors, and production readiness
+
+### Monad Transformers
+For the cases where the Path API does not fit (a different outer monad, polymorphic library code, or integrating with raw `Kind` shapes).
+
+1. **[Path or Transformer?](transformers/when_to_drop_to_transformers.md):** The triage page; read this first to know whether the rest of the chapter applies to you
+2. **[Quickstart](transformers/quickstart.md):** Three runnable transformer examples in about 150 lines
+3. **[Stack Archetypes](transformers/archetypes.md):** Seven named patterns covering the most common composition problems
+4. **[MTL Capabilities](transformers/mtl_capabilities.md):** Stack-independent capability abstractions for polymorphic library code
+5. **[Capstone](transformers/transformer_capstone.md):** End-to-end multi-capability workflow combining typed errors, configuration, audit, and async
+6. **[Common Compiler Errors](transformers/common_errors.md):** Six common errors and the fix for each
 
 ### Optics
 1. **[Quickstart](optics/quickstart.md):** Three runnable examples covering generated lenses, prisms and traversals, plus `@ImportOptics` for Jackson

--- a/hkj-book/src/transformers/archetypes.md
+++ b/hkj-book/src/transformers/archetypes.md
@@ -532,5 +532,5 @@ Each archetype's Path type provides a fluent, concrete API. For most use cases, 
 
 ---
 
-**Previous:** [Introduction](ch_intro.md)
+**Previous:** [Migration Cookbook](migration_cookbook.md)
 **Next:** [Monad Transformers](transformers.md)

--- a/hkj-book/src/transformers/ch_intro.md
+++ b/hkj-book/src/transformers/ch_intro.md
@@ -91,8 +91,8 @@ Same semantics. Vastly different ergonomics.
 | Transformer | Inner Effect | Use Case |
 |-------------|--------------|----------|
 | `EitherT<F, E, A>` | Typed error (`Either<E, A>`) | Async operations that fail with domain errors |
-| `MaybeT<F, A>` | Optional value (`Maybe<A>`) | Async operations that might return nothing |
-| `OptionalT<F, A>` | Java Optional (`Optional<A>`) | Same as MaybeT, for java.util.Optional |
+| `OptionalT<F, A>` | Java Optional (`Optional<A>`) | Async operations that might return nothing |
+| `MaybeT<F, A>` | Optional value (`Maybe<A>`) | Same as OptionalT, for Higher-Kinded-J's `Maybe` |
 | `ReaderT<F, R, A>` | Environment (`Reader<R, A>`) | Dependency injection in effectful contexts |
 | `StateT<S, F, A>` | State (`State<S, A>`) | Stateful computation within other effects |
 | `WriterT<F, W, A>` | Output (`Pair<A, W>`) | Logging, audit trails, diagnostic accumulation |
@@ -100,6 +100,10 @@ Same semantics. Vastly different ergonomics.
 ---
 
 ~~~admonish info title="In This Chapter"
+- **Path or Transformer?** – A short triage page that names the three signals you have outgrown the Effect Path API. Read this first if you are not yet sure whether the rest of the chapter applies to you.
+- **Quickstart** – Three runnable transformer examples in about 150 lines: `EitherT` for async-plus-typed-error, `OptionalT` for async lookup chains, and an MTL example for stack-independent code. The fastest path from zero to working code.
+- **Transformers at a Glance** – A one-page reference card listing every transformer, its factory methods, key operations, the equivalent Effect Path type, and the matching MTL capability.
+- **Migration Cookbook** – Pattern-by-pattern translations from imperative Java (and from the Effect Path API) into raw transformers. Recipes for nested `thenCompose`, manual config threading, manual log threading, and manual state threading.
 - **Stack Archetypes** – Seven named patterns (Service, Lookup, Validation, Context, Audit, Workflow, Safe Recursion) that cover the most common enterprise composition problems. Start here to find the right pattern for your use case.
 - **The Problem** – Monads don't compose naturally. A `CompletableFuture<Either<E, A>>` requires nested operations that become unwieldy. Transformers restore ergonomic composition.
 - **EitherT** – Adds typed error handling to any monad. Wrap your async operations with `EitherT` to get a single `flatMap` that handles both async sequencing and error propagation.
@@ -109,6 +113,8 @@ Same semantics. Vastly different ergonomics.
 - **StateT** – Manages state within effectful computations. Track state changes across async boundaries or error-handling paths.
 - **WriterT** – Accumulates output (logs, audit trails, diagnostics) alongside computation. Each step appends to the output via a `Monoid`, and `flatMap` combines outputs automatically.
 - **MTL Capabilities** – `MonadReader`, `MonadState`, and `MonadWriter` abstract effect capabilities independently of the concrete transformer stack. Write polymorphic functions that declare *what they need* without specifying *how* it is assembled.
+- **Common Compiler Errors** – The six error messages developers hit most often when working with raw transformers, with the minimal trigger for each and the fix.
+- **Capstone: A Multi-Capability Workflow** – A complete order-processing example that combines typed errors, configuration, audit, and async execution. Three side-by-side versions (imperative, MTL polymorphic, Effect Path) make the trade-offs concrete.
 
 See also [Capstone: Effects Meet Optics](../effect/capstone_focus_effect.md) for a complete example combining effect paths with optics in a single pipeline.
 ~~~
@@ -117,20 +123,26 @@ See also [Capstone: Effects Meet Optics](../effect/capstone_focus_effect.md) for
 
 ## Chapter Contents
 
-1. [Stack Archetypes](archetypes.md) - Named patterns for the most common composition problems
-2. [Monad Transformers](transformers.md) - Why monads stack poorly and what transformers solve
-3. [EitherT](eithert_transformer.md) - Typed errors in any monadic context
-4. [OptionalT](optionalt_transformer.md) - Java Optional lifting
-5. [MaybeT](maybet_transformer.md) - Maybe lifting
-6. [ReaderT](readert_transformer.md) - Environment threading
-7. [StateT](statet_transformer.md) - State management in effectful computation
-8. [WriterT](writert_transformer.md) - Output accumulation and audit trails
-9. [MTL Capabilities](mtl_capabilities.md) - Stack-independent capability abstractions
-   - [MonadReader](mtl_reader.md) - Environment access and scoped modification
-   - [MonadState](mtl_state.md) - State threading and mutation
-   - [MonadWriter](mtl_writer.md) - Output accumulation and log inspection
-   - [Combining Capabilities](mtl_combining.md) - Multi-capability functions and concrete instances
+1. [Path or Transformer?](when_to_drop_to_transformers.md) - The three signals that mean you have outgrown the Path API
+2. [Quickstart](quickstart.md) - Three runnable transformer examples
+3. [Transformers at a Glance](transformers_at_a_glance.md) - One-page reference card
+4. [Migration Cookbook](migration_cookbook.md) - Imperative and Path translations
+5. [Stack Archetypes](archetypes.md) - Named patterns for the most common composition problems
+6. [Monad Transformers](transformers.md) - Why monads stack poorly and what transformers solve
+7. [EitherT](eithert_transformer.md) - Typed errors in any monadic context
+8. [OptionalT](optionalt_transformer.md) - Java Optional lifting
+9. [MaybeT](maybet_transformer.md) - Maybe lifting
+10. [ReaderT](readert_transformer.md) - Environment threading
+11. [StateT](statet_transformer.md) - State management in effectful computation
+12. [WriterT](writert_transformer.md) - Output accumulation and audit trails
+13. [MTL Capabilities](mtl_capabilities.md) - Stack-independent capability abstractions
+    - [MonadReader](mtl_reader.md) - Environment access and scoped modification
+    - [MonadState](mtl_state.md) - State threading and mutation
+    - [MonadWriter](mtl_writer.md) - Output accumulation and log inspection
+    - [Combining Capabilities](mtl_combining.md) - Multi-capability functions and concrete instances
+14. [Common Compiler Errors](common_errors.md) - The six errors developers hit most often, with the fix for each
+15. [Capstone: A Multi-Capability Workflow](transformer_capstone.md) - End-to-end example combining typed errors, config, audit, and async
 
 ---
 
-**Next:** [Stack Archetypes](archetypes.md)
+**Next:** [Path or Transformer?](when_to_drop_to_transformers.md)

--- a/hkj-book/src/transformers/common_errors.md
+++ b/hkj-book/src/transformers/common_errors.md
@@ -1,0 +1,277 @@
+# Common Compiler Errors
+
+Transformer code is generic-heavy by nature: a typical signature like `Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Result>` packs three type parameters into two layers. When something goes wrong, the compiler messages can be hard to read. This page documents the errors developers hit most often, what they actually mean, and the fix.
+
+~~~admonish info title="What You'll Learn"
+- How to satisfy the missing-Monad constraint when constructing a transformer monad
+- How to unify error types across an `EitherT` chain
+- Why `StateT.mapT` takes an extra parameter that the other `mapT` methods do not
+- When to call `.value()` and when to leave a transformer alone
+- How to spot type-inference failures in `EitherT.fromEither` and similar factories
+~~~
+
+---
+
+## 1. "Cannot resolve constructor `EitherTMonad`"
+
+**The error:**
+
+```
+error: constructor EitherTMonad in class EitherTMonad<F, L> cannot be applied to given types;
+    var eitherTMonad = new EitherTMonad<>();
+                       ^
+  required: Monad<F>
+  found:    no arguments
+  reason:   actual and formal argument lists differ in length
+```
+
+**The trigger:**
+
+```java
+var eitherTMonad =
+    new EitherTMonad<CompletableFutureKind.Witness, DomainError>();   // missing argument
+```
+
+Every transformer monad needs a `Monad<F>` instance for the *outer* effect. The constructor cannot infer it from thin air.
+
+**The fix:** pass the outer monad to the constructor.
+
+```java
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var eitherTMonad =
+    new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+```
+
+The same rule applies to `OptionalTMonad`, `MaybeTMonad`, `ReaderTMonad`, `StateTMonad`, and `WriterTMonad`. `WriterTMonad` additionally requires a `Monoid<W>` for the output type.
+
+---
+
+## 2. "Incompatible types: error type mismatch in EitherT chain"
+
+**The error:**
+
+```
+error: incompatible types: Kind<EitherTKind.Witness<F,String>,User> cannot be converted to
+    Kind<EitherTKind.Witness<F,DomainError>,User>
+```
+
+**The trigger:**
+
+```java
+var eitherTMonad =
+    new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+
+// lookupUser returns EitherT<F, String, User>: error type is String, not DomainError
+EitherT<CompletableFutureKind.Witness, String, User> lookupUser(String id) { ... }
+
+For.from(eitherTMonad, validatedET)
+    .from(id -> lookupUser(id));   // String vs DomainError mismatch
+```
+
+Every step in an `EitherT` comprehension shares the same error type `L`. Mixing a step that fails with `String` and one that fails with `DomainError` will not compile.
+
+**The fix:** unify the error type, either by changing the function or by mapping at the boundary.
+
+```java
+// Option 1: change lookupUser to use DomainError
+EitherT<CompletableFutureKind.Witness, DomainError, User> lookupUser(String id) { ... }
+
+// Option 2: lift the foreign error type at the call site
+EitherT<CompletableFutureKind.Witness, DomainError, User> liftLookup(String id) {
+    var raw = lookupUser(id);                                            // EitherT<F, String, User>
+    return EitherT.fromKind(
+        futureMonad.map(
+            either -> either.mapLeft(DomainError.UserLookup::new),       // String -> DomainError
+            raw.value()));
+}
+```
+
+Option 1 is preferred for new code. Option 2 is useful when integrating with code you cannot change.
+
+---
+
+## 3. "Method `mapT` cannot be applied" on `StateT`
+
+**The error:**
+
+```
+error: method mapT in class StateT<S,F,A> cannot be applied to given types;
+    stateT.mapT(f);
+           ^
+  required: Monad<G>, Function<Kind<F,StateTuple<S,A>>,Kind<G,StateTuple<S,A>>>
+  found:    Function<Kind<F,StateTuple<S,A>>,Kind<G,StateTuple<S,A>>>
+```
+
+**The trigger:**
+
+```java
+StateT<Counter, IdKind.Witness, Integer> idState = ...;
+
+var taskState = idState.mapT(idKind -> ioToTask.apply(idKind));   // missing first argument
+```
+
+Most transformers' `mapT` takes a single function. `StateT.mapT` is the exception: because the state-threading function `S -> Kind<G, (S, A)>` must close over the new monad, the call requires an explicit `Monad<G>` instance as the first argument.
+
+**The fix:** pass the target monad alongside the function.
+
+```java
+var taskMonad = TaskMonad.INSTANCE;
+var taskState = idState.mapT(taskMonad, idKind -> ioToTask.apply(idKind));
+```
+
+`EitherT.mapT`, `OptionalT.mapT`, `MaybeT.mapT`, `ReaderT.mapT`, and `WriterT.mapT` do not take this extra argument. Only `StateT` does.
+
+---
+
+## 4. "Cannot infer type-variable `L` for `EitherT.fromEither`"
+
+**The error:**
+
+```
+error: method fromEither in class EitherT<F,L,R> cannot be applied to given types;
+    EitherT.fromEither(futureMonad, Either.right(value));
+           ^
+  reason: cannot infer type-variable(s) F, L, R
+```
+
+**The trigger:**
+
+```java
+var eitherTMonad =
+    new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+
+return For.from(eitherTMonad,
+        EitherT.fromEither(futureMonad, Either.right(validated)));   // L cannot be inferred
+```
+
+`Either.right(value)` has no `Left` value to infer the error type from, so the compiler cannot determine `L` for the resulting `EitherT`. The same problem appears with `Path.right` in the Effect Path API (see [Effect Compiler Errors](../effect/compiler_errors.md#1-cannot-infer-type-arguments-for-pathright)).
+
+**The fix:** add an explicit type witness on the `Either`.
+
+```java
+return For.from(eitherTMonad,
+        EitherT.fromEither(futureMonad, Either.<DomainError, Validated>right(validated)));
+```
+
+Inference works when the surrounding context constrains `L`, for example when assigning to a variable with an explicit type:
+
+```java
+EitherT<CompletableFutureKind.Witness, DomainError, Validated> step =
+    EitherT.fromEither(futureMonad, Either.right(validated));     // L inferred from variable
+```
+
+When in doubt, add the witness. It costs nothing at runtime.
+
+---
+
+## 5. "Cannot find symbol `.value()`" on a `Kind`
+
+**The error:**
+
+```
+error: cannot find symbol
+    var future = workflow.value();
+                         ^
+  symbol:   method value()
+  location: variable workflow of type Kind<EitherTKind.Witness<...>, Result>
+```
+
+**The trigger:**
+
+```java
+Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Result> workflow =
+    eitherTMonad.flatMap(...);
+
+var future = workflow.value();   // Kind has no value() method
+```
+
+`.value()` is defined on the concrete `EitherT<F, L, R>` (and equivalently on `OptionalT`, `MaybeT`, `ReaderT`, `StateT`, `WriterT`). It is not part of the `Kind` interface. When you have a `Kind` value, you must narrow it back to the concrete transformer first.
+
+**The fix:** call the matching narrow helper before extracting the underlying value.
+
+```java
+import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
+
+var future = EITHER_T.narrow(workflow).value();
+```
+
+This boundary conversion is unavoidable when a method is typed in `Kind` but you need a concrete operation. If you control the call site, declaring the variable as the concrete `EitherT<...>` removes the need:
+
+```java
+EitherT<CompletableFutureKind.Witness, DomainError, Result> workflow =
+    EITHER_T.narrow(eitherTMonad.flatMap(...));    // narrow once at the assignment
+
+var future = workflow.value();
+```
+
+---
+
+## 6. "Method `For.from` is not applicable" with the wrong monad
+
+**The error:**
+
+```
+error: method from in class For cannot be applied to given types;
+    For.from(eitherTMonad, OptionalT.fromKind(future));
+        ^
+  required: Monad<M>, Kind<M,A>
+  found:    EitherTMonad<...>, OptionalT<...>
+  reason:   inference variable M has incompatible bounds
+```
+
+**The trigger:**
+
+```java
+var eitherTMonad =
+    new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+
+For.from(eitherTMonad, OptionalT.fromKind(future))    // mismatched witness types
+    .from(...)
+    .yield(...);
+```
+
+`For.from(monad, source)` requires the source's witness type to match the monad's witness type. Passing an `EitherTMonad` and an `OptionalT` mixes two different transformer stacks.
+
+**The fix:** make sure the monad you pass to `For.from` matches the witness of every step.
+
+```java
+// Either use EitherT throughout:
+For.from(eitherTMonad, EitherT.fromKind(fetchEither(...)))
+    .from(...)
+    .yield(...);
+
+// Or build the matching OptionalTMonad and use OptionalT throughout:
+var optionalTMonad = new OptionalTMonad<CompletableFutureKind.Witness>(futureMonad);
+For.from(optionalTMonad, OptionalT.fromKind(future))
+    .from(...)
+    .yield(...);
+```
+
+If you genuinely need to combine two effect layers (typed errors *and* absence in the same workflow), you are in stacking territory. See [Tutorial 03: Stacking Transformers](../tutorials/transformers/transformers_journey.md) and [Stack Archetypes](archetypes.md).
+
+---
+
+## Quick Diagnostic Table
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| "constructor cannot be applied", expects `Monad<F>` | Forgot to pass the outer monad | `new EitherTMonad<>(futureMonad)` |
+| "incompatible types" with two `EitherTKind.Witness` shapes | Different error types `L` in the chain | Unify the error type or `mapLeft` at the boundary |
+| `mapT` "cannot be applied" on `StateT` | Missing `Monad<G>` first argument | `stateT.mapT(targetMonad, f)` |
+| "cannot infer type-variable" on `Either.right` / `EitherT.fromEither` | No `Left` value to infer `L` from | Add `Either.<E, A>right(...)` |
+| "cannot find symbol `.value()`" on a `Kind` | Need to narrow first | `EITHER_T.narrow(kind).value()` |
+| "For.from not applicable" with two stack types | Mixed transformer stacks | Use one consistent monad and lift accordingly |
+
+---
+
+~~~admonish tip title="See Also"
+- [Path or Transformer?](when_to_drop_to_transformers.md), the decision page that may save you from this chapter entirely
+- [Transformers at a Glance](transformers_at_a_glance.md), reference card for every transformer
+- [Effect Path Common Compiler Errors](../effect/compiler_errors.md), the equivalent for the Path API
+- [Migration Cookbook](migration_cookbook.md), side-by-side translations between styles
+~~~
+
+---
+
+**Previous:** [Combining Capabilities](mtl_combining.md)
+**Next:** [Capstone: A Multi-Capability Workflow](transformer_capstone.md)

--- a/hkj-book/src/transformers/eithert_transformer.md
+++ b/hkj-book/src/transformers/eithert_transformer.md
@@ -8,15 +8,21 @@
 The Either inside a Future exists in a place Java's type system cannot natively map to. EitherT creates the map.
 
 ~~~admonish info title="What You'll Learn"
-- How to combine async operations (CompletableFuture) with typed error handling (Either)
+- How to combine async operations (`CompletableFuture`) with typed error handling (`Either`)
 - Building workflows that can fail with specific domain errors while remaining async
-- Using `fromKind`, `fromEither`, and `liftF` to construct EitherT values
+- Using `For` comprehensions to keep witness types localised and the body readable
 - Real-world order processing with validation, inventory checks, and payment processing
-- Why EitherT eliminates "callback hell" in complex async workflows
+- When to use the [`EitherPath`](../effect/path_either.md) Path type instead of raw `EitherT`
 ~~~
 
-~~~ admonish example title="See Example Code:"
+~~~admonish example title="See Example Code"
 [EitherTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java)
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+For most use cases, [`EitherPath<E, A>`](../effect/path_either.md) is the better starting point. It wraps `EitherT` in a fluent API, hides the witness types, and removes the `Kind` widening calls.
+
+Reach for raw `EitherT` only when you need to combine typed errors with a specific outer monad (`CompletableFuture`, `IO`, `VTask`, custom) or when you are writing polymorphic library code that names `MonadError<F, E>`. The [Migration Cookbook](migration_cookbook.md) shows the side-by-side translation.
 ~~~
 
 ---
@@ -26,7 +32,6 @@ The Either inside a Future exists in a place Java's type system cannot natively 
 Consider a typical order processing flow. Each step is asynchronous and can fail with a domain error:
 
 ```java
-// Without EitherT: manual nesting
 CompletableFuture<Either<DomainError, Receipt>> processOrder(OrderData data) {
     return validateOrder(data).thenCompose(eitherValidated ->
         eitherValidated.fold(
@@ -46,22 +51,45 @@ CompletableFuture<Either<DomainError, Receipt>> processOrder(OrderData data) {
 
 Four steps, four levels of nesting, identical error-propagation boilerplate at every level. The actual business logic is buried inside the structure. Add error recovery for a specific step and this becomes nearly unreadable.
 
-## The Solution: EitherT
+---
+
+## The Solution
+
+### With the Effect Path API
+
+The simplest fix is to switch to `EitherPath`. It composes the same way as a transformer but with no witness types in your code:
 
 ```java
-// With EitherT: flat composition
-Kind<W, Receipt> processOrder(OrderData data) {
-    return For.from(eitherTMonad, EitherT.fromKind(validateOrder(data)))
-        .from(validated -> EitherT.fromKind(checkInventory(validated)))
-        .from(inventory -> EitherT.fromKind(processPayment(inventory)))
-        .from(payment -> EitherT.fromKind(createReceipt(payment)))
-        .yield((v, i, p, r) -> r);
+EitherPath<DomainError, Receipt> processOrder(OrderData data) {
+    return Path.either(validateOrder(data))
+        .via(validated -> Path.either(checkInventory(validated)))
+        .via(inventory -> Path.either(processPayment(inventory)))
+        .via(payment   -> Path.either(createReceipt(payment)));
 }
 ```
 
-Same four steps. No manual error propagation. If any step returns `Left`, subsequent steps are skipped automatically. The error type `DomainError` flows through the entire chain.
+Use this whenever the outer monad is one Path already wraps.
 
-### The Railway View
+### With raw `EitherT`
+
+When you need a specific outer monad (here `CompletableFuture`), use `EitherT` with a `For` comprehension:
+
+```java
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var eitherTMonad = new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+
+var workflow = For.from(eitherTMonad, EitherT.fromKind(validateOrder(data)))
+    .from(validated -> EitherT.fromKind(checkInventory(validated)))
+    .from(inventory -> EitherT.fromKind(processPayment(inventory)))
+    .from(payment   -> EitherT.fromKind(createReceipt(payment)))
+    .yield((v, i, p, r) -> r);
+```
+
+Same four steps. No manual error propagation. If any step returns `Left`, subsequent steps are skipped automatically. The witness type appears once, on the `eitherTMonad` declaration.
+
+---
+
+## The Railway View
 
 <pre style="line-height:1.5;font-size:0.95em">
     <span style="color:#4CAF50"><b>Right</b>  ═══●══════════●══════════●══════════●═══▶  Receipt</span>
@@ -107,9 +135,7 @@ Each `flatMap` runs inside the outer monad `F` (e.g. `CompletableFuture`). If th
     └──────────────────────────────────────────────────────────┘
 </pre>
 
-![eithert_transformer.svg](../images/puml/eithert_transformer.svg)
-
-* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`). This monad handles the primary effect.
+* **`F`**: The witness type of the **outer monad** (e.g. `CompletableFutureKind.Witness`). This monad handles the primary effect.
 * **`L`**: The **Left type** of the inner `Either`, typically the error type.
 * **`R`**: The **Right type** of the inner `Either`, typically the success value.
 
@@ -125,24 +151,18 @@ public record EitherT<F, L, R>(@NonNull Kind<F, Either<L, R>> value) {
 The `EitherTMonad<F, L>` class implements `MonadError<EitherTKind.Witness<F, L>, L>`, providing the standard monadic operations for the combined structure. It requires a `Monad<F>` instance for the outer monad:
 
 ```java
-// F = CompletableFutureKind.Witness, L = DomainError
-MonadError<CompletableFutureKind.Witness, Throwable> futureMonad = CompletableFutureMonad.INSTANCE;
-
-MonadError<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, DomainError> eitherTMonad =
-    new EitherTMonad<>(futureMonad);
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var eitherTMonad = new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
 ```
 
-~~~admonish note title="Type Witness and Helpers"
+~~~admonish note title="Working with Kind"
 **Witness Type:** `EitherTKind<F, L, R>` extends `Kind<EitherTKind.Witness<F, L>, R>`. The types `F` and `L` are fixed for a given context; `R` is the variable value type.
 
-**KindHelper:** `EitherTKindHelper` provides `EITHER_T.widen` and `EITHER_T.narrow` for safe conversion between the concrete `EitherT<F, L, R>` and its `Kind` representation.
+**KindHelper:** `EitherTKindHelper` provides `EITHER_T.widen` and `EITHER_T.narrow` for safe conversion between the concrete `EitherT<F, L, R>` and its `Kind` representation. You rarely need them when using `For` comprehensions; they appear at the boundaries when interoperating with raw `flatMap` chains or other `Kind`-returning code.
 
 ```java
-// Widen: concrete → Kind
 Kind<EitherTKind.Witness<F, L>, R> kind = EITHER_T.widen(eitherT);
-
-// Narrow: Kind → concrete
-EitherT<F, L, R> concrete = EITHER_T.narrow(kind);
+EitherT<F, L, R> concrete                = EITHER_T.narrow(kind);
 ```
 ~~~
 
@@ -150,21 +170,121 @@ EitherT<F, L, R> concrete = EITHER_T.narrow(kind);
 
 ## Key Operations
 
-~~~admonish info title="Key Operations with _EitherTMonad_:"
-* **`eitherTMonad.of(value)`:** Lifts a pure value `A` into the `EitherT` context. Result: `F<Right(A)>`.
-* **`eitherTMonad.map(f, eitherTKind)`:** Applies function `A -> B` to the `Right` value inside the nested structure. If `Left`, the error propagates unchanged. Result: `F<Either<L, B>>`.
-* **`eitherTMonad.flatMap(f, eitherTKind)`:** The core sequencing operation. Takes `A -> Kind<EitherTKind.Witness<F, L>, B>`:
-  * If `Left(l)`, propagates `F<Left(l)>` (subsequent steps skipped)
-  * If `Right(a)`, applies `f(a)` to get the next `EitherT<F, L, B>`
-* **`eitherTMonad.raiseError(errorL)`:** Creates an `EitherT` representing a failure. Result: `F<Left(L)>`.
-* **`eitherTMonad.handleErrorWith(eitherTKind, handler)`:** Handles a failure `L` from the inner `Either`. If `Right(a)`, propagates unchanged. If `Left(l)`, applies `handler(l)` to attempt recovery.
+| Operation | Behaviour |
+|-----------|-----------|
+| `eitherTMonad.of(value)`                          | Lifts a pure value into the `EitherT` context as `F<Right(value)>` |
+| `eitherTMonad.map(f, kind)`                       | Applies `A -> B` to the `Right`; `Left` propagates unchanged |
+| `eitherTMonad.flatMap(f, kind)`                   | Sequences operations; `Left` short-circuits the rest |
+| `eitherTMonad.raiseError(error)`                  | Creates `F<Left(error)>` |
+| `eitherTMonad.handleErrorWith(kind, handler)`     | Recovers from a `Left` by applying `handler` |
+
+---
+
+## Creating EitherT Instances
+
+`EitherT` provides several factory methods for different starting points:
+
+```java
+var optMonad = OptionalMonad.INSTANCE;
+
+// 1. From a pure Right value: F<Right(value)>
+var etRight = EitherT.<OptionalKind.Witness, String, String>right(optMonad, "OK");
+
+// 2. From a pure Left value: F<Left(error)>
+var etLeft  = EitherT.<OptionalKind.Witness, String, Integer>left(optMonad, "FAILED");
+
+// 3. From an existing Either: F<input>
+Either<String, String> plainEither = Either.left("FAILED");
+var etFromEither = EitherT.fromEither(optMonad, plainEither);
+
+// 4. Lifting an outer-monad value F<R> into F<Right(R)>
+Kind<OptionalKind.Witness, Integer> outerOptional = OPTIONAL.widen(Optional.of(123));
+var etLiftF = EitherT.<OptionalKind.Witness, String, Integer>liftF(optMonad, outerOptional);
+
+// 5. Wrapping an existing nested Kind F<Either<L, R>>
+Kind<OptionalKind.Witness, Either<String, String>> nestedKind =
+    OPTIONAL.widen(Optional.of(Either.right("OK")));
+var etFromKind = EitherT.fromKind(nestedKind);
+```
+
+`etRight.value()` returns the underlying `Kind<F, Either<L, R>>`, which you narrow back to the outer monad's concrete form when you need the result.
+
+---
+
+## Real-World Example: Async Workflow with Error Handling
+
+~~~admonish example title="Async Workflow with Error Handling"
+
+- [EitherTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java)
+
+**The problem:** validate input, process it asynchronously, and handle domain-specific errors at each step without nested `thenCompose`/`fold` chains.
+
+**The solution:**
+
+```java
+record DomainError(String message) {}
+record ValidatedData(String data) {}
+record ProcessedData(String data) {}
+
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var eitherTMonad = new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+
+// Sync validation returning Either
+Either<DomainError, ValidatedData> validateSync(String input) {
+  return input.isEmpty()
+      ? Either.left(new DomainError("Input empty"))
+      : Either.right(new ValidatedData("Validated:" + input));
+}
+
+// Async processing returning Future<Either>
+Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>>
+    processAsync(ValidatedData vd) {
+  var future = CompletableFuture.supplyAsync(() ->
+      vd.data().contains("fail")
+          ? Either.<DomainError, ProcessedData>left(new DomainError("Processing failed"))
+          : Either.<DomainError, ProcessedData>right(new ProcessedData("Processed:" + vd.data())));
+  return FUTURE.widen(future);
+}
+
+// Compose with For: validate (sync Either) then process (async Future<Either>)
+var workflow = For.from(eitherTMonad, EitherT.fromEither(futureMonad, validateSync(input)))
+    .from(validated -> EitherT.fromKind(processAsync(validated)))
+    .yield((validated, processed) -> processed);
+```
+
+**Why this works:** the `For` comprehension threads each step through `eitherTMonad.flatMap`. The first step lifts a synchronous `Either` into the transformer; the second wraps an existing `Future<Either>`. If validation returns `Left`, processing is skipped and the error propagates through the future.
+~~~
+
+---
+
+## Advanced Example: Error Recovery
+
+~~~admonish example title="Error Recovery"
+
+- [OrderWorkflowRunner.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflowRunner.java)
+
+**The problem:** a shipping step might fail with a temporary error, and you want to recover by using a default shipping option rather than failing the entire workflow.
+
+**The solution:**
+
+```java
+var shipmentAttempt = EitherT.fromKind(steps.createShipmentAsync(orderId, address));
+
+var recoveredShipment = eitherTMonad.handleErrorWith(
+    shipmentAttempt,
+    error -> error instanceof DomainError.ShippingError se && "Temporary Glitch".equals(se.reason())
+        ? eitherTMonad.of(new ShipmentInfo("DEFAULT_SHIPPING_USED"))
+        : eitherTMonad.raiseError(error));
+```
+
+`EitherT` already implements the `Kind` interface, so it can be passed straight to `handleErrorWith` without an explicit widen. The handler only fires when the inner `Either` is `Left`, and the outer `CompletableFuture` context is preserved throughout.
 ~~~
 
 ---
 
 ## Transforming the Outer Monad with `mapT`
 
-Sometimes you need to change the *outer monad* of an `EitherT` without touching the inner `Either` at all. Imagine you have built a pipeline over `CompletableFuture` but now want to continue in a synchronous `Optional` context — or you want to apply a cross-cutting concern (logging, retry) at the monad level.
+Sometimes you need to change the *outer monad* of an `EitherT` without touching the inner `Either` at all. Imagine you have built a pipeline over `CompletableFuture` but now want to continue in a synchronous `Optional` context, or you want to apply a cross-cutting concern (logging, retry) at the monad level.
 
 `mapT` does exactly this. It applies a function to the wrapped `Kind<F, Either<L, R>>` and produces a new `EitherT<G, L, R>`:
 
@@ -181,176 +301,26 @@ Sometimes you need to change the *outer monad* of an `EitherT` without touching 
 ```
 
 ```java
-// Switch from Future to Optional after awaiting a result
 EitherT<CompletableFutureKind.Witness, Error, Data> futureET = ...;
 
-EitherT<OptionalKind.Witness, Error, Data> optionalET =
-    futureET.mapT(futureKind -> {
-      Either<Error, Data> awaited = FUTURE.join(futureKind);
-      return OPTIONAL.widen(Optional.of(awaited));
-    });
+var optionalET = futureET.mapT(futureKind -> {
+  Either<Error, Data> awaited = FUTURE.join(futureKind);
+  return OPTIONAL.widen(Optional.of(awaited));
+});
 ```
 
 ~~~admonish note title="mapT vs map"
 `map` transforms the *value* inside the `Either` (the `R` in `Right(R)`).
-`mapT` transforms the *outer monad* wrapping the `Either` — the `F` in `F<Either<L, R>>`.
+`mapT` transforms the *outer monad* wrapping the `Either`, the `F` in `F<Either<L, R>>`.
 They operate at different levels of the transformer stack.
 ~~~
 
 ---
 
-## Creating EitherT Instances
-
-~~~admonish title="Creating _EitherT_ Instances"
-`EitherT` provides several factory methods for different starting points:
-
-```java
-Monad<OptionalKind.Witness> optMonad = OptionalMonad.INSTANCE;
-
-// 1. From a pure Right value: F<Right(value)>
-EitherT<OptionalKind.Witness, String, String> etRight =
-    EitherT.right(optMonad, "OK");
-
-// 2. From a pure Left value: F<Left(error)>
-EitherT<OptionalKind.Witness, String, Integer> etLeft =
-    EitherT.left(optMonad, "FAILED");
-
-// 3. From an existing Either: F<Either(input)>
-Either<String, String> plainEither = Either.left("FAILED");
-EitherT<OptionalKind.Witness, String, String> etFromEither =
-    EitherT.fromEither(optMonad, plainEither);
-
-// 4. Lifting an outer monad value F<R> → F<Right(R)>
-Kind<OptionalKind.Witness, Integer> outerOptional =
-    OPTIONAL.widen(Optional.of(123));
-EitherT<OptionalKind.Witness, String, Integer> etLiftF =
-    EitherT.liftF(optMonad, outerOptional);
-
-// 5. Wrapping an existing nested Kind F<Either<L, R>>
-Kind<OptionalKind.Witness, Either<String, String>> nestedKind =
-    OPTIONAL.widen(Optional.of(Either.right("OK")));
-EitherT<OptionalKind.Witness, String, String> etFromKind =
-    EitherT.fromKind(nestedKind);
-
-// Accessing the wrapped value:
-Kind<OptionalKind.Witness, Either<String, String>> wrappedValue = etRight.value();
-Optional<Either<String, String>> unwrappedOptional = OPTIONAL.narrow(wrappedValue);
-// → Optional.of(Either.right("OK"))
-```
-~~~
-
----
-
-## Real-World Example: Async Workflow with Error Handling
-
-~~~admonish Example title="Async Workflow with Error Handling"
-
-- [EitherTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/either_t/EitherTExample.java)
-
-**The problem:** You need to validate input, process it asynchronously, and handle domain-specific errors at each step, all without nested `thenCompose`/`fold` chains.
-
-**The solution:**
-
-```java
-public class EitherTExample {
-
-  record DomainError(String message) {}
-  record ValidatedData(String data) {}
-  record ProcessedData(String data) {}
-
-  MonadError<CompletableFutureKind.Witness, Throwable> futureMonad =
-      CompletableFutureMonad.INSTANCE;
-  MonadError<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>,
-      DomainError> eitherTMonad = new EitherTMonad<>(futureMonad);
-
-  // Sync validation returning Either
-  Kind<EitherKind.Witness<DomainError>, ValidatedData> validateSync(String input) {
-    if (input.isEmpty()) {
-      return EITHER.widen(Either.left(new DomainError("Input empty")));
-    }
-    return EITHER.widen(Either.right(new ValidatedData("Validated:" + input)));
-  }
-
-  // Async processing returning Future<Either>
-  Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>>
-      processAsync(ValidatedData vd) {
-    CompletableFuture<Either<DomainError, ProcessedData>> future =
-        CompletableFuture.supplyAsync(() -> {
-          if (vd.data().contains("fail")) {
-            return Either.left(new DomainError("Processing failed"));
-          }
-          return Either.right(new ProcessedData("Processed:" + vd.data()));
-        });
-    return FUTURE.widen(future);
-  }
-
-  Kind<CompletableFutureKind.Witness, Either<DomainError, ProcessedData>>
-      runWorkflow(String input) {
-    // Lift initial value into EitherT
-    var initialET = eitherTMonad.of(input);
-
-    // Step 1: Validate (sync Either → EitherT)
-    var validatedET = eitherTMonad.flatMap(
-        in -> EitherT.fromEither(futureMonad, EITHER.narrow(validateSync(in))),
-        initialET);
-
-    // Step 2: Process (async Future<Either> → EitherT)
-    var processedET = eitherTMonad.flatMap(
-        vd -> EitherT.fromKind(processAsync(vd)),
-        validatedET);
-
-    // Unwrap to get Future<Either>
-    return EITHER_T.narrow(processedET).value();
-  }
-}
-```
-
-**Why this works:** Each step produces an `EitherT` value. The `flatMap` handles both the `CompletableFuture` sequencing and the `Either` error propagation. If validation returns `Left`, processing is skipped entirely. No manual error checking at any point.
-~~~
-
----
-
-## Advanced Example: Error Recovery
-
-~~~admonish Example title="Using _EitherTMonad_ for Sequencing and Error Handling"
-
-- [OrderWorkflowRunner.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflowRunner.java)
-
-**The problem:** A shipping step might fail with a temporary error, and you want to recover by using a default shipping option rather than failing the entire workflow.
-
-**The solution:**
-
-```java
-// Attempt shipment
-Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>,
-    ShipmentInfo> shipmentAttemptET =
-    EitherT.fromKind(steps.createShipmentAsync(orderId, address));
-
-// Recover from specific errors
-Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>,
-    ShipmentInfo> recoveredShipmentET =
-    eitherTMonad.handleErrorWith(
-        shipmentAttemptET,
-        error -> {
-            if (error instanceof DomainError.ShippingError se
-                    && "Temporary Glitch".equals(se.reason())) {
-                // Recoverable: use default shipping
-                return eitherTMonad.of(new ShipmentInfo("DEFAULT_SHIPPING_USED"));
-            } else {
-                // Non-recoverable: re-raise
-                return eitherTMonad.raiseError(error);
-            }
-        });
-```
-
-The `handleErrorWith` only fires when the inner `Either` is `Left`. The outer `CompletableFuture` context is preserved throughout.
-~~~
-
----
-
 ~~~admonish warning title="Common Mistakes"
-- **Mixing up `fromEither` and `fromKind`:** Use `fromEither` when you have a plain `Either<L, R>` (e.g., from a synchronous validation). Use `fromKind` when you have `Kind<F, Either<L, R>>` (e.g., from an async operation that already returns `Future<Either>`).
-- **Forgetting `.value()`:** The final result of an `EitherT` chain is still an `EitherT`. Call `.value()` to extract the underlying `Kind<F, Either<L, R>>` when you need to interact with the outer monad directly.
+- **Mixing up `fromEither` and `fromKind`:** use `fromEither` when you have a plain `Either<L, R>` (e.g. from a synchronous validation). Use `fromKind` when you have `Kind<F, Either<L, R>>` (e.g. from an async operation that already returns `Future<Either>`).
+- **Forgetting `.value()`:** the final result of an `EitherT` chain is still an `EitherT`. Call `.value()` to extract the underlying `Kind<F, Either<L, R>>` when you need to interact with the outer monad directly.
+- **Reaching for the transformer when `EitherPath` would do:** if your outer monad is one Path already wraps, `EitherPath` is shorter, has less ceremony, and reads more naturally. The transformer is the right choice when the outer monad is fixed by an external constraint.
 ~~~
 
 ---
@@ -362,6 +332,9 @@ Without HKT simulation, you would need a separate transformer for each outer mon
 ---
 
 ~~~admonish tip title="See Also"
+- [EitherPath](../effect/path_either.md) - The Path-API equivalent, recommended for most use cases
+- [Stack Archetypes](archetypes.md) - The Service Stack archetype maps directly to `EitherT`/`EitherPath`
+- [Migration Cookbook](migration_cookbook.md) - Side-by-side translations
 - [Monad Transformers](transformers.md) - General concept and choosing the right transformer
 - [OptionalT](optionalt_transformer.md) - When your inner effect is absence rather than typed errors
 - [Either Monad](../monads/either_monad.md) - The underlying Either type
@@ -374,6 +347,11 @@ Without HKT simulation, you would need a separate transformer for each outer mon
 - [Railway Oriented Programming](https://dev.tube/video/fYo3LN9Vf_M) - Scott Wlaschin's classic talk on functional error handling (60 min watch)
 ~~~
 
+~~~admonish info title="Hands-On Learning"
+Practice composing async-and-typed-error workflows in [Tutorial 01: When Path Isn't Enough](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial01_WhenPathIsNotEnough.java) (6 exercises, ~25 minutes).
+~~~
+
+---
 
 **Previous:** [Monad Transformers](transformers.md)
 **Next:** [OptionalT](optionalt_transformer.md)

--- a/hkj-book/src/transformers/maybet_transformer.md
+++ b/hkj-book/src/transformers/maybet_transformer.md
@@ -1,16 +1,29 @@
 # The MaybeT Transformer:
 ## _Functional Optionality Across Monads_
 
+> *"Some things are present, others not."*
+>
+> -- Aristotle, *Categories*
+
+`MaybeT` is the FP-native cousin of `OptionalT`. Same idea, same composition story, slightly different host type, and a slightly cleaner pairing with the rest of Higher-Kinded-J.
+
 ~~~admonish info title="What You'll Learn"
-- How to combine Maybe's optionality with other monadic effects
-- Building workflows where operations might produce Nothing within async contexts
-- Understanding the difference between MaybeT and OptionalT
-- Using `just`, `nothing`, and `fromMaybe` to construct MaybeT values
-- Handling Nothing states with Unit as the error type in MonadError
+- How to combine `Maybe`'s optionality with other monadic effects
+- Building workflows where operations might produce `Nothing` within async contexts
+- Understanding the difference between `MaybeT` and `OptionalT`
+- Using `For` comprehensions to keep witness types localised
+- Using `just`, `nothing`, `fromMaybe`, `liftF`, and `fromKind` to construct `MaybeT` values
+- When to use the [`MaybePath`](../effect/path_maybe.md) Path type instead of raw `MaybeT`
 ~~~
 
-~~~ admonish example title="See Example Code:"
+~~~admonish example title="See Example Code"
 [MaybeTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/maybe_t/MaybeTExample.java)
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+For most use cases, [`MaybePath<A>`](../effect/path_maybe.md) is the better starting point. It wraps `MaybeT` in a fluent API, hides the witness types, and removes the `Kind` widening calls.
+
+Reach for raw `MaybeT` only when you need to combine absence with a specific outer monad (`CompletableFuture`, `IO`, `VTask`, custom) or when you are writing polymorphic library code that names `MonadError<F, Unit>`.
 ~~~
 
 ---
@@ -20,7 +33,6 @@
 When an async lookup returns `Maybe` rather than `Optional`, you face the same nesting problem:
 
 ```java
-// Without MaybeT: manual nesting
 CompletableFuture<Maybe<UserPreferences>> getPreferences(String userId) {
     return fetchUserAsync(userId).thenCompose(maybeUser ->
         maybeUser.fold(
@@ -36,24 +48,35 @@ CompletableFuture<Maybe<UserPreferences>> getPreferences(String userId) {
 
 Each step requires folding over the `Maybe`, providing a `Nothing` fallback wrapped in a completed future, and nesting deeper. The pattern is identical to the `Optional` case but uses `Maybe`'s API.
 
-## The Solution: MaybeT
+---
+
+## The Solution
+
+### With the Effect Path API
 
 ```java
-// With MaybeT: flat composition
-Kind<MaybeTKind.Witness<CompletableFutureKind.Witness>, UserPreferences>
-    getPreferences(String userId) {
-
-  var userMT = MAYBE_T.widen(MaybeT.fromKind(fetchUserAsync(userId)));
-
-  return maybeTMonad.flatMap(user ->
-      MAYBE_T.widen(MaybeT.fromKind(fetchPreferencesAsync(user.id()))),
-      userMT);
+MaybePath<UserPreferences> getPreferences(String userId) {
+    return Path.maybe(fetchUserAsync(userId))
+        .via(user -> Path.maybe(fetchPreferencesAsync(user.id())));
 }
+```
+
+### With raw `MaybeT`
+
+```java
+var futureMonad = CompletableFutureMonad.INSTANCE;
+var maybeTMonad = new MaybeTMonad<CompletableFutureKind.Witness>(futureMonad);
+
+var prefs = For.from(maybeTMonad, MaybeT.fromKind(fetchUserAsync(userId)))
+    .from(user -> MaybeT.fromKind(fetchPreferencesAsync(user.id())))
+    .yield((user, prefs) -> prefs);
 ```
 
 If `fetchUserAsync` returns `Nothing`, the preferences lookup is skipped entirely. No manual folding, no fallback wrapping.
 
-### The Railway View
+---
+
+## The Railway View
 
 <pre style="line-height:1.5;font-size:0.95em">
     <span style="color:#4CAF50"><b>Just</b>     ═══●═══════════════●═══════════════════▶  UserPreferences</span>
@@ -70,7 +93,7 @@ If `fetchUserAsync` returns `Nothing`, the preferences lookup is skipped entirel
     <span style="color:#4CAF50">                                ●═══▶  default UserPreferences</span>
 </pre>
 
-Each `flatMap` runs inside the outer monad `F` (e.g. `CompletableFuture`). If the inner `Maybe` is `Nothing`, subsequent steps are skipped. `handleErrorWith` can provide a fallback value when the chain yields nothing.
+Each `flatMap` runs inside the outer monad `F`. If the inner `Maybe` is `Nothing`, subsequent steps are skipped. `handleErrorWith` can provide a fallback value when the chain yields nothing.
 
 ---
 
@@ -99,9 +122,7 @@ Each `flatMap` runs inside the outer monad `F` (e.g. `CompletableFuture`). If th
     └──────────────────────────────────────────────────────────┘
 </pre>
 
-![maybet_transformer.svg](../images/puml/maybet_transformer.svg)
-
-* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`, `ListKind.Witness`).
+* **`F`**: The witness type of the **outer monad** (e.g. `CompletableFutureKind.Witness`, `ListKind.Witness`).
 * **`A`**: The type of the value potentially held by the inner `Maybe`.
 
 ```java
@@ -116,20 +137,18 @@ public record MaybeT<F, A>(@NonNull Kind<F, Maybe<A>> value) {
 The `MaybeTMonad<F>` class implements `MonadError<MaybeTKind.Witness<F>, Unit>`. Like `OptionalTMonad`, the error type is `Unit`, signifying that `Nothing` carries no information beyond its occurrence.
 
 ```java
-Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-
-MonadError<MaybeTKind.Witness<CompletableFutureKind.Witness>, Unit> maybeTMonad =
-    new MaybeTMonad<>(futureMonad);
+var futureMonad = CompletableFutureMonad.INSTANCE;
+var maybeTMonad = new MaybeTMonad<CompletableFutureKind.Witness>(futureMonad);
 ```
 
-~~~admonish note title="Type Witness and Helpers"
+~~~admonish note title="Working with Kind"
 **Witness Type:** `MaybeTKind<F, A>` extends `Kind<MaybeTKind.Witness<F>, A>`. The outer monad `F` is fixed; `A` is the variable value type.
 
-**KindHelper:** `MaybeTKindHelper` provides `MAYBE_T.widen` and `MAYBE_T.narrow` for safe conversion between `MaybeT<F, A>` and its `Kind` representation.
+**KindHelper:** `MaybeTKindHelper` provides `MAYBE_T.widen` and `MAYBE_T.narrow` for safe conversion. With `For` comprehensions you rarely need them; they appear at the boundaries when interoperating with raw `flatMap` chains.
 
 ```java
 Kind<MaybeTKind.Witness<F>, A> kind = MAYBE_T.widen(maybeT);
-MaybeT<F, A> concrete = MAYBE_T.narrow(kind);
+MaybeT<F, A> concrete                = MAYBE_T.narrow(kind);
 ```
 ~~~
 
@@ -137,19 +156,77 @@ MaybeT<F, A> concrete = MAYBE_T.narrow(kind);
 
 ## Key Operations
 
-~~~admonish info title="Key Operations with _MaybeTMonad_:"
-* **`maybeTMonad.of(value)`:** Lifts a nullable value `A` into `MaybeT`. Result: `F<Maybe.fromNullable(value)>`.
-* **`maybeTMonad.map(f, maybeTKind)`:** Applies `A -> B` to the `Just` value. If `f` returns `null`, it propagates `F<Nothing>`. Result: `F<Maybe<B>>`.
-* **`maybeTMonad.flatMap(f, maybeTKind)`:** Sequences operations. If `Just(a)`, applies `f(a)` to get the next `MaybeT`. If `Nothing`, short-circuits to `F<Nothing>`.
-* **`maybeTMonad.raiseError(Unit.INSTANCE)`:** Creates `MaybeT` representing `F<Nothing>`.
-* **`maybeTMonad.handleErrorWith(maybeTKind, handler)`:** Recovers from `Nothing`. The handler `Unit -> Kind<MaybeTKind.Witness<F>, A>` is invoked with `Unit.INSTANCE`.
+| Operation | Behaviour |
+|-----------|-----------|
+| `maybeTMonad.of(value)`                          | Lifts a nullable value as `F<Maybe.fromNullable(value)>` |
+| `maybeTMonad.map(f, kind)`                       | Applies `A -> B` to the `Just` value; `null` propagates as `Nothing` |
+| `maybeTMonad.flatMap(f, kind)`                   | Sequences operations; `Nothing` short-circuits the rest |
+| `maybeTMonad.raiseError(Unit.INSTANCE)`          | Creates `F<Nothing>` |
+| `maybeTMonad.handleErrorWith(kind, handler)`     | Recovers from `Nothing` by applying `handler` |
+
+---
+
+## Creating MaybeT Instances
+
+```java
+var optMonad = OptionalMonad.INSTANCE;
+
+// 1. From a non-null value: F<Just(value)>
+var mtJust = MaybeT.just(optMonad, "Hello");
+
+// 2. Nothing state: F<Nothing>
+var mtNothing = MaybeT.<OptionalKind.Witness, String>nothing(optMonad);
+
+// 3. From a plain Maybe: F<Maybe(input)>
+var mtFromMaybe = MaybeT.fromMaybe(optMonad, Maybe.just(123));
+
+// 4. Lifting F<A> into MaybeT (using fromNullable)
+Kind<OptionalKind.Witness, String> outerOptional = OPTIONAL.widen(Optional.of("World"));
+var mtLiftF = MaybeT.liftF(optMonad, outerOptional);
+
+// 5. Wrapping an existing F<Maybe<A>>
+Kind<OptionalKind.Witness, Maybe<String>> nestedKind =
+    OPTIONAL.widen(Optional.of(Maybe.just("Present")));
+var mtFromKind = MaybeT.fromKind(nestedKind);
+```
+
+`mtJust.value()` returns the underlying `Kind<F, Maybe<A>>`, which you narrow back to the concrete outer monad form when you need the result.
+
+---
+
+## Real-World Example: Async Resource Fetching
+
+~~~admonish example title="Asynchronous Optional Resource Fetching"
+
+**The problem:** fetch a user asynchronously, and if found, fetch their preferences. Each step might return `Nothing`. Compose without manual `Maybe.fold` at every step.
+
+**The solution:**
+
+```java
+var futureMonad = CompletableFutureMonad.INSTANCE;
+var maybeTMonad = new MaybeTMonad<CompletableFutureKind.Witness>(futureMonad);
+
+// Service stubs return Future<Maybe<T>>
+Kind<CompletableFutureKind.Witness, Maybe<User>> fetchUserAsync(String userId) {
+    return FUTURE.widen(CompletableFuture.supplyAsync(() ->
+        "user123".equals(userId) ? Maybe.just(new User(userId, "Alice"))
+                                 : Maybe.nothing()));
+}
+
+// Workflow: user -> preferences
+var preferences = For.from(maybeTMonad, MaybeT.fromKind(fetchUserAsync(userId)))
+    .from(user -> MaybeT.fromKind(fetchPreferencesAsync(user.id())))
+    .yield((user, prefs) -> prefs);
+```
+
+**Why this works:** the `from` lambda only executes if the user was found (`Just`). If `fetchUserAsync` returns `Nothing`, the entire chain short-circuits to `Future<Nothing>`.
 ~~~
 
 ---
 
 ## Transforming the Outer Monad with `mapT`
 
-Sometimes you need to change the *outer monad* of a `MaybeT` without touching the inner `Maybe` at all. Perhaps you have an `IO`-based pipeline but want to switch to a `Task` for structured concurrency, or you want to collapse two layers of optionality by moving from `Optional<Maybe<A>>` to `Id<Maybe<A>>`.
+Sometimes you need to change the *outer monad* of a `MaybeT` without touching the inner `Maybe`. Perhaps you have an `IO`-based pipeline but want to switch to a `Task` for structured concurrency, or you want to collapse two layers of optionality by moving from `Optional<Maybe<A>>` to `Id<Maybe<A>>`.
 
 `mapT` applies a function to the wrapped `Kind<F, Maybe<A>>` and produces a new `MaybeT<G, A>`:
 
@@ -166,98 +243,18 @@ Sometimes you need to change the *outer monad* of a `MaybeT` without touching th
 ```
 
 ```java
-// Collapse Optional<Maybe<A>> into Id<Maybe<A>>
 MaybeT<OptionalKind.Witness, String> optMt = MaybeT.just(optMonad, "Hello");
 
-MaybeT<IdKind.Witness, String> idMt =
-    optMt.mapT(optKind -> {
-      Optional<Maybe<String>> opt = OPTIONAL.narrow(optKind);
-      return ID.widen(Id.of(opt.orElse(Maybe.nothing())));
-    });
+var idMt = optMt.mapT(optKind -> {
+  Optional<Maybe<String>> opt = OPTIONAL.narrow(optKind);
+  return ID.widen(Id.of(opt.orElse(Maybe.nothing())));
+});
 ```
 
 ~~~admonish note title="mapT vs map"
 `map` transforms the *value* inside the `Maybe` (the `A` in `Just(A)`).
-`mapT` transforms the *outer monad* wrapping the `Maybe` — the `F` in `F<Maybe<A>>`.
+`mapT` transforms the *outer monad* wrapping the `Maybe`, the `F` in `F<Maybe<A>>`.
 They operate at different levels of the transformer stack.
-~~~
-
----
-
-## Creating MaybeT Instances
-
-~~~admonish title="Creating _MaybeT_ Instances"
-```java
-Monad<OptionalKind.Witness> optMonad = OptionalMonad.INSTANCE;
-
-// 1. From a non-null value: F<Just(value)>
-MaybeT<OptionalKind.Witness, String> mtJust = MaybeT.just(optMonad, "Hello");
-
-// 2. Nothing state: F<Nothing>
-MaybeT<OptionalKind.Witness, String> mtNothing = MaybeT.nothing(optMonad);
-
-// 3. From a plain Maybe: F<Maybe(input)>
-MaybeT<OptionalKind.Witness, Integer> mtFromMaybe =
-    MaybeT.fromMaybe(optMonad, Maybe.just(123));
-
-// 4. Lifting F<A> into MaybeT (using fromNullable)
-Kind<OptionalKind.Witness, String> outerOptional =
-    OPTIONAL.widen(Optional.of("World"));
-MaybeT<OptionalKind.Witness, String> mtLiftF = MaybeT.liftF(optMonad, outerOptional);
-
-// 5. Wrapping an existing F<Maybe<A>>
-Kind<OptionalKind.Witness, Maybe<String>> nestedKind =
-    OPTIONAL.widen(Optional.of(Maybe.just("Present")));
-MaybeT<OptionalKind.Witness, String> mtFromKind = MaybeT.fromKind(nestedKind);
-
-// Accessing the wrapped value:
-Kind<OptionalKind.Witness, Maybe<String>> wrappedValue = mtJust.value();
-Optional<Maybe<String>> unwrappedOptional = OPTIONAL.narrow(wrappedValue);
-// → Optional.of(Maybe.just("Hello"))
-```
-~~~
-
----
-
-## Real-World Example: Async Resource Fetching
-
-~~~admonish Example title="Asynchronous Optional Resource Fetching"
-
-**The problem:** You need to fetch a user asynchronously, and if found, fetch their preferences. Each step might return `Nothing`. You want clean composition without manual `Maybe.fold` at every step.
-
-**The solution:**
-
-```java
-Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-MonadError<MaybeTKind.Witness<CompletableFutureKind.Witness>, Unit> maybeTMonad =
-    new MaybeTMonad<>(futureMonad);
-
-// Service stubs return Future<Maybe<T>>
-Kind<CompletableFutureKind.Witness, Maybe<User>> fetchUserAsync(String userId) {
-    return FUTURE.widen(CompletableFuture.supplyAsync(() ->
-        "user123".equals(userId) ? Maybe.just(new User(userId, "Alice"))
-                                 : Maybe.nothing()));
-}
-
-// Workflow: user → preferences
-Kind<CompletableFutureKind.Witness, Maybe<UserPreferences>>
-    getUserPreferencesWorkflow(String userId) {
-
-  var userMT = MAYBE_T.widen(MaybeT.fromKind(fetchUserAsync(userId)));
-
-  var preferencesMT = maybeTMonad.flatMap(
-      user -> {
-          System.out.println("User found: " + user.name());
-          return MAYBE_T.widen(MaybeT.fromKind(fetchPreferencesAsync(user.id())));
-      },
-      userMT);
-
-  // Unwrap to get Future<Maybe<UserPreferences>>
-  return MAYBE_T.narrow(preferencesMT).value();
-}
-```
-
-**Why this works:** The `flatMap` lambda only executes if the user was found (`Just`). If `fetchUserAsync` returns `Nothing`, the entire chain short-circuits to `Future<Nothing>`.
 ~~~
 
 ---
@@ -284,20 +281,24 @@ Both `MaybeT` and `OptionalT` combine optionality with other effects. The functi
 - Your team is more comfortable with standard Java types
 - You're wrapping external libraries that return `Optional`
 
-**In practice:** Choose whichever matches your existing codebase. Both offer equivalent functionality through their `MonadError` instances.
+In practice, choose whichever matches your existing codebase. Both offer equivalent functionality through their `MonadError` instances.
 
 ---
 
 ~~~admonish warning title="Common Mistakes"
-- **Confusing Maybe.nothing() with null:** `MaybeT.of(null)` will use `Maybe.fromNullable(null)`, which produces `Nothing`. Be explicit about intent; use `MaybeT.nothing(monad)` when you mean absence.
-- **Using MaybeT when you need error information:** `Nothing` carries no reason for the absence. If you need to know *why* a value is missing, use `EitherT` with a descriptive error type instead.
+- **Confusing `Maybe.nothing()` with null:** `MaybeT.of(null)` will use `Maybe.fromNullable(null)`, which produces `Nothing`. Be explicit about intent; use `MaybeT.nothing(monad)` when you mean absence.
+- **Using `MaybeT` when you need error information:** `Nothing` carries no reason for the absence. If you need to know *why* a value is missing, use [`EitherT`](eithert_transformer.md) with a descriptive error type instead.
+- **Reaching for the transformer when `MaybePath` would do:** if your outer monad is one Path already wraps, `MaybePath` is shorter, has less ceremony, and reads more naturally.
 ~~~
 
 ---
 
 ~~~admonish tip title="See Also"
+- [MaybePath](../effect/path_maybe.md) - The Path-API equivalent, recommended for most use cases
+- [Stack Archetypes](archetypes.md) - The Lookup Stack archetype maps to `MaybeT`/`MaybePath`
+- [Migration Cookbook](migration_cookbook.md) - Side-by-side translations
 - [Monad Transformers](transformers.md) - General concept and choosing the right transformer
-- [OptionalT](optionalt_transformer.md) - Equivalent functionality for java.util.Optional
+- [OptionalT](optionalt_transformer.md) - Equivalent functionality for `java.util.Optional`
 - [EitherT](eithert_transformer.md) - When you need typed errors, not just absence
 - [Maybe Monad](../monads/maybe_monad.md) - The underlying Maybe type
 ~~~
@@ -308,6 +309,11 @@ Both `MaybeT` and `OptionalT` combine optionality with other effects. The functi
 - [Null Handling Patterns in Modern Java](https://www.baeldung.com/java-avoid-null-check) - Comprehensive guide to null safety (15 min read)
 ~~~
 
+~~~admonish info title="Hands-On Learning"
+The MaybeT exercise lives alongside the OptionalT exercises in [Tutorial 02: Async with Absence](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial02_AsyncWithAbsence.java) (5 exercises, ~25 minutes).
+~~~
+
+---
 
 **Previous:** [OptionalT](optionalt_transformer.md)
 **Next:** [ReaderT](readert_transformer.md)

--- a/hkj-book/src/transformers/migration_cookbook.md
+++ b/hkj-book/src/transformers/migration_cookbook.md
@@ -1,0 +1,321 @@
+# Migration Cookbook
+
+Side-by-side translations from imperative Java and the Effect Path API into raw monad transformers. Use this page when you have a working solution in one form and need to express it as a transformer stack, typically because you need a different outer monad or because you are writing polymorphic library code.
+
+~~~admonish info title="What You'll Learn"
+- Recipes for moving from nested `thenCompose` chains to `EitherT`, `OptionalT`, and `MaybeT`
+- How to migrate manual configuration threading to `ReaderT`
+- How to migrate manual log threading to `WriterT`
+- How to migrate manual state threading to `StateT`
+- When the Effect Path API is the better destination and when the raw transformer is unavoidable
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+Most readers should migrate to the [Effect Path API](../effect/ch_intro.md) first. The Path types wrap these transformers in a fluent interface that hides the witness types and `Kind` widening. Reach for the raw transformer only when you need a different outer monad (`CompletableFuture`, `IO`, custom) or when you are writing polymorphic code that names an MTL capability.
+~~~
+
+---
+
+## Imperative to Transformer
+
+### Recipe 1: Nested `thenCompose` with `Either`
+
+**The problem:** an async pipeline whose steps can fail with typed domain errors. Without a transformer, every step needs a manual `Either.fold` to propagate the error.
+
+**Before:**
+
+```java
+CompletableFuture<Either<DomainError, Receipt>> processOrder(OrderData data) {
+    return validateOrder(data).thenCompose(eitherValidated ->
+        eitherValidated.fold(
+            error -> CompletableFuture.completedFuture(Either.left(error)),
+            validated -> checkInventory(validated).thenCompose(eitherInventory ->
+                eitherInventory.fold(
+                    error -> CompletableFuture.completedFuture(Either.left(error)),
+                    inventory -> processPayment(inventory)))));
+}
+```
+
+**After (Effect Path API):**
+
+```java
+EitherPath<DomainError, Receipt> processOrder(OrderData data) {
+    return Path.either(validateOrder(data))
+        .via(validated -> Path.either(checkInventory(validated)))
+        .via(inventory -> Path.either(processPayment(inventory)));
+}
+```
+
+**After (raw `EitherT`, when you must keep `CompletableFuture` as the outer monad):**
+
+```java
+var eitherTMonad = new EitherTMonad<CompletableFutureKind.Witness, DomainError>(futureMonad);
+
+var workflow = For.from(eitherTMonad, EitherT.fromKind(validateOrder(data)))
+    .from(validated -> EitherT.fromKind(checkInventory(validated)))
+    .from(inventory -> EitherT.fromKind(processPayment(inventory)))
+    .yield((v, i, r) -> r);
+```
+
+**Why this works:** `EitherT` runs each `flatMap` inside the outer monad and routes on the inner `Either`. A `Left` short-circuits the rest of the comprehension; a `Right` feeds into the next step.
+
+---
+
+### Recipe 2: Nested `Optional` lookups
+
+**The problem:** chained lookups where any step might return nothing. Manual nesting forces an `orElse(CompletableFuture.completedFuture(Optional.empty()))` at every level.
+
+**Before:**
+
+```java
+CompletableFuture<Optional<UserPreferences>> getPreferences(String userId) {
+    return fetchUserAsync(userId).thenCompose(optUser ->
+        optUser.map(user ->
+            fetchProfileAsync(user.id()).thenCompose(optProfile ->
+                optProfile.map(profile ->
+                    fetchPrefsAsync(profile.userId())
+                ).orElse(CompletableFuture.completedFuture(Optional.empty()))
+            )
+        ).orElse(CompletableFuture.completedFuture(Optional.empty())));
+}
+```
+
+**After (Effect Path API):**
+
+```java
+OptionalPath<UserPreferences> getPreferences(String userId) {
+    return Path.optional(fetchUserAsync(userId))
+        .via(user -> Path.optional(fetchProfileAsync(user.id())))
+        .via(profile -> Path.optional(fetchPrefsAsync(profile.userId())));
+}
+```
+
+**After (raw `OptionalT`):**
+
+```java
+var optionalTMonad = new OptionalTMonad<CompletableFutureKind.Witness>(futureMonad);
+
+var prefsLookup = For.from(optionalTMonad, OptionalT.fromKind(fetchUserAsync(userId)))
+    .from(user    -> OptionalT.fromKind(fetchProfileAsync(user.id())))
+    .from(profile -> OptionalT.fromKind(fetchPrefsAsync(profile.userId())))
+    .yield((user, profile, prefs) -> prefs);
+```
+
+**Why this works:** an empty `Optional` short-circuits the rest of the chain. The transformer hides the per-step fallback wiring.
+
+---
+
+### Recipe 3: Threading configuration through every signature
+
+**The problem:** every function in a chain needs the same `AppConfig`. The parameter clutters every signature and every call site.
+
+**Before:**
+
+```java
+CompletableFuture<ServiceData> fetchData(AppConfig config, String itemId) { ... }
+CompletableFuture<ProcessedData> processData(AppConfig config, ServiceData data) { ... }
+
+CompletableFuture<ProcessedData> workflow(AppConfig config) {
+    return fetchData(config, "item-123")
+        .thenCompose(data -> processData(config, data));
+}
+```
+
+**After (Effect Path API):**
+
+```java
+ReaderPath<AppConfig, ProcessedData> workflow() {
+    return Path.<AppConfig>ask()
+        .via(config -> Path.right(fetchData(config, "item-123")))
+        .via(data   -> Path.<AppConfig>ask().map(config -> processData(config, data)));
+}
+```
+
+**After (raw `ReaderT`, when you must combine the environment with `CompletableFuture`):**
+
+```java
+var readerT = new ReaderTMonad<CompletableFutureKind.Witness, AppConfig>(futureMonad);
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData>
+    fetchDataRT(String itemId) {
+  return ReaderT.of(config -> FUTURE.widen(
+      CompletableFuture.supplyAsync(() -> callApi(config.apiKey(), itemId))));
+}
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData>
+    processDataRT(ServiceData data) {
+  return ReaderT.reader(futureMonad, config -> transform(data, config));
+}
+```
+
+**Why this works:** `ReaderT` wraps the function `R -> Kind<F, A>`. The environment threads through `flatMap` automatically, and you supply it once when you call `.run().apply(config)`.
+
+---
+
+### Recipe 4: Manual log threading
+
+**The problem:** every step in a pipeline must record an audit entry. Without a transformer the log either lives as a mutable side channel (easy to forget) or threads through every signature alongside the value.
+
+**Before:**
+
+```java
+Pair<BigDecimal, List<String>> applyDiscount(BigDecimal price, List<String> log) {
+    var newLog = new ArrayList<>(log);
+    newLog.add("Applied 10% discount");
+    return Pair.of(price.multiply(new BigDecimal("0.9")), newLog);
+}
+
+Pair<BigDecimal, List<String>> addShipping(BigDecimal price, List<String> log) {
+    var newLog = new ArrayList<>(log);
+    newLog.add("Added shipping");
+    return Pair.of(price.add(new BigDecimal("5.00")), newLog);
+}
+```
+
+**After (Effect Path API):**
+
+```java
+WriterPath<List<AuditEntry>, BigDecimal> workflow(BigDecimal price) {
+    return WriterPath.<List<AuditEntry>, BigDecimal>writer(
+            price.multiply(new BigDecimal("0.9")),
+            List.of(new AuditEntry("Applied 10% discount")),
+            auditMonoid)
+        .via(discounted -> WriterPath.writer(
+            discounted.add(new BigDecimal("5.00")),
+            List.of(new AuditEntry("Added shipping")),
+            auditMonoid));
+}
+```
+
+**After (raw `WriterT`):**
+
+```java
+var listMonoid  = Monoids.list();
+var writerMonad = new WriterTMonad<IdKind.Witness, List<String>>(IdMonad.instance(), listMonoid);
+
+var workflow = For.from(writerMonad, writerMonad.tell(List.of("Applied 10% discount")))
+    .from(_ -> writerMonad.of(new BigDecimal("90.00")))
+    .from(p -> writerMonad.tell(List.of("Added shipping")))
+    .yield((_, price, _) -> price.add(new BigDecimal("5.00")));
+```
+
+**Why this works:** the `Monoid` combines successive logs automatically; `flatMap` does the rest. No step can forget to thread the log forward.
+
+---
+
+### Recipe 5: Manual state threading
+
+**The problem:** stateful operations where the state is also wrapped in another effect. Manual threading makes it easy to use stale state and easy to forget the optionality / error layer.
+
+**Before:**
+
+```java
+Optional<StateTuple<List<Integer>, Integer>> workflow(List<Integer> initial) {
+    var afterPush1 = push(initial, 10);
+    var afterPush2 = push(afterPush1.state(), 20);
+    var pop1 = pop(afterPush2.state());
+    if (pop1.isEmpty()) return Optional.empty();
+    var pop2 = pop(pop1.get().state());
+    if (pop2.isEmpty()) return Optional.empty();
+    int sum = pop1.get().value() + pop2.get().value();
+    return Optional.of(StateTuple.of(pop2.get().state(), sum));
+}
+```
+
+**After (Effect Path API, when no other effect is required):**
+
+```java
+WithStatePath<List<Integer>, Integer> workflow() {
+    return WithStatePath.<List<Integer>>modify(s -> prepend(s, 10))
+        .then(() -> WithStatePath.modify(s -> prepend(s, 20)))
+        .then(() -> WithStatePath.<List<Integer>>get())
+        .map(state -> state.get(0) + state.get(1));
+}
+```
+
+**After (raw `StateT`, when state must combine with another effect):**
+
+```java
+var stateTMonad = StateTMonad.<List<Integer>, OptionalKind.Witness>instance(OptionalMonad.INSTANCE);
+
+var workflow = For.from(stateTMonad, push(10))
+    .from(_ -> push(20))
+    .from(_ -> pop())
+    .from(_ -> pop())
+    .yield((_, _, p1, p2) -> p1 + p2);
+```
+
+**Why this works:** `StateT` threads the updated state into the next step automatically. The outer `Optional` short-circuits the whole computation when `pop` fails.
+
+---
+
+## From Effect Path API to Transformer
+
+The Path types are the recommended starting point. You only drop down to a raw transformer when one of these signals applies:
+
+- **The outer monad is wrong.** Path types choose their outer monad for you. If your stack needs to live inside `CompletableFuture`, `IO`, `VTask`, or a third-party monad that Path does not wrap, the transformer gives you that choice.
+- **You are writing a polymorphic library.** Code that names an MTL capability (`MonadReader`, `MonadState`, `MonadWriter`) works with any stack the caller provides. Path types are concrete and do not abstract over the outer monad.
+- **You need to interoperate with `Kind<F, ...>` directly.** If a downstream API or type class instance already exposes `Kind`, the transformer's `Kind` form is the natural meeting point.
+
+If none of these apply, stay with the Path type.
+
+### Path-to-Transformer Translation Table
+
+| Path Operation | Transformer Equivalent |
+|----------------|------------------------|
+| `Path.right(value)`              | `EitherT.right(monad, value)` |
+| `Path.left(error)`               | `EitherT.left(monad, error)` |
+| `Path.maybe(value)` (`Just`)     | `MaybeT.just(monad, value)` |
+| `Path.maybe(value)` (`Nothing`)  | `MaybeT.nothing(monad)` |
+| `Path.optional(opt)`             | `OptionalT.fromOptional(monad, opt)` |
+| `Path.<R>ask()`                  | `ReaderT.ask(monad)` |
+| `path.via(f)`                    | `monad.flatMap(f, kind)` (typically inside `For`) |
+| `path.map(f)`                    | `monad.map(f, kind)` |
+| `path.recoverWith(f)`            | `monad.handleErrorWith(kind, f)` |
+| `WithStatePath.modify(f)`        | `StateT.create(s -> ..., monad)` |
+| `WriterPath.writer(v, w, mon)`   | `WriterT.writer(monad, v, w)` |
+
+---
+
+## Migration Decision Tree
+
+```
+                   ┌────────────────────────────────────┐
+                   │  Is the outer monad fixed and one  │
+                   │  the Path API already wraps?       │
+                   └──────────┬─────────────────────────┘
+                              │
+                  ┌───────────┴───────────┐
+                  │                       │
+                 Yes                      No
+                  │                       │
+                  ▼                       ▼
+           Use the Path type     ┌────────────────────────┐
+           directly.             │  Are you writing       │
+                                 │  polymorphic library   │
+                                 │  code?                 │
+                                 └──────────┬─────────────┘
+                                            │
+                                ┌───────────┴───────────┐
+                                │                       │
+                               Yes                      No
+                                │                       │
+                                ▼                       ▼
+                         Use the matching        Use the raw
+                         MTL capability          transformer with
+                         (MonadReader, ...).     For comprehension.
+```
+
+---
+
+~~~admonish tip title="See Also"
+- [Quickstart](quickstart.md) -- three runnable examples in 150 lines
+- [Stack Archetypes](archetypes.md) -- named patterns for common composition problems
+- [Effect Path Migration Cookbook](../effect/migration_cookbook.md) -- imperative-to-Path migrations (read this first)
+- [MTL Capabilities](mtl_capabilities.md) -- when to write polymorphic code instead of using a concrete transformer
+~~~
+
+---
+
+**Previous:** [Transformers at a Glance](transformers_at_a_glance.md)
+**Next:** [Stack Archetypes](archetypes.md)

--- a/hkj-book/src/transformers/mtl_capabilities.md
+++ b/hkj-book/src/transformers/mtl_capabilities.md
@@ -27,7 +27,7 @@ That is what MTL-style capability interfaces do. They separate the declaration o
 Consider a function that reads a URL from configuration and fetches a user profile:
 
 ```java
-// Locked to ReaderT over CompletableFuture — cannot be reused with IO, Id, or VTask
+// Locked to ReaderT over CompletableFuture; cannot be reused with IO, Id, or VTask
 ReaderT<CompletableFutureKind.Witness, AppConfig, UserProfile>
     fetchProfile(String userId) {
   return ReaderT.of(config ->
@@ -131,23 +131,20 @@ MTL adds a layer of abstraction. If your entire application uses a single transf
 ---
 
 ~~~admonish info title="In This Section"
-- **[MonadReader](mtl_reader.md)** -- Read-only environment access. Inject configuration, database URLs, API keys, and other dependencies without threading parameters through every function.
-
-- **[MonadState](mtl_state.md)** -- Mutable state management. Read and update state as a computation progresses, with automatic state threading through `flatMap` chains.
-
-- **[MonadWriter](mtl_writer.md)** -- Append-only output accumulation. Build audit trails, diagnostic logs, and computation summaries that travel with the result.
-
-- **[Combining Capabilities](mtl_combining.md)** -- Using multiple MTL interfaces together. Concrete instances, ForState integration, and practical patterns for multi-capability functions.
+- **[MonadReader](mtl_reader.md)** – Read-only environment access. Inject configuration, database URLs, API keys, and other dependencies without threading parameters through every function.
+- **[MonadState](mtl_state.md)** – Mutable state management. Read and update state as a computation progresses, with automatic state threading through `flatMap` chains.
+- **[MonadWriter](mtl_writer.md)** – Append-only output accumulation. Build audit trails, diagnostic logs, and computation summaries that travel with the result.
+- **[Combining Capabilities](mtl_combining.md)** – Using multiple MTL interfaces together. Concrete instances, ForState integration, and practical patterns for multi-capability functions.
 ~~~
 
 ---
 
 ## Section Contents
 
-1. [MonadReader](mtl_reader.md) -- Environment access and scoped modification
-2. [MonadState](mtl_state.md) -- State threading and mutation
-3. [MonadWriter](mtl_writer.md) -- Output accumulation and log inspection
-4. [Combining Capabilities](mtl_combining.md) -- Multi-capability functions and concrete instances
+1. [MonadReader](mtl_reader.md) - Environment access and scoped modification
+2. [MonadState](mtl_state.md) - State threading and mutation
+3. [MonadWriter](mtl_writer.md) - Output accumulation and log inspection
+4. [Combining Capabilities](mtl_combining.md) - Multi-capability functions and concrete instances
 
 ---
 

--- a/hkj-book/src/transformers/mtl_combining.md
+++ b/hkj-book/src/transformers/mtl_combining.md
@@ -203,3 +203,4 @@ record LogConfig(boolean verbose) {}
 ---
 
 **Previous:** [MonadWriter](mtl_writer.md)
+**Next:** [Common Compiler Errors](common_errors.md)

--- a/hkj-book/src/transformers/optionalt_transformer.md
+++ b/hkj-book/src/transformers/optionalt_transformer.md
@@ -1,16 +1,28 @@
 # The OptionalT Transformer:
 ## _When Absence Meets Other Effects_
 
+> *"The most beautiful experience we can have is the mysterious."*
+>
+> -- Albert Einstein
+
+`OptionalT` lets a chain of asynchronous lookups disappear cleanly the moment a value is missing. The mystery of "did this resolve?" stays inside the type and never leaks into your control flow.
+
 ~~~admonish info title="What You'll Learn"
-- How to integrate Java's Optional with other monadic contexts
+- How to integrate Java's `Optional` with other monadic contexts
 - Building async workflows where each step might return empty results
-- Using `some`, `none`, and `fromOptional` to construct OptionalT values
-- Creating multi-step data retrieval with graceful failure handling
-- Providing default values when optional chains result in empty
+- Using `For` comprehensions to compose multi-step lookups without manual fallback wiring
+- Using `some`, `none`, `fromOptional`, `liftF`, and `fromKind` to construct `OptionalT` values
+- When to use the [`OptionalPath`](../effect/path_optional.md) Path type instead of raw `OptionalT`
 ~~~
 
-~~~ admonish example title="See Example Code:"
+~~~admonish example title="See Example Code"
 [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+For most use cases, [`OptionalPath<A>`](../effect/path_optional.md) (or [`MaybePath<A>`](../effect/path_maybe.md) for the FP-native equivalent) is the better starting point. It wraps `OptionalT` in a fluent API that hides the witness types and `Kind` widening.
+
+Reach for raw `OptionalT` only when you need to combine optionality with a specific outer monad (`CompletableFuture`, `IO`, `VTask`, custom) or when you are writing polymorphic library code that names `MonadError<F, Unit>`.
 ~~~
 
 ---
@@ -20,7 +32,6 @@
 Consider fetching a user, then their profile, then their preferences. Each step is async and might return empty:
 
 ```java
-// Without OptionalT: manual nesting
 CompletableFuture<Optional<UserPreferences>> getPreferences(String userId) {
     return fetchUserAsync(userId).thenCompose(optUser ->
         optUser.map(user ->
@@ -36,23 +47,41 @@ CompletableFuture<Optional<UserPreferences>> getPreferences(String userId) {
 
 Each step requires checking the `Optional`, providing a fallback `CompletableFuture.completedFuture(Optional.empty())` for the absent case, and nesting deeper. Three lookups; three layers of `map`/`orElse`. The fallback expression is identical every time.
 
-## The Solution: OptionalT
+---
+
+## The Solution
+
+### With the Effect Path API
 
 ```java
-// With OptionalT: flat composition
-OptionalT<CompletableFutureKind.Witness, UserPreferences> getPreferences(String userId) {
-    var userOT = OPTIONAL_T.widen(OptionalT.fromKind(fetchUserAsync(userId)));
-    var workflow = For.from(optionalTMonad, userOT)
-        .from(user -> OPTIONAL_T.widen(OptionalT.fromKind(fetchProfileAsync(user.id()))))
-        .from(profile -> OPTIONAL_T.widen(OptionalT.fromKind(fetchPrefsAsync(profile.userId()))))
-        .yield((user, profile, prefs) -> prefs);
-    return OPTIONAL_T.narrow(workflow);
+OptionalPath<UserPreferences> getPreferences(String userId) {
+    return Path.optional(fetchUserAsync(userId))
+        .via(user    -> Path.optional(fetchProfileAsync(user.id())))
+        .via(profile -> Path.optional(fetchPrefsAsync(profile.userId())));
 }
+```
+
+Use this whenever the outer monad is one Path already wraps.
+
+### With raw `OptionalT`
+
+When you need a specific outer monad, use `OptionalT` with a `For` comprehension:
+
+```java
+var futureMonad    = CompletableFutureMonad.INSTANCE;
+var optionalTMonad = new OptionalTMonad<CompletableFutureKind.Witness>(futureMonad);
+
+var prefsLookup = For.from(optionalTMonad, OptionalT.fromKind(fetchUserAsync(userId)))
+    .from(user    -> OptionalT.fromKind(fetchProfileAsync(user.id())))
+    .from(profile -> OptionalT.fromKind(fetchPrefsAsync(profile.userId())))
+    .yield((user, profile, prefs) -> prefs);
 ```
 
 If any step returns empty, subsequent steps are skipped. No manual `orElse` fallbacks, no repeated `Optional.empty()` wrapping.
 
-### The Railway View
+---
+
+## The Railway View
 
 <pre style="line-height:1.5;font-size:0.95em">
     <span style="color:#4CAF50"><b>Present</b>  ═══●═══════════●═══════════●═══════════▶  UserPreferences</span>
@@ -69,7 +98,7 @@ If any step returns empty, subsequent steps are skipped. No manual `orElse` fall
     <span style="color:#4CAF50">                                      ●═══▶  default UserPreferences</span>
 </pre>
 
-Each `flatMap` runs inside the outer monad `F` (e.g. `CompletableFuture`). If the inner `Optional` is empty, subsequent steps are skipped. `handleErrorWith` can provide a fallback value when the chain yields nothing.
+Each `flatMap` runs inside the outer monad `F`. If the inner `Optional` is empty, subsequent steps are skipped. `handleErrorWith` can provide a fallback value when the chain yields nothing.
 
 ---
 
@@ -98,16 +127,12 @@ Each `flatMap` runs inside the outer monad `F` (e.g. `CompletableFuture`). If th
     └──────────────────────────────────────────────────────────┘
 </pre>
 
-![optional_t_transformer.svg](../images/puml/optional_t_transformer.svg)
-
-* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`).
+* **`F`**: The witness type of the **outer monad** (e.g. `CompletableFutureKind.Witness`).
 * **`A`**: The type of the value that might be present within the `Optional`.
 
 ```java
 public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value)
-    implements OptionalTKind<F, A> {
-  // ... static factory methods ...
-}
+    implements OptionalTKind<F, A> { /* ... static factories ... */ }
 ```
 
 ---
@@ -117,20 +142,18 @@ public record OptionalT<F, A>(@NonNull Kind<F, Optional<A>> value)
 The `OptionalTMonad<F>` class implements `MonadError<OptionalTKind.Witness<F>, Unit>`. The error type is `Unit`, signifying that an "error" is the `Optional.empty()` state (absence carries no information beyond its occurrence).
 
 ```java
-Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-
-OptionalTMonad<CompletableFutureKind.Witness> optionalTFutureMonad =
-    new OptionalTMonad<>(futureMonad);
+var futureMonad    = CompletableFutureMonad.INSTANCE;
+var optionalTMonad = new OptionalTMonad<CompletableFutureKind.Witness>(futureMonad);
 ```
 
-~~~admonish note title="Type Witness and Helpers"
+~~~admonish note title="Working with Kind"
 **Witness Type:** `OptionalTKind<F, A>` extends `Kind<OptionalTKind.Witness<F>, A>`. The outer monad `F` is fixed; `A` is the variable value type.
 
-**KindHelper:** `OptionalTKindHelper` provides `OPTIONAL_T.widen` and `OPTIONAL_T.narrow` for safe conversion between `OptionalT<F, A>` and its `Kind` representation.
+**KindHelper:** `OptionalTKindHelper` provides `OPTIONAL_T.widen` and `OPTIONAL_T.narrow` for safe conversion between `OptionalT<F, A>` and its `Kind` representation. With `For` comprehensions you rarely need them; they appear at the boundaries when interoperating with raw `flatMap` chains.
 
 ```java
 Kind<OptionalTKind.Witness<F>, A> kind = OPTIONAL_T.widen(optionalT);
-OptionalT<F, A> concrete = OPTIONAL_T.narrow(kind);
+OptionalT<F, A> concrete                = OPTIONAL_T.narrow(kind);
 ```
 ~~~
 
@@ -138,19 +161,105 @@ OptionalT<F, A> concrete = OPTIONAL_T.narrow(kind);
 
 ## Key Operations
 
-~~~admonish info title="Key Operations with _OptionalTMonad_:"
-* **`optionalTMonad.of(value)`**: Lifts a nullable value `A` into `OptionalT`. Result: `F<Optional.ofNullable(value)>`.
-* **`optionalTMonad.map(func, optionalTKind)`**: Applies `A -> B` to the present value. If `func` returns `null`, the result becomes `F<Optional.empty()>`. Result: `OptionalT(F<Optional<B>>)`.
-* **`optionalTMonad.flatMap(func, optionalTKind)`**: Sequences operations. If present, applies `func` to get the next `OptionalT`. If empty at any point, short-circuits to `F<Optional.empty()>`.
-* **`optionalTMonad.raiseError(Unit.INSTANCE)`**: Creates an `OptionalT` representing absence. Result: `F<Optional.empty()>`.
-* **`optionalTMonad.handleErrorWith(optionalTKind, handler)`**: Handles an empty state. The handler `Unit -> Kind<OptionalTKind.Witness<F>, A>` is invoked when the inner `Optional` is empty.
+| Operation | Behaviour |
+|-----------|-----------|
+| `optionalTMonad.of(value)`                          | Lifts a nullable value as `F<Optional.ofNullable(value)>` |
+| `optionalTMonad.map(f, kind)`                       | Applies `A -> B` to the present value; `null` results become `empty` |
+| `optionalTMonad.flatMap(f, kind)`                   | Sequences operations; empty short-circuits the rest |
+| `optionalTMonad.raiseError(Unit.INSTANCE)`          | Creates `F<Optional.empty()>` |
+| `optionalTMonad.handleErrorWith(kind, handler)`     | Recovers from empty by applying `handler` |
+
+---
+
+## Creating OptionalT Instances
+
+```java
+var futureMonad = CompletableFutureMonad.INSTANCE;
+
+// 1. From an existing F<Optional<A>>
+Kind<CompletableFutureKind.Witness, Optional<String>> fOptional =
+    FUTURE.widen(CompletableFuture.completedFuture(Optional.of("Data")));
+var ot1 = OptionalT.fromKind(fOptional);
+
+// 2. From a present value: F<Optional.of(a)>
+var ot2 = OptionalT.some(futureMonad, "Data");
+
+// 3. Empty: F<Optional.empty()>
+var ot3 = OptionalT.<CompletableFutureKind.Witness, String>none(futureMonad);
+
+// 4. From a plain java.util.Optional: F<Optional<A>>
+var ot4 = OptionalT.fromOptional(futureMonad, Optional.of(123));
+
+// 5. Lifting F<A> into OptionalT (null -> empty, non-null -> present)
+Kind<CompletableFutureKind.Witness, String> fValue =
+    FUTURE.widen(CompletableFuture.completedFuture("Data"));
+var ot5 = OptionalT.liftF(futureMonad, fValue);
+```
+
+`ot1.value()` returns the underlying `Kind<CompletableFutureKind.Witness, Optional<String>>`, which you narrow back to a concrete `CompletableFuture<Optional<String>>` when you need the result.
+
+---
+
+## Real-World Example: Async Multi-Step Data Retrieval
+
+~~~admonish example title="Asynchronous Multi-Step Data Retrieval"
+
+- [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
+
+**The problem:** fetch a user, then their profile, then their preferences. Each step is async and might not find data. The chain should short-circuit on the first empty result.
+
+**The solution:**
+
+```java
+var futureMonad    = CompletableFutureMonad.INSTANCE;
+var optionalTMonad = new OptionalTMonad<CompletableFutureKind.Witness>(futureMonad);
+
+// Service stubs return Future<Optional<T>>
+Kind<CompletableFutureKind.Witness, Optional<User>> fetchUserAsync(String userId) {
+    return FUTURE.widen(CompletableFuture.supplyAsync(() ->
+        "user1".equals(userId) ? Optional.of(new User(userId, "Alice"))
+                               : Optional.empty()));
+}
+
+// Workflow: user -> profile -> preferences
+var workflow = For.from(optionalTMonad, OptionalT.fromKind(fetchUserAsync(userId)))
+    .from(user    -> OptionalT.fromKind(fetchProfileAsync(user.id())))
+    .from(profile -> OptionalT.fromKind(fetchPrefsAsync(profile.userId())))
+    .yield((user, profile, prefs) -> prefs);
+```
+
+**Why this works:** each `from` only executes its lambda if the previous step produced a present value. If `fetchUserAsync` returns empty, neither `fetchProfileAsync` nor `fetchPrefsAsync` is called.
+~~~
+
+---
+
+## Providing Defaults with Error Recovery
+
+~~~admonish example title="Recovery with Default Values"
+
+**The problem:** when the preference chain returns empty, you want to provide default preferences rather than propagating the absence.
+
+**The solution:**
+
+```java
+Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, UserPreferences>
+    getPrefsWithDefault(String userId) {
+  var prefsAttempt = getFullUserPreferences(userId);
+
+  return optionalTMonad.handleErrorWith(
+      prefsAttempt,
+      (Unit v) -> OptionalT.some(futureMonad, new UserPreferences(userId, "default-light")));
+}
+```
+
+`OptionalT` already implements the `Kind` interface, so neither the source value nor the handler's result need an explicit `OPTIONAL_T.widen` call. The `handleErrorWith` handler receives `Unit` (since absence carries no information) and returns an `OptionalT` containing the default preferences.
 ~~~
 
 ---
 
 ## Transforming the Outer Monad with `mapT`
 
-Sometimes you need to change the *outer monad* of an `OptionalT` without touching the inner `Optional`. Perhaps you have awaited an async result and want to continue in a synchronous context, or you want to apply a natural transformation to switch effect types.
+Sometimes you need to change the *outer monad* of an `OptionalT` without touching the inner `Optional`. Perhaps you have awaited an async result and want to continue in a synchronous context.
 
 `mapT` applies a function to the wrapped `Kind<F, Optional<A>>` and produces a new `OptionalT<G, A>`:
 
@@ -167,152 +276,34 @@ Sometimes you need to change the *outer monad* of an `OptionalT` without touchin
 ```
 
 ```java
-// Switch from Future to Optional after awaiting an async result
 OptionalT<CompletableFutureKind.Witness, String> asyncOt = ...;
 
-OptionalT<OptionalKind.Witness, String> syncOt =
-    asyncOt.mapT(futureKind -> {
-      Optional<String> awaited = FUTURE.narrow(futureKind).join();
-      return OPTIONAL.widen(Optional.of(awaited));
-    });
+var syncOt = asyncOt.mapT(futureKind -> {
+  Optional<String> awaited = FUTURE.narrow(futureKind).join();
+  return OPTIONAL.widen(Optional.of(awaited));
+});
 ```
 
 ~~~admonish note title="mapT vs map"
 `map` transforms the *value* inside the `Optional` (the `A` in `Optional.of(A)`).
-`mapT` transforms the *outer monad* wrapping the `Optional` — the `F` in `F<Optional<A>>`.
+`mapT` transforms the *outer monad* wrapping the `Optional`, the `F` in `F<Optional<A>>`.
 They operate at different levels of the transformer stack.
-~~~
-
----
-
-## Creating OptionalT Instances
-
-~~~admonish title="Creating _OptionalT_ Instances"
-
-- [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
-
-```java
-Monad<CompletableFutureKind.Witness> futureMonad = CompletableFutureMonad.INSTANCE;
-
-// 1. From an existing F<Optional<A>>
-Kind<CompletableFutureKind.Witness, Optional<String>> fOptional =
-    FUTURE.widen(CompletableFuture.completedFuture(Optional.of("Data")));
-OptionalT<CompletableFutureKind.Witness, String> ot1 = OptionalT.fromKind(fOptional);
-
-// 2. From a present value: F<Optional.of(a)>
-OptionalT<CompletableFutureKind.Witness, String> ot2 =
-    OptionalT.some(futureMonad, "Data");
-
-// 3. Empty: F<Optional.empty()>
-OptionalT<CompletableFutureKind.Witness, String> ot3 = OptionalT.none(futureMonad);
-
-// 4. From a plain java.util.Optional: F<Optional<A>>
-OptionalT<CompletableFutureKind.Witness, Integer> ot4 =
-    OptionalT.fromOptional(futureMonad, Optional.of(123));
-
-// 5. Lifting F<A> into OptionalT (null → empty, non-null → present)
-Kind<CompletableFutureKind.Witness, String> fValue =
-    FUTURE.widen(CompletableFuture.completedFuture("Data"));
-OptionalT<CompletableFutureKind.Witness, String> ot5 =
-    OptionalT.liftF(futureMonad, fValue);
-
-// Accessing the wrapped value:
-Kind<CompletableFutureKind.Witness, Optional<String>> wrappedFVO = ot1.value();
-CompletableFuture<Optional<String>> futureOptional = FUTURE.narrow(wrappedFVO);
-```
-~~~
-
----
-
-## Real-World Example: Async Multi-Step Data Retrieval
-
-~~~admonish Example title="Asynchronous Multi-Step Data Retrieval"
-
-- [OptionalTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/optional_t/OptionalTExample.java)
-
-**The problem:** You need to fetch a user, then their profile, then their preferences. Each step is async and might not find data. You want the chain to short-circuit on the first empty result.
-
-**The solution:**
-
-```java
-static final Monad<CompletableFutureKind.Witness> futureMonad =
-    CompletableFutureMonad.INSTANCE;
-static final OptionalTMonad<CompletableFutureKind.Witness> optionalTFutureMonad =
-    new OptionalTMonad<>(futureMonad);
-
-// Service stubs return Future<Optional<T>>
-static Kind<CompletableFutureKind.Witness, Optional<User>> fetchUserAsync(String userId) {
-    return FUTURE.widen(CompletableFuture.supplyAsync(() ->
-        "user1".equals(userId) ? Optional.of(new User(userId, "Alice"))
-                               : Optional.empty()));
-}
-
-// Workflow: user → profile → preferences
-static OptionalT<CompletableFutureKind.Witness, UserPreferences>
-    getFullUserPreferences(String userId) {
-
-  OptionalT<CompletableFutureKind.Witness, User> userOT =
-      OptionalT.fromKind(fetchUserAsync(userId));
-
-  OptionalT<CompletableFutureKind.Witness, UserProfile> profileOT =
-      OPTIONAL_T.narrow(optionalTFutureMonad.flatMap(
-          user -> OPTIONAL_T.widen(
-              OptionalT.fromKind(fetchProfileAsync(user.id()))),
-          OPTIONAL_T.widen(userOT)));
-
-  return OPTIONAL_T.narrow(optionalTFutureMonad.flatMap(
-      profile -> OPTIONAL_T.widen(
-          OptionalT.fromKind(fetchPrefsAsync(profile.userId()))),
-      OPTIONAL_T.widen(profileOT)));
-}
-```
-
-**Why this works:** Each `flatMap` only executes its lambda if the previous step produced a present value. If `fetchUserAsync` returns empty, neither `fetchProfileAsync` nor `fetchPrefsAsync` are called.
-~~~
-
----
-
-## Providing Defaults with Error Recovery
-
-~~~admonish Example title="Recovery with Default Values"
-
-**The problem:** When the preference chain returns empty, you want to provide default preferences rather than propagating the absence.
-
-**The solution:**
-
-```java
-static OptionalT<CompletableFutureKind.Witness, UserPreferences>
-    getPrefsWithDefault(String userId) {
-
-  OptionalT<CompletableFutureKind.Witness, UserPreferences> prefsAttempt =
-      getFullUserPreferences(userId);
-
-  Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, UserPreferences>
-      recovered = optionalTFutureMonad.handleErrorWith(
-          OPTIONAL_T.widen(prefsAttempt),
-          (Unit v) -> {
-              UserPreferences defaultPrefs =
-                  new UserPreferences(userId, "default-light");
-              return OPTIONAL_T.widen(OptionalT.some(futureMonad, defaultPrefs));
-          });
-
-  return OPTIONAL_T.narrow(recovered);
-}
-```
-
-The `handleErrorWith` handler receives `Unit` (since absence carries no information) and returns an `OptionalT` containing the default preferences.
 ~~~
 
 ---
 
 ~~~admonish warning title="Common Mistakes"
 - **Null vs. empty confusion:** `OptionalT.liftF` treats a `null` value inside `F<A>` as `Optional.empty()`. If you want to explicitly signal absence, use `OptionalT.none` rather than relying on null propagation.
-- **Unit as error type:** When using `handleErrorWith`, the handler function receives `Unit.INSTANCE`, not a descriptive error. If you need typed error information, consider `EitherT` instead.
+- **Unit as error type:** when using `handleErrorWith`, the handler function receives `Unit.INSTANCE`, not a descriptive error. If you need typed error information, consider [`EitherT`](eithert_transformer.md) instead.
+- **Reaching for the transformer when `OptionalPath` would do:** if your outer monad is one Path already wraps, `OptionalPath` is shorter, has less ceremony, and reads more naturally.
 ~~~
 
 ---
 
 ~~~admonish tip title="See Also"
+- [OptionalPath](../effect/path_optional.md) - The Path-API equivalent, recommended for most use cases
+- [Stack Archetypes](archetypes.md) - The Lookup Stack archetype maps to `OptionalT`/`MaybePath`
+- [Migration Cookbook](migration_cookbook.md) - Side-by-side translations
 - [Monad Transformers](transformers.md) - General concept and choosing the right transformer
 - [MaybeT](maybet_transformer.md) - Equivalent functionality for Higher-Kinded-J's Maybe type
 - [EitherT](eithert_transformer.md) - When you need typed errors, not just absence
@@ -325,6 +316,11 @@ The `handleErrorWith` handler receives `Unit` (since absence carries no informat
 - [Null References: The Billion Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare/) - Tony Hoare's historic talk on why Optional matters (60 min watch)
 ~~~
 
+~~~admonish info title="Hands-On Learning"
+Practice async lookup chains in [Tutorial 02: Async with Absence](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial02_AsyncWithAbsence.java) (5 exercises, ~25 minutes).
+~~~
+
+---
 
 **Previous:** [EitherT](eithert_transformer.md)
 **Next:** [MaybeT](maybet_transformer.md)

--- a/hkj-book/src/transformers/quickstart.md
+++ b/hkj-book/src/transformers/quickstart.md
@@ -1,0 +1,109 @@
+# Monad Transformers Quickstart
+
+~~~admonish info title="What You'll Learn"
+- Your first `EitherT` workflow combining typed errors with `CompletableFuture`
+- Combining `OptionalT` and `For` for an async lookup chain in a few lines
+- A two-capability MTL example showing polymorphic, stack-independent code
+- Where to read next depending on what you want to do
+~~~
+
+This page assumes you have Higher-Kinded-J on your classpath. If not, start with the [book-level Quickstart](../quickstart.md).
+
+~~~admonish note title="Path First, Stack Later"
+Before reaching for a raw transformer, check whether the [Effect Path API](../effect/ch_intro.md) already covers your case. `EitherPath`, `MaybePath`, `OptionalPath`, `ReaderPath`, and `WithStatePath` wrap these transformers in a fluent API that handles witness types and `Kind` widening for you.
+
+The transformer machinery on this page is for the cases where Path types do not fit, typically because you need a *different* outer monad (`CompletableFuture`, `IO`, a custom effect) or because you are writing polymorphic library code.
+~~~
+
+---
+
+## 1. Combine async with typed errors using `EitherT`
+
+The most common transformer use case: an asynchronous workflow whose steps can fail with typed domain errors. Without `EitherT` you end up nesting `thenCompose` inside `Either.fold` calls; with it the whole chain reads as a sequence.
+
+```java
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.either_t.EitherT;
+import org.higherkindedj.hkt.either_t.EitherTMonad;
+import org.higherkindedj.hkt.expression.For;
+
+sealed interface OrderError {
+    record InvalidOrder(String reason) implements OrderError {}
+    record OutOfStock(String sku)      implements OrderError {}
+}
+
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var eitherTMonad = new EitherTMonad<CompletableFutureKind.Witness, OrderError>(futureMonad);
+
+var workflow = For.from(eitherTMonad, EitherT.fromKind(validateOrder(order)))
+    .from(validated -> EitherT.fromKind(checkInventory(validated)))
+    .from(reserved  -> EitherT.fromKind(processPayment(reserved)))
+    .yield((validated, reserved, receipt) -> receipt);
+```
+
+If any step yields `Left`, the rest are skipped and the error propagates through the `CompletableFuture`. The witness type appears in one place (the `eitherTMonad`); the body of the comprehension reads like ordinary sequential code.
+
+---
+
+## 2. Async lookup chains with `OptionalT`
+
+Multi-step lookups where any step might return nothing are the bread and butter of `OptionalT`. The same `For` shape works with the change of monad.
+
+```java
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.expression.For;
+import org.higherkindedj.hkt.optional_t.OptionalT;
+import org.higherkindedj.hkt.optional_t.OptionalTMonad;
+
+var futureMonad    = CompletableFutureMonad.INSTANCE;
+var optionalTMonad = new OptionalTMonad<CompletableFutureKind.Witness>(futureMonad);
+
+var prefsLookup = For.from(optionalTMonad, OptionalT.fromKind(fetchUserAsync(userId)))
+    .from(user    -> OptionalT.fromKind(fetchProfileAsync(user.id())))
+    .from(profile -> OptionalT.fromKind(fetchPrefsAsync(profile.userId())))
+    .yield((user, profile, prefs) -> prefs);
+```
+
+If `fetchUserAsync` returns `Optional.empty()`, neither `fetchProfileAsync` nor `fetchPrefsAsync` is called. No nested `orElse(CompletableFuture.completedFuture(Optional.empty()))` boilerplate, no manual fallback wiring.
+
+---
+
+## 3. Capability-based code with MTL
+
+When the same business logic must run against different stacks (production async, synchronous tests, audit interpreter) write it once against an MTL capability. Here a function reads configuration without naming a concrete transformer:
+
+```java
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.MonadReader;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.expression.For;
+
+record AppConfig(String dbUrl, int maxRetries) {}
+
+<F extends WitnessArity<TypeArity.Unary>> Kind<F, String>
+    buildConnectionString(MonadReader<F, AppConfig> env) {
+  return For.from(env, env.ask())
+      .yield(config -> config.dbUrl() + "?retries=" + config.maxRetries());
+}
+```
+
+The function declares "I need to read an `AppConfig`" and nothing else. A test caller can supply a `ReaderTMonadReader<IdKind.Witness, AppConfig>` to run synchronously; a production caller can supply a `ReaderTMonadReader<CompletableFutureKind.Witness, AppConfig>`. The function does not change.
+
+---
+
+## Where next?
+
+- **First time on this page?** Read [Stack Archetypes](archetypes.md), which presents seven named patterns covering most enterprise composition needs.
+- **Need a quick lookup?** [Transformers at a Glance](transformers_at_a_glance.md) is a one-page reference card.
+- **Coming from imperative Java or the Effect Path API?** The [Migration Cookbook](migration_cookbook.md) has side-by-side translations.
+- **Need the underlying mechanics?** [Monad Transformers](transformers.md) explains why monads do not compose and what transformers fix.
+- **Specific transformer?** Each of the per-transformer pages ([EitherT](eithert_transformer.md), [OptionalT](optionalt_transformer.md), [MaybeT](maybet_transformer.md), [ReaderT](readert_transformer.md), [StateT](statet_transformer.md), [WriterT](writert_transformer.md)) has its own worked example.
+- **Stack-independent code?** Start with [MTL Capabilities](mtl_capabilities.md).
+
+---
+
+**Previous:** [Path or Transformer?](when_to_drop_to_transformers.md)
+**Next:** [Transformers at a Glance](transformers_at_a_glance.md)

--- a/hkj-book/src/transformers/readert_transformer.md
+++ b/hkj-book/src/transformers/readert_transformer.md
@@ -8,19 +8,23 @@
 No computation is independent of its environment. ReaderT makes that dependency explicit and composable.
 
 ~~~admonish info title="What You'll Learn"
-- How to combine dependency injection (Reader) with other effects like async operations
+- How to combine dependency injection (`Reader`) with other effects like async operations
 - Building configuration-dependent workflows that are also async or failable
-- Using `ask`, `reader`, and `lift` to work with environment-dependent computations
+- Using `For` comprehensions with `ask`, `reader`, and `lift` to keep witness types localised
 - Creating testable microservice clients with injected configuration
-- Managing database connections, API keys, and other contextual dependencies
+- When to use the [`ReaderPath`](../effect/advanced_effects.md) Path type or the [`MonadReader`](mtl_reader.md) capability instead of raw `ReaderT`
 ~~~
 
-~~~ admonish example title="See Example Code:"
+~~~admonish example title="See Example Code"
 - [ReaderTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTExample.java)
-
 - [ReaderTAsyncExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncExample.java)
-
 - [ReaderTAsyncUnitExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncUnitExample.java)
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+For most use cases, [`ReaderPath<R, A>`](../effect/advanced_effects.md) is the better starting point when the environment is the only effect. When you need polymorphic, stack-independent code, the [`MonadReader<F, R>`](mtl_reader.md) capability is usually a better fit than the concrete `ReaderT`.
+
+Reach for raw `ReaderT` only when you need to combine an environment with a specific outer monad that Path does not wrap, or when you are constructing your own MTL instance.
 ~~~
 
 ---
@@ -30,7 +34,6 @@ No computation is independent of its environment. ReaderT makes that dependency 
 Consider a service that needs API keys and URLs for every operation:
 
 ```java
-// Without ReaderT: passing config through every function
 CompletableFuture<ServiceData> fetchData(AppConfig config, String itemId) {
     return CompletableFuture.supplyAsync(() ->
         callApi(config.apiKey(), config.serviceUrl(), itemId));
@@ -41,7 +44,6 @@ CompletableFuture<ProcessedData> processData(AppConfig config, ServiceData data)
         transform(data, config.apiKey()));
 }
 
-// Every call requires explicit config passing:
 CompletableFuture<ProcessedData> workflow(AppConfig config) {
     return fetchData(config, "item123")
         .thenCompose(data -> processData(config, data));
@@ -50,29 +52,76 @@ CompletableFuture<ProcessedData> workflow(AppConfig config) {
 
 The `config` parameter threads through every function signature, every call site, every test. It's noise that obscures the actual logic. Rename a config field, and you touch every function in the chain.
 
-## The Solution: ReaderT
+---
+
+## The Solution
+
+### With the Effect Path API (single effect)
+
+If the environment is the only effect, `ReaderPath` is the simplest expression:
 
 ```java
-// With ReaderT: config is implicit
-ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData>
-    fetchDataRT(String itemId) {
+ReaderPath<AppConfig, ProcessedData> workflow() {
+    return Path.<AppConfig>ask()
+        .via(config -> Path.right(callApi(config.apiKey(), "item123")))
+        .via(data   -> Path.<AppConfig>ask()
+            .map(config -> transform(data, config.apiKey())));
+}
+```
+
+### With raw `ReaderT` (combined effect)
+
+When the environment must combine with another monad (here `CompletableFuture`):
+
+```java
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var readerTMonad = new ReaderTMonad<CompletableFutureKind.Witness, AppConfig>(futureMonad);
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData> fetchDataRT(String itemId) {
   return ReaderT.of(config ->
       FUTURE.widen(CompletableFuture.supplyAsync(() ->
           callApi(config.apiKey(), config.serviceUrl(), itemId))));
 }
 
-ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData>
-    processDataRT(ServiceData data) {
+ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData> processDataRT(ServiceData data) {
   return ReaderT.reader(futureMonad,
       config -> transform(data, config.apiKey()));
 }
 
-// Config provided once, at the end:
-Kind<CompletableFutureKind.Witness, ProcessedData> result =
-    composedWorkflow.run().apply(prodConfig);
+// Compose with For:
+var workflowRT = For.from(readerTMonad, fetchDataRT("item123"))
+    .from(data -> processDataRT(data))
+    .yield((data, processed) -> processed);
+
+// Provide the config once at the edge:
+var result = FUTURE.join(READER_T.narrow(workflowRT).run().apply(prodConfig));
 ```
 
-The `AppConfig` is threaded implicitly through `flatMap`. Each operation declares its dependency on `AppConfig` in its return type, but never receives it as a parameter. The config is provided once, when you run the computation.
+The `AppConfig` is threaded implicitly through `flatMap`. Each operation declares its dependency on `AppConfig` in its return type but never receives it as a parameter.
+
+---
+
+## The Railway View
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Value</b>     ═══●═══════════●═══════════●═══▶  ProcessedData (in F)</span>
+    <span style="color:#4CAF50">              fetchData    process       map</span>
+    <span style="color:#4CAF50">              (flatMap)    (flatMap)</span>
+                  ▲            ▲            ▲    <i>config read at each step</i>
+    <span style="color:#2196F3"><b>AppConfig</b> ═══╧═══════════╧═══════════╧═══▶  read-only, never modified</span>
+    <span style="color:#2196F3">              apiKey       serviceUrl    executor</span>
+
+                                              │
+                                         <i>run(prodConfig)</i>  provide the environment once at the edge
+</pre>
+
+The configuration sits on its own track and is never consumed; each `flatMap` step reads from it without changing it. `run().apply(config)` supplies the environment at the boundary, after which the value track collapses into the outer monad `F`.
+
+---
+
+## How ReaderT Works
+
+`ReaderT<F, R, A>` wraps a function `R -> Kind<F, A>`. When you supply an environment of type `R`, you get back a monadic value `Kind<F, A>`.
 
 ```
     ┌──────────────────────────────────────────────────────────┐
@@ -99,15 +148,7 @@ The `AppConfig` is threaded implicitly through `flatMap`. Each operation declare
     └──────────────────────────────────────────────────────────┘
 ```
 
----
-
-## How ReaderT Works
-
-`ReaderT<F, R, A>` wraps a function `R -> Kind<F, A>`. When you supply an environment of type `R`, you get back a monadic value `Kind<F, A>`.
-
-![readert_transformer.svg](../images/puml/readert_transformer.svg)
-
-* **`F`**: The witness type of the **outer monad** (e.g., `CompletableFutureKind.Witness`).
+* **`F`**: The witness type of the **outer monad** (e.g. `CompletableFutureKind.Witness`).
 * **`R`**: The type of the **read-only environment** (configuration, dependencies).
 * **`A`**: The type of the value produced, within the outer monad `F`.
 * **`run`**: The core function `R -> Kind<F, A>`.
@@ -126,21 +167,19 @@ public record ReaderT<F, R, A>(@NonNull Function<R, Kind<F, A>> run)
 The `ReaderTMonad<F, R>` class implements `Monad<ReaderTKind.Witness<F, R>>`, providing standard monadic operations. It requires a `Monad<F>` instance for the outer monad:
 
 ```java
-OptionalMonad optionalMonad = OptionalMonad.INSTANCE;
 record AppConfig(String apiKey) {}
 
-ReaderTMonad<OptionalKind.Witness, AppConfig> readerTOptionalMonad =
-    new ReaderTMonad<>(optionalMonad);
+var readerTOptionalMonad = new ReaderTMonad<OptionalKind.Witness, AppConfig>(OptionalMonad.INSTANCE);
 ```
 
-~~~admonish note title="Type Witness and Helpers"
+~~~admonish note title="Working with Kind"
 **Witness Type:** `ReaderTKind<F, R, A>` extends `Kind<ReaderTKind.Witness<F, R>, A>`. The outer monad `F` and environment `R` are fixed; `A` is the variable value type.
 
-**KindHelper:** `ReaderTKindHelper` provides `READER_T.widen` and `READER_T.narrow` for safe conversion.
+**KindHelper:** `ReaderTKindHelper` provides `READER_T.widen` and `READER_T.narrow` for safe conversion. With `For` comprehensions you rarely need them; they appear at the boundaries when interoperating with raw `flatMap` chains.
 
 ```java
 Kind<ReaderTKind.Witness<F, R>, A> kind = READER_T.widen(readerT);
-ReaderT<F, R, A> concrete = READER_T.narrow(kind);
+ReaderT<F, R, A> concrete                = READER_T.narrow(kind);
 ```
 ~~~
 
@@ -148,10 +187,132 @@ ReaderT<F, R, A> concrete = READER_T.narrow(kind);
 
 ## Key Operations
 
-~~~admonish info title="Key Operations with _ReaderTMonad_"
-* **`readerTMonad.of(value)`**: Lifts a pure value into `ReaderT`. The environment is ignored. Result: `ReaderT(r -> outerMonad.of(value))`.
-* **`readerTMonad.map(func, readerTKind)`**: Transforms the result value `A -> B` within the outer monad. The environment passes through unchanged. Result: `ReaderT(r -> F<B>)`.
-* **`readerTMonad.flatMap(func, readerTKind)`**: The core sequencing operation. Runs the first `ReaderT` with the environment to get `Kind<F, A>`. If it yields an `A`, applies `func` to get a new `ReaderT<F, R, B>`, which is then also run with the **same environment**. This is what makes configuration threading automatic.
+| Operation | Behaviour |
+|-----------|-----------|
+| `readerTMonad.of(value)`        | Lifts a pure value; environment is ignored. Returns `ReaderT(r -> outerMonad.of(value))` |
+| `readerTMonad.map(f, kind)`     | Transforms the result value `A -> B` within the outer monad; environment unchanged |
+| `readerTMonad.flatMap(f, kind)` | Sequences operations; threads the *same* environment to the next step |
+
+The `MonadReader` capability adds `ask()`, `reader(f)`, and `local(f, ma)` on top.
+
+---
+
+## Creating ReaderT Instances
+
+```java
+var optMonad   = OptionalMonad.INSTANCE;
+record Config(String setting) {}
+
+// 1. Directly from R -> F<A> function
+var rt1 = ReaderT.<OptionalKind.Witness, Config, String>of(
+    cfg -> OPTIONAL.widen(Optional.of("Data based on " + cfg.setting())));
+
+// 2. Lifting an existing F<A> (environment ignored)
+Kind<OptionalKind.Witness, Integer> optionalValue = OPTIONAL.widen(Optional.of(123));
+var rt2 = ReaderT.<OptionalKind.Witness, Config, Integer>lift(optMonad, optionalValue);
+
+// 3. From R -> A function (result lifted into F)
+var rt3 = ReaderT.<OptionalKind.Witness, Config, String>reader(
+    optMonad, cfg -> "Hello from " + cfg.setting());
+
+// 4. ask: provides the environment itself as the result
+var rt4 = ReaderT.<OptionalKind.Witness, Config>ask(optMonad);
+```
+
+---
+
+## Real-World Example: Configuration-Dependent Async Services
+
+~~~admonish example title="Configuration-Dependent Asynchronous Service Calls"
+
+- [ReaderTAsyncExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncExample.java)
+
+**The problem:** async service operations that all need an `AppConfig` (API keys, URLs, executor). Compose them without passing config through every call.
+
+**The solution:**
+
+```java
+record AppConfig(String apiKey, String serviceUrl, ExecutorService executor) {}
+record ServiceData(String rawData) {}
+record ProcessedData(String info) {}
+
+var futureMonad  = CompletableFutureMonad.INSTANCE;
+var readerTMonad = new ReaderTMonad<CompletableFutureKind.Witness, AppConfig>(futureMonad);
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData> fetchServiceDataRT(String itemId) {
+  return ReaderT.of(config -> FUTURE.widen(
+      CompletableFuture.supplyAsync(() ->
+          new ServiceData("Raw data for " + itemId + " from " + config.serviceUrl()),
+          config.executor())));
+}
+
+ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData> processDataRT(ServiceData data) {
+  return ReaderT.reader(futureMonad,
+      config -> new ProcessedData("Processed: " + data.rawData().toUpperCase()));
+}
+
+// Compose with For:
+var workflowRT = For.from(readerTMonad, fetchServiceDataRT("item123"))
+    .from(data -> processDataRT(data))
+    .yield((data, processed) -> processed);
+
+// Run with different configs:
+var prodConfig    = new AppConfig("prod_key", "https://api.prod.example.com", executor);
+var stagingConfig = new AppConfig("staging_key", "https://api.staging.example.com", executor);
+
+var prodResult    = FUTURE.join(READER_T.narrow(workflowRT).run().apply(prodConfig));
+var stagingResult = FUTURE.join(READER_T.narrow(workflowRT).run().apply(stagingConfig));
+```
+
+**Why this works:** the `AppConfig` is threaded through both operations by `flatMap`. The same workflow runs against production and staging by changing the argument to `run().apply(...)`. The workflow definition is completely decoupled from the environment.
+~~~
+
+---
+
+## Using `ask` to Access Configuration Mid-Workflow
+
+~~~admonish example title="Accessing Configuration with `ask`"
+
+**The problem:** within a composed workflow, read a specific config value without restructuring the computation.
+
+**The solution:**
+
+```java
+var getConfigRT  = ReaderT.<CompletableFutureKind.Witness, AppConfig>ask(futureMonad);
+var serviceUrlRT = readerTMonad.map(
+    (AppConfig cfg) -> "Service URL: " + cfg.serviceUrl(),
+    getConfigRT);
+
+var stagingUrl = FUTURE.join(READER_T.narrow(serviceUrlRT).run().apply(stagingConfig));
+// → "Service URL: https://api.staging.example.com"
+```
+
+`ReaderT.ask` returns the entire environment as the result, which you can then `map` over to extract specific fields.
+~~~
+
+---
+
+## Fire-and-Forget Operations with Unit
+
+~~~admonish example title="`ReaderT` for Actions Returning `Unit`"
+
+- [ReaderTAsyncUnitExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncUnitExample.java)
+
+**The problem:** some operations (logging, initialisation, sending metrics) depend on configuration but don't produce a meaningful return value.
+
+**The solution:** use `Unit` as the value type:
+
+```java
+ReaderT<CompletableFutureKind.Witness, AppConfig, Unit> initialiseComponentRT() {
+    return ReaderT.of(config -> FUTURE.widen(
+        CompletableFuture.runAsync(() -> {
+            System.out.println("Initialising with API Key: " + config.apiKey());
+        }, config.executor()).thenApply(v -> Unit.INSTANCE)));
+}
+
+var result = FUTURE.join(initialiseComponentRT().run().apply(prodConfig));
+// → () (Unit.INSTANCE, signifying successful completion)
+```
 ~~~
 
 ---
@@ -169,180 +330,36 @@ Because `ReaderT` wraps a function rather than a value, `mapT` composes the tran
 ```
 
 ```java
-// Switch from Optional to Id, providing a default for empty results
 ReaderT<OptionalKind.Witness, Config, String> optReader = ...;
 
-ReaderT<IdKind.Witness, Config, String> idReader =
-    optReader.mapT(optKind -> {
-      Optional<String> opt = OPTIONAL.narrow(optKind);
-      return ID.widen(Id.of(opt.orElse("default")));
-    });
+var idReader = optReader.mapT(optKind -> {
+  Optional<String> opt = OPTIONAL.narrow(optKind);
+  return ID.widen(Id.of(opt.orElse("default")));
+});
 ```
 
 ~~~admonish note title="mapT vs map"
 `map` transforms the *value* produced by the reader (the `A` in `Kind<F, A>`).
-`mapT` transforms the *outer monad* that wraps each result — the `F` in `R -> F<A>`.
+`mapT` transforms the *outer monad* that wraps each result, the `F` in `R -> F<A>`.
 The environment-threading is completely unaffected.
 ~~~
 
 ---
 
-## Creating ReaderT Instances
-
-~~~admonish title="Creating _ReaderT_ Instances"
-
-```java
-OptionalMonad optMonad = OptionalMonad.INSTANCE;
-record Config(String setting) {}
-Config testConfig = new Config("TestValue");
-
-// 1. Directly from R -> F<A> function
-ReaderT<OptionalKind.Witness, Config, String> rt1 = ReaderT.of(
-    cfg -> OPTIONAL.widen(Optional.of("Data based on " + cfg.setting())));
-// Run: OPTIONAL.narrow(rt1.run().apply(testConfig))
-// → Optional.of("Data based on TestValue")
-
-// 2. Lifting an existing F<A> (environment ignored)
-Kind<OptionalKind.Witness, Integer> optionalValue =
-    OPTIONAL.widen(Optional.of(123));
-ReaderT<OptionalKind.Witness, Config, Integer> rt2 =
-    ReaderT.lift(optMonad, optionalValue);
-// Run: always returns Optional.of(123) regardless of config
-
-// 3. From R -> A function (result lifted into F)
-ReaderT<OptionalKind.Witness, Config, String> rt3 =
-    ReaderT.reader(optMonad, cfg -> "Hello from " + cfg.setting());
-// Run: Optional.of("Hello from TestValue")
-
-// 4. ask: provides the environment itself as the result
-ReaderT<OptionalKind.Witness, Config, Config> rt4 = ReaderT.ask(optMonad);
-// Run: Optional.of(Config("TestValue"))
-```
-~~~
-
----
-
-## Real-World Example: Configuration-Dependent Async Services
-
-~~~admonish Example title="Configuration-Dependent Asynchronous Service Calls"
-
-- [ReaderTAsyncExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncExample.java)
-
-**The problem:** You have async service operations that all need an `AppConfig` (API keys, URLs, executor). You want to compose them without passing config through every call.
-
-**The solution:**
-
-```java
-static final Monad<CompletableFutureKind.Witness> futureMonad =
-    CompletableFutureMonad.INSTANCE;
-static final ReaderTMonad<CompletableFutureKind.Witness, AppConfig> cfReaderTMonad =
-    new ReaderTMonad<>(futureMonad);
-
-record AppConfig(String apiKey, String serviceUrl, ExecutorService executor) {}
-record ServiceData(String rawData) {}
-record ProcessedData(String info) {}
-
-// Operation 1: fetch data (needs config for URL and API key)
-static ReaderT<CompletableFutureKind.Witness, AppConfig, ServiceData>
-    fetchServiceDataRT(String itemId) {
-  return ReaderT.of(config -> FUTURE.widen(
-      CompletableFuture.supplyAsync(() ->
-          new ServiceData("Raw data for " + itemId + " from " + config.serviceUrl()),
-          config.executor())));
-}
-
-// Operation 2: process data (needs config for API key)
-static ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData>
-    processDataRT(ServiceData data) {
-  return ReaderT.reader(futureMonad,
-      config -> new ProcessedData("Processed: " + data.rawData().toUpperCase()));
-}
-
-// Compose: fetch then process
-Kind<ReaderTKind.Witness<CompletableFutureKind.Witness, AppConfig>, ProcessedData>
-    workflowRT = cfReaderTMonad.flatMap(
-        data -> READER_T.widen(processDataRT(data)),
-        READER_T.widen(fetchServiceDataRT("item123")));
-
-ReaderT<CompletableFutureKind.Witness, AppConfig, ProcessedData> composedWorkflow =
-    READER_T.narrow(workflowRT);
-
-// Run with different configs:
-AppConfig prodConfig = new AppConfig("prod_key", "https://api.prod.example.com", executor);
-AppConfig stagingConfig = new AppConfig("staging_key", "https://api.staging.example.com", executor);
-
-ProcessedData prodResult = FUTURE.join(composedWorkflow.run().apply(prodConfig));
-ProcessedData stagingResult = FUTURE.join(composedWorkflow.run().apply(stagingConfig));
-```
-
-**Why this works:** The `AppConfig` is threaded through both `fetchServiceDataRT` and `processDataRT` by `flatMap`. The same workflow runs against production and staging simply by providing different configs at the `run().apply(...)` call. The workflow definition is completely decoupled from the environment.
-~~~
-
----
-
-## Using `ask` to Access Configuration Mid-Workflow
-
-~~~admonish Example title="Accessing Configuration with `ask`"
-
-**The problem:** Within a composed workflow, you need to read a specific config value without restructuring the computation.
-
-**The solution:**
-
-```java
-ReaderT<CompletableFutureKind.Witness, AppConfig, AppConfig> getConfigRT =
-    ReaderT.ask(futureMonad);
-
-Kind<ReaderTKind.Witness<CompletableFutureKind.Witness, AppConfig>, String>
-    getServiceUrlRT = cfReaderTMonad.map(
-        (AppConfig cfg) -> "Service URL: " + cfg.serviceUrl(),
-        READER_T.widen(getConfigRT));
-
-String stagingUrl = FUTURE.join(
-    READER_T.narrow(getServiceUrlRT).run().apply(stagingConfig));
-// → "Service URL: https://api.staging.example.com"
-```
-
-`ReaderT.ask` returns the entire environment as the result, which you can then `map` over to extract specific fields.
-~~~
-
----
-
-## Fire-and-Forget Operations with Unit
-
-~~~admonish Example title="`ReaderT` for Actions Returning `Unit`"
-
-- [ReaderTAsyncUnitExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/reader_t/ReaderTAsyncUnitExample.java)
-
-**The problem:** Some operations (logging, initialisation, sending metrics) depend on configuration but don't produce a meaningful return value.
-
-**The solution:** Use `Unit` as the value type:
-
-```java
-static ReaderT<CompletableFutureKind.Witness, AppConfig, Unit> initialiseComponentRT() {
-    return ReaderT.of(config -> FUTURE.widen(
-        CompletableFuture.runAsync(() -> {
-            System.out.println("Initialising with API Key: " + config.apiKey());
-            // ... initialisation work ...
-        }, config.executor()).thenApply(v -> Unit.INSTANCE)));
-}
-
-// Run:
-Unit result = FUTURE.join(initialiseComponentRT().run().apply(prodConfig));
-// → () (Unit.INSTANCE, signifying successful completion)
-```
-~~~
-
----
-
 ~~~admonish warning title="Common Mistakes"
-- **Forgetting to run:** A `ReaderT` is a *description* of a computation, not the computation itself. It does nothing until you call `.run().apply(config)`. If your tests pass but nothing happens, check that you are running the `ReaderT`.
+- **Forgetting to run:** a `ReaderT` is a *description* of a computation, not the computation itself. It does nothing until you call `.run().apply(config)`. If your tests pass but nothing happens, check that you are running the `ReaderT`.
 - **Mutating the environment:** `R` should be immutable. `ReaderT` passes the same `R` to every operation in a chain. Mutating it would break referential transparency and produce unpredictable results.
-- **Using ReaderT when you need state changes:** If the configuration changes between steps, you need `StateT`, not `ReaderT`. The "Reader" in `ReaderT` means *read-only*.
+- **Using `ReaderT` when you need state changes:** if the configuration changes between steps, you need [`StateT`](statet_transformer.md), not `ReaderT`. The "Reader" in `ReaderT` means *read-only*.
+- **Reaching for the transformer when `ReaderPath` would do:** if your only effect is the environment, `ReaderPath` is shorter and reads more naturally.
 ~~~
 
 ---
 
 ~~~admonish tip title="See Also"
+- [ReaderPath / Advanced Effects](../effect/advanced_effects.md) - The Path-API equivalent
+- [MonadReader](mtl_reader.md) - The MTL capability for stack-independent code
+- [Stack Archetypes](archetypes.md) - The Context Stack archetype maps to `ReaderT`/`ReaderPath`
+- [Migration Cookbook](migration_cookbook.md) - Side-by-side translations
 - [Monad Transformers](transformers.md) - General concept and choosing the right transformer
 - [StateT](statet_transformer.md) - When your environment needs to change between steps
 - [EitherT](eithert_transformer.md) - When operations can fail with typed errors
@@ -356,6 +373,12 @@ Unit result = FUTURE.join(initialiseComponentRT().run().apply(prodConfig));
 - [ReaderT Design Pattern](https://academy.fpblock.com/blog/2017/06/readert-design-pattern/) - Michael Snoyman's production patterns (30 min read)
 - [A Fresh Perspective on Monads](https://rockthejvm.com/articles/a-fresh-perspective-on-monads) - Rock the JVM on composing monadic effects (20 min read)
 ~~~
+
+~~~admonish info title="Hands-On Learning"
+The `MonadReader` capability that wraps `ReaderT` is exercised in [Tutorial 04: Polymorphic Capabilities (MTL)](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial04_PolymorphicCapabilities.java) (14 exercises, ~30-40 minutes).
+~~~
+
+---
 
 **Previous:** [MaybeT](maybet_transformer.md)
 **Next:** [StateT](statet_transformer.md)

--- a/hkj-book/src/transformers/statet_transformer.md
+++ b/hkj-book/src/transformers/statet_transformer.md
@@ -1,18 +1,29 @@
 # The StateT Transformer:
 ## _Managing State Across Effect Boundaries_
 
+> *"You could not step twice into the same river."*
+>
+> -- Heraclitus
+
+State that changes between steps is exactly the river Heraclitus described. `StateT` lets each step see the river it actually faces while keeping the same composable surface.
+
 ~~~admonish info title="What You'll Learn"
 - How to add stateful computation to any existing monad
-- Building stack operations that can fail (StateT with Optional)
-- Understanding the relationship between State and StateT<S, Identity, A>
-- Creating complex workflows that manage both state and other effects
-- Using `get`, `set`, `modify` operations within transformer contexts
+- Building stack operations that can fail (`StateT` with `Optional`)
+- Understanding the relationship between `State` and `StateT<S, Identity, A>`
+- Using `For` comprehensions with `get`, `put`, `modify` to keep witness types localised
+- When to use the [`WithStatePath`](../effect/advanced_effects.md) Path type or the [`MonadState`](mtl_state.md) capability instead of raw `StateT`
 ~~~
 
-~~~ admonish example title="See Example Code:"
+~~~admonish example title="See Example Code"
 - [StateTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTExample.java)
-
 - [StateTStackExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTStackExample.java)
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+For most use cases, [`WithStatePath<S, A>`](../effect/advanced_effects.md) is the better starting point when state is the only effect. When you need polymorphic, stack-independent code, the [`MonadState<F, S>`](mtl_state.md) capability is usually a better fit than the concrete `StateT`.
+
+Reach for raw `StateT` only when you need to combine state with a specific outer monad that Path does not wrap, or when you are constructing your own MTL instance.
 ~~~
 
 ---
@@ -22,17 +33,15 @@
 Imagine a stack data structure where `pop` might fail on an empty stack. Without `StateT`, you end up managing both the state transitions and the optionality by hand:
 
 ```java
-// Without StateT: manual state + optional management
 Optional<StateTuple<List<Integer>, Integer>> pop(List<Integer> stack) {
     if (stack.isEmpty()) return Optional.empty();
-    List<Integer> newStack = new LinkedList<>(stack);
+    var newStack = new LinkedList<>(stack);
     Integer value = newStack.remove(0);
     return Optional.of(StateTuple.of(newStack, value));
 }
 
-// Composing: push, push, pop, pop, sum the popped values
 Optional<StateTuple<List<Integer>, Integer>> workflow(List<Integer> initial) {
-    var afterPush1 = push(initial, 10);   // Returns StateTuple (always succeeds)
+    var afterPush1 = push(initial, 10);
     var afterPush2 = push(afterPush1.state(), 20);
     var pop1Result = pop(afterPush2.state());
     if (pop1Result.isEmpty()) return Optional.empty();
@@ -45,26 +54,58 @@ Optional<StateTuple<List<Integer>, Integer>> workflow(List<Integer> initial) {
 
 Each operation returns both a new state and a value; the optionality adds another layer of checking. The state threading is manual and error-prone. Miss one `.get().state()` call and you use stale state.
 
-## The Solution: StateT
+---
+
+## The Solution
+
+### With the Effect Path API (single effect)
+
+If state is the only effect, `WithStatePath` is the simplest expression:
 
 ```java
-// With StateT: state threading + optionality handled automatically
-var computation =
-    For.from(ST_OPT_MONAD, push(10))
-        .from(_ -> push(20))
-        .from(_ -> pop())
-        .from(_ -> pop())
-        .yield((a, b, p1, p2) -> {
-            System.out.println("Popped: " + p1 + ", " + p2);
-            return p1 + p2;
-        });
+WithStatePath<List<Integer>, Integer> workflow() {
+    return WithStatePath.<List<Integer>>modify(s -> prepend(s, 10))
+        .then(() -> WithStatePath.modify(s -> prepend(s, 20)))
+        .then(() -> WithStatePath.<List<Integer>>get())
+        .map(state -> state.get(0) + state.get(1));
+}
+```
 
-Optional<StateTuple<List<Integer>, Integer>> result =
-    OPTIONAL.narrow(StateTKindHelper.runStateT(computation, Collections.emptyList()));
+### With raw `StateT` (combined effect)
+
+When state must combine with another effect (here `Optional`):
+
+```java
+var optMonad    = OptionalMonad.INSTANCE;
+var stateTMonad = StateTMonad.<List<Integer>, OptionalKind.Witness>instance(optMonad);
+
+var computation = For.from(stateTMonad, push(10))
+    .from(_ -> push(20))
+    .from(_ -> pop())
+    .from(_ -> pop())
+    .yield((a, b, p1, p2) -> p1 + p2);
+
+var result = OPTIONAL.narrow(StateTKindHelper.runStateT(computation, Collections.emptyList()));
 // → Optional.of(StateTuple([], 30))
 ```
 
-The state flows from one operation to the next through `flatMap`. If any operation returns `Optional.empty()` (e.g., popping an empty stack), the rest are skipped. No manual state passing, no null checks.
+The state flows from one operation to the next through `flatMap`. If any operation returns `Optional.empty()` (e.g. popping an empty stack), the rest are skipped. No manual state passing, no null checks.
+
+---
+
+## The Railway View
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Value</b>   ═══●═══════════●═══════════●═══════════●═══▶  result A (in F)</span>
+    <span style="color:#4CAF50">           push(10)    push(20)    pop         pop</span>
+    <span style="color:#4CAF50">           (flatMap)   (flatMap)   (flatMap)   (flatMap)</span>
+               │           │           │           │
+               ▼           ▼           ▼           ▼
+    <span style="color:#2196F3"><b>State</b>   ═══●═══════════●═══════════●═══════════●═══▶  final state S</span>
+    <span style="color:#2196F3">           [10]        [20,10]     [10]        []</span>
+</pre>
+
+Both tracks advance in lockstep: each `flatMap` produces a new `(value, state)` pair. Calling `runStateT(initialState)` at the boundary kicks the whole computation off and yields the final state alongside the result. If the outer monad `F` short-circuits (here `Optional.empty()` on an empty pop), subsequent steps are skipped and both tracks freeze.
 
 ---
 
@@ -96,25 +137,19 @@ The state flows from one operation to the next through `flatMap`. If any operati
     └──────────────────────────────────────────────────────────┘
 ```
 
-![statet_transformer.svg](../images/puml/statet_transformer.svg)
-
 * **`S`**: The type of the state.
-* **`F`**: The witness type for the underlying monad (e.g., `OptionalKind.Witness`, `IOKind.Witness`).
+* **`F`**: The witness type for the underlying monad (e.g. `OptionalKind.Witness`, `IOKind.Witness`).
 * **`A`**: The type of the computed value.
 * **`StateTuple<S, A>`**: A container holding the pair `(state, value)`.
 
-The fundamental structure is a function: `S -> F<StateTuple<S, A>>`
+The fundamental structure is a function `S -> F<StateTuple<S, A>>`:
 
 ```java
-// StateT holds: Function<S, Kind<F, StateTuple<S, A>>>
-StateT<Integer, OptionalKind.Witness, String> computation =
-    StateT.create(
-        currentState -> {
-            if (currentState < 0) return OPTIONAL.widen(Optional.empty());
-            return OPTIONAL.widen(Optional.of(
-                StateTuple.of(currentState + 1, "Value: " + currentState)));
-        },
-        optionalMonad);
+StateT<Integer, OptionalKind.Witness, String> computation = StateT.create(
+    currentState -> currentState < 0
+        ? OPTIONAL.widen(Optional.empty())
+        : OPTIONAL.widen(Optional.of(StateTuple.of(currentState + 1, "Value: " + currentState))),
+    optionalMonad);
 ```
 
 ---
@@ -124,19 +159,17 @@ StateT<Integer, OptionalKind.Witness, String> computation =
 The `StateTMonad<S, F>` class implements `Monad<StateTKind.Witness<S, F>>`. It requires a `Monad<F>` instance for the underlying monad:
 
 ```java
-OptionalMonad optionalMonad = OptionalMonad.INSTANCE;
-
-StateTMonad<Integer, OptionalKind.Witness> stateTMonad =
-    StateTMonad.instance(optionalMonad);
+var optionalMonad = OptionalMonad.INSTANCE;
+var stateTMonad   = StateTMonad.<Integer, OptionalKind.Witness>instance(optionalMonad);
 ```
 
-~~~admonish note title="Key Classes"
-* **`StateT<S, F, A>`**: The primary data type holding `S -> Kind<F, StateTuple<S, A>>`.
-* **`StateTKind<S, F, A>`**: The `Kind` representation for generic monadic usage.
-* **`StateTKind.Witness<S, F>`**: The higher-kinded type witness. Both `S` and `F` are part of the witness.
-* **`StateTMonad<S, F>`**: The `Monad` instance, providing `of`, `map`, `flatMap`, `ap`.
-* **`StateTKindHelper`**: Utility for `narrow`, `runStateT`, `evalStateT`, `execStateT`.
-* **`StateTuple<S, A>`**: A record holding `(S state, A value)`.
+~~~admonish note title="Working with Kind"
+- **`StateT<S, F, A>`**: the primary data type holding `S -> Kind<F, StateTuple<S, A>>`.
+- **`StateTKind<S, F, A>`**: the `Kind` representation for generic monadic usage.
+- **`StateTKind.Witness<S, F>`**: the higher-kinded type witness. Both `S` and `F` are part of the witness.
+- **`StateTMonad<S, F>`**: the `Monad` instance, providing `of`, `map`, `flatMap`, `ap`.
+- **`StateTKindHelper`**: utility for `narrow`, `runStateT`, `evalStateT`, `execStateT`.
+- **`StateTuple<S, A>`**: a record holding `(S state, A value)`.
 ~~~
 
 ---
@@ -145,101 +178,66 @@ StateTMonad<Integer, OptionalKind.Witness> stateTMonad =
 
 ```java
 // Run: returns F<StateTuple<S, A>>
-Kind<OptionalKind.Witness, StateTuple<Integer, String>> result =
-    StateTKindHelper.runStateT(computation, 10);
+var result    = StateTKindHelper.runStateT(computation, 10);
 // → Optional.of(StateTuple(11, "Value: 10"))
 
 // Eval: returns F<A> (discards state)
-Kind<OptionalKind.Witness, String> valueOnly =
-    StateTKindHelper.evalStateT(computation, 10);
+var valueOnly = StateTKindHelper.evalStateT(computation, 10);
 // → Optional.of("Value: 10")
 
 // Exec: returns F<S> (discards value)
-Kind<OptionalKind.Witness, Integer> stateOnly =
-    StateTKindHelper.execStateT(computation, 10);
+var stateOnly = StateTKindHelper.execStateT(computation, 10);
 // → Optional.of(11)
 ```
 
 ---
 
-## Composing StateT Actions
+## Key Operations
 
-Like any monad, `StateT` computations compose with `map` and `flatMap`:
+| Operation | Behaviour |
+|-----------|-----------|
+| `stateTMonad.of(value)`        | Wraps a pure value, leaving state unchanged |
+| `stateTMonad.map(f, kind)`     | Transforms the value; state passes through |
+| `stateTMonad.flatMap(f, kind)` | Sequences operations, threading the updated state |
 
-~~~admonish Example title="map: Transforming the Value"
-```java
-Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, Integer> initial =
-    StateT.create(s -> OPTIONAL.widen(
-        Optional.of(StateTuple.of(s + 1, s * 2))), optionalMonad);
-
-Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, String> mapped =
-    stateTMonad.map(val -> "Computed: " + val, initial);
-
-// Run with state 5:
-// 1. initial: state=6, value=10
-// 2. map: value → "Computed: 10"
-// Result: Optional.of(StateTuple(6, "Computed: 10"))
-```
-~~~
-
-~~~admonish Example title="flatMap: Sequencing State Operations"
-```java
-Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, Integer> firstStep =
-    StateT.create(s -> OPTIONAL.widen(
-        Optional.of(StateTuple.of(s + 1, s * 10))), optionalMonad);
-
-Function<Integer, Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, String>>
-    secondStepFn = prevValue -> StateT.create(
-        s -> {
-            if (prevValue > 100) {
-                return OPTIONAL.widen(Optional.of(
-                    StateTuple.of(s + prevValue, "Large: " + prevValue)));
-            }
-            return OPTIONAL.widen(Optional.empty()); // Fail if too small
-        }, optionalMonad);
-
-Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, String> combined =
-    stateTMonad.flatMap(secondStepFn, firstStep);
-
-// Run with state 15: firstStep → (16, 150), secondStep(150) → (166, "Large: 150")
-// Run with state 5:  firstStep → (6, 50), secondStep(50) → empty (too small)
-```
-~~~
+The `MonadState` capability adds `get()`, `put(s)`, `modify(f)`, `gets(f)`, and `inspect(f)` on top.
 
 ---
 
-## Transforming the Outer Monad with `mapT`
+## Composing StateT Actions
 
-Sometimes you need to change the *outer monad* of a `StateT` without touching the state-threading logic. Perhaps you want to switch from `Optional` to `Id` (guaranteeing a result with a default), or apply a natural transformation to move between effect types.
+Like any monad, `StateT` computations compose with `map` and `flatMap`. Most pages in this chapter show this through `For` comprehensions; the explicit forms are equivalent:
 
-Because `StateT` stores its `Monad<F>` instance internally, switching from `F` to `G` requires supplying a new `Monad<G>`. This is the one transformer where `mapT` takes an extra parameter:
-
-```
-  state ──> runStateTFn() ──> Kind<F, StateTuple<S, A>> ──> f ──> Kind<G, StateTuple<S, A>>
-    │                                                                        │
-    └──── combined into new StateT<S, G, A> with monadG ────────────────────┘
-```
-
+~~~admonish example title="map: transforming the value"
 ```java
-// Switch from Optional to Id, providing a default for empty results
-StateT<Integer, OptionalKind.Witness, String> optStateT = ...;
-Monad<IdKind.Witness> idMonad = IdMonad.instance();
+var initial = StateT.<Integer, OptionalKind.Witness, Integer>create(
+    s -> OPTIONAL.widen(Optional.of(StateTuple.of(s + 1, s * 2))),
+    optionalMonad);
 
-StateT<Integer, IdKind.Witness, String> idStateT =
-    optStateT.mapT(idMonad, optKind -> {
-      Optional<StateTuple<Integer, String>> opt = OPTIONAL.narrow(optKind);
-      return ID.widen(Id.of(opt.orElse(StateTuple.of(0, "default"))));
-    });
+var mapped = stateTMonad.map(val -> "Computed: " + val, initial);
+
+// Run with state 5: initial → state=6, value=10; map → "Computed: 10"
+// → Optional.of(StateTuple(6, "Computed: 10"))
 ```
-
-~~~admonish note title="mapT vs map"
-`map` transforms the *value* produced by the state computation (the `A` in `StateTuple<S, A>`).
-`mapT` transforms the *outer monad* wrapping each state transition — the `F` in `S -> F<StateTuple<S, A>>`.
-The state-threading is completely unaffected.
 ~~~
 
-~~~admonish warning title="StateT requires a new Monad instance"
-Unlike the other five transformers, `StateT.mapT` takes `Monad<G> monadG` as its first parameter. This is because `StateT` stores the monad instance for internal sequencing — when you switch monads, the new `StateT` needs the new monad to continue operating correctly.
+~~~admonish example title="flatMap: sequencing state operations"
+```java
+var firstStep = StateT.<Integer, OptionalKind.Witness, Integer>create(
+    s -> OPTIONAL.widen(Optional.of(StateTuple.of(s + 1, s * 10))),
+    optionalMonad);
+
+Function<Integer, Kind<StateTKind.Witness<Integer, OptionalKind.Witness>, String>> secondStepFn =
+    prevValue -> StateT.create(
+        s -> prevValue > 100
+            ? OPTIONAL.widen(Optional.of(StateTuple.of(s + prevValue, "Large: " + prevValue)))
+            : OPTIONAL.widen(Optional.empty()),
+        optionalMonad);
+
+var combined = stateTMonad.flatMap(secondStepFn, firstStep);
+// state 15: firstStep → (16, 150), secondStep(150) → (166, "Large: 150")
+// state 5:  firstStep → (6, 50),  secondStep(50)  → empty
+```
 ~~~
 
 ---
@@ -260,14 +258,12 @@ static <S, F> Kind<StateTKind.Witness<S, F>, Unit> set(S newState, Monad<F> mona
 }
 
 // modify: update the state with a function, return Unit
-static <S, F> Kind<StateTKind.Witness<S, F>, Unit> modify(
-        Function<S, S> f, Monad<F> monadF) {
+static <S, F> Kind<StateTKind.Witness<S, F>, Unit> modify(Function<S, S> f, Monad<F> monadF) {
     return StateT.create(s -> monadF.of(StateTuple.of(f.apply(s), Unit.INSTANCE)), monadF);
 }
 
 // gets: extract a value derived from the state
-static <S, F, A> Kind<StateTKind.Witness<S, F>, A> gets(
-        Function<S, A> f, Monad<F> monadF) {
+static <S, F, A> Kind<StateTKind.Witness<S, F>, A> gets(Function<S, A> f, Monad<F> monadF) {
     return StateT.create(s -> monadF.of(StateTuple.of(s, f.apply(s))), monadF);
 }
 ```
@@ -276,11 +272,11 @@ static <S, F, A> Kind<StateTKind.Witness<S, F>, A> gets(
 
 ## Real-World Example: Stack with Failure
 
-~~~admonish Example title="Stack Operations with Optional Failure"
+~~~admonish example title="Stack Operations with Optional Failure"
 
 - [StateTStackExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/state_t/StateTStackExample.java)
 
-**The problem:** You need stack push/pop operations where popping an empty stack produces an absence rather than an exception, and you want to compose these operations cleanly.
+**The problem:** stack push/pop operations where popping an empty stack produces an absence rather than an exception. Compose them cleanly.
 
 **The solution:**
 
@@ -289,10 +285,9 @@ private static final OptionalMonad OPT_MONAD = OptionalMonad.INSTANCE;
 private static final StateTMonad<List<Integer>, OptionalKind.Witness> ST_OPT_MONAD =
     StateTMonad.instance(OPT_MONAD);
 
-static Kind<StateTKind.Witness<List<Integer>, OptionalKind.Witness>, Unit>
-    push(Integer value) {
+static Kind<StateTKind.Witness<List<Integer>, OptionalKind.Witness>, Unit> push(Integer value) {
   return StateTKindHelper.stateT(stack -> {
-      List<Integer> newStack = new LinkedList<>(stack);
+      var newStack = new LinkedList<>(stack);
       newStack.add(0, value);
       return OPTIONAL.widen(Optional.of(StateTuple.of(newStack, Unit.INSTANCE)));
   }, OPT_MONAD);
@@ -300,38 +295,62 @@ static Kind<StateTKind.Witness<List<Integer>, OptionalKind.Witness>, Unit>
 
 static Kind<StateTKind.Witness<List<Integer>, OptionalKind.Witness>, Integer> pop() {
   return StateTKindHelper.stateT(stack -> {
-      if (stack.isEmpty()) {
-          return OPTIONAL.widen(Optional.empty()); // Cannot pop empty stack
-      }
-      List<Integer> newStack = new LinkedList<>(stack);
+      if (stack.isEmpty()) return OPTIONAL.widen(Optional.empty());
+      var newStack = new LinkedList<>(stack);
       Integer popped = newStack.remove(0);
       return OPTIONAL.widen(Optional.of(StateTuple.of(newStack, popped)));
   }, OPT_MONAD);
 }
 
-// Compose with For comprehension:
-var computation =
-    For.from(ST_OPT_MONAD, push(10))
-        .from(_ -> push(20))
-        .from(_ -> pop())
-        .from(_ -> pop())
-        .yield((a, b, p1, p2) -> {
-            System.out.println("Popped in order: " + p1 + ", then " + p2);
-            return p1 + p2;
-        });
+// Compose with For:
+var computation = For.from(ST_OPT_MONAD, push(10))
+    .from(_ -> push(20))
+    .from(_ -> pop())
+    .from(_ -> pop())
+    .yield((a, b, p1, p2) -> p1 + p2);
 
-List<Integer> initialStack = Collections.emptyList();
-Optional<StateTuple<List<Integer>, Integer>> result =
-    OPTIONAL.narrow(StateTKindHelper.runStateT(computation, initialStack));
+var result = OPTIONAL.narrow(StateTKindHelper.runStateT(computation, Collections.emptyList()));
 // → Optional.of(StateTuple([], 30))
 
-// Popping an empty stack:
-Optional<StateTuple<List<Integer>, Integer>> emptyPop =
-    OPTIONAL.narrow(StateTKindHelper.runStateT(pop(), Collections.emptyList()));
+var emptyPop = OPTIONAL.narrow(StateTKindHelper.runStateT(pop(), Collections.emptyList()));
 // → Optional.empty()
 ```
 
-**Why this works:** The `For` comprehension sequences state operations through `flatMap`. Each `push` returns the updated stack as new state; each `pop` either returns the popped value with an updated stack, or `Optional.empty()` which short-circuits the rest. The state threading is completely automatic.
+**Why this works:** the `For` comprehension sequences state operations through `flatMap`. Each `push` returns the updated stack as new state; each `pop` either returns the popped value with an updated stack or `Optional.empty()`, which short-circuits the rest. The state threading is completely automatic.
+~~~
+
+---
+
+## Transforming the Outer Monad with `mapT`
+
+Sometimes you need to change the *outer monad* of a `StateT` without touching the state-threading logic. Perhaps you want to switch from `Optional` to `Id` (guaranteeing a result with a default), or apply a natural transformation to move between effect types.
+
+Because `StateT` stores its `Monad<F>` instance internally, switching from `F` to `G` requires supplying a new `Monad<G>`. This is the one transformer where `mapT` takes an extra parameter:
+
+```
+  state ──> runStateTFn() ──> Kind<F, StateTuple<S, A>> ──> f ──> Kind<G, StateTuple<S, A>>
+    │                                                                        │
+    └──── combined into new StateT<S, G, A> with monadG ────────────────────┘
+```
+
+```java
+StateT<Integer, OptionalKind.Witness, String> optStateT = ...;
+var idMonad = IdMonad.instance();
+
+var idStateT = optStateT.mapT(idMonad, optKind -> {
+  Optional<StateTuple<Integer, String>> opt = OPTIONAL.narrow(optKind);
+  return ID.widen(Id.of(opt.orElse(StateTuple.of(0, "default"))));
+});
+```
+
+~~~admonish note title="mapT vs map"
+`map` transforms the *value* produced by the state computation (the `A` in `StateTuple<S, A>`).
+`mapT` transforms the *outer monad* wrapping each state transition, the `F` in `S -> F<StateTuple<S, A>>`.
+The state-threading is completely unaffected.
+~~~
+
+~~~admonish warning title="StateT requires a new Monad instance"
+Unlike the other five transformers, `StateT.mapT` takes `Monad<G> monadG` as its first parameter. This is because `StateT` stores the monad instance for internal sequencing; when you switch monads, the new `StateT` needs the new monad to continue operating correctly.
 ~~~
 
 ---
@@ -340,28 +359,35 @@ Optional<StateTuple<List<Integer>, Integer>> emptyPop =
 
 The [State Monad](../monads/state_monad.md) (`State<S, A>`) is a specialised case of `StateT`. Specifically, `State<S, A>` is equivalent to `StateT<S, IdKind.Witness, A>`, where `Id` is the Identity monad (a monad that adds no effects).
 
-If your stateful computation doesn't need to combine with another effect, use `State<S, A>` directly. Reach for `StateT` when you need state *and* another effect (optionality, error handling, async).
+If your stateful computation does not need to combine with another effect, use `State<S, A>` directly (or `WithStatePath<S, A>`). Reach for `StateT` when you need state *and* another effect (optionality, error handling, async).
 
 ---
 
 ~~~admonish warning title="Common Mistakes"
-- **Using stale state:** In manual state threading, it's easy to accidentally use the state from step 1 in step 3. `StateT.flatMap` eliminates this by threading updated state automatically.
-- **Null in `ap`:** The `ap` method requires the function it extracts from the first `StateT` computation to be non-null. A `null` function will cause a `NullPointerException`.
-- **Confusing StateT with ReaderT:** If your "state" never changes, you probably want `ReaderT`. Use `StateT` only when operations need to *modify* the state.
+- **Using stale state:** in manual state threading, it is easy to accidentally use the state from step 1 in step 3. `StateT.flatMap` eliminates this by threading updated state automatically.
+- **Null in `ap`:** the `ap` method requires the function it extracts from the first `StateT` computation to be non-null. A `null` function will cause a `NullPointerException`.
+- **Confusing `StateT` with `ReaderT`:** if your "state" never changes, you probably want [`ReaderT`](readert_transformer.md). Use `StateT` only when operations need to *modify* the state.
+- **Reaching for the transformer when `WithStatePath` would do:** if state is your only effect, `WithStatePath` is shorter and reads more naturally.
 ~~~
 
 ---
 
 ~~~admonish tip title="See Also"
+- [WithStatePath / Advanced Effects](../effect/advanced_effects.md) - The Path-API equivalent
+- [MonadState](mtl_state.md) - The MTL capability for stack-independent code
+- [Stack Archetypes](archetypes.md) - The Workflow Stack archetype maps to `StateT`/`WithStatePath`
+- [Migration Cookbook](migration_cookbook.md) - Side-by-side translations
 - [State Monad](../monads/state_monad.md) - Understand the basics of stateful computations
-- [Monad Transformers](./transformers.md) - General concept of monad transformers
+- [Monad Transformers](transformers.md) - General concept of monad transformers
 - [ReaderT](readert_transformer.md) - When you need read-only environment, not mutable state
-- [Draughts Example ("checkers")](../examples/examples_draughts.md) - See the HKJ State Monad used in a game 
+- [Draughts Example ("checkers")](../examples/examples_draughts.md) - See the HKJ State Monad used in a game
+~~~
+
+~~~admonish info title="Hands-On Learning"
+The `MonadState` capability that wraps `StateT` is exercised in [Tutorial 04: Polymorphic Capabilities (MTL)](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial04_PolymorphicCapabilities.java) (14 exercises, ~30-40 minutes).
 ~~~
 
 ---
-
-
 
 **Previous:** [ReaderT](readert_transformer.md)
 **Next:** [WriterT](writert_transformer.md)

--- a/hkj-book/src/transformers/transformer_capstone.md
+++ b/hkj-book/src/transformers/transformer_capstone.md
@@ -1,0 +1,248 @@
+# Capstone: A Multi-Capability Workflow
+
+> *"The chief end of man is to compose effects."*
+>
+> -- A modernised paraphrase of Westminster, with apologies
+
+~~~admonish info title="What You'll Learn"
+- How a real workflow combines typed errors, configuration, audit, and async execution
+- A complete before/after comparison: imperative Java vs MTL vs Effect Path API
+- Why the MTL capability style is the right answer for polymorphic library code
+- When the Effect Path API equivalent reads more naturally for application code
+~~~
+
+---
+
+## The Scenario
+
+You are writing the order-processing layer of an e-commerce service. Every order goes through three steps:
+
+1. **Validate** the order (sync, may fail with `InvalidOrder`)
+2. **Reserve** stock against an inventory service (async, reads the inventory URL from config, may fail with `OutOfStock`)
+3. **Charge** the customer through a payment gateway (async, reads the gateway URL and API key from config, may fail with `PaymentDeclined`)
+
+Each step appends an audit entry to a running log so the operations team can reconstruct what happened to any order.
+
+```java
+record AppConfig(String inventoryUrl, String paymentUrl, String apiKey) {}
+
+record AuditEntry(String step, String detail) {}
+
+record Order(String id, String sku, int quantity, double amount) {}
+
+record Receipt(String orderId, String confirmationCode) {}
+
+sealed interface DomainError {
+    record InvalidOrder(String reason) implements DomainError {}
+    record OutOfStock(String sku) implements DomainError {}
+    record PaymentDeclined(String reason) implements DomainError {}
+}
+```
+
+The pipeline must:
+
+- Read `AppConfig` for service URLs and the API key
+- Append an `AuditEntry` at each step
+- Short-circuit with the appropriate `DomainError` if any step fails
+- Run asynchronously throughout
+
+---
+
+## The Imperative Approach
+
+The straightforward Java solution threads three concerns through every signature:
+
+```java
+CompletableFuture<Either<DomainError, Receipt>> processOrder(
+        Order order, AppConfig config, List<AuditEntry> log) {
+
+    // 1. Validate
+    if (order.quantity() <= 0) {
+        log.add(new AuditEntry("validate", "rejected: quantity must be positive"));
+        return CompletableFuture.completedFuture(
+            Either.left(new DomainError.InvalidOrder("quantity must be positive")));
+    }
+    log.add(new AuditEntry("validate", "ok: " + order.id()));
+
+    // 2. Reserve stock (async)
+    return reserveAsync(config.inventoryUrl(), order.sku(), order.quantity())
+        .thenCompose(reserveResult -> {
+            if (reserveResult.isLeft()) {
+                log.add(new AuditEntry("reserve", "failed: " + reserveResult.getLeft()));
+                return CompletableFuture.completedFuture(Either.left(reserveResult.getLeft()));
+            }
+            log.add(new AuditEntry("reserve", "ok: sku=" + order.sku()));
+
+            // 3. Charge (async)
+            return chargeAsync(config.paymentUrl(), config.apiKey(), order.amount())
+                .thenApply(chargeResult -> {
+                    if (chargeResult.isLeft()) {
+                        log.add(new AuditEntry("charge", "declined"));
+                        return Either.<DomainError, Receipt>left(chargeResult.getLeft());
+                    }
+                    log.add(new AuditEntry("charge", "ok: " + chargeResult.getRight()));
+                    return Either.<DomainError, Receipt>right(
+                        new Receipt(order.id(), chargeResult.getRight()));
+                });
+        });
+}
+```
+
+The business logic ("validate, then reserve, then charge") is buried under explicit `thenCompose`/`thenApply` plumbing. The audit log is a mutable parameter that every caller must remember to thread. The `AppConfig` is passed through every helper. Three concerns crash through every line.
+
+---
+
+## The MTL Approach
+
+When the same logic must run against different concrete stacks (production async, synchronous tests, audit-only interpreter), write it once against capability interfaces:
+
+```java
+import org.higherkindedj.hkt.MonadError;
+import org.higherkindedj.hkt.MonadReader;
+import org.higherkindedj.hkt.MonadWriter;
+import org.higherkindedj.hkt.expression.For;
+
+<F extends WitnessArity<TypeArity.Unary>> Kind<F, Receipt> processOrder(
+        Order order,
+        MonadReader<F, AppConfig> env,
+        MonadWriter<F, List<AuditEntry>> audit,
+        MonadError<F, DomainError> errors) {
+
+    return For.from(env, validate(order, errors, audit))
+        .from(_ -> env.ask())
+        .from((_, config) -> reserve(order, config.inventoryUrl(), errors, audit))
+        .from((_, config, _) -> charge(order, config, errors, audit))
+        .yield((_, _, _, code) -> new Receipt(order.id(), code));
+}
+```
+
+The function declares exactly the capabilities it needs: read-only `AppConfig`, append-only `List<AuditEntry>`, typed error of `DomainError`. It says nothing about *how* those capabilities are assembled, only *that* they are available.
+
+The helper steps follow the same shape:
+
+```java
+<F extends WitnessArity<TypeArity.Unary>> Kind<F, Unit> validate(
+        Order order,
+        MonadError<F, DomainError> errors,
+        MonadWriter<F, List<AuditEntry>> audit) {
+    if (order.quantity() <= 0) {
+        return For.from(audit, audit.tell(List.of(new AuditEntry("validate", "rejected"))))
+            .from(_ -> errors.raiseError(new DomainError.InvalidOrder("quantity must be positive")))
+            .yield((_, e) -> e);
+    }
+    return audit.tell(List.of(new AuditEntry("validate", "ok: " + order.id())));
+}
+```
+
+`validate` declares only the two capabilities it actually uses (`MonadError` and `MonadWriter`). It does not see, and cannot accidentally depend on, the `MonadReader` capability that other steps need.
+
+### Running the polymorphic function
+
+To execute `processOrder`, the caller assembles a concrete stack that provides all three capabilities. For tests, a synchronous stack over `Id` is enough:
+
+```java
+// Compose three transformers over Id: ReaderT outside, WriterT in the middle, EitherT inside.
+// Build the concrete monad once at the boundary; pass it as the three capability views.
+var stack = buildTestStack(idMonad, listMonoid);
+
+Kind<TestStack.Witness, Receipt> program =
+    processOrder(order, stack.reader(), stack.writer(), stack.errors());
+
+TestStack.Result<Receipt> result = stack.run(program, prodConfig);
+//   result.value()  -> Either<DomainError, Receipt>
+//   result.audit()  -> List<AuditEntry>
+```
+
+The full mechanics of stacking three transformers live in [Combining Capabilities](mtl_combining.md). What matters here is that the *workflow definition* never named a stack: the same `processOrder` function runs against a production stack over `CompletableFuture`, a test stack over `Id`, an audit-only interpreter, or any future stack a caller invents.
+
+---
+
+## The Effect Path Approach
+
+For workflows where you do not need stack polymorphism (most application code), the Effect Path API expresses the same pipeline more directly. Each capability has its own Path type, and a `ForPath` comprehension threads them together:
+
+```java
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.WriterPath;
+
+EitherPath<DomainError, Receipt> processOrder(Order order, AppConfig config) {
+    return validate(order)
+        .via(_ -> reserve(order, config.inventoryUrl()))
+        .via(_ -> charge(order, config))
+        .map(code -> new Receipt(order.id(), code));
+}
+
+EitherPath<DomainError, Unit> validate(Order order) {
+    return order.quantity() <= 0
+        ? Path.<DomainError, Unit>left(new DomainError.InvalidOrder("quantity must be positive"))
+        : Path.right(Unit.INSTANCE);
+}
+```
+
+`EitherPath` carries the typed errors. The audit log can be threaded with a separate `WriterPath` chain, or recorded out-of-band via a logging context. Configuration is passed as a plain parameter because it does not vary mid-workflow; if you need to compose it through `For`, swap in `ReaderPath<AppConfig, A>`.
+
+The Path API trades the polymorphism of MTL for shorter, more concrete code. When you control the call site and know the outer monad, that is usually a better trade.
+
+---
+
+## What Happened
+
+The railway diagram for the success-and-failure tracks of the polymorphic version:
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Success</b> ═══●══════════════●══════════════●══════════●═══▶  Receipt</span>
+    <span style="color:#4CAF50">         validate       reserve         charge       map</span>
+    <span style="color:#4CAF50">         (errors)        (env+errors)    (env+errors)</span>
+              │                │                │
+              ▼ <i>tell</i>          ▼ <i>tell</i>          ▼ <i>tell</i>
+    <span style="color:#FFB300"><b>Audit</b>   ──●──────────────●──────────────●─────────────────▶  List&lt;AuditEntry&gt;</span>
+    <span style="color:#FFB300">         "validate ok"  "reserve ok"   "charge ok"</span>
+              ╲                ╲                ╲
+               ╲                ╲                ╲  Left: skip remaining steps
+                ╲                ╲                ╲
+    <span style="color:#F44336"><b>Failure</b> ──●────────────────●──────────────●────────────────▶  DomainError</span>
+    <span style="color:#F44336">         InvalidOrder    OutOfStock     PaymentDeclined</span>
+</pre>
+
+The audit track and the value track advance together. The error track absorbs any `Left` from any step and short-circuits the rest. All three concerns coexist in one comprehension because the capabilities composed through MTL share the same monad witness `F`.
+
+---
+
+## Side-by-side
+
+| Aspect | Imperative | MTL polymorphic | Effect Path |
+|--------|-----------|------------------|-------------|
+| Lines of plumbing | ~25 | ~10 | ~6 |
+| Stack polymorphism | None | Full | None |
+| Capability declarations | Implicit (parameters) | Explicit (interfaces) | Implicit (Path types) |
+| Reusable across stacks | Rewrite | Yes | No |
+| Best for | Small, throwaway code | Library code | Application code |
+
+The MTL version pays for its polymorphism with explicit capability parameters and the cost of constructing a concrete stack at the call site. That is the right cost when callers will plug their own outer monad underneath your function: you cannot know in advance whether they want `CompletableFuture`, `IO`, `VTask`, or something else.
+
+The Effect Path version pays nothing for that polymorphism it never uses, and reads more directly. When you control the runtime, that is the better trade.
+
+---
+
+## Key Takeaways
+
+~~~admonish info title="Key Takeaways"
+* **MTL is the polymorphism story.** When the same business logic must run against many concrete stacks, declare capabilities on the function signature and let the caller assemble a stack that satisfies them. The function never names a transformer.
+* **Effect Paths are the directness story.** When you control the call site and know the outer monad, the Path API expresses the same workflow with less ceremony. Most application code lives here.
+* **Multiple concerns ride together.** The audit track, the configuration track, and the error track all compose through the same `For` body because every step shares one monad witness. The body of the comprehension reads like ordinary sequential code.
+* **The cost of polymorphism is the cost of stack assembly.** The MTL function is short. Constructing a concrete stack that implements `MonadReader<F, AppConfig>`, `MonadWriter<F, List<AuditEntry>>`, and `MonadError<F, DomainError>` over `CompletableFuture` is not. Reach for MTL when that cost buys you something the Path API cannot.
+~~~
+
+~~~admonish tip title="See Also"
+- [MTL Capabilities](mtl_capabilities.md), the conceptual reference for capability-based effects
+- [Combining Capabilities](mtl_combining.md), the full mechanics of multi-capability functions and concrete instances
+- [Stack Archetypes](archetypes.md), seven named patterns covering most enterprise composition needs
+- [Effect Path API Capstone](../effect/capstone_focus_effect.md), the equivalent worked example for the Path API
+- [Migration Cookbook](migration_cookbook.md), side-by-side translations between the styles shown here
+~~~
+
+---
+
+**Previous:** [Common Compiler Errors](common_errors.md)
+**Next:** [Foundations](../hkts/foundations_intro.md)

--- a/hkj-book/src/transformers/transformers.md
+++ b/hkj-book/src/transformers/transformers.md
@@ -10,7 +10,7 @@ If you've ever written a utility method that takes a `CompletableFuture<Either<E
 ~~~admonish info title="What You'll Learn"
 - Why directly nesting monadic types like `CompletableFuture<Either<E, A>>` leads to complex, unwieldy code
 - How monad transformers wrap nested monads to provide a unified interface with familiar `map` and `flatMap` operations
-- The available transformers in Higher-Kinded-J: EitherT, MaybeT, OptionalT, ReaderT, and StateT
+- The available transformers in Higher-Kinded-J: EitherT, OptionalT, MaybeT, ReaderT, and StateT
 - How to choose the right transformer for your use case based on the effect you need to add
 ~~~
 
@@ -20,8 +20,8 @@ The [Effect Path API](../effect/ch_intro.md) provides a fluent, concrete wrapper
 | Path Type | Corresponding Transformer |
 |-----------|--------------------------|
 | `EitherPath<E, A>` | `EitherT<F, E, A>` |
-| `MaybePath<A>` | `MaybeT<F, A>` |
 | `OptionalPath<A>` | `OptionalT<F, A>` |
+| `MaybePath<A>` | `MaybeT<F, A>` |
 | `ReaderPath<R, A>` | `ReaderT<F, R, A>` |
 | `WithStatePath<S, A>` | `StateT<S, F, A>` |
 

--- a/hkj-book/src/transformers/transformers_at_a_glance.md
+++ b/hkj-book/src/transformers/transformers_at_a_glance.md
@@ -1,0 +1,187 @@
+# Transformers at a Glance
+
+A one-page reference card for every monad transformer in Higher-Kinded-J. Use this page to locate a factory, an operation, or the equivalent Path type without reading prose.
+
+~~~admonish info title="What You'll Learn"
+- The signature, witness, and primary use case for each transformer
+- The equivalent Effect Path type for readers crossing between APIs
+- The matching MTL capability when one exists
+- The smallest meaningful example for each transformer
+~~~
+
+---
+
+## The Family
+
+| Transformer | Wraps | MonadError? | Path Type | MTL Capability |
+|-------------|-------|-------------|-----------|----------------|
+| `EitherT<F, L, R>`   | `Kind<F, Either<L, R>>` | yes (`L`)    | [`EitherPath<E, A>`](../effect/path_either.md) | -- |
+| `OptionalT<F, A>`    | `Kind<F, Optional<A>>`  | yes (`Unit`) | [`OptionalPath<A>`](../effect/path_optional.md) | -- |
+| `MaybeT<F, A>`       | `Kind<F, Maybe<A>>`     | yes (`Unit`) | [`MaybePath<A>`](../effect/path_maybe.md) | -- |
+| `ReaderT<F, R, A>`   | `R -> Kind<F, A>`       | no           | [`ReaderPath<R, A>`](../effect/advanced_effects.md) | [`MonadReader`](mtl_reader.md) |
+| `StateT<S, F, A>`    | `S -> Kind<F, (S, A)>`  | no           | [`WithStatePath<S, A>`](../effect/advanced_effects.md) | [`MonadState`](mtl_state.md) |
+| `WriterT<F, W, A>`   | `Kind<F, Pair<A, W>>`   | no           | [`WriterPath<W, A>`](../effect/advanced_effects.md) | [`MonadWriter`](mtl_writer.md) |
+
+`F` is always the outer monad witness. The transformer adds its own effect on top of whatever `F` provides (async, optional, error, identity).
+
+---
+
+## Factory Methods
+
+Every transformer exposes a small set of static factories. The names follow a consistent shape: `lift` for outer-monad values, `fromKind` for already-nested values, and a primitive constructor for each effect-specific case.
+
+### EitherT
+
+| Factory | Produces |
+|---------|----------|
+| `EitherT.right(monad, value)`        | `F<Right(value)>` |
+| `EitherT.left(monad, error)`         | `F<Left(error)>` |
+| `EitherT.fromEither(monad, either)`  | `F<either>` |
+| `EitherT.liftF(monad, fa)`           | `F<Right(a)>` from `F<A>` |
+| `EitherT.fromKind(fEither)`          | wraps an existing `Kind<F, Either<L, R>>` |
+
+### OptionalT
+
+| Factory | Produces |
+|---------|----------|
+| `OptionalT.some(monad, value)`           | `F<Optional.of(value)>` |
+| `OptionalT.none(monad)`                  | `F<Optional.empty()>` |
+| `OptionalT.fromOptional(monad, opt)`     | `F<opt>` |
+| `OptionalT.liftF(monad, fa)`             | `F<Optional.ofNullable(a)>` from `F<A>` |
+| `OptionalT.fromKind(fOptional)`          | wraps an existing `Kind<F, Optional<A>>` |
+
+### MaybeT
+
+| Factory | Produces |
+|---------|----------|
+| `MaybeT.just(monad, value)`              | `F<Just(value)>` |
+| `MaybeT.nothing(monad)`                  | `F<Nothing>` |
+| `MaybeT.fromMaybe(monad, maybe)`         | `F<maybe>` |
+| `MaybeT.liftF(monad, fa)`                | `F<Maybe.fromNullable(a)>` from `F<A>` |
+| `MaybeT.fromKind(fMaybe)`                | wraps an existing `Kind<F, Maybe<A>>` |
+
+### ReaderT
+
+| Factory | Produces |
+|---------|----------|
+| `ReaderT.of(r -> fa)`                    | from `R -> Kind<F, A>` |
+| `ReaderT.lift(monad, fa)`                | environment ignored, returns `F<A>` |
+| `ReaderT.reader(monad, r -> a)`          | result lifted into `F` |
+| `ReaderT.ask(monad)`                     | the environment as the value |
+
+### StateT
+
+| Factory | Produces |
+|---------|----------|
+| `StateT.create(s -> fStateTuple, monad)` | from a state-transition function |
+| `StateTKindHelper.stateT(...)`           | helper that returns the `Kind<>` form directly |
+
+### WriterT
+
+| Factory | Produces |
+|---------|----------|
+| `WriterT.of(monad, monoid, value)`       | `F<Pair(value, empty)>` |
+| `WriterT.tell(monad, w)`                 | `F<Pair(Unit, w)>` |
+| `WriterT.writer(monad, value, w)`        | explicit value and output |
+| `WriterT.liftF(monad, monoid, fa)`       | `F<Pair(a, empty)>` from `F<A>` |
+| `WriterT.fromKind(fPair)`                | wraps an existing `Kind<F, Pair<A, W>>` |
+
+---
+
+## Key Operations
+
+| Transformer | Operations beyond `of`/`map`/`flatMap` |
+|-------------|-----------------------------------------|
+| `EitherT`   | `raiseError(err)`, `handleErrorWith(handler)` |
+| `OptionalT` | `raiseError(Unit.INSTANCE)`, `handleErrorWith(handler)` |
+| `MaybeT`    | `raiseError(Unit.INSTANCE)`, `handleErrorWith(handler)` |
+| `ReaderT`   | `ask`, `local(f)` |
+| `StateT`    | `get`, `put(s)`, `modify(f)`, `gets(f)`, `inspect(f)` |
+| `WriterT`   | `tell(w)`, `listen(ma)`, `pass(ma)`, `listens(f, ma)`, `censor(f, ma)` |
+
+Every transformer supports `mapT(f)` to change the outer monad without touching the inner effect. Note that `StateT.mapT` requires an extra `Monad<G>` parameter because `StateT` stores its monad instance internally.
+
+---
+
+## Smallest Meaningful Example
+
+Each example below is the shortest snippet that exercises the transformer's primary effect.
+
+### EitherT
+
+```java
+var monad   = new EitherTMonad<CompletableFutureKind.Witness, String>(CompletableFutureMonad.INSTANCE);
+var success = EitherT.right(CompletableFutureMonad.INSTANCE, 42);
+var failed  = EitherT.left(CompletableFutureMonad.INSTANCE, "oops");
+```
+
+### OptionalT
+
+```java
+var monad   = new OptionalTMonad<CompletableFutureKind.Witness>(CompletableFutureMonad.INSTANCE);
+var present = OptionalT.some(CompletableFutureMonad.INSTANCE, 42);
+var absent  = OptionalT.none(CompletableFutureMonad.INSTANCE);
+```
+
+### MaybeT
+
+```java
+var monad = new MaybeTMonad<CompletableFutureKind.Witness>(CompletableFutureMonad.INSTANCE);
+var just  = MaybeT.just(CompletableFutureMonad.INSTANCE, 42);
+var none  = MaybeT.nothing(CompletableFutureMonad.INSTANCE);
+```
+
+### ReaderT
+
+```java
+var monad  = new ReaderTMonad<CompletableFutureKind.Witness, AppConfig>(CompletableFutureMonad.INSTANCE);
+var reader = ReaderT.<CompletableFutureKind.Witness, AppConfig, String>reader(
+    CompletableFutureMonad.INSTANCE,
+    config -> config.dbUrl());
+```
+
+### StateT
+
+```java
+var optMonad = OptionalMonad.INSTANCE;
+var stMonad  = StateTMonad.<Integer, OptionalKind.Witness>instance(optMonad);
+var counter  = StateT.create(
+    (Integer s) -> OPTIONAL.widen(Optional.of(StateTuple.of(s + 1, s))),
+    optMonad);
+```
+
+### WriterT
+
+```java
+var listMonoid = Monoids.list();
+var monad      = new WriterTMonad<IdKind.Witness, List<String>>(IdMonad.instance(), listMonoid);
+var logged     = WriterT.tell(IdMonad.instance(), List.of("started"));
+```
+
+---
+
+## When to Use the Transformer Instead of the Path Type
+
+| Path Type | Reach for the Transformer When |
+|-----------|--------------------------------|
+| `EitherPath<E, A>`    | The outer monad must be `CompletableFuture`, `IO`, `VTask`, or a custom monad rather than the Path's default |
+| `MaybePath<A>` / `OptionalPath<A>` | Same as above, plus you need to combine absence with another effect |
+| `ReaderPath<R, A>`    | You need environment threading inside an explicit async or error monad |
+| `WithStatePath<S, A>` | You need stateful threading combined with another effect |
+| All of the above      | You are writing polymorphic library code that names an MTL capability |
+
+If none of those apply, the corresponding Path type is simpler to read and write.
+
+---
+
+~~~admonish tip title="See Also"
+- [Quickstart](quickstart.md) -- three runnable examples in 150 lines
+- [Stack Archetypes](archetypes.md) -- named patterns for common composition problems
+- [Migration Cookbook](migration_cookbook.md) -- imperative and Path translations
+- [Monad Transformers](transformers.md) -- the underlying mechanics
+~~~
+
+---
+
+**Previous:** [Quickstart](quickstart.md)
+**Next:** [Migration Cookbook](migration_cookbook.md)

--- a/hkj-book/src/transformers/when_to_drop_to_transformers.md
+++ b/hkj-book/src/transformers/when_to_drop_to_transformers.md
@@ -1,0 +1,126 @@
+# Path or Transformer? When to Drop Down
+
+Most workflows you write in Higher-Kinded-J live happily on the [Effect Path API](../effect/ch_intro.md). `EitherPath`, `MaybePath`, `OptionalPath`, `ReaderPath`, `WithStatePath`, and `WriterPath` cover the same ground as their transformer counterparts and add a fluent, Java-friendly facade that hides witness types and `Kind` widening. This page exists for the moments when a Path no longer fits and you need the raw transformer.
+
+~~~admonish info title="What You'll Learn"
+- The three signals that mean you have outgrown the Path API
+- Why the chapter ahead is optional for most readers
+- Where to go next if a Path type already covers your case
+~~~
+
+---
+
+## The default answer is "use the Path"
+
+If you are starting a new workflow, reach for a Path type first. The mapping is straightforward:
+
+| Path type | Replaces transformer |
+|-----------|----------------------|
+| `EitherPath<E, A>` | `EitherT<F, E, A>` |
+| `MaybePath<A>` / `OptionalPath<A>` | `MaybeT<F, A>` / `OptionalT<F, A>` |
+| `ReaderPath<R, A>` | `ReaderT<F, R, A>` |
+| `WithStatePath<S, A>` | `StateT<S, F, A>` |
+| `WriterPath<W, A>` | `WriterT<F, W, A>` |
+
+Path types compose with [`ForPath` comprehensions](../effect/forpath_comprehension.md), integrate with [optics](../effect/focus_integration.md), and surface errors at compile time through the [HKJ Gradle plugin](../tooling/compile_checks.md). They are the recommended interface.
+
+The chapter ahead is for the cases where the Path API genuinely cannot help. There are three of them.
+
+---
+
+## Signal 1: You need an outer monad Path does not wrap
+
+The Path API is opinionated about its outer monad. Each Path type is built on top of a specific underlying effect (`Either`, `Optional`, `CompletableFuture` via `CompletableFuturePath`, and so on), and you cannot swap that out.
+
+If you need to combine an inner effect (such as typed errors) with a *different* outer monad, you have to drop down to the transformer. Common cases:
+
+- A third-party library returns `Mono<Either<E, A>>`, `IO<Either<E, A>>`, or some other library-specific shape that wraps an `Either`. `EitherPath` cannot reach inside that container; `EitherT<F, E, A>` can, given a `Monad<F>` for the outer effect.
+- You are integrating with a custom IO or task type that has a `Monad` instance but no Path counterpart.
+- You need an effect stack like `EitherT<VTaskKind.Witness, E, A>` for virtual-thread-backed work that returns typed errors before the result is awaited.
+
+When the *outer* effect is what does not fit, the transformer is the right tool.
+
+---
+
+## Signal 2: You are writing polymorphic library code
+
+Path types fix both the inner and outer effect at the call site. That is exactly what you want for application code, but it is the wrong shape for a library that wants to accept any caller's stack.
+
+If you are publishing a function that other teams will compose with their own effect choices, MTL capabilities are usually a better fit than a concrete Path. A function that declares "I need to read an `AppConfig`" with the signature
+
+```java
+<F extends WitnessArity<TypeArity.Unary>> Kind<F, ConnectionString>
+    buildConnectionString(MonadReader<F, AppConfig> env) { ... }
+```
+
+works against any stack the caller assembles, including stacks that wrap effects you have never heard of. The same function written against `ReaderPath<AppConfig, ConnectionString>` would force every caller into the Path's outer effect.
+
+The same reasoning applies to `MonadState` over `WithStatePath` and `MonadWriter` over `WriterPath`. See [MTL Capabilities](mtl_capabilities.md) for the full story.
+
+---
+
+## Signal 3: You are integrating with existing `Kind<F, ...>` code
+
+The Path API hides `Kind<F, A>` from its users. That is a feature for application code; it is a problem when you are working with code that already exposes raw `Kind<F, ...>` values, for example:
+
+- Existing transformer code in the same codebase you cannot refactor today
+- Library code (including parts of Higher-Kinded-J itself) that returns `Kind` shapes
+- Bridging across modules where one side has adopted Paths and the other has not
+
+In those cases the lift from `Kind<F, A>` into a Path and back is mostly noise. Working in the transformer layer directly, with `EitherT.fromKind(...)` to bridge in and `.value()` to bridge back out, is shorter.
+
+---
+
+## Decision summary
+
+```
+    ┌──────────────────────────────────────────────────────────┐
+    │              PATH OR TRANSFORMER?                        │
+    ├──────────────────────────────────────────────────────────┤
+    │                                                          │
+    │  Are you writing application code with a standard        │
+    │  effect (CompletableFuture, IO, sync)?                   │
+    │    └──▶  Use the Path API                                │
+    │                                                          │
+    │  Do you need a custom or third-party outer monad?        │
+    │    └──▶  Drop to the transformer                         │
+    │                                                          │
+    │  Are you publishing a function for other teams           │
+    │  to compose with their own stack?                        │
+    │    └──▶  Use an MTL capability                           │
+    │                                                          │
+    │  Are you integrating with existing Kind<F, ...> code?    │
+    │    └──▶  Drop to the transformer                         │
+    │                                                          │
+    └──────────────────────────────────────────────────────────┘
+```
+
+If none of those signals apply, the rest of this chapter is reference material rather than required reading.
+
+---
+
+## Where to go from here
+
+If a Path type covers your case, leave this chapter and go to:
+
+- [Effect Path API Quickstart](../effect/quickstart.md), three runnable examples in 150 lines
+- [Path Types Overview](../effect/path_types.md), the reference for every Path
+- [ForPath Comprehension](../effect/forpath_comprehension.md), composition syntax for Paths
+
+If you do need a transformer:
+
+- [Quickstart](quickstart.md), three runnable transformer examples
+- [Stack Archetypes](archetypes.md), seven named patterns
+- [Migration Cookbook](migration_cookbook.md), Path-to-transformer translations
+- [MTL Capabilities](mtl_capabilities.md) for polymorphic library code
+
+~~~admonish tip title="See Also"
+- [Effect Path API Introduction](../effect/ch_intro.md), the recommended starting point
+- [Transformers at a Glance](transformers_at_a_glance.md), reference card for every transformer
+- [Common Compiler Errors](common_errors.md), what to do when the type checker disagrees with you
+~~~
+
+---
+
+**Previous:** [Monad Transformers Introduction](ch_intro.md)
+**Next:** [Quickstart](quickstart.md)

--- a/hkj-book/src/transformers/writert_transformer.md
+++ b/hkj-book/src/transformers/writert_transformer.md
@@ -11,8 +11,19 @@ A writer accumulates, sentence by sentence, until a complete work emerges. `Writ
 - How to add **output accumulation** (logging, audit trails, diagnostics) to any monad
 - Building workflows that record every step without threading a mutable log
 - Understanding the `Monoid` requirement and how it controls output combination
-- Using `tell`, `listen`, `pass`, and `censor` within transformer contexts
+- Using `For` comprehensions with `tell`, `listen`, `pass`, and `censor`
 - The relationship between `Writer` and `WriterT<F, W, A>`
+- When to use the [`WriterPath`](../effect/advanced_effects.md) Path type or the [`MonadWriter`](mtl_writer.md) capability instead of raw `WriterT`
+~~~
+
+~~~admonish example title="See Example Code"
+[WriterTExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer_t/WriterTExample.java)
+~~~
+
+~~~admonish note title="Path First, Stack Later"
+For most use cases, [`WriterPath<W, A>`](../effect/advanced_effects.md) is the better starting point when accumulating output is the only effect. When you need polymorphic, stack-independent code, the [`MonadWriter<F, W>`](mtl_writer.md) capability is usually a better fit than the concrete `WriterT`.
+
+Reach for raw `WriterT` only when you need to combine accumulation with a specific outer monad that Path does not wrap, or when you are constructing your own MTL instance.
 ~~~
 
 ---
@@ -22,12 +33,11 @@ A writer accumulates, sentence by sentence, until a complete work emerges. `Writ
 Consider an async pipeline that needs an audit trail:
 
 ```java
-// Without WriterT: manually pairing results with logs
 CompletableFuture<Pair<BigDecimal, List<String>>> applyDiscount(
         BigDecimal price, List<String> logSoFar) {
     return CompletableFuture.supplyAsync(() -> {
-        BigDecimal discounted = price.multiply(new BigDecimal("0.9"));
-        List<String> newLog = new ArrayList<>(logSoFar);
+        var discounted = price.multiply(new BigDecimal("0.9"));
+        var newLog = new ArrayList<>(logSoFar);
         newLog.add("Applied 10% discount");
         return Pair.of(discounted, newLog);
     });
@@ -36,8 +46,8 @@ CompletableFuture<Pair<BigDecimal, List<String>>> applyDiscount(
 CompletableFuture<Pair<BigDecimal, List<String>>> addShipping(
         BigDecimal price, List<String> logSoFar) {
     return CompletableFuture.supplyAsync(() -> {
-        BigDecimal withShipping = price.add(new BigDecimal("5.00"));
-        List<String> newLog = new ArrayList<>(logSoFar);
+        var withShipping = price.add(new BigDecimal("5.00"));
+        var newLog = new ArrayList<>(logSoFar);
         newLog.add("Added shipping");
         return Pair.of(withShipping, newLog);
     });
@@ -46,26 +56,66 @@ CompletableFuture<Pair<BigDecimal, List<String>>> addShipping(
 
 Every function must accept a log, copy it, append to it, and return it alongside the result. The log leaks into every signature. Composition requires manual log threading at every call site. Miss one handoff and entries disappear.
 
-## The Solution: WriterT
+---
+
+## The Solution
+
+### With the Effect Path API (single effect)
+
+If accumulation is the only effect, `WriterPath` is the simplest expression:
 
 ```java
-// With WriterT: the log accumulates automatically
-WriterTMonad<CompletableFutureKind.Witness, List<String>> writerMonad =
-    new WriterTMonad<>(futureMonad, listMonoid);
-
-Kind<WriterTKind.Witness<CompletableFutureKind.Witness, List<String>>, BigDecimal>
-    workflow = writerMonad.flatMap(
-        price -> writerMonad.flatMap(
-            discounted -> writerMonad.flatMap(
-                _ -> writerMonad.of(discounted),
-                writerMonad.tell(List.of("Added shipping"))),
-            writerMonad.flatMap(
-                _ -> writerMonad.of(price.multiply(new BigDecimal("0.9"))),
-                writerMonad.tell(List.of("Applied 10% discount")))),
-        writerMonad.of(new BigDecimal("100.00")));
-
-// One flatMap chain. The log combines via List's Monoid. No manual threading.
+WriterPath<List<String>, BigDecimal> workflow(BigDecimal price) {
+    return WriterPath.<List<String>, BigDecimal>writer(
+            price.multiply(new BigDecimal("0.9")),
+            List.of("Applied 10% discount"),
+            listMonoid)
+        .via(discounted -> WriterPath.writer(
+            discounted.add(new BigDecimal("5.00")),
+            List.of("Added shipping"),
+            listMonoid));
+}
 ```
+
+### With raw `WriterT` (combined effect)
+
+When accumulation must combine with another monad (here `Id` for a pure example, but the same shape works over `CompletableFuture`):
+
+```java
+var idMonad     = IdMonad.instance();
+var listMonoid  = Monoids.list();
+var writerMonad = new WriterTMonad<IdKind.Witness, List<String>>(idMonad, listMonoid);
+
+var workflow = For.from(writerMonad, writerMonad.tell(List.of("Applied 10% discount")))
+    .from(_ -> writerMonad.of(new BigDecimal("90.00")))
+    .from(p -> writerMonad.tell(List.of("Added shipping")))
+    .yield((_, price, _) -> price.add(new BigDecimal("5.00")));
+```
+
+One comprehension. The log combines via `List`'s `Monoid`. No manual threading.
+
+---
+
+## The Railway View
+
+<pre style="line-height:1.5;font-size:0.95em">
+    <span style="color:#4CAF50"><b>Value</b>   ═══●═══════════════●═══════════════●═══▶  final price (in F)</span>
+    <span style="color:#4CAF50">         applyDiscount   addShipping     yield</span>
+    <span style="color:#4CAF50">         (flatMap)       (flatMap)</span>
+              │                  │
+              ▼ <i>tell</i>            ▼ <i>tell</i>
+    <span style="color:#FFB300"><b>Log</b>     ──●──────────────●──────────────────────▶  ["Discount", "Shipping"]</span>
+    <span style="color:#FFB300">       "Applied 10%"  "Added shipping"</span>
+    <span style="color:#FFB300">                  combined via Monoid&lt;List&lt;String&gt;&gt;</span>
+</pre>
+
+The value track and the log track advance together. Each `tell` appends to the log without interrupting the computation; `flatMap` combines accumulated logs through the supplied `Monoid`. The final `Kind<F, Pair<A, W>>` carries both the result and the full audit trail.
+
+---
+
+## How WriterT Works
+
+`WriterT<F, W, A>` wraps `Kind<F, Pair<A, W>>`. The outer monad `F` provides the computational context (async, optional, error-handling); the `Pair<A, W>` carries both the computed value and the accumulated output.
 
 ```
     ┌──────────────────────────────────────────────────────────┐
@@ -85,34 +135,10 @@ Kind<WriterTKind.Witness<CompletableFutureKind.Witness, List<String>>, BigDecima
     └──────────────────────────────────────────────────────────┘
 ```
 
----
-
-## How WriterT Works
-
-`WriterT<F, W, A>` wraps `Kind<F, Pair<A, W>>`. The outer monad `F` provides the computational context (async, optional, error-handling); the `Pair<A, W>` carries both the computed value and the accumulated output.
-
-```
-    ┌───────────────────────────────────────────────────────────────┐
-    │  WriterT<F, W, A>                                             │
-    │                                                               │
-    │  ┌─── Kind<F, Pair<A, W>> ─────────────────────────────────┐  │
-    │  │                                                         │  │
-    │  │  F provides:  async / optional / error / identity       │  │
-    │  │  Pair.first:  the computed value (A)                    │  │
-    │  │  Pair.second: the accumulated output (W)                │  │
-    │  │                                                         │  │
-    │  └─────────────────────────────────────────────────────────┘  │
-    │                                                               │
-    │  Monoid<W> controls combination:                              │
-    │    empty()         →  starting output for of()                │
-    │    combine(w1, w2) →  merges outputs during flatMap           │
-    └───────────────────────────────────────────────────────────────┘
-```
-
-* **`F`**: The witness type of the **outer monad** (e.g., `IdKind.Witness`, `CompletableFutureKind.Witness`).
+* **`F`**: The witness type of the **outer monad** (e.g. `IdKind.Witness`, `CompletableFutureKind.Witness`).
 * **`W`**: The **output type** that accumulates. Must have a `Monoid<W>` instance.
 * **`A`**: The type of the computed value.
-* **`run()`**: Returns the wrapped `Kind<F, Pair<A, W>>`.
+* **`run()`**: returns the wrapped `Kind<F, Pair<A, W>>`.
 
 ```java
 public record WriterT<F, W, A>(Kind<F, Pair<A, W>> run)
@@ -128,26 +154,23 @@ public record WriterT<F, W, A>(Kind<F, Pair<A, W>> run)
 The `WriterTMonad<F, W>` class implements both `Monad` and `MonadWriter`, providing monadic operations and output accumulation. It requires a `Monad<F>` for the outer monad and a `Monoid<W>` for combining outputs:
 
 ```java
-// String output with concatenation
 Monoid<String> stringMonoid = new Monoid<>() {
-    public String empty() { return ""; }
-    public String combine(String a, String b) { return a + b; }
+    public String empty()                      { return ""; }
+    public String combine(String a, String b)  { return a + b; }
 };
 
-Monad<IdKind.Witness> idMonad = IdMonad.instance();
-
-WriterTMonad<IdKind.Witness, String> writerMonad =
-    new WriterTMonad<>(idMonad, stringMonoid);
+var idMonad     = IdMonad.instance();
+var writerMonad = new WriterTMonad<IdKind.Witness, String>(idMonad, stringMonoid);
 ```
 
-~~~admonish note title="Type Witness and Helpers"
+~~~admonish note title="Working with Kind"
 **Witness Type:** `WriterTKind<F, W, A>` extends `Kind<WriterTKind.Witness<F, W>, A>`. The outer monad `F` and output type `W` are fixed; `A` is the variable value type.
 
-**KindHelper:** `WriterTKindHelper` provides `WRITER_T.widen` and `WRITER_T.narrow` for safe conversion.
+**KindHelper:** `WriterTKindHelper` provides `WRITER_T.widen` and `WRITER_T.narrow` for safe conversion. With `For` comprehensions you rarely need them; they appear at the boundaries when interoperating with raw `flatMap` chains.
 
 ```java
 Kind<WriterTKind.Witness<F, W>, A> kind = WRITER_T.widen(writerT);
-WriterT<F, W, A> concrete = WRITER_T.narrow(kind);
+WriterT<F, W, A> concrete                = WRITER_T.narrow(kind);
 ```
 ~~~
 
@@ -164,22 +187,121 @@ The `Monoid<W>` determines how output from successive steps is combined. This is
 | `Integer` (sum) | `0` | `a + b` | Counting operations |
 | `Set<T>` | `{}` | union | Collecting unique tags |
 
-Without a `Monoid`, WriterT cannot combine the output from `flatMap` chains. The `Monoid` is what makes the accumulation lawful: `combine(empty(), w) == w`, `combine(w, empty()) == w`, and `combine` is associative.
+Without a `Monoid`, `WriterT` cannot combine the output from `flatMap` chains. The `Monoid` is what makes the accumulation lawful: `combine(empty(), w) == w`, `combine(w, empty()) == w`, and `combine` is associative.
 
 ---
 
 ## Key Operations
 
-~~~admonish info title="Core Operations"
-* **`of(value)`**: Lifts a pure value with empty output. Result: `F<Pair(value, empty)>`.
-* **`map(f, ma)`**: Transforms the value, preserves output unchanged.
-* **`flatMap(f, ma)`**: Sequences computations. Runs `ma` to get `(a, w1)`, applies `f(a)` to get `(b, w2)`, returns `(b, combine(w1, w2))`.
-* **`tell(w)`**: Appends `w` to the output. Returns `Unit`.
-* **`listen(ma)`**: Runs `ma` and returns `Pair(Pair(a, w), w)` -- the result paired with its accumulated output.
-* **`pass(ma)`**: Runs `ma` which returns `Pair(a, f)`, then applies `f` to transform the output.
-* **`listens(f, ma)`**: Like `listen`, but maps a function over the accumulated output in the pair.
-* **`censor(f, ma)`**: Modifies the accumulated output without seeing the result.
+| Operation | Behaviour |
+|-----------|-----------|
+| `of(value)`         | Lifts a pure value with empty output as `F<Pair(value, empty)>` |
+| `map(f, kind)`      | Transforms the value; output preserved unchanged |
+| `flatMap(f, kind)`  | Sequences computations; combines outputs via the `Monoid` |
+| `tell(w)`           | Appends `w` to the output, returns `Unit` |
+| `listen(kind)`      | Runs the computation and returns the output alongside the result |
+| `pass(kind)`        | Computation returns `Pair(a, f)`; applies `f` to transform the output |
+| `listens(f, kind)`  | Like `listen` but maps `f` over the accumulated output in the pair |
+| `censor(f, kind)`   | Modifies the accumulated output without seeing the result |
+
+---
+
+## Creating WriterT Instances
+
+```java
+var idMonad      = IdMonad.instance();
+Monoid<String> stringMonoid = /* as above */;
+
+// 1. Pure value with empty output
+var pure = WriterT.of(idMonad, stringMonoid, 42);
+// → Pair(42, "")
+
+// 2. Record output with no meaningful value
+var logged = WriterT.tell(idMonad, "initialised; ");
+// → Pair(Unit.INSTANCE, "initialised; ")
+
+// 3. Lift an outer-monad value with empty output
+Kind<IdKind.Witness, Integer> idValue = IdKindHelper.ID.widen(new Id<>(42));
+var lifted = WriterT.liftF(idMonad, stringMonoid, idValue);
+// → Pair(42, "")
+
+// 4. Explicit value and output
+var explicit = WriterT.writer(idMonad, 42, "created; ");
+// → Pair(42, "created; ")
+
+// 5. From an existing Kind<F, Pair<A, W>>
+var fromKind = WriterT.fromKind(idMonad.of(Pair.of(42, "restored; ")));
+// → Pair(42, "restored; ")
+```
+
+---
+
+## Real-World Example: Audit Trail
+
+~~~admonish example title="Building an Audit Trail"
+
+**The problem:** a multi-step order processing pipeline must record every decision for compliance. The log must travel with the computation, not sit in a mutable side channel.
+
+**The solution:**
+
+```java
+var idMonad    = IdMonad.instance();
+var listMonoid = Monoids.list();
+var audit      = new WriterTMonad<IdKind.Witness, List<String>>(idMonad, listMonoid);
+
+var workflow = For.from(audit, audit.tell(List.of("Validated order")))
+    .from(_ -> audit.of("order-123"))
+    .from(orderId -> audit.tell(List.of("Applied 10% discount to " + orderId)))
+    .from((_, _, _) -> audit.of(new BigDecimal("90.00")))
+    .from(amount   -> audit.tell(List.of("Charged " + amount)))
+    .yield((_, _, _, _, _) -> "receipt-456");
+
+var concrete = WRITER_T.narrow(workflow);
+var pair     = IdKindHelper.ID.narrow(concrete.run()).value();
+
+pair.first();   // → "receipt-456"
+pair.second();  // → ["Validated order",
+                //     "Applied 10% discount to order-123",
+                //     "Charged 90.00"]
+```
+
+**Why this works:** each `tell` appends entries. Each `from` step combines outputs via the `List` monoid. The audit trail is complete, ordered, and immutable. No step can forget to pass the log forward; `WriterT` handles it.
 ~~~
+
+---
+
+## Inspecting and Transforming Output
+
+### `listen`: see what was written
+
+`listen` runs a computation and returns the result paired with the output that computation produced:
+
+```java
+var computation = For.from(audit, audit.tell(List.of("computed value")))
+    .yield(_ -> 42);
+
+var listened = audit.listen(computation);
+// → Pair(Pair(42, ["computed value"]), ["computed value"])
+//         result paired with output    output preserved
+```
+
+This is useful for conditional logic based on what was logged.
+
+### `censor`: redact sensitive output
+
+`censor` applies a function to the output without seeing the result:
+
+```java
+var withSensitiveData = For.from(audit, audit.tell(List.of("API key: sk_live_abc123")))
+    .yield(_ -> "done");
+
+var redacted = audit.censor(
+    entries -> entries.stream()
+        .map(e -> e.contains("API key") ? "API key: [REDACTED]" : e)
+        .toList(),
+    withSensitiveData);
+// Output: ["API key: [REDACTED]"]
+```
 
 ---
 
@@ -202,147 +324,25 @@ Sometimes you need to change the *outer monad* of a `WriterT` without touching t
 ```
 
 ```java
-// Switch from Id to Optional — wrapping a pure writer into an optional context
-WriterT<IdKind.Witness, List<String>, String> idWriter =
-    WriterT.writer(idMonad, "result", List.of("step 1", "step 2"));
+var idWriter = WriterT.writer(idMonad, "result", List.of("step 1", "step 2"));
 
-WriterT<OptionalKind.Witness, List<String>, String> optWriter =
-    idWriter.mapT(idKind -> {
-      Pair<String, List<String>> pair = ID.unwrap(idKind);
-      return OPTIONAL.widen(Optional.of(pair));
-    });
+var optWriter = idWriter.mapT(idKind -> {
+  Pair<String, List<String>> pair = ID.unwrap(idKind);
+  return OPTIONAL.widen(Optional.of(pair));
+});
 ```
 
 ~~~admonish note title="mapT vs map"
 `map` transforms the *value* inside the `Pair` (the `A` in `Pair<A, W>`).
-`mapT` transforms the *outer monad* wrapping the `Pair` — the `F` in `F<Pair<A, W>>`.
+`mapT` transforms the *outer monad* wrapping the `Pair`, the `F` in `F<Pair<A, W>>`.
 The accumulated output `W` is completely unaffected.
 ~~~
 
 ---
 
-## Creating WriterT Instances
-
-```java
-Monad<IdKind.Witness> idMonad = IdMonad.instance();
-Monoid<String> stringMonoid = /* as above */;
-
-// 1. Pure value with empty output
-WriterT<IdKind.Witness, String, Integer> pure =
-    WriterT.of(idMonad, stringMonoid, 42);
-// → Pair(42, "")
-
-// 2. Record output with no meaningful value
-WriterT<IdKind.Witness, String, Unit> logged =
-    WriterT.tell(idMonad, "initialised; ");
-// → Pair(Unit.INSTANCE, "initialised; ")
-
-// 3. Lift an outer monad value with empty output
-Kind<IdKind.Witness, Integer> idValue = IdKindHelper.ID.widen(new Id<>(42));
-WriterT<IdKind.Witness, String, Integer> lifted =
-    WriterT.liftF(idMonad, stringMonoid, idValue);
-// → Pair(42, "")
-
-// 4. Explicit value and output
-WriterT<IdKind.Witness, String, Integer> explicit =
-    WriterT.writer(idMonad, 42, "created; ");
-// → Pair(42, "created; ")
-
-// 5. From an existing Kind<F, Pair<A, W>>
-WriterT<IdKind.Witness, String, Integer> fromKind =
-    WriterT.fromKind(idMonad.of(Pair.of(42, "restored; ")));
-// → Pair(42, "restored; ")
-```
-
----
-
-## Real-World Example: Audit Trail
-
-~~~admonish Example title="Building an Audit Trail"
-
-**The problem:** You have a multi-step order processing pipeline and need to record every decision for compliance. The log must travel with the computation, not sit in a mutable side channel.
-
-**The solution:**
-
-```java
-WriterTMonad<IdKind.Witness, List<String>> audit =
-    new WriterTMonad<>(idMonad, listMonoid);
-
-// Each step records what it did
-var validateOrder = audit.flatMap(
-    _ -> audit.of("order-123"),
-    audit.tell(List.of("Validated order")));
-
-var applyDiscount = audit.flatMap(
-    orderId -> audit.flatMap(
-        _ -> audit.of(new BigDecimal("90.00")),
-        audit.tell(List.of("Applied 10% discount to " + orderId))),
-    validateOrder);
-
-var chargePayment = audit.flatMap(
-    amount -> audit.flatMap(
-        _ -> audit.of("receipt-456"),
-        audit.tell(List.of("Charged " + amount))),
-    applyDiscount);
-
-// Run it
-WriterT<IdKind.Witness, List<String>, String> result =
-    WRITER_T.narrow(chargePayment);
-Pair<String, List<String>> pair =
-    IdKindHelper.ID.narrow(result.run()).value();
-
-pair.first();   // → "receipt-456"
-pair.second();  // → ["Validated order",
-                //     "Applied 10% discount to order-123",
-                //     "Charged 90.00"]
-```
-
-**Why this works:** Each `tell` appends entries. Each `flatMap` combines outputs via the `List` monoid (concatenation). The audit trail is complete, ordered, and immutable. No step can forget to pass the log forward -- `WriterT` handles it.
-~~~
-
----
-
-## Inspecting and Transforming Output
-
-### `listen`: See What Was Written
-
-`listen` runs a computation and returns the result paired with the output that computation produced:
-
-```java
-var computation = audit.flatMap(
-    _ -> audit.of(42),
-    audit.tell(List.of("computed value")));
-
-var listened = audit.listen(computation);
-// → Pair(Pair(42, ["computed value"]), ["computed value"])
-//         ^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^
-//         result paired with output    output preserved
-```
-
-This is useful for conditional logic based on what was logged.
-
-### `censor`: Redact Sensitive Output
-
-`censor` applies a function to the output without seeing the result:
-
-```java
-var withSensitiveData = audit.flatMap(
-    _ -> audit.of("done"),
-    audit.tell(List.of("API key: sk_live_abc123")));
-
-var redacted = audit.censor(
-    entries -> entries.stream()
-        .map(e -> e.contains("API key") ? "API key: [REDACTED]" : e)
-        .toList(),
-    withSensitiveData);
-// Output: ["API key: [REDACTED]"]
-```
-
----
-
 ## Relationship to Writer
 
-`Writer<W, A>` is the non-transformer version: it pairs a value with accumulated output directly, with no outer monad. `WriterT<IdKind.Witness, W, A>` is equivalent to `Writer<W, A>` -- the identity monad adds no additional effect.
+`Writer<W, A>` is the non-transformer version: it pairs a value with accumulated output directly, with no outer monad. `WriterT<IdKind.Witness, W, A>` is equivalent to `Writer<W, A>`, the identity monad adds no additional effect.
 
 ```
     Writer<W, A>              ≡  WriterT<Id, W, A>
@@ -362,18 +362,26 @@ Use `Writer` when you need output accumulation in pure code. Use `WriterT` when 
 
 ~~~admonish warning title="Common Mistakes"
 - **Forgetting the Monoid:** `WriterT` requires a `Monoid<W>` at construction. If you pass `null`, you get a `NullPointerException`. If your monoid's `combine` is incorrect (not associative), law tests will fail.
-- **Large accumulated output:** Unlike streaming, `WriterT` accumulates the entire output in memory. For high-volume logging, consider `VStream` with a logging side effect instead.
-- **Using WriterT when you need state:** `WriterT` is *append-only*. You cannot read the accumulated output mid-computation (use `listen` to observe it). If you need to read and modify state, use `StateT`.
+- **Large accumulated output:** unlike streaming, `WriterT` accumulates the entire output in memory. For high-volume logging, consider `VStream` with a logging side effect instead.
+- **Using `WriterT` when you need state:** `WriterT` is *append-only*. You cannot read the accumulated output mid-computation (use `listen` to observe it). If you need to read and modify state, use [`StateT`](statet_transformer.md).
+- **Reaching for the transformer when `WriterPath` would do:** if accumulation is your only effect, `WriterPath` is shorter and reads more naturally.
 ~~~
 
 ---
 
 ~~~admonish tip title="See Also"
-- [Writer Monad](../monads/writer_monad.md) -- The non-transformer version for pure computations
-- [Monad Transformers](transformers.md) -- General concept and choosing the right transformer
-- [MTL Capabilities](mtl_capabilities.md) -- `MonadWriter` interface for stack-independent code
-- [StateT](statet_transformer.md) -- When you need read-write state, not append-only output
-- [ReaderT](readert_transformer.md) -- When you need read-only environment access
+- [WriterPath / Advanced Effects](../effect/advanced_effects.md) - The Path-API equivalent
+- [MonadWriter](mtl_writer.md) - The MTL capability for stack-independent code
+- [Stack Archetypes](archetypes.md) - The Audit Stack archetype maps to `WriterT`/`WriterPath`
+- [Migration Cookbook](migration_cookbook.md) - Side-by-side translations
+- [Writer Monad](../monads/writer_monad.md) - The non-transformer version for pure computations
+- [Monad Transformers](transformers.md) - General concept and choosing the right transformer
+- [StateT](statet_transformer.md) - When you need read-write state, not append-only output
+- [ReaderT](readert_transformer.md) - When you need read-only environment access
+~~~
+
+~~~admonish info title="Hands-On Learning"
+The `MonadWriter` capability that wraps `WriterT` is exercised in [Tutorial 04: Polymorphic Capabilities (MTL)](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial04_PolymorphicCapabilities.java) (14 exercises, ~30-40 minutes).
 ~~~
 
 ---

--- a/hkj-book/src/tutorials/transformers/transformers_journey.md
+++ b/hkj-book/src/tutorials/transformers/transformers_journey.md
@@ -1,0 +1,145 @@
+# Monad Transformers Journey
+
+**Estimated Duration**: ~90 minutes (four sub-journeys) | **Exercises**: ~28
+
+~~~admonish info title="When to Take This Journey"
+The Effect Path API ([Tutorial 01: Effect Path Basics](../effect/effect_journey.md)) covers most workflows you will write in Java. Take this journey when you have hit one of the corners that Path types do not reach: integrating with code that returns a different outer monad, or writing library code that should work against any caller's effect stack.
+~~~
+
+## What You'll Learn
+
+The Monad Transformers Journey builds on the Effect Path API to cover the cases where you need to drop down to the underlying transformer machinery.
+
+### Tutorial 01: When Path Isn't Enough (~30 min, 6 exercises)
+- Bridging an existing `CompletableFuture<Either<L, R>>` into `EitherT`
+- Lifting synchronous `Either` values into the same workflow
+- Composing async-and-typed-error steps with `For` comprehensions
+- Recovering from typed errors with `handleErrorWith`
+- Collapsing back to ordinary Java at the boundary
+
+### Tutorial 02: Async with Absence (~25 min, 5 exercises)
+- The same shape applied to `CompletableFuture<Optional<T>>`
+- Chaining async lookups with `For`
+- Providing defaults when a lookup yields nothing
+- A short tour of `MaybeT` for codebases that prefer `Maybe`
+
+### Tutorial 03: Stacking Transformers (~15 min, 4 exercises)
+- Two effects in one workflow: `EitherT` over `Optional`
+- Why `For` keeps stacked code readable
+- When stacking gets uncomfortable, what to reach for instead
+
+### Tutorial 04: Polymorphic Capabilities (MTL) (~30-40 min, 14 exercises)
+- `MonadReader`: read-only access to a shared environment
+- `MonadState`: read-write state threading
+- `MonadWriter`: append-only output accumulation
+- Writing polymorphic functions that accept capability interfaces, not concrete types
+
+## Why Transformers Second?
+
+The Effect Path API is designed to be the primary interface. Reach for raw transformers only when:
+
+1. You need to integrate with code that already returns a different outer monad
+2. You are writing a library and want callers to plug in their own effect stack
+3. You need an outer monad that no Path type wraps
+
+If none of those apply, stay on the Path API. Your code will be shorter and clearer.
+
+## Getting Started
+
+The tutorials are located in `hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/`:
+
+### Tutorial 01: When Path Isn't Enough
+
+**File**: `Tutorial01_WhenPathIsNotEnough.java`
+
+```java
+// Bridge an existing Future<Either> into the transformer
+var london = fetchWeather("London");
+EitherT<CompletableFutureKind.Witness, WeatherError, WeatherReport> wrapped =
+    EitherT.fromKind(london);
+
+// Compose two steps with For
+var workflow = For.from(eitherTMonad, EitherT.fromKind(fetchWeather("Berlin")))
+    .yield(report -> new TravelAdvice(report.city(),
+        report.temperature() < 10 ? "Pack a coat" : "Travel light"));
+```
+
+### Tutorial 02: Async with Absence
+
+**File**: `Tutorial02_AsyncWithAbsence.java`
+
+```java
+// Chain two async lookups
+var workflow = For.from(optionalTMonad, OptionalT.fromKind(fetchUser("alice")))
+    .from(user -> OptionalT.fromKind(fetchProfile(user.id())))
+    .yield((user, profile) -> profile);
+```
+
+### Tutorial 03: Stacking Transformers
+
+**File**: `Tutorial03_StackingTransformers.java`
+
+```java
+// EitherT layered over Optional: a value that may be absent AND may have failed validation
+var sum = For.from(eitherTOverOptional,
+        EitherT.fromEither(optionalMonad, Either.<AppError, Integer>right(10)))
+    .from(_ -> EitherT.fromEither(optionalMonad, Either.<AppError, Integer>right(32)))
+    .yield((a, b) -> a + b);
+```
+
+### Tutorial 04: Polymorphic Capabilities (MTL)
+
+**File**: `Tutorial04_PolymorphicCapabilities.java`
+
+```java
+// A function that declares "I need to read an AppConfig" and nothing else
+static <F extends WitnessArity<TypeArity.Unary>> Kind<F, String> buildUrl(
+    MonadReader<F, AppConfig> env) {
+  return For.from(env, env.ask())
+      .yield(c -> c.dbUrl() + "?retries=" + c.maxRetries());
+}
+```
+
+## Prerequisites
+
+Before starting this journey, you should:
+
+1. Be comfortable with Java lambdas, generics, and `var`
+2. Have completed the [Effect API Journey](../effect/effect_journey.md)
+
+**Helpful background**: skim the [Monad Transformers Quickstart](../../transformers/quickstart.md) and [Stack Archetypes](../../transformers/archetypes.md) so you have the high-level picture before drilling into exercises.
+
+## Running the Tutorials
+
+```bash
+# Run all transformer tutorials
+./gradlew :hkj-examples:test --tests "*tutorial.transformers.*"
+
+# Run a specific tutorial
+./gradlew :hkj-examples:test --tests "*Tutorial01_WhenPathIsNotEnough*"
+./gradlew :hkj-examples:test --tests "*Tutorial02_AsyncWithAbsence*"
+./gradlew :hkj-examples:test --tests "*Tutorial03_StackingTransformers*"
+./gradlew :hkj-examples:test --tests "*Tutorial04_PolymorphicCapabilities*"
+```
+
+## Further Resources
+
+After completing this journey, explore:
+
+- [Monad Transformers Quickstart](../../transformers/quickstart.md), three runnable examples in 150 lines
+- [Stack Archetypes](../../transformers/archetypes.md), seven named patterns
+- [Migration Cookbook](../../transformers/migration_cookbook.md), imperative and Path translations
+- [MTL Capabilities](../../transformers/mtl_capabilities.md), the conceptual reference for Tutorial 04
+- [EitherT](../../transformers/eithert_transformer.md), [OptionalT](../../transformers/optionalt_transformer.md), [MaybeT](../../transformers/maybet_transformer.md), [ReaderT](../../transformers/readert_transformer.md), [StateT](../../transformers/statet_transformer.md), [WriterT](../../transformers/writert_transformer.md), the per-transformer reference pages
+
+## What's Next?
+
+After completing the transformers journey:
+
+- **Polymorphic library code**: study [MTL Combining Capabilities](../../transformers/mtl_combining.md) for multi-capability functions
+- **Production patterns**: explore the order-workflow examples in `hkj-examples/src/main/java/org/higherkindedj/example/order/`
+
+---
+
+**Previous:** [Effect API](../effect/effect_journey.md)
+**Next:** [Concurrency: VTask](../concurrency/vtask_journey.md)

--- a/hkj-examples/build.gradle.kts
+++ b/hkj-examples/build.gradle.kts
@@ -45,6 +45,7 @@ tasks.named<Test>("test") {
     exclude("**/tutorial/effecthandlers/**")
     exclude("**/tutorial/context/**")
     exclude("**/tutorial/mtl/**")
+    exclude("**/tutorial/transformers/**")
     // Solutions are in tutorial/solutions/ and will run
 }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/SOLUTIONS.md
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/SOLUTIONS.md
@@ -12,6 +12,7 @@ The solution files mirror the structure of the tutorial files, but with all `___
 
 - `coretypes/` - Solutions for Core Types tutorials (01-07)
 - `optics/` - Solutions for Optics tutorials (01-07)
+- `transformers/` - Solutions for Monad Transformers tutorials (01-04)
 
 Each solution file:
 - Has the same structure as the corresponding tutorial

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial01_WhenPathIsNotEnough_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial01_WhenPathIsNotEnough_Solution.java
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
+import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
+
+import java.util.concurrent.CompletableFuture;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either_t.EitherT;
+import org.higherkindedj.hkt.either_t.EitherTKind;
+import org.higherkindedj.hkt.either_t.EitherTMonad;
+import org.higherkindedj.hkt.expression.For;
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 01: When Path Isn't Enough.
+ *
+ * <p>This file contains the completed solutions for all exercises. Compare your answers with these
+ * solutions after attempting the tutorial.
+ */
+@DisplayName("Tutorial 01: When Path Isn't Enough - Solutions")
+public class Tutorial01_WhenPathIsNotEnough_Solution {
+
+  sealed interface WeatherError {
+    record CityNotFound(String city) implements WeatherError {}
+
+    record ServiceUnavailable(String reason) implements WeatherError {}
+  }
+
+  record WeatherReport(String city, int temperature) {}
+
+  record TravelAdvice(String city, String advice) {}
+
+  private CompletableFutureMonad futureMonad;
+  private EitherTMonad<CompletableFutureKind.Witness, WeatherError> eitherTMonad;
+
+  @BeforeEach
+  void setUp() {
+    futureMonad = CompletableFutureMonad.INSTANCE;
+    eitherTMonad = new EitherTMonad<>(futureMonad);
+  }
+
+  private Kind<CompletableFutureKind.Witness, Either<WeatherError, WeatherReport>> fetchWeather(
+      String city) {
+    if (city.equals("Atlantis")) {
+      return FUTURE.widen(
+          CompletableFuture.completedFuture(Either.left(new WeatherError.CityNotFound(city))));
+    }
+    return FUTURE.widen(
+        CompletableFuture.completedFuture(Either.right(new WeatherReport(city, 18))));
+  }
+
+  @Nested
+  @DisplayName("Part 1: Bridging the gap")
+  class BridgingExercises {
+
+    @Test
+    @DisplayName("Exercise 1: fromKind lifts a Future<Either> into EitherT")
+    void exercise1_fromKindLiftsFutureEither() {
+      var london = fetchWeather("London");
+
+      // SOLUTION: lift the Kind<F, Either<L, R>> into EitherT.
+      EitherT<CompletableFutureKind.Witness, WeatherError, WeatherReport> wrapped =
+          EitherT.fromKind(london);
+
+      var report = FUTURE.join(wrapped.value());
+      assertThat(report.isRight()).isTrue();
+      assertThat(report.getRight().city()).isEqualTo("London");
+    }
+
+    @Test
+    @DisplayName("Exercise 2: .value() returns to the underlying Future<Either>")
+    void exercise2_valueReturnsUnderlyingShape() {
+      var wrapped = EitherT.fromKind(fetchWeather("Paris"));
+
+      // SOLUTION: .value() collapses the EitherT back to its Kind<F, Either<L, R>>.
+      Kind<CompletableFutureKind.Witness, Either<WeatherError, WeatherReport>> underlying =
+          wrapped.value();
+
+      var report = FUTURE.join(underlying);
+      assertThat(report.getRight().city()).isEqualTo("Paris");
+    }
+  }
+
+  @Nested
+  @DisplayName("Part 2: Composing steps")
+  class ComposingExercises {
+
+    @Test
+    @DisplayName("Exercise 3: fromEither lifts a synchronous Either")
+    void exercise3_fromEitherLiftsSyncEither() {
+      Either<WeatherError, String> validated = Either.right("Rome");
+
+      // SOLUTION: fromEither needs the outer monad plus the synchronous Either.
+      EitherT<CompletableFutureKind.Witness, WeatherError, String> lifted =
+          EitherT.fromEither(futureMonad, validated);
+
+      var result = FUTURE.join(lifted.value());
+      assertThat(result.getRight()).isEqualTo("Rome");
+    }
+
+    @Test
+    @DisplayName("Exercise 4: For.from chains two async-Either steps")
+    void exercise4_forChainsAsyncSteps() {
+      // SOLUTION: For.yield returns a Kind; narrow before extracting .value() at the boundary.
+      Kind<EitherTKind.Witness<CompletableFutureKind.Witness, WeatherError>, TravelAdvice>
+          workflow =
+              For.from(eitherTMonad, EitherT.fromKind(fetchWeather("Berlin")))
+                  .yield(
+                      report ->
+                          new TravelAdvice(
+                              report.city(),
+                              report.temperature() < 10 ? "Pack a coat" : "Travel light"));
+
+      var result = FUTURE.join(EITHER_T.narrow(workflow).value());
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.getRight().city()).isEqualTo("Berlin");
+      assertThat(result.getRight().advice()).isEqualTo("Travel light");
+    }
+
+    @Test
+    @DisplayName("Exercise 5: Left short-circuits the comprehension")
+    void exercise5_leftShortCircuits() {
+      // SOLUTION: same shape but the service rejects "Atlantis" with a CityNotFound Left.
+      Kind<EitherTKind.Witness<CompletableFutureKind.Witness, WeatherError>, TravelAdvice>
+          workflow =
+              For.from(eitherTMonad, EitherT.fromKind(fetchWeather("Atlantis")))
+                  .yield(report -> new TravelAdvice(report.city(), "any advice"));
+
+      var result = FUTURE.join(EITHER_T.narrow(workflow).value());
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft()).isInstanceOf(WeatherError.CityNotFound.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("Part 3: Recovery")
+  class RecoveryExercises {
+
+    @Test
+    @DisplayName("Exercise 6: handleErrorWith substitutes a default for known errors")
+    void exercise6_handleErrorWithRecovers() {
+      var attempt = EitherT.fromKind(fetchWeather("Atlantis"));
+
+      // SOLUTION: handleErrorWith receives the Left, returns a fresh EitherT for known errors,
+      // and re-raises the rest.
+      Kind<EitherTKind.Witness<CompletableFutureKind.Witness, WeatherError>, WeatherReport>
+          recovered =
+              eitherTMonad.handleErrorWith(
+                  attempt,
+                  err ->
+                      err instanceof WeatherError.CityNotFound
+                          ? eitherTMonad.of(new WeatherReport("Unknown", 15))
+                          : eitherTMonad.raiseError(err));
+
+      var result = FUTURE.join(EITHER_T.narrow(recovered).value());
+
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.getRight().city()).isEqualTo("Unknown");
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial02_AsyncWithAbsence_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial02_AsyncWithAbsence_Solution.java
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
+import static org.higherkindedj.hkt.optional_t.OptionalTKindHelper.OPTIONAL_T;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
+import org.higherkindedj.hkt.expression.For;
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe_t.MaybeT;
+import org.higherkindedj.hkt.optional_t.OptionalT;
+import org.higherkindedj.hkt.optional_t.OptionalTKind;
+import org.higherkindedj.hkt.optional_t.OptionalTMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 02: Async with Absence.
+ *
+ * <p>This file contains the completed solutions for all exercises. Compare your answers with these
+ * solutions after attempting the tutorial.
+ */
+@DisplayName("Tutorial 02: Async with Absence - Solutions")
+public class Tutorial02_AsyncWithAbsence_Solution {
+
+  record User(String id, String name) {}
+
+  record Profile(String userId, String avatarUrl) {}
+
+  record Preferences(String userId, String theme) {}
+
+  private CompletableFutureMonad futureMonad;
+  private OptionalTMonad<CompletableFutureKind.Witness> optionalTMonad;
+
+  @BeforeEach
+  void setUp() {
+    futureMonad = CompletableFutureMonad.INSTANCE;
+    optionalTMonad = new OptionalTMonad<>(futureMonad);
+  }
+
+  private Kind<CompletableFutureKind.Witness, Optional<User>> fetchUser(String userId) {
+    if (userId.equals("missing")) {
+      return FUTURE.widen(CompletableFuture.completedFuture(Optional.empty()));
+    }
+    return FUTURE.widen(CompletableFuture.completedFuture(Optional.of(new User(userId, "Alice"))));
+  }
+
+  private Kind<CompletableFutureKind.Witness, Optional<Profile>> fetchProfile(String userId) {
+    return FUTURE.widen(
+        CompletableFuture.completedFuture(
+            Optional.of(new Profile(userId, "https://example.com/" + userId + ".png"))));
+  }
+
+  @Nested
+  @DisplayName("Part 1: OptionalT")
+  class OptionalTExercises {
+
+    @Test
+    @DisplayName("Exercise 1: fromKind lifts a Future<Optional> into OptionalT")
+    void exercise1_fromKindLiftsFutureOptional() {
+      var alice = fetchUser("alice");
+
+      // SOLUTION: OptionalT.fromKind wraps an existing Kind<F, Optional<A>>.
+      OptionalT<CompletableFutureKind.Witness, User> wrapped = OptionalT.fromKind(alice);
+
+      var result = FUTURE.join(wrapped.value());
+      assertThat(result).isPresent();
+      assertThat(result.get().name()).isEqualTo("Alice");
+    }
+
+    @Test
+    @DisplayName("Exercise 2: For chains two async lookups")
+    void exercise2_forChainsAsyncLookups() {
+      // SOLUTION: For.yield returns a Kind; narrow before extracting .value().
+      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, Profile> workflow =
+          For.from(optionalTMonad, OptionalT.fromKind(fetchUser("alice")))
+              .from(user -> OptionalT.fromKind(fetchProfile(user.id())))
+              .yield((user, profile) -> profile);
+
+      var result = FUTURE.join(OPTIONAL_T.narrow(workflow).value());
+      assertThat(result).isPresent();
+      assertThat(result.get().userId()).isEqualTo("alice");
+    }
+
+    @Test
+    @DisplayName("Exercise 3: Empty short-circuits the chain")
+    void exercise3_emptyShortCircuits() {
+      // SOLUTION: same comprehension, but the first lookup returns empty so the second is skipped.
+      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, Profile> workflow =
+          For.from(optionalTMonad, OptionalT.fromKind(fetchUser("missing")))
+              .from(user -> OptionalT.fromKind(fetchProfile(user.id())))
+              .yield((user, profile) -> profile);
+
+      var result = FUTURE.join(OPTIONAL_T.narrow(workflow).value());
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Exercise 4: handleErrorWith provides a default for empty")
+    void exercise4_handleErrorWithProvidesDefault() {
+      Kind<CompletableFutureKind.Witness, Optional<Preferences>> emptyLookup =
+          FUTURE.widen(CompletableFuture.completedFuture(Optional.empty()));
+      var attempt = OptionalT.fromKind(emptyLookup);
+      var defaults = new Preferences("guest", "default-light");
+
+      // SOLUTION: the recovery handler receives Unit (absence has no payload) and returns a
+      // fresh OptionalT. No widen needed: OptionalT already implements Kind.
+      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, Preferences> recovered =
+          optionalTMonad.handleErrorWith(
+              attempt, (Unit v) -> OptionalT.some(futureMonad, defaults));
+
+      var result = FUTURE.join(OPTIONAL_T.narrow(recovered).value());
+      assertThat(result).isPresent();
+      assertThat(result.get().theme()).isEqualTo("default-light");
+    }
+  }
+
+  @Nested
+  @DisplayName("Part 2: MaybeT")
+  class MaybeTExercises {
+
+    @Test
+    @DisplayName("Exercise 5: MaybeT.fromKind for an async Maybe")
+    void exercise5_maybeTFromKind() {
+      Kind<CompletableFutureKind.Witness, Maybe<User>> bob =
+          FUTURE.widen(CompletableFuture.completedFuture(Maybe.just(new User("bob", "Bob"))));
+
+      // SOLUTION: MaybeT.fromKind mirrors OptionalT.fromKind for Higher-Kinded-J's Maybe.
+      MaybeT<CompletableFutureKind.Witness, User> wrapped = MaybeT.fromKind(bob);
+
+      var result = FUTURE.join(wrapped.value());
+      assertThat(result.isJust()).isTrue();
+      assertThat(result.get().name()).isEqualTo("Bob");
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial03_StackingTransformers_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial03_StackingTransformers_Solution.java
@@ -1,0 +1,114 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+import java.util.Optional;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either_t.EitherT;
+import org.higherkindedj.hkt.either_t.EitherTKind;
+import org.higherkindedj.hkt.either_t.EitherTMonad;
+import org.higherkindedj.hkt.expression.For;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 03: Stacking Transformers.
+ *
+ * <p>This file contains the completed solutions for all exercises. Compare your answers with these
+ * solutions after attempting the tutorial.
+ */
+@DisplayName("Tutorial 03: Stacking Transformers - Solutions")
+public class Tutorial03_StackingTransformers_Solution {
+
+  sealed interface AppError {
+    record InvalidInput(String reason) implements AppError {}
+  }
+
+  private OptionalMonad optionalMonad;
+  private EitherTMonad<OptionalKind.Witness, AppError> eitherTOverOptional;
+
+  @BeforeEach
+  void setUp() {
+    optionalMonad = OptionalMonad.INSTANCE;
+    eitherTOverOptional = new EitherTMonad<>(optionalMonad);
+  }
+
+  @Nested
+  @DisplayName("Part 1: Building the stack")
+  class BuildingExercises {
+
+    @Test
+    @DisplayName("Exercise 1: fromEither lifts a plain Either")
+    void exercise1_fromEitherLifts() {
+      Either<AppError, Integer> success = Either.right(42);
+
+      // SOLUTION: fromEither lifts the synchronous Either through the lower-stack monad.
+      EitherT<OptionalKind.Witness, AppError, Integer> wrapped =
+          EitherT.fromEither(optionalMonad, success);
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(wrapped.value());
+      assertThat(outer).isPresent();
+      assertThat(outer.get().getRight()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("Exercise 2: fromKind on Optional.empty() makes the whole stack absent")
+    void exercise2_emptyOuterOptional() {
+      var emptyOuter = OPTIONAL.<Either<AppError, Integer>>widen(Optional.empty());
+
+      // SOLUTION: when the outer Optional is empty, the whole computation is skipped.
+      EitherT<OptionalKind.Witness, AppError, Integer> wrapped = EitherT.fromKind(emptyOuter);
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(wrapped.value());
+      assertThat(outer).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Part 2: Composing stacked steps")
+  class ComposingExercises {
+
+    @Test
+    @DisplayName("Exercise 3: For threads through both layers")
+    void exercise3_forOverStackedMonad() {
+      Either<AppError, Integer> first = Either.right(10);
+      Either<AppError, Integer> second = Either.right(32);
+
+      // SOLUTION: For.from with the stacked monad keeps the comprehension body readable.
+      Kind<EitherTKind.Witness<OptionalKind.Witness, AppError>, Integer> sum =
+          For.from(eitherTOverOptional, EitherT.fromEither(optionalMonad, first))
+              .from(_ -> EitherT.fromEither(optionalMonad, second))
+              .yield((a, b) -> a + b);
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(sum).value());
+      assertThat(outer.get().getRight()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("Exercise 4: Inner Left propagates while the outer Optional stays present")
+    void exercise4_innerLeftPropagates() {
+      Either<AppError, Integer> ok = Either.right(10);
+      Either<AppError, Integer> bad = Either.left(new AppError.InvalidInput("nope"));
+
+      // SOLUTION: Left short-circuits the comprehension; the outer Optional is still present.
+      Kind<EitherTKind.Witness<OptionalKind.Witness, AppError>, Integer> result =
+          For.from(eitherTOverOptional, EitherT.fromEither(optionalMonad, ok))
+              .from(_ -> EitherT.fromEither(optionalMonad, bad))
+              .yield((a, b) -> a + b);
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(result).value());
+      assertThat(outer).isPresent();
+      assertThat(outer.get().isLeft()).isTrue();
+      assertThat(outer.get().getLeft()).isInstanceOf(AppError.InvalidInput.class);
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial04_PolymorphicCapabilities_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial04_PolymorphicCapabilities_Solution.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 - 2026 Magnus Smith
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
-package org.higherkindedj.tutorial.solutions.mtl;
+package org.higherkindedj.tutorial.solutions.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.reader_t.ReaderTKindHelper.READER_T;
@@ -37,13 +37,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Solutions for Tutorial 02: MTL Basics
+ * Solutions for Tutorial 04: Polymorphic Capabilities (MTL).
  *
  * <p>This file contains the completed solutions for all exercises. Compare your answers with these
  * solutions after attempting the tutorial.
  */
-@DisplayName("Tutorial 02: MTL Basics - Solutions")
-public class Tutorial02_MTLBasics_Solution {
+@DisplayName("Tutorial 04: Polymorphic Capabilities (MTL) - Solutions")
+public class Tutorial04_PolymorphicCapabilities_Solution {
 
   record AppConfig(String dbUrl, int maxRetries) {}
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial01_WhenPathIsNotEnough.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial01_WhenPathIsNotEnough.java
@@ -1,0 +1,287 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
+import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
+
+import java.util.concurrent.CompletableFuture;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either_t.EitherT;
+import org.higherkindedj.hkt.either_t.EitherTKind;
+import org.higherkindedj.hkt.either_t.EitherTMonad;
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 01: When Path Isn't Enough - Async Workflows with Typed Errors
+ *
+ * <p>The Effect Path API ({@code EitherPath}, {@code MaybePath}, ...) is the recommended starting
+ * point for most workflows. It handles the type plumbing for you and reads naturally in Java. But
+ * sometimes you need to integrate with code that already exposes a different shape, for example a
+ * third-party library that returns {@code CompletableFuture<Either<DomainError, A>>}. {@code
+ * EitherPath} cannot reach inside the future, and writing nested {@code thenCompose} plus {@code
+ * fold} calls is verbose and error-prone.
+ *
+ * <p>{@code EitherT} is the escape hatch. It lets you compose {@code CompletableFuture<Either<L,
+ * R>>} as if it were a single layer, then collapse back to the future when you cross the boundary
+ * into ordinary Java.
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>Bridge an existing {@code Future<Either>} into {@code EitherT} with {@code fromKind}
+ *   <li>Lift a synchronous {@code Either} into {@code EitherT} with {@code fromEither}
+ *   <li>Use {@code For} comprehensions to compose async-and-typed-error steps
+ *   <li>Recover from typed errors with {@code handleErrorWith}
+ *   <li>Collapse back to {@code CompletableFuture<Either<L, R>>} via {@code .value()}
+ * </ul>
+ *
+ * <p>Prerequisites: complete Tutorial 01 and 02 of the Effect Path Journey first.
+ *
+ * <p>Estimated time: 25-35 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial 01: When Path Isn't Enough")
+public class Tutorial01_WhenPathIsNotEnough {
+
+  // --- Domain types ---
+
+  sealed interface WeatherError {
+    record CityNotFound(String city) implements WeatherError {}
+
+    record ServiceUnavailable(String reason) implements WeatherError {}
+  }
+
+  record WeatherReport(String city, int temperature) {}
+
+  record TravelAdvice(String city, String advice) {}
+
+  // --- Fixtures ---
+
+  private CompletableFutureMonad futureMonad;
+  private EitherTMonad<CompletableFutureKind.Witness, WeatherError> eitherTMonad;
+
+  @BeforeEach
+  void setUp() {
+    futureMonad = CompletableFutureMonad.INSTANCE;
+    eitherTMonad = new EitherTMonad<>(futureMonad);
+  }
+
+  /** Helper for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  /**
+   * A simulated third-party weather service. It returns the kind of shape you cannot reach into
+   * with {@code EitherPath}: a {@code CompletableFuture} whose result is an {@code Either}.
+   */
+  private Kind<CompletableFutureKind.Witness, Either<WeatherError, WeatherReport>> fetchWeather(
+      String city) {
+    if (city.equals("Atlantis")) {
+      return FUTURE.widen(
+          CompletableFuture.completedFuture(Either.left(new WeatherError.CityNotFound(city))));
+    }
+    return FUTURE.widen(
+        CompletableFuture.completedFuture(Either.right(new WeatherReport(city, 18))));
+  }
+
+  // ===========================================================================
+  // Part 1: Bridging Future<Either> into EitherT
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Bridging the gap")
+  class BridgingExercises {
+
+    /**
+     * Exercise 1: Wrap an existing Future&lt;Either&gt; into EitherT.
+     *
+     * <p>Given a value of type {@code Kind<F, Either<L, R>>}, {@code EitherT.fromKind} turns it
+     * into an {@code EitherT<F, L, R>} that you can compose with For comprehensions.
+     *
+     * <p>Task: Lift the result of {@code fetchWeather("London")} into {@code EitherT}.
+     */
+    @Test
+    @DisplayName("Exercise 1: fromKind lifts a Future<Either> into EitherT")
+    void exercise1_fromKindLiftsFutureEither() {
+      var london = fetchWeather("London");
+
+      // TODO: Replace answerRequired() with EitherT.fromKind(london)
+      EitherT<CompletableFutureKind.Witness, WeatherError, WeatherReport> wrapped =
+          answerRequired();
+
+      var report = FUTURE.join(wrapped.value());
+      assertThat(report.isRight()).isTrue();
+      assertThat(report.getRight().city()).isEqualTo("London");
+    }
+
+    /**
+     * Exercise 2: Collapse an EitherT back to its underlying shape.
+     *
+     * <p>Once you reach the edge of your effectful code, call {@code .value()} on an {@code
+     * EitherT} to recover the original {@code Kind<F, Either<L, R>>}. From there you can join the
+     * future or hand it back to legacy Java code.
+     *
+     * <p>Task: Extract the underlying future-of-either from the EitherT.
+     */
+    @Test
+    @DisplayName("Exercise 2: .value() returns to the underlying Future<Either>")
+    void exercise2_valueReturnsUnderlyingShape() {
+      var wrapped = EitherT.fromKind(fetchWeather("Paris"));
+
+      // TODO: Replace answerRequired() with wrapped.value()
+      Kind<CompletableFutureKind.Witness, Either<WeatherError, WeatherReport>> underlying =
+          answerRequired();
+
+      var report = FUTURE.join(underlying);
+      assertThat(report.getRight().city()).isEqualTo("Paris");
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Composing Steps with For
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Composing steps")
+  class ComposingExercises {
+
+    /**
+     * Exercise 3: Lift a synchronous Either into EitherT.
+     *
+     * <p>Not every step in a workflow is async. A synchronous validation step returns a plain
+     * {@code Either<L, R>}. {@code EitherT.fromEither} lifts it into the same transformer you are
+     * using for async steps, so a single {@code For} comprehension covers the whole workflow.
+     *
+     * <p>Task: Wrap a synchronous validation result so it can sit alongside async steps.
+     */
+    @Test
+    @DisplayName("Exercise 3: fromEither lifts a synchronous Either")
+    void exercise3_fromEitherLiftsSyncEither() {
+      Either<WeatherError, String> validated = Either.right("Rome");
+
+      // TODO: Replace answerRequired() with EitherT.fromEither(futureMonad, validated)
+      EitherT<CompletableFutureKind.Witness, WeatherError, String> lifted = answerRequired();
+
+      var result = FUTURE.join(lifted.value());
+      assertThat(result.getRight()).isEqualTo("Rome");
+    }
+
+    /**
+     * Exercise 4: Chain two async steps with For.
+     *
+     * <p>The whole point of {@code EitherT} is that two {@code Future<Either>} steps compose like
+     * ordinary monadic actions. If the first step yields {@code Left}, the second is skipped and
+     * the error propagates through the future.
+     *
+     * <p>Task: First fetch the weather for the city, then build a {@code TravelAdvice} from the
+     * report. Use {@code For.from(eitherTMonad, ...)} with one {@code .from(...)} step and a {@code
+     * .yield(...)}.
+     */
+    @Test
+    @DisplayName("Exercise 4: For.from chains two async-Either steps")
+    void exercise4_forChainsAsyncSteps() {
+      // TODO: Replace answerRequired() with:
+      // For.from(eitherTMonad, EitherT.fromKind(fetchWeather("Berlin")))
+      //     .yield(report -> new TravelAdvice(report.city(),
+      //         report.temperature() < 10 ? "Pack a coat" : "Travel light"))
+      Kind<EitherTKind.Witness<CompletableFutureKind.Witness, WeatherError>, TravelAdvice>
+          workflow = answerRequired();
+
+      var result = FUTURE.join(EITHER_T.narrow(workflow).value());
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.getRight().city()).isEqualTo("Berlin");
+      assertThat(result.getRight().advice()).isEqualTo("Travel light");
+    }
+
+    /**
+     * Exercise 5: An error in the middle short-circuits the rest.
+     *
+     * <p>If any step in the comprehension yields {@code Left}, every subsequent step is skipped. No
+     * nested {@code thenCompose}/{@code fold} calls, no manual error propagation.
+     *
+     * <p>Task: Use the same shape as exercise 4 but for the city {@code "Atlantis"}, which the
+     * service rejects with {@code CityNotFound}.
+     */
+    @Test
+    @DisplayName("Exercise 5: Left short-circuits the comprehension")
+    void exercise5_leftShortCircuits() {
+      // TODO: Replace answerRequired() with the same For comprehension as exercise 4 but for
+      // "Atlantis":
+      // For.from(eitherTMonad, EitherT.fromKind(fetchWeather("Atlantis")))
+      //     .yield(report -> new TravelAdvice(report.city(), "any advice"))
+      Kind<EitherTKind.Witness<CompletableFutureKind.Witness, WeatherError>, TravelAdvice>
+          workflow = answerRequired();
+
+      var result = FUTURE.join(EITHER_T.narrow(workflow).value());
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft()).isInstanceOf(WeatherError.CityNotFound.class);
+    }
+  }
+
+  // ===========================================================================
+  // Part 3: Recovery
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 3: Recovery")
+  class RecoveryExercises {
+
+    /**
+     * Exercise 6: Recover from a specific error with handleErrorWith.
+     *
+     * <p>{@code handleErrorWith} only fires when the inner {@code Either} is {@code Left}. Use it
+     * to substitute a default report for a known recoverable error, while letting other errors
+     * propagate.
+     *
+     * <p>Note: {@code EitherT} already implements the {@code Kind} interface, so you can pass it
+     * directly to {@code handleErrorWith} without an explicit widen.
+     *
+     * <p>Task: When fetching weather for {@code "Atlantis"} returns {@code CityNotFound}, return a
+     * default {@code WeatherReport("Unknown", 15)} instead. For other errors, re-raise.
+     */
+    @Test
+    @DisplayName("Exercise 6: handleErrorWith substitutes a default for known errors")
+    void exercise6_handleErrorWithRecovers() {
+      var attempt = EitherT.fromKind(fetchWeather("Atlantis"));
+
+      // TODO: Replace answerRequired() with:
+      // eitherTMonad.handleErrorWith(
+      //     attempt,
+      //     err -> err instanceof WeatherError.CityNotFound
+      //         ? eitherTMonad.of(new WeatherReport("Unknown", 15))
+      //         : eitherTMonad.raiseError(err))
+      Kind<EitherTKind.Witness<CompletableFutureKind.Witness, WeatherError>, WeatherReport>
+          recovered = answerRequired();
+
+      var result = FUTURE.join(EITHER_T.narrow(recovered).value());
+
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.getRight().city()).isEqualTo("Unknown");
+    }
+  }
+
+  /**
+   * Congratulations! You've completed Tutorial 01: When Path Isn't Enough.
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How to bridge a third-party {@code Future<Either>} into the transformer world
+   *   <li>How to mix synchronous validation with async steps in a single {@code For} comprehension
+   *   <li>How to recover from typed errors without rebuilding the workflow
+   *   <li>How to collapse back to {@code CompletableFuture<Either>} at the boundary
+   * </ul>
+   *
+   * <p>Next up: Tutorial 02 applies the same shape to async lookups that may return nothing.
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial02_AsyncWithAbsence.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial02_AsyncWithAbsence.java
@@ -1,0 +1,247 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
+import static org.higherkindedj.hkt.optional_t.OptionalTKindHelper.OPTIONAL_T;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.future.CompletableFutureKind;
+import org.higherkindedj.hkt.future.CompletableFutureMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe_t.MaybeT;
+import org.higherkindedj.hkt.optional_t.OptionalT;
+import org.higherkindedj.hkt.optional_t.OptionalTKind;
+import org.higherkindedj.hkt.optional_t.OptionalTMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 02: Async with Absence - Composing Future&lt;Optional&gt; chains
+ *
+ * <p>Many libraries (caching layers, repositories, configuration loaders) return values shaped as
+ * {@code CompletableFuture<Optional<T>>}: an asynchronous lookup that may not find anything. The
+ * Effect Path API gives you {@code OptionalPath} for synchronous absence and {@code
+ * CompletableFuturePath} for async, but neither covers the intersection. {@code OptionalT} bridges
+ * the gap so you can chain async lookups without nested {@code
+ * orElse(CompletableFuture.completedFuture(Optional.empty()))} boilerplate.
+ *
+ * <p>Higher-Kinded-J also offers a sister type, {@code Maybe}, with its own transformer {@code
+ * MaybeT}. Use whichever matches the absence representation in your codebase.
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>Bridge an existing {@code Future<Optional>} into {@code OptionalT} with {@code fromKind}
+ *   <li>Use {@code For} comprehensions to chain async lookups
+ *   <li>Recover from absence with {@code handleErrorWith} (the error type is {@code Unit})
+ *   <li>Apply the same shape to {@code MaybeT} when you prefer {@code Maybe} over {@code Optional}
+ * </ul>
+ *
+ * <p>Prerequisites: complete Tutorial 01 (When Path Isn't Enough).
+ *
+ * <p>Estimated time: 20-30 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial 02: Async with Absence")
+public class Tutorial02_AsyncWithAbsence {
+
+  // --- Domain types ---
+
+  record User(String id, String name) {}
+
+  record Profile(String userId, String avatarUrl) {}
+
+  record Preferences(String userId, String theme) {}
+
+  // --- Fixtures ---
+
+  private CompletableFutureMonad futureMonad;
+  private OptionalTMonad<CompletableFutureKind.Witness> optionalTMonad;
+
+  @BeforeEach
+  void setUp() {
+    futureMonad = CompletableFutureMonad.INSTANCE;
+    optionalTMonad = new OptionalTMonad<>(futureMonad);
+  }
+
+  /** Helper for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  // Simulated async repository: returns CompletableFuture<Optional<T>>.
+
+  private Kind<CompletableFutureKind.Witness, Optional<User>> fetchUser(String userId) {
+    if (userId.equals("missing")) {
+      return FUTURE.widen(CompletableFuture.completedFuture(Optional.empty()));
+    }
+    return FUTURE.widen(CompletableFuture.completedFuture(Optional.of(new User(userId, "Alice"))));
+  }
+
+  private Kind<CompletableFutureKind.Witness, Optional<Profile>> fetchProfile(String userId) {
+    return FUTURE.widen(
+        CompletableFuture.completedFuture(
+            Optional.of(new Profile(userId, "https://example.com/" + userId + ".png"))));
+  }
+
+  // ===========================================================================
+  // Part 1: OptionalT
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: OptionalT")
+  class OptionalTExercises {
+
+    /**
+     * Exercise 1: Bridge a Future&lt;Optional&gt; into OptionalT.
+     *
+     * <p>Just like {@code EitherT.fromKind} in Tutorial 01, {@code OptionalT.fromKind} accepts an
+     * existing {@code Kind<F, Optional<A>>} and wraps it.
+     *
+     * <p>Task: Lift the result of {@code fetchUser("alice")} into an OptionalT.
+     */
+    @Test
+    @DisplayName("Exercise 1: fromKind lifts a Future<Optional> into OptionalT")
+    void exercise1_fromKindLiftsFutureOptional() {
+      var alice = fetchUser("alice");
+
+      // TODO: Replace answerRequired() with OptionalT.fromKind(alice)
+      OptionalT<CompletableFutureKind.Witness, User> wrapped = answerRequired();
+
+      var result = FUTURE.join(wrapped.value());
+      assertThat(result).isPresent();
+      assertThat(result.get().name()).isEqualTo("Alice");
+    }
+
+    /**
+     * Exercise 2: Chain two async lookups with For.
+     *
+     * <p>If the first lookup returns {@code Optional.empty()}, the second is skipped and the final
+     * result is empty. No null checks, no nested {@code orElse} on futures.
+     *
+     * <p>Task: First fetch the user, then fetch their profile.
+     */
+    @Test
+    @DisplayName("Exercise 2: For chains two async lookups")
+    void exercise2_forChainsAsyncLookups() {
+      // TODO: Replace answerRequired() with:
+      // For.from(optionalTMonad, OptionalT.fromKind(fetchUser("alice")))
+      //     .from(user -> OptionalT.fromKind(fetchProfile(user.id())))
+      //     .yield((user, profile) -> profile)
+      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, Profile> workflow =
+          answerRequired();
+
+      var result = FUTURE.join(OPTIONAL_T.narrow(workflow).value());
+      assertThat(result).isPresent();
+      assertThat(result.get().userId()).isEqualTo("alice");
+    }
+
+    /**
+     * Exercise 3: An empty result short-circuits the chain.
+     *
+     * <p>Use the same shape as exercise 2 but with {@code "missing"} as the user id. The chain
+     * should yield {@code Optional.empty()} without ever calling {@code fetchProfile}.
+     *
+     * <p>Task: Fill in the comprehension as before, but for the missing user.
+     */
+    @Test
+    @DisplayName("Exercise 3: Empty short-circuits the chain")
+    void exercise3_emptyShortCircuits() {
+      // TODO: Replace answerRequired() with the same For shape as exercise 2 but for "missing":
+      // For.from(optionalTMonad, OptionalT.fromKind(fetchUser("missing")))
+      //     .from(user -> OptionalT.fromKind(fetchProfile(user.id())))
+      //     .yield((user, profile) -> profile)
+      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, Profile> workflow =
+          answerRequired();
+
+      var result = FUTURE.join(OPTIONAL_T.narrow(workflow).value());
+      assertThat(result).isEmpty();
+    }
+
+    /**
+     * Exercise 4: Recover from absence with handleErrorWith.
+     *
+     * <p>{@code OptionalT}'s error type is {@code Unit}: absence carries no information beyond
+     * itself. The recovery handler receives a {@code Unit} value and returns a fresh OptionalT.
+     *
+     * <p>Note: {@code OptionalT} already implements {@code Kind}, so you can pass it directly to
+     * {@code handleErrorWith} without a widen call.
+     *
+     * <p>Task: When the lookup is empty, substitute a default {@code Preferences} record.
+     */
+    @Test
+    @DisplayName("Exercise 4: handleErrorWith provides a default for empty")
+    void exercise4_handleErrorWithProvidesDefault() {
+      Kind<CompletableFutureKind.Witness, Optional<Preferences>> emptyLookup =
+          FUTURE.widen(CompletableFuture.completedFuture(Optional.empty()));
+      var attempt = OptionalT.fromKind(emptyLookup);
+      var defaults = new Preferences("guest", "default-light");
+
+      // TODO: Replace answerRequired() with:
+      // optionalTMonad.handleErrorWith(
+      //     attempt,
+      //     (Unit v) -> OptionalT.some(futureMonad, defaults))
+      Kind<OptionalTKind.Witness<CompletableFutureKind.Witness>, Preferences> recovered =
+          answerRequired();
+
+      var result = FUTURE.join(OPTIONAL_T.narrow(recovered).value());
+      assertThat(result).isPresent();
+      assertThat(result.get().theme()).isEqualTo("default-light");
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: MaybeT
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: MaybeT")
+  class MaybeTExercises {
+
+    /**
+     * Exercise 5: MaybeT mirrors OptionalT for Higher-Kinded-J's Maybe type.
+     *
+     * <p>If your codebase uses {@code Maybe} rather than {@code java.util.Optional}, reach for
+     * {@code MaybeT} instead. The factory methods are {@code just}, {@code nothing}, {@code
+     * fromMaybe}, and {@code fromKind}, mirroring the Optional versions.
+     *
+     * <p>Task: Build a {@code MaybeT} containing the user "Bob" by lifting a future-of-Maybe.
+     */
+    @Test
+    @DisplayName("Exercise 5: MaybeT.fromKind for an async Maybe")
+    void exercise5_maybeTFromKind() {
+      Kind<CompletableFutureKind.Witness, Maybe<User>> bob =
+          FUTURE.widen(CompletableFuture.completedFuture(Maybe.just(new User("bob", "Bob"))));
+
+      // TODO: Replace answerRequired() with MaybeT.fromKind(bob)
+      MaybeT<CompletableFutureKind.Witness, User> wrapped = answerRequired();
+
+      var result = FUTURE.join(wrapped.value());
+      assertThat(result.isJust()).isTrue();
+      assertThat(result.get().name()).isEqualTo("Bob");
+    }
+  }
+
+  /**
+   * Congratulations! You've completed Tutorial 02: Async with Absence.
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How to bridge {@code CompletableFuture<Optional<T>>} into the transformer world
+   *   <li>How {@code For} keeps async lookup chains readable
+   *   <li>How to provide defaults when a lookup yields no result
+   *   <li>That {@code MaybeT} follows the same shape if your code uses {@code Maybe}
+   * </ul>
+   *
+   * <p>Next up: Tutorial 03 shows what stacking two transformers looks like, and why you should
+   * almost never need to.
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial03_StackingTransformers.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial03_StackingTransformers.java
@@ -1,0 +1,205 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+import java.util.Optional;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either_t.EitherT;
+import org.higherkindedj.hkt.either_t.EitherTKind;
+import org.higherkindedj.hkt.either_t.EitherTMonad;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 03: Stacking Transformers - Two Effects in One Workflow
+ *
+ * <p>Most workflows need only one transformer. When you genuinely need two effects together (for
+ * example, "a value that may be absent AND may have failed validation"), transformers can stack:
+ * one layer wraps another. The outer monad of the upper layer is the witness type of the lower
+ * layer.
+ *
+ * <p>This tutorial walks through one stack: {@code EitherT<OptionalKind.Witness, AppError, A>}, an
+ * Either that lives inside an Optional. The semantics: each step can fail with a typed error
+ * (Either) and the whole computation can also be skipped if the host Optional is empty.
+ *
+ * <p>When stacking gets uncomfortable, there is a better tool: MTL (Tutorial 04) lets you write
+ * polymorphic code without naming any concrete stack at all.
+ *
+ * <p>Key Concepts:
+ *
+ * <ul>
+ *   <li>The outer monad of an upper transformer is the witness type of the lower transformer
+ *   <li>You need a {@code Monad} instance for the lower stack to build the upper
+ *   <li>{@code For} comprehensions still work; the witness type is just longer
+ *   <li>Reach for MTL when the type signatures start to dominate the code
+ * </ul>
+ *
+ * <p>Prerequisites: complete Tutorial 01 and 02.
+ *
+ * <p>Estimated time: 15-20 minutes
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial 03: Stacking Transformers")
+public class Tutorial03_StackingTransformers {
+
+  // --- Domain types ---
+
+  sealed interface AppError {
+    record InvalidInput(String reason) implements AppError {}
+  }
+
+  // --- Fixtures ---
+
+  private OptionalMonad optionalMonad;
+  private EitherTMonad<OptionalKind.Witness, AppError> eitherTOverOptional;
+
+  @BeforeEach
+  void setUp() {
+    optionalMonad = OptionalMonad.INSTANCE;
+    // The outer monad of EitherT is OptionalKind.Witness — an Optional sits underneath.
+    eitherTOverOptional = new EitherTMonad<>(optionalMonad);
+  }
+
+  /** Helper for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required - replace answerRequired() with your solution");
+  }
+
+  // ===========================================================================
+  // Part 1: Building a stacked value
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 1: Building the stack")
+  class BuildingExercises {
+
+    /**
+     * Exercise 1: Lift a plain Either into the stacked transformer.
+     *
+     * <p>{@code EitherT.fromEither} accepts the lower-stack monad ({@code optionalMonad} here) and
+     * a synchronous {@code Either}, then wraps everything so the result can compose with other
+     * stacked operations.
+     *
+     * <p>Task: Lift {@code Either.right(42)} into the {@code EitherT<OptionalKind.Witness,
+     * AppError, Integer>} stack.
+     */
+    @Test
+    @DisplayName("Exercise 1: fromEither lifts a plain Either")
+    void exercise1_fromEitherLifts() {
+      Either<AppError, Integer> success = Either.right(42);
+
+      // TODO: Replace answerRequired() with EitherT.fromEither(optionalMonad, success)
+      EitherT<OptionalKind.Witness, AppError, Integer> wrapped = answerRequired();
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(wrapped.value());
+      assertThat(outer).isPresent();
+      assertThat(outer.get().getRight()).isEqualTo(42);
+    }
+
+    /**
+     * Exercise 2: Build a stacked value where the host Optional is empty.
+     *
+     * <p>Use {@code EitherT.fromKind} with an outer {@code Optional.empty()} to represent "the
+     * whole computation is skipped". The inner {@code Either} layer never even gets evaluated.
+     *
+     * <p>Task: Wrap an empty Optional so the resulting EitherT carries no value at all.
+     */
+    @Test
+    @DisplayName("Exercise 2: fromKind on Optional.empty() makes the whole stack absent")
+    void exercise2_emptyOuterOptional() {
+      var emptyOuter = OPTIONAL.<Either<AppError, Integer>>widen(Optional.empty());
+
+      // TODO: Replace answerRequired() with EitherT.fromKind(emptyOuter)
+      EitherT<OptionalKind.Witness, AppError, Integer> wrapped = answerRequired();
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(wrapped.value());
+      assertThat(outer).isEmpty();
+    }
+  }
+
+  // ===========================================================================
+  // Part 2: Composing
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("Part 2: Composing stacked steps")
+  class ComposingExercises {
+
+    /**
+     * Exercise 3: For still works on a stacked monad.
+     *
+     * <p>The witness type {@code EitherTKind.Witness<OptionalKind.Witness, AppError>} is verbose,
+     * but {@code For.from(eitherTOverOptional, ...)} hides it. The body of the comprehension looks
+     * identical to a single-layer workflow.
+     *
+     * <p>Task: Chain two {@code fromEither} steps and yield their sum.
+     */
+    @Test
+    @DisplayName("Exercise 3: For threads through both layers")
+    void exercise3_forOverStackedMonad() {
+      Either<AppError, Integer> first = Either.right(10);
+      Either<AppError, Integer> second = Either.right(32);
+
+      // TODO: Replace answerRequired() with:
+      // For.from(eitherTOverOptional, EitherT.fromEither(optionalMonad, first))
+      //     .from(_ -> EitherT.fromEither(optionalMonad, second))
+      //     .yield((a, b) -> a + b)
+      Kind<EitherTKind.Witness<OptionalKind.Witness, AppError>, Integer> sum = answerRequired();
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(sum).value());
+      assertThat(outer.get().getRight()).isEqualTo(42);
+    }
+
+    /**
+     * Exercise 4: An inner Left short-circuits the comprehension.
+     *
+     * <p>Just like the single-layer case, a {@code Left} stops further steps. The outer Optional is
+     * still present (the workflow ran), but its content is the propagated error.
+     *
+     * <p>Task: Use the same shape as exercise 3, but the second step is a Left.
+     */
+    @Test
+    @DisplayName("Exercise 4: Inner Left propagates while the outer Optional stays present")
+    void exercise4_innerLeftPropagates() {
+      Either<AppError, Integer> ok = Either.right(10);
+      Either<AppError, Integer> bad = Either.left(new AppError.InvalidInput("nope"));
+
+      // TODO: Replace answerRequired() with:
+      // For.from(eitherTOverOptional, EitherT.fromEither(optionalMonad, ok))
+      //     .from(_ -> EitherT.fromEither(optionalMonad, bad))
+      //     .yield((a, b) -> a + b)
+      Kind<EitherTKind.Witness<OptionalKind.Witness, AppError>, Integer> result = answerRequired();
+
+      Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(result).value());
+      assertThat(outer).isPresent();
+      assertThat(outer.get().isLeft()).isTrue();
+      assertThat(outer.get().getLeft()).isInstanceOf(AppError.InvalidInput.class);
+    }
+  }
+
+  /**
+   * Congratulations! You've completed Tutorial 03: Stacking Transformers.
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How a transformer's outer monad can itself be the witness of another transformer
+   *   <li>Why the corresponding {@code Monad} instance for the inner stack matters
+   *   <li>That {@code For} comprehensions absorb the verbosity of stacked witness types
+   *   <li>That stacking adds cognitive load fast; MTL is usually the cleaner answer
+   * </ul>
+   *
+   * <p>Next up: Tutorial 04 introduces the MTL capabilities (MonadReader, MonadState, MonadWriter)
+   * that let library authors write polymorphic code without naming any concrete stack.
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial04_PolymorphicCapabilities.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial04_PolymorphicCapabilities.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 - 2026 Magnus Smith
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
-package org.higherkindedj.tutorial.mtl;
+package org.higherkindedj.tutorial.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.reader_t.ReaderTKindHelper.READER_T;
@@ -37,11 +37,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tutorial: MTL Basics - Writing Stack-Independent Effectful Code
+ * Tutorial 04: Polymorphic Capabilities (MTL) - Writing Stack-Independent Effectful Code
+ *
+ * <p>Prerequisites: complete Tutorial 01 (When Path Isn't Enough), Tutorial 02 (Async with
+ * Absence), and ideally Tutorial 03 (Stacking Transformers) first. This tutorial builds on the raw
+ * transformer types you have already met.
  *
  * <p>Learn to use MonadReader, MonadState, and MonadWriter to declare capabilities without fixing a
  * concrete transformer stack. These interfaces let you write polymorphic functions that work with
- * any stack providing the required capability.
+ * any stack providing the required capability. This is the layer of abstraction that library
+ * authors reach for when callers need to plug their own effect stack underneath.
  *
  * <p>Key Concepts:
  *
@@ -56,8 +61,8 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Replace each placeholder with the correct code to make the tests pass.
  */
-@DisplayName("Tutorial 02: MTL Basics")
-public class Tutorial02_MTLBasics {
+@DisplayName("Tutorial 04: Polymorphic Capabilities (MTL)")
+public class Tutorial04_PolymorphicCapabilities {
 
   // --- Test Data ---
 
@@ -481,7 +486,7 @@ public class Tutorial02_MTLBasics {
   }
 
   /**
-   * Congratulations! You've completed Tutorial 02: MTL Basics
+   * Congratulations! You've completed Tutorial 04: Polymorphic Capabilities (MTL).
    *
    * <p>You now understand:
    *


### PR DESCRIPTION
Restructure of the Monad Transformers chapter from a set of independent reference pages into a coherent learning path that matches the rest of the book. Addresses ten proposals covering page structure, prose style, runnable examples, tutorials, and reference material.

New pages:
- quickstart.md: three runnable transformer examples (~150 lines)
- transformers_at_a_glance.md: one-page reference card
- migration_cookbook.md: imperative-to-transformer and Path-to- transformer side-by-side translations
- when_to_drop_to_transformers.md: triage page naming the three signals that mean you have outgrown the Effect Path API
- common_errors.md: six common compiler errors with the fix for each
- transformer_capstone.md: end-to-end multi-capability worked example comparing imperative, MTL polymorphic, and Effect Path API styles
- tutorials/transformers/transformers_journey.md: narrative wrapper for the new tutorial track

Per-transformer page consistency (eithert, optionalt, maybet, readert, statet, writert):
- Standardised section structure per the new STYLE-GUIDE.md Monad Transformer Pages template (Path First, Problem, Solution, Railway View, How It Works, Setting Up, Key Operations, Creating Instances, Real-World Example, mapT, Common Mistakes, See Also)
- Added Railway View ASCII diagrams to ReaderT, StateT, WriterT
- Added See Example Code admonishment to WriterT
- Added Hands-On Learning admonishments linking to the new tutorials
- Reduced widen/narrow ceremony in headline examples; remaining calls are pedagogical or legitimate boundary conversions

Hands-on tutorial track in hkj-examples:
- Tutorial 01: When Path Isn't Enough (6 exercises, EitherT entry)
- Tutorial 02: Async with Absence (5 exercises, OptionalT/MaybeT)
- Tutorial 03: Stacking Transformers (4 exercises, deliberate small scope to discourage routine stacking)
- Tutorial 04: Polymorphic Capabilities (moved from tutorial/mtl/, reframed as the final step of the journey)
- Solution files for all four
- build.gradle.kts updated: default test task excludes the in-progress tutorials and runs only the solutions; tutorialTest task includes the tutorials so users can run them with predictable failures

Polish and consistency:
- Maybe/Optional ordering normalised across SUMMARY.md, ch_intro, transformers.md, and per-page navigation (OptionalT before MaybeT)
- mtl_capabilities Section Contents uses single-hyphen separators matching the rest of the book
- StyleGUIDE.md adds a new section codifying the per-transformer page template
- StateT railway view rebuilt with strict column alignment

Cross-references:
- SUMMARY.md wires every new page into the chapter
- ch_intro.md In This Chapter and Chapter Contents updated
- README.md and hkj-book/src/home.md mention the new chapter and the Monad Transformers journey in the Learn by Doing tables
- Documentation Guide in home.md adds a Monad Transformers section
