### PR TITLE
Improve railway diagram alignment and apply shared CSS class

### DIFF
--- a/hkj-book/src/effect/capstone_focus_effect.md
+++ b/hkj-book/src/effect/capstone_focus_effect.md
@@ -181,15 +181,15 @@ As a rule of thumb: use optics for *where* the data lives (structure), and strea
 
 The railway diagram for this pipeline:
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●══════════════●════════════════●══════════●══════════●═══▶  Company</span>
-    <span style="color:#4CAF50">       findDept    focus(manager)  focus(contact)  via       map</span>
-    <span style="color:#4CAF50">                                                (validate) (setAll)</span>
-                         ╲
-                          ╲  absent: NoManager
-                           ╲
-    <span style="color:#F44336"><b>Failure</b> ──●───────────────●────────────────────────────●──────────────▶  DirectoryError</span>
-    <span style="color:#F44336">    DeptNotFound    NoManager                   InvalidEmail</span>
+    <span style="color:#4CAF50">       findDept    focus(manager)   focus(contact)   via        map</span>
+    <span style="color:#4CAF50">                                                 (validate)  (setAll)</span>
+                            ╲
+                             ╲  absent: NoManager
+                              ╲
+    <span style="color:#F44336"><b>Failure</b> ───●──────────────●───────────────────────────●──────────────▶  DirectoryError</span>
+    <span style="color:#F44336">     DeptNotFound     NoManager                 InvalidEmail</span>
 </pre>
 
 Let's trace what the pipeline does, step by step:

--- a/hkj-book/src/effect/effect_path_overview.md
+++ b/hkj-book/src/effect/effect_path_overview.md
@@ -80,7 +80,7 @@ chaos: decisions that don't so much get made as reluctantly emerge.
 Functional programmers solved this problem decades ago with a simple model:
 the **railway**.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
                          <b>THE EFFECT RAILWAY</b>
 
     <span style="color:#4CAF50"><b>Success</b> ═══●═══●═══●═══●═══●═══════════════════▶  Result</span>
@@ -91,7 +91,7 @@ the **railway**.
                    │       │
     <span style="color:#F44336"><b>Failure</b>  ──────●───────┼───────────────────────▶  Error</span>
     <span style="color:#F44336">               │       │</span>
-    <span style="color:#F44336">            mapError</span>  <span style="color:#4CAF50">recover</span>
+    <span style="color:#F44336">           mapError</span> <span style="color:#4CAF50">recover</span>
                            │
                            ╳                         recovery, switch back
 </pre>
@@ -130,21 +130,21 @@ the operator executes.
 
 Transforms the value on the success track. Failures pass through untouched.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●═══ map(fn) ═══●═══▶  transformed value</span>
     <span style="color:#4CAF50">           A              f(A)</span>
 
-    <span style="color:#F44336"><b>Failure</b> ═══●══════════════●═══▶  unchanged error</span>
-    <span style="color:#F44336">           E              E          (skipped)</span>
+    <span style="color:#F44336"><b>Failure</b> ═══●═══════════════●═══▶  unchanged error</span>
+    <span style="color:#F44336">           E               E          (skipped)</span>
 </pre>
 
 #### mapError(fn)
 
 The mirror of `map`: transforms the value on the failure track. Successes pass through untouched.
 
-<pre style="line-height:1.5;font-size:0.95em">
-    <span style="color:#4CAF50"><b>Success</b> ═══●══════════════●═══▶  unchanged value</span>
-    <span style="color:#4CAF50">           A              A          (skipped)</span>
+<pre class="hkj-railway-diagram">
+    <span style="color:#4CAF50"><b>Success</b> ═══●════════════════════●═══▶  unchanged value</span>
+    <span style="color:#4CAF50">           A                    A          (skipped)</span>
 
     <span style="color:#F44336"><b>Failure</b> ═══●═══ mapError(fn) ═══●═══▶  transformed error</span>
     <span style="color:#F44336">           E                  f(E)</span>
@@ -155,21 +155,21 @@ The mirror of `map`: transforms the value on the failure track. Successes pass t
 Chains an operation that may itself fail. The function receives the success value and returns
 a new Path; if that Path fails, the data switches to the failure track.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●═══ via(fn) ═══●═══▶  continues on success</span>
     <span style="color:#4CAF50">           A           fn(A)</span>  ╲
                                    ╲
                                     <span style="color:#F44336">╲═══▶  diverts to failure (fn returned Left/Nothing)</span>
 
-    <span style="color:#F44336"><b>Failure</b> ═══●════════════════●═══▶  unchanged error (skipped)</span>
+    <span style="color:#F44336"><b>Failure</b> ═══●═══════════════●═══▶  unchanged error (skipped)</span>
 </pre>
 
 #### recover(fn)
 
 Switches from the failure track back to the success track by converting the error into a value.
 
-<pre style="line-height:1.5;font-size:0.95em">
-    <span style="color:#4CAF50"><b>Success</b> ═══●══════════════════●═══▶  unchanged value (skipped)</span>
+<pre class="hkj-railway-diagram">
+    <span style="color:#4CAF50"><b>Success</b> ═══●═══════════════════●═══▶  unchanged value (skipped)</span>
 
     <span style="color:#F44336"><b>Failure</b> ═══●═══ recover(fn) </span><span style="color:#4CAF50">═══●═══▶  recovered value</span>
     <span style="color:#F44336">           E             </span><span style="color:#4CAF50">   fn(E)</span>
@@ -180,8 +180,8 @@ Switches from the failure track back to the success track by converting the erro
 Like `recover`, but the function returns a new Path rather than a raw value. The recovery
 itself may fail, keeping the data on the failure track.
 
-<pre style="line-height:1.5;font-size:0.95em">
-    <span style="color:#4CAF50"><b>Success</b> ═══●══════════════════════●═══▶  unchanged value (skipped)</span>
+<pre class="hkj-railway-diagram">
+    <span style="color:#4CAF50"><b>Success</b> ═══●═══════════════════════●═══▶  unchanged value (skipped)</span>
 
     <span style="color:#F44336"><b>Failure</b> ═══●═══ recoverWith(fn) </span><span style="color:#4CAF50">═══●═══▶  recovered value</span>
     <span style="color:#F44336">           E                fn(E)</span>  ╲
@@ -193,12 +193,12 @@ itself may fail, keeping the data on the failure track.
 
 A fallback junction: if the first path failed, try a completely different path.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●══════════════════════════▶  original value</span>
 
     <span style="color:#F44336"><b>Failure</b> ═══●═══ orElse(supplier)</span>
     <span style="color:#F44336">           E         │</span>
-                       ▼
+                         ▼
               <span style="color:#4CAF50">supplier.get() ═══●═══▶  alternative value</span>
                                     ╲
                                      <span style="color:#F44336">╲═══▶  alternative also failed</span>
@@ -209,11 +209,11 @@ A fallback junction: if the first path failed, try a completely different path.
 A siding: the function observes the success value but does not change it or the track.
 Commonly used for logging and debugging.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●═══ peek(fn) ═══●═══▶  same value, same track</span>
     <span style="color:#4CAF50">           A      │         A</span>
-                    ▼
-              <i>side effect</i>       (e.g. log, metric, debug)
+                      ▼
+                 <i>side effect</i>    (e.g. log, metric, debug)
 
     <span style="color:#F44336"><b>Failure</b> ═══●════════════════●═══▶  unchanged error (skipped)</span>
 </pre>
@@ -224,17 +224,17 @@ A wormhole into nested structure: the lens extracts a field from the success val
 and the result stays on the same track. If the optic is an `AffinePath` and the
 field is absent, the data switches to the failure track.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●═══ focus(lens) ═══●═══▶  focused field</span>
     <span style="color:#4CAF50">        Order              Address       (lens extracted nested value)</span>
 
-    <span style="color:#F44336"><b>Failure</b> ═══●════════════════════●═══▶  unchanged error (skipped)</span>
+    <span style="color:#F44336"><b>Failure</b> ═══●═══════════════════●═══▶  unchanged error (skipped)</span>
 
     <i>With AffinePath (optional field):</i>
     <span style="color:#4CAF50"><b>Success</b> ═══●═══ focus(affine) </span>
     <span style="color:#4CAF50">        Order</span>         ╲
-                          ╲  field absent
-                           <span style="color:#F44336">╲═══▶  Left(providedError) / Nothing</span>
+                           ╲  field absent
+                            <span style="color:#F44336">╲═══▶  Left(providedError) / Nothing</span>
 </pre>
 
 ---

--- a/hkj-book/src/transformers/archetypes.md
+++ b/hkj-book/src/transformers/archetypes.md
@@ -39,13 +39,13 @@ Every enterprise application juggles multiple concerns: typed errors, optional l
 
 Your service method can fail in multiple, domain-specific ways: insufficient funds, account suspended, gateway timeout. Traditional Java forces a choice between checked exceptions (verbose, uncompilable in lambdas) and unchecked exceptions (invisible, unsafe). Neither option composes cleanly across a multi-step pipeline.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●══════════●══════════●══════════●═══▶  Confirmation</span>
     <span style="color:#4CAF50">          right      via        via       map</span>
     <span style="color:#4CAF50">        (account)  (validate)  (charge)</span>
+                      ╲            ╲
+                       ╲            ╲  error: switch tracks
                         ╲            ╲
-                         ╲            ╲  error: switch tracks
-                          ╲            ╲
     <span style="color:#F44336"><b>Failure</b> ────────────●────────────●──────────────▶  PaymentError</span>
     <span style="color:#F44336">              InsufficientFunds  GatewayTimeout</span>
                                         │
@@ -116,20 +116,20 @@ try {
 
 You need to resolve a value from multiple sources with a defined priority: first check the database, then the environment, then fall back to defaults. Each source might return nothing. With `Optional`, you end up with nested `flatMap` chains that obscure the fallback logic.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Present</b>  ═══●═══════════════════════════════════════▶  Config</span>
     <span style="color:#4CAF50">         database</span>
                 ╲
                  ╲  nothing: try next source
                   ╲
-    <span style="color:#F44336"><b>Absent</b></span>   ──────●
+    <span style="color:#F44336"><b>Absent</b></span>   ─────●
                   │ <span style="color:#4CAF50">orElse</span>
     <span style="color:#4CAF50"><b>Present</b>  ═════●═════════════════════════════════════▶  Config</span>
     <span style="color:#4CAF50">         environment</span>
                   ╲
                    ╲  nothing: try next source
                     ╲
-    <span style="color:#F44336"><b>Absent</b></span>   ────────●
+    <span style="color:#F44336"><b>Absent</b></span>   ───────●
                     │ <span style="color:#4CAF50">orElse</span>
     <span style="color:#4CAF50"><b>Present</b>  ═══════●═══════════════════════════════════▶  Config</span>
     <span style="color:#4CAF50">          defaults (guaranteed)</span>
@@ -179,12 +179,12 @@ if (config == null) {
 
 A REST API receives a request body with multiple fields. Each field has its own validation rules. The caller expects *all* validation failures in a single response, not one at a time. The Service Stack's short-circuit behaviour is wrong here; you need error accumulation.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50">validateName ════●═══╗</span>
     <span style="color:#4CAF50">                     ║</span>
     <span style="color:#4CAF50">validateEmail ═══●═══╬═══ zipWith3Accum ═══●═══▶  Registration</span>
     <span style="color:#4CAF50">                     ║</span>
-    <span style="color:#4CAF50">validateAge ════●════╝</span>
+    <span style="color:#4CAF50">validateAge ═════●═══╝</span>
 
     If any fail, errors <b>accumulate</b> (not short-circuit):
 
@@ -194,7 +194,7 @@ A REST API receives a request body with multiple fields. Each field has its own 
     <span style="color:#F44336">validateEmail ───●───╝</span>
     <span style="color:#F44336">  "Invalid email"</span><span style="color:#4CAF50">    ║</span>
     <span style="color:#4CAF50">                     ║</span>
-    <span style="color:#4CAF50">validateAge ════●════╝</span>
+    <span style="color:#4CAF50">validateAge ═════●═══╝</span>
     <span style="color:#4CAF50">  (valid, but still</span>
     <span style="color:#4CAF50">   collected with errors)</span>
 </pre>
@@ -311,12 +311,12 @@ ProductPage buildProductPage(TenantContext ctx) {
 
 Financial regulations require every step in a transaction to produce an audit entry. The audit log must be accumulated alongside the computation, not scattered across side-effecting logger calls that are invisible in the type system and easily forgotten.
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Value</b>   ═══●══════════════●══════════════●═══▶  TransferResult</span>
     <span style="color:#4CAF50">         debit          credit         map</span>
-              │               │
-              ▼ <i>siding</i>        ▼ <i>siding</i>
-    <span style="color:#FFB300"><b>Log</b>     ──●──────────────●──────────────────▶  [DEBIT, CREDIT]</span>
+               │              │
+               ▼ <i>siding</i>       ▼ <i>siding</i>
+    <span style="color:#FFB300"><b>Log</b>     ───●──────────────●──────────────────▶  [DEBIT, CREDIT]</span>
     <span style="color:#FFB300">       [DEBIT ...]    [CREDIT ...]</span>
     <span style="color:#FFB300">                 accumulated via Monoid</span>
 </pre>

--- a/hkj-book/src/transformers/ch_intro.md
+++ b/hkj-book/src/transformers/ch_intro.md
@@ -27,7 +27,7 @@ Higher-Kinded-J provides six transformers, each adding a specific capability to 
 
 ## The Stacking Concept
 
-<pre style="line-height:1.4;font-size:0.95em">
+<pre class="hkj-ascii-diagram">
 <span style="color:#F44336">    ┌─────────────────────────────────────────────────────────────┐
     │  WITHOUT TRANSFORMER                                        │
     │                                                             │

--- a/hkj-book/src/transformers/eithert_transformer.md
+++ b/hkj-book/src/transformers/eithert_transformer.md
@@ -91,13 +91,13 @@ Same four steps. No manual error propagation. If any step returns `Left`, subseq
 
 ## The Railway View
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Right</b>  ═══●══════════●══════════●══════════●═══▶  Receipt</span>
     <span style="color:#4CAF50">       validate   inventory   payment   receipt</span>
     <span style="color:#4CAF50">       (flatMap)  (flatMap)   (flatMap)  (map)</span>
-                ╲            ╲            ╲
-                 ╲            ╲            ╲  Left: skip remaining steps
-                  ╲            ╲            ╲
+              ╲         ╲             ╲
+               ╲         ╲             ╲  Left: skip remaining steps
+                ╲         ╲             ╲
     <span style="color:#F44336"><b>Left</b>   ─────●─────────●─────────────●──────────▶  DomainError</span>
     <span style="color:#F44336">       InvalidOrder  OutOfStock  PaymentFailed</span>
                                         │
@@ -114,7 +114,7 @@ Each `flatMap` runs inside the outer monad `F` (e.g. `CompletableFuture`). If th
 
 `EitherT<F, L, R>` wraps a value of type `Kind<F, Either<L, R>>`. It represents a computation within the context `F` that will eventually yield an `Either<L, R>`.
 
-<pre style="line-height:1.4;font-size:0.95em;font-family:ui-monospace,SFMono-Regular,'SF Mono','Cascadia Mono','Roboto Mono','DejaVu Sans Mono','Source Code Pro',Menlo,Consolas,monospace,monospace;">
+<pre class="hkj-ascii-diagram">
     ┌──────────────────────────────────────────────────────────┐
     │  EitherT&lt;CompletableFutureKind.Witness, Error, Value&gt;    │
     │                                                          │

--- a/hkj-book/src/transformers/maybet_transformer.md
+++ b/hkj-book/src/transformers/maybet_transformer.md
@@ -78,13 +78,13 @@ If `fetchUserAsync` returns `Nothing`, the preferences lookup is skipped entirel
 
 ## The Railway View
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Just</b>     ═══●═══════════════●═══════════════════▶  UserPreferences</span>
     <span style="color:#4CAF50">          fetchUser       fetchPreferences</span>
     <span style="color:#4CAF50">          (flatMap)        (flatMap)</span>
-                  ╲               ╲
-                   ╲               ╲  Nothing: skip remaining steps
-                    ╲               ╲
+               ╲                ╲
+                ╲                ╲  Nothing: skip remaining steps
+                 ╲                ╲
     <span style="color:#F44336"><b>Nothing</b>  ────●────────────────●──────────────────▶  Nothing</span>
     <span style="color:#F44336">         user absent     prefs absent</span>
                                     │
@@ -101,7 +101,7 @@ Each `flatMap` runs inside the outer monad `F`. If the inner `Maybe` is `Nothing
 
 `MaybeT<F, A>` wraps a computation yielding `Kind<F, Maybe<A>>`. It represents an effectful computation in `F` that may produce `Just(value)` or `Nothing`.
 
-<pre style="line-height:1.4;font-size:0.95em;font-family:ui-monospace,SFMono-Regular,'SF Mono','Cascadia Mono','Roboto Mono','DejaVu Sans Mono','Source Code Pro',Menlo,Consolas,monospace,monospace;">
+<pre class="hkj-ascii-diagram">
     ┌──────────────────────────────────────────────────────────┐
     │  MaybeT&lt;CompletableFutureKind.Witness, Value&gt;            │
     │                                                          │

--- a/hkj-book/src/transformers/optionalt_transformer.md
+++ b/hkj-book/src/transformers/optionalt_transformer.md
@@ -83,13 +83,13 @@ If any step returns empty, subsequent steps are skipped. No manual `orElse` fall
 
 ## The Railway View
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Present</b>  ═══●═══════════●═══════════●═══════════▶  UserPreferences</span>
     <span style="color:#4CAF50">          fetchUser   fetchProfile fetchPrefs</span>
     <span style="color:#4CAF50">          (flatMap)   (flatMap)    (flatMap)</span>
-                  ╲           ╲            ╲
-                   ╲           ╲            ╲  empty: skip remaining steps
-                    ╲           ╲            ╲
+               ╲          ╲             ╲
+                ╲          ╲             ╲  empty: skip remaining steps
+                 ╲          ╲             ╲
     <span style="color:#F44336"><b>Empty</b>    ────●──────────●─────────────●──────────▶  Optional.empty()</span>
     <span style="color:#F44336">        user absent  profile absent  prefs absent</span>
                                           │
@@ -106,7 +106,7 @@ Each `flatMap` runs inside the outer monad `F`. If the inner `Optional` is empty
 
 `OptionalT<F, A>` wraps a computation yielding `Kind<F, Optional<A>>`. It represents an effectful computation in `F` that may or may not produce a value.
 
-<pre style="line-height:1.4;font-size:0.95em;font-family:ui-monospace,SFMono-Regular,'SF Mono','Cascadia Mono','Roboto Mono','DejaVu Sans Mono','Source Code Pro',Menlo,Consolas,monospace,monospace;">
+<pre class="hkj-ascii-diagram">
     ┌──────────────────────────────────────────────────────────┐
     │  OptionalT&lt;CompletableFutureKind.Witness, Value&gt;         │
     │                                                          │

--- a/hkj-book/src/transformers/readert_transformer.md
+++ b/hkj-book/src/transformers/readert_transformer.md
@@ -103,11 +103,11 @@ The `AppConfig` is threaded implicitly through `flatMap`. Each operation declare
 
 ## The Railway View
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Value</b>     ═══●═══════════●═══════════●═══▶  ProcessedData (in F)</span>
     <span style="color:#4CAF50">              fetchData    process       map</span>
     <span style="color:#4CAF50">              (flatMap)    (flatMap)</span>
-                  ▲            ▲            ▲    <i>config read at each step</i>
+                 ▲           ▲           ▲    <i>config read at each step</i>
     <span style="color:#2196F3"><b>AppConfig</b> ═══╧═══════════╧═══════════╧═══▶  read-only, never modified</span>
     <span style="color:#2196F3">              apiKey       serviceUrl    executor</span>
 

--- a/hkj-book/src/transformers/statet_transformer.md
+++ b/hkj-book/src/transformers/statet_transformer.md
@@ -95,7 +95,7 @@ The state flows from one operation to the next through `flatMap`. If any operati
 
 ## The Railway View
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Value</b>   ═══●═══════════●═══════════●═══════════●═══▶  result A (in F)</span>
     <span style="color:#4CAF50">           push(10)    push(20)    pop         pop</span>
     <span style="color:#4CAF50">           (flatMap)   (flatMap)   (flatMap)   (flatMap)</span>

--- a/hkj-book/src/transformers/transformer_capstone.md
+++ b/hkj-book/src/transformers/transformer_capstone.md
@@ -190,19 +190,19 @@ The Path API trades the polymorphism of MTL for shorter, more concrete code. Whe
 
 The railway diagram for the success-and-failure tracks of the polymorphic version:
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Success</b> ═══●══════════════●══════════════●══════════●═══▶  Receipt</span>
-    <span style="color:#4CAF50">         validate       reserve         charge       map</span>
-    <span style="color:#4CAF50">         (errors)        (env+errors)    (env+errors)</span>
-              │                │                │
-              ▼ <i>tell</i>          ▼ <i>tell</i>          ▼ <i>tell</i>
-    <span style="color:#FFB300"><b>Audit</b>   ──●──────────────●──────────────●─────────────────▶  List&lt;AuditEntry&gt;</span>
+    <span style="color:#4CAF50">           validate        reserve         charge      map</span>
+    <span style="color:#4CAF50">           (errors)     (env+errors)   (env+errors)</span>
+               │              │              │
+               ▼ <i>tell</i>         ▼ <i>tell</i>         ▼ <i>tell</i>
+    <span style="color:#FFB300"><b>Audit</b>   ───●──────────────●──────────────●──────────────▶  List&lt;AuditEntry&gt;</span>
     <span style="color:#FFB300">         "validate ok"  "reserve ok"   "charge ok"</span>
-              ╲                ╲                ╲
-               ╲                ╲                ╲  Left: skip remaining steps
-                ╲                ╲                ╲
-    <span style="color:#F44336"><b>Failure</b> ──●────────────────●──────────────●────────────────▶  DomainError</span>
-    <span style="color:#F44336">         InvalidOrder    OutOfStock     PaymentDeclined</span>
+               ╲              ╲              ╲
+                ╲              ╲              ╲  Left: skip remaining steps
+                 ╲              ╲              ╲
+    <span style="color:#F44336"><b>Failure</b> ─────●──────────────●──────────────●────────────▶  DomainError</span>
+    <span style="color:#F44336">           InvalidOrder    OutOfStock     PaymentDeclined</span>
 </pre>
 
 The audit track and the value track advance together. The error track absorbs any `Left` from any step and short-circuits the rest. All three concerns coexist in one comprehension because the capabilities composed through MTL share the same monad witness `F`.

--- a/hkj-book/src/transformers/writert_transformer.md
+++ b/hkj-book/src/transformers/writert_transformer.md
@@ -98,12 +98,12 @@ One comprehension. The log combines via `List`'s `Monoid`. No manual threading.
 
 ## The Railway View
 
-<pre style="line-height:1.5;font-size:0.95em">
+<pre class="hkj-railway-diagram">
     <span style="color:#4CAF50"><b>Value</b>   ═══●═══════════════●═══════════════●═══▶  final price (in F)</span>
     <span style="color:#4CAF50">         applyDiscount   addShipping     yield</span>
     <span style="color:#4CAF50">         (flatMap)       (flatMap)</span>
               │                  │
-              ▼ <i>tell</i>            ▼ <i>tell</i>
+              ▼ <i>tell</i>             ▼ <i>tell</i>
     <span style="color:#FFB300"><b>Log</b>     ──●──────────────●──────────────────────▶  ["Discount", "Shipping"]</span>
     <span style="color:#FFB300">       "Applied 10%"  "Added shipping"</span>
     <span style="color:#FFB300">                  combined via Monoid&lt;List&lt;String&gt;&gt;</span>

--- a/hkj-book/src/tutorials/resilience/resilience_journey.md
+++ b/hkj-book/src/tutorials/resilience/resilience_journey.md
@@ -77,4 +77,11 @@ Learn to use resilience patterns through the fluent Path API.
 
 ## Solutions
 
-Each tutorial has a corresponding solution file in the `solutions/` subdirectory. Try to complete the exercises on your own before checking the solutions.
+Each tutorial has a corresponding solution file under `hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/`. Try to complete the exercises on your own before checking the solutions.
+
+| Tutorial | Solution File |
+|----------|--------------|
+| `Tutorial01_CircuitBreaker.java` | `solutions/resilience/Tutorial01_CircuitBreaker_Solution.java` |
+| `Tutorial02_Saga.java` | `solutions/resilience/Tutorial02_Saga_Solution.java` |
+| `Tutorial03_RetryBulkheadResilience.java` | `solutions/resilience/Tutorial03_RetryBulkheadResilience_Solution.java` |
+| `Tutorial04_PathResilience.java` | `solutions/resilience/Tutorial04_PathResilience_Solution.java` |

--- a/hkj-book/src/tutorials/solutions_guide.md
+++ b/hkj-book/src/tutorials/solutions_guide.md
@@ -282,16 +282,21 @@ hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/
 │   ├── Tutorial05_MonadErrorHandling_Solution.java
 │   ├── Tutorial06_ConcreteTypes_Solution.java
 │   └── Tutorial07_RealWorld_Solution.java
-└── optics/
-    ├── Tutorial01_LensBasics_Solution.java
-    ├── Tutorial02_LensComposition_Solution.java
-    ├── Tutorial03_PrismBasics_Solution.java
-    ├── Tutorial04_TraversalBasics_Solution.java
-    ├── Tutorial05_OpticsComposition_Solution.java
-    ├── Tutorial06_GeneratedOptics_Solution.java
-    ├── Tutorial07_RealWorldOptics_Solution.java
-    ├── Tutorial08_FluentOpticsAPI_Solution.java
-    └── Tutorial09_AdvancedOpticsDSL_Solution.java
+├── optics/
+│   ├── Tutorial01_LensBasics_Solution.java
+│   ├── Tutorial02_LensComposition_Solution.java
+│   ├── Tutorial03_PrismBasics_Solution.java
+│   ├── Tutorial04_TraversalBasics_Solution.java
+│   ├── Tutorial05_OpticsComposition_Solution.java
+│   ├── Tutorial06_GeneratedOptics_Solution.java
+│   ├── Tutorial07_RealWorldOptics_Solution.java
+│   ├── Tutorial08_FluentOpticsAPI_Solution.java
+│   └── Tutorial09_AdvancedOpticsDSL_Solution.java
+└── resilience/
+    ├── Tutorial01_CircuitBreaker_Solution.java
+    ├── Tutorial02_Saga_Solution.java
+    ├── Tutorial03_RetryBulkheadResilience_Solution.java
+    └── Tutorial04_PathResilience_Solution.java
 ```
 
 Each solution file:

--- a/hkj-book/theme/additional-hkj.css
+++ b/hkj-book/theme/additional-hkj.css
@@ -530,3 +530,29 @@ html.latte body.chapter-intro main > h1:first-of-type     { color: #0b6455 !impo
 html.frappe body.chapter-intro main > h1:first-of-type    { color: #dad126 !important; } /* Citron Yellow — dark-logo wordmark */
 html.macchiato body.chapter-intro main > h1:first-of-type { color: #dad126 !important; } /* Citron Yellow — dark-logo wordmark */
 html.mocha body.chapter-intro main > h1:first-of-type     { color: #dad126 !important; } /* Citron Yellow — dark-logo wordmark */
+
+/* ===== ASCII Diagram Styles =====
+   Box-drawing glyphs (┌ ─ ┐ │ └ ┘) render at non-standard widths in some
+   default UI monospace fonts (notably iOS Safari and several Android
+   webviews), which breaks the alignment of the box edges. Force a known-
+   good monospace stack and enable horizontal scroll on narrow viewports so
+   the diagram stays flush on phones and tablets. */
+
+.hkj-ascii-diagram,
+.hkj-railway-diagram {
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', 'Cascadia Mono',
+                 'Roboto Mono', 'DejaVu Sans Mono', 'Source Code Pro',
+                 Menlo, Consolas, monospace, monospace;
+    font-size: 0.95em;
+    white-space: pre;
+    overflow-x: auto;
+    -webkit-text-size-adjust: 100%;
+}
+
+/* Tighter line-height for box-drawing diagrams so the vertical edges stay
+   visually flush. */
+.hkj-ascii-diagram { line-height: 1.4; }
+
+/* Slightly looser line-height for railway-track diagrams, where the rows
+   carry labels above and below the track and need breathing room. */
+.hkj-railway-diagram { line-height: 1.5; }

--- a/hkj-examples/build.gradle.kts
+++ b/hkj-examples/build.gradle.kts
@@ -46,6 +46,7 @@ tasks.named<Test>("test") {
     exclude("**/tutorial/context/**")
     exclude("**/tutorial/mtl/**")
     exclude("**/tutorial/transformers/**")
+    exclude("**/tutorial/resilience/**")
     // Solutions are in tutorial/solutions/ and will run
 }
 
@@ -68,6 +69,7 @@ tasks.register<Test>("tutorialTest") {
     include("**/tutorial/expression/**")
     include("**/tutorial/effecthandlers/**")
     include("**/tutorial/mtl/**")
+    include("**/tutorial/resilience/**")
     exclude("**/tutorial/solutions/**")
     // Don't fail the build - tutorials are expected to fail
     ignoreFailures = true

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/README.md
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/README.md
@@ -257,6 +257,7 @@ Complete solutions for all exercises are available in:
 - `solutions/coretypes/` - Core types solutions
 - `solutions/optics/` - Optics solutions
 - `solutions/mtl/` - MTL solutions
+- `solutions/resilience/` - Resilience patterns solutions
 
 Try to solve the exercises yourself before looking at the solutions!
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial01_CircuitBreaker.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial01_CircuitBreaker.java
@@ -34,10 +34,15 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Requirements: Java 25+ (virtual threads and structured concurrency)
  *
- * <p>Replace each {@code fail("TODO: ...")} with the correct code to make the tests pass.
+ * <p>Replace each {@code answerRequired()} call with the correct code to make the tests pass.
  */
 @DisplayName("Tutorial 01: Circuit Breaker Pattern")
 public class Tutorial01_CircuitBreaker {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
 
   // ===========================================================================
   // Part 1: Creating and Configuring a Circuit Breaker
@@ -62,15 +67,12 @@ public class Tutorial01_CircuitBreaker {
     @Test
     @DisplayName("Exercise 1: Create a CircuitBreaker with custom config")
     void exercise1_createCircuitBreaker() {
-      // Create a CircuitBreakerConfig using the builder pattern
-      CircuitBreakerConfig config =
-          CircuitBreakerConfig.builder()
-              .failureThreshold(3)
-              .openDuration(Duration.ofMillis(100))
-              .build();
+      // TODO: Build a CircuitBreakerConfig with failureThreshold(3) and
+      //       openDuration(Duration.ofMillis(100)) using CircuitBreakerConfig.builder()
+      CircuitBreakerConfig config = answerRequired();
 
-      // Create a CircuitBreaker from the config
-      CircuitBreaker breaker = CircuitBreaker.create(config);
+      // TODO: Create a CircuitBreaker from the config using CircuitBreaker.create(config)
+      CircuitBreaker breaker = answerRequired();
 
       assertThat(breaker.currentStatus()).isEqualTo(CircuitBreaker.Status.CLOSED);
     }
@@ -87,8 +89,8 @@ public class Tutorial01_CircuitBreaker {
       CircuitBreaker breaker = CircuitBreaker.withDefaults();
       VTask<String> fetchData = VTask.succeed("Hello from service");
 
-      // Wrap fetchData with circuit breaker protection
-      VTask<String> protectedTask = breaker.protect(fetchData);
+      // TODO: Wrap fetchData with circuit breaker protection using breaker.protect(...)
+      VTask<String> protectedTask = answerRequired();
 
       String result = protectedTask.run();
       assertThat(result).isEqualTo("Hello from service");
@@ -107,7 +109,7 @@ public class Tutorial01_CircuitBreaker {
      * Exercise 3: Verify the circuit opens after threshold failures
      *
      * <p>Create a circuit breaker with failureThreshold=3. Send 3 failing tasks through it, then
-     * verify that the circuit has transitioned to OPEN (or HALF_OPEN if enough time passes).
+     * verify that the circuit has transitioned to OPEN.
      */
     @Test
     @DisplayName("Exercise 3: Circuit opens after threshold failures")
@@ -121,10 +123,10 @@ public class Tutorial01_CircuitBreaker {
 
       VTask<String> failingTask = VTask.fail(new RuntimeException("Service down"));
 
-      // Execute the protected failing task 3 times using runSafe()
-      breaker.protect(failingTask).runSafe();
-      breaker.protect(failingTask).runSafe();
-      breaker.protect(failingTask).runSafe();
+      // TODO: Execute the protected failing task 3 times.
+      //       Use breaker.protect(failingTask).runSafe() to swallow exceptions
+      //       so the loop can drive the circuit through 3 consecutive failures.
+      answerRequired();
 
       // After 3 failures, the circuit should be OPEN
       assertThat(breaker.currentStatus()).isEqualTo(CircuitBreaker.Status.OPEN);
@@ -145,13 +147,13 @@ public class Tutorial01_CircuitBreaker {
 
       VTask<String> task = VTask.succeed("Should not execute");
 
-      // Protect the task and execute it with runSafe()
-      Try<String> result = breaker.protect(task).runSafe();
+      // TODO: Protect the task and execute it with runSafe() to obtain Try<String>
+      Try<String> result = answerRequired();
 
       assertThat(result.isFailure()).isTrue();
 
-      // Extract the exception and verify it is a CircuitOpenException
-      Throwable error = result.fold(value -> null, ex -> ex);
+      // TODO: Extract the exception from the Try (hint: result.fold(value -> null, ex -> ex))
+      Throwable error = answerRequired();
 
       assertThat(error).isInstanceOf(CircuitOpenException.class);
       CircuitOpenException coe = (CircuitOpenException) error;
@@ -181,8 +183,8 @@ public class Tutorial01_CircuitBreaker {
 
       VTask<String> task = VTask.succeed("Primary response");
 
-      // Use breaker.protectWithFallback() with a fallback that returns "Fallback response"
-      VTask<String> protectedTask = breaker.protectWithFallback(task, error -> "Fallback response");
+      // TODO: Use breaker.protectWithFallback(task, error -> "Fallback response")
+      VTask<String> protectedTask = answerRequired();
 
       String result = protectedTask.run();
       assertThat(result).isEqualTo("Fallback response");
@@ -211,8 +213,8 @@ public class Tutorial01_CircuitBreaker {
       // Run 1 failed call
       breaker.protect(VTask.fail(new RuntimeException("fail"))).runSafe();
 
-      // Get the metrics from the circuit breaker
-      CircuitBreakerMetrics metrics = breaker.metrics();
+      // TODO: Get the CircuitBreakerMetrics from the breaker (hint: breaker.metrics())
+      CircuitBreakerMetrics metrics = answerRequired();
 
       assertThat(metrics.totalCalls()).isEqualTo(3);
       assertThat(metrics.successfulCalls()).isEqualTo(2);

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial02_Saga.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial02_Saga.java
@@ -5,7 +5,6 @@ package org.higherkindedj.tutorial.resilience;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.hkt.resilience.Saga;
@@ -35,10 +34,15 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Requirements: Java 25+ (virtual threads and structured concurrency)
  *
- * <p>Replace each {@code fail("TODO: ...")} with the correct code to make the tests pass.
+ * <p>Replace each {@code answerRequired()} call with the correct code to make the tests pass.
  */
 @DisplayName("Tutorial 02: Saga Pattern")
 public class Tutorial02_Saga {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
 
   // ===========================================================================
   // Part 1: Creating Simple Sagas
@@ -59,10 +63,11 @@ public class Tutorial02_Saga {
     void exercise1_createSimpleSaga() {
       AtomicBoolean compensated = new AtomicBoolean(false);
 
-      // Create a saga with Saga.of()
-      Saga<String> saga =
-          Saga.of(
-              VTask.succeed("payment-123"), (Consumer<String>) paymentId -> compensated.set(true));
+      // TODO: Create a Saga<String> using Saga.of() with:
+      //       - forward action: VTask.succeed("payment-123")
+      //       - compensation: a Consumer<String> that sets compensated.set(true)
+      //       Hint: cast the lambda as (Consumer<String>) to disambiguate the overload.
+      Saga<String> saga = answerRequired();
 
       // Execute the saga - since it succeeds, compensation should NOT be called
       String result = saga.run().run();
@@ -79,10 +84,11 @@ public class Tutorial02_Saga {
     @Test
     @DisplayName("Exercise 2: Chain saga steps with andThen")
     void exercise2_chainSagaSteps() {
-      // Chain two saga steps with andThen
-      Saga<String> saga =
-          Saga.of(VTask.succeed("step1-result"), (String _) -> {})
-              .andThen(prev -> Saga.of(VTask.succeed(prev + ":step2-result"), (String _) -> {}));
+      // TODO: Build a Saga<String> by chaining two steps with andThen:
+      //       Step 1: Saga.of(VTask.succeed("step1-result"), (String _) -> {})
+      //       Step 2 (depends on prev): Saga.of(VTask.succeed(prev + ":step2-result"),
+      //                                          (String _) -> {})
+      Saga<String> saga = answerRequired();
 
       String result = saga.run().run();
       assertThat(result).isEqualTo("step1-result:step2-result");
@@ -108,14 +114,11 @@ public class Tutorial02_Saga {
     void exercise3_compensationOnFailure() {
       AtomicBoolean step1Compensated = new AtomicBoolean(false);
 
-      // Create a saga where step 2 fails, triggering step 1 compensation
-      Saga<String> saga =
-          Saga.of(VTask.succeed("ok"), (String _) -> step1Compensated.set(true))
-              .andThen(
-                  _ ->
-                      Saga.of(
-                          VTask.<String>fail(new RuntimeException("step2 failed")),
-                          (String _) -> {}));
+      // TODO: Build a Saga<String> where:
+      //       Step 1 succeeds and its compensation sets step1Compensated to true
+      //       Step 2 fails with VTask.<String>fail(new RuntimeException("step2 failed"))
+      //       The failure of step 2 should cause step 1's compensation to run.
+      Saga<String> saga = answerRequired();
 
       // Execute safely - the saga should fail, triggering compensation
       var tryResult = saga.run().runSafe();
@@ -142,12 +145,11 @@ public class Tutorial02_Saga {
     @Test
     @DisplayName("Exercise 4: Use SagaBuilder for multi-step saga")
     void exercise4_sagaBuilder() {
-      // Use SagaBuilder for fluent multi-step construction
-      Saga<String> saga =
-          SagaBuilder.<Unit>start()
-              .step("charge", VTask.succeed("payment-456"), _ -> {})
-              .step("reserve", prev -> VTask.succeed(prev + ":reserved"), _ -> {})
-              .build();
+      // TODO: Build a Saga<String> using SagaBuilder.<Unit>start() with two named steps:
+      //       .step("charge", VTask.succeed("payment-456"), _ -> {})
+      //       .step("reserve", prev -> VTask.succeed(prev + ":reserved"), _ -> {})
+      //       and finally .build()
+      Saga<String> saga = answerRequired();
 
       String result = saga.run().run();
       assertThat(result).isEqualTo("payment-456:reserved");
@@ -170,8 +172,8 @@ public class Tutorial02_Saga {
                           VTask.<String>fail(new RuntimeException("Network timeout")),
                           (String s) -> {}));
 
-      // Use runSafe() to get Either<SagaError, String>
-      Either<SagaError, String> result = failingSaga.runSafe().run();
+      // TODO: Use failingSaga.runSafe().run() to obtain Either<SagaError, String>
+      Either<SagaError, String> result = answerRequired();
 
       // The result should be a Left containing the SagaError
       assertThat(result.isLeft()).isTrue();

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial03_RetryBulkheadResilience.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial03_RetryBulkheadResilience.java
@@ -39,10 +39,15 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Requirements: Java 25+ (virtual threads and structured concurrency)
  *
- * <p>Replace each {@code fail("TODO: ...")} with the correct code to make the tests pass.
+ * <p>Replace each {@code answerRequired()} call with the correct code to make the tests pass.
  */
 @DisplayName("Tutorial 03: Retry, Bulkhead, and Resilience Composition")
 public class Tutorial03_RetryBulkheadResilience {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
 
   // ===========================================================================
   // Part 1: Retry with RetryPolicy
@@ -73,11 +78,12 @@ public class Tutorial03_RetryBulkheadResilience {
                 return "Success on attempt " + attempt;
               });
 
-      // Create a fixed retry policy
-      RetryPolicy policy = RetryPolicy.fixed(3, Duration.ofMillis(10));
+      // TODO: Create a fixed retry policy with 3 attempts and 10ms delay.
+      //       Hint: RetryPolicy.fixed(3, Duration.ofMillis(10))
+      RetryPolicy policy = answerRequired();
 
-      // Wrap the task with retry logic
-      VTask<String> retriedTask = Retry.retryTask(unstableTask, policy);
+      // TODO: Wrap unstableTask with retry logic using Retry.retryTask(unstableTask, policy)
+      VTask<String> retriedTask = answerRequired();
 
       String result = retriedTask.run();
       assertThat(result).isEqualTo("Success on attempt 3");
@@ -106,8 +112,9 @@ public class Tutorial03_RetryBulkheadResilience {
                 return "done";
               });
 
-      // Create policy with onRetry listener
-      RetryPolicy policy = RetryPolicy.fixed(3, Duration.ofMillis(10)).onRetry(events::add);
+      // TODO: Create a fixed retry policy and attach an onRetry listener that records each
+      //       RetryEvent into the `events` list. Hint: .onRetry(events::add)
+      RetryPolicy policy = answerRequired();
 
       VTask<String> retriedTask = Retry.retryTask(unstableTask, policy);
       retriedTask.run();
@@ -136,13 +143,14 @@ public class Tutorial03_RetryBulkheadResilience {
     @Test
     @DisplayName("Exercise 3: Protect a VTask with a Bulkhead")
     void exercise3_bulkheadProtect() {
-      // Create a Bulkhead that allows at most 5 concurrent executions
-      Bulkhead bulkhead = Bulkhead.withMaxConcurrent(5);
+      // TODO: Create a Bulkhead allowing at most 5 concurrent executions
+      //       Hint: Bulkhead.withMaxConcurrent(5)
+      Bulkhead bulkhead = answerRequired();
 
       VTask<String> task = VTask.succeed("protected result");
 
-      // Protect the task with the bulkhead
-      VTask<String> protectedTask = bulkhead.protect(task);
+      // TODO: Protect the task with the bulkhead using bulkhead.protect(task)
+      VTask<String> protectedTask = answerRequired();
 
       String result = protectedTask.run();
       assertThat(result).isEqualTo("protected result");
@@ -175,13 +183,12 @@ public class Tutorial03_RetryBulkheadResilience {
 
       VTask<String> serviceCall = VTask.succeed("service response");
 
-      // Build a resilient task using ResilienceBuilder
-      VTask<String> resilientTask =
-          Resilience.<String>builder(serviceCall)
-              .withCircuitBreaker(breaker)
-              .withRetry(RetryPolicy.fixed(3, Duration.ofMillis(10)))
-              .withFallback(error -> "fallback value")
-              .build();
+      // TODO: Build a resilient VTask<String> using Resilience.<String>builder(serviceCall):
+      //       .withCircuitBreaker(breaker)
+      //       .withRetry(RetryPolicy.fixed(3, Duration.ofMillis(10)))
+      //       .withFallback(error -> "fallback value")
+      //       .build()
+      VTask<String> resilientTask = answerRequired();
 
       String result = resilientTask.run();
       assertThat(result).isEqualTo("service response");
@@ -210,9 +217,8 @@ public class Tutorial03_RetryBulkheadResilience {
                 return "recovered";
               });
 
-      // Use the convenience method for circuit breaker + retry
-      VTask<String> resilientTask =
-          Resilience.withCircuitBreakerAndRetry(unstableTask, breaker, policy);
+      // TODO: Use Resilience.withCircuitBreakerAndRetry(unstableTask, breaker, policy)
+      VTask<String> resilientTask = answerRequired();
 
       String result = resilientTask.run();
       assertThat(result).isEqualTo("recovered");

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial04_PathResilience.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial04_PathResilience.java
@@ -42,10 +42,15 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Requirements: Java 25+ (virtual threads and structured concurrency)
  *
- * <p>Replace each {@code fail("TODO: ...")} with the correct code to make the tests pass.
+ * <p>Replace each {@code answerRequired()} call with the correct code to make the tests pass.
  */
 @DisplayName("Tutorial 04: Path-Based Resilience")
 public class Tutorial04_PathResilience {
+
+  /** Helper method for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
 
   // ===========================================================================
   // Part 1: VTaskPath Retry
@@ -76,9 +81,9 @@ public class Tutorial04_PathResilience {
                 return "success";
               });
 
-      // Add retry using withRetry and a fixed policy
-      VTaskPath<String> retriedPath =
-          unstable.withRetry(RetryPolicy.fixed(3, Duration.ofMillis(10)));
+      // TODO: Add retry to `unstable` using withRetry(...) and a fixed RetryPolicy
+      //       Hint: unstable.withRetry(RetryPolicy.fixed(3, Duration.ofMillis(10)))
+      VTaskPath<String> retriedPath = answerRequired();
 
       String result = retriedPath.unsafeRun();
       assertThat(result).isEqualTo("success");
@@ -114,8 +119,9 @@ public class Tutorial04_PathResilience {
                 throw new RuntimeException("Connection refused");
               });
 
-      // Use catching to wrap the error as Either<String, String>
-      VTaskPath<Either<String, String>> caught = failing.catching(Throwable::getMessage);
+      // TODO: Wrap the failure as Either<String, String> using
+      //       failing.catching(Throwable::getMessage)
+      VTaskPath<Either<String, String>> caught = answerRequired();
 
       Either<String, String> result = caught.unsafeRun();
       assertThat(result.isLeft()).isTrue();
@@ -131,8 +137,8 @@ public class Tutorial04_PathResilience {
                 throw new RuntimeException("Not found");
               });
 
-      // Use asMaybe to convert failure to Nothing
-      VTaskPath<Maybe<String>> maybePath = failing.asMaybe();
+      // TODO: Convert the failure to Nothing using failing.asMaybe()
+      VTaskPath<Maybe<String>> maybePath = answerRequired();
 
       Maybe<String> result = maybePath.unsafeRun();
       assertThat(result.isNothing()).isTrue();
@@ -147,8 +153,8 @@ public class Tutorial04_PathResilience {
                 throw new ArithmeticException("Division by zero");
               });
 
-      // Use asTry to wrap the result in Try<Integer>
-      VTaskPath<Try<Integer>> tryPath = failing.asTry();
+      // TODO: Wrap the result in Try<Integer> using failing.asTry()
+      VTaskPath<Try<Integer>> tryPath = answerRequired();
 
       Try<Integer> result = tryPath.unsafeRun();
       assertThat(result.isFailure()).isTrue();
@@ -178,9 +184,11 @@ public class Tutorial04_PathResilience {
                   .openDuration(Duration.ofSeconds(30))
                   .build());
 
-      // Chain map and withCircuitBreaker
-      VTaskPath<String> protectedPath =
-          Path.vtaskPure(42).map(n -> "Answer: " + n).withCircuitBreaker(breaker);
+      // TODO: Build a VTaskPath<String> by:
+      //       starting with Path.vtaskPure(42)
+      //       mapping it to "Answer: " + n
+      //       protecting with withCircuitBreaker(breaker)
+      VTaskPath<String> protectedPath = answerRequired();
 
       String result = protectedPath.unsafeRun();
       assertThat(result).isEqualTo("Answer: 42");
@@ -219,13 +227,10 @@ public class Tutorial04_PathResilience {
                             return "item-" + n;
                           }));
 
-      // Use recover for both error counting and fallback value
-      VStreamPath<String> safeStream =
-          stream.recover(
-              error -> {
-                errorCount.incrementAndGet();
-                return "recovered";
-              });
+      // TODO: Use stream.recover(error -> ...) to:
+      //       - increment errorCount on each failure
+      //       - return "recovered" as the fallback value
+      VStreamPath<String> safeStream = answerRequired();
 
       List<String> result = safeStream.toList().unsafeRun();
       assertThat(result).containsExactly("item-1", "item-2", "recovered", "item-4", "item-5");
@@ -241,11 +246,10 @@ public class Tutorial04_PathResilience {
     @Test
     @DisplayName("Exercise 5: VStreamPath mapTask with per-element retry")
     void exercise5_vstreamPathMapTask() {
-      AtomicInteger callCount = new AtomicInteger(0);
-
-      // Use mapTask to apply a VTask function to each element
-      VStreamPath<String> processed =
-          Path.vstreamOf("a", "b").mapTask(s -> VTask.succeed(s.toUpperCase()));
+      // TODO: Build a VStreamPath<String> from "a", "b" and apply
+      //       mapTask(s -> VTask.succeed(s.toUpperCase()))
+      //       Hint: Path.vstreamOf("a", "b").mapTask(...)
+      VStreamPath<String> processed = answerRequired();
 
       List<String> result = processed.toList().unsafeRun();
       assertThat(result).containsExactly("A", "B");
@@ -273,19 +277,15 @@ public class Tutorial04_PathResilience {
       CircuitBreaker breaker = CircuitBreaker.withDefaults();
       AtomicInteger attempts = new AtomicInteger(0);
 
-      // Build VTaskContext with retry, circuit breaker, and recovery
-      VTaskContext<String> ctx =
-          VTaskContext.<String>of(
-                  () -> {
-                    int attempt = attempts.incrementAndGet();
-                    if (attempt < 2) {
-                      throw new RuntimeException("fail");
-                    }
-                    return "context-result";
-                  })
-              .retry(3, Duration.ofMillis(10))
-              .withCircuitBreaker(breaker)
-              .recover(error -> "fallback");
+      // TODO: Build a VTaskContext<String> by chaining:
+      //       VTaskContext.<String>of(() -> { ...attempt logic... })
+      //         .retry(3, Duration.ofMillis(10))
+      //         .withCircuitBreaker(breaker)
+      //         .recover(error -> "fallback")
+      //
+      //       The supplier should increment attempts; throw on attempt < 2;
+      //       otherwise return "context-result".
+      VTaskContext<String> ctx = answerRequired();
 
       // VTaskContext.run() returns Try<String>
       Try<String> result = ctx.run();

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/SOLUTIONS.md
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/SOLUTIONS.md
@@ -13,6 +13,7 @@ The solution files mirror the structure of the tutorial files, but with all `___
 - `coretypes/` - Solutions for Core Types tutorials (01-07)
 - `optics/` - Solutions for Optics tutorials (01-07)
 - `transformers/` - Solutions for Monad Transformers tutorials (01-04)
+- `resilience/` - Solutions for Resilience Patterns tutorials (01-04)
 
 Each solution file:
 - Has the same structure as the corresponding tutorial

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial01_CircuitBreaker_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial01_CircuitBreaker_Solution.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 - 2026 Magnus Smith
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
-package org.higherkindedj.tutorial.resilience.solutions;
+package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial02_Saga_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial02_Saga_Solution.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 - 2026 Magnus Smith
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
-package org.higherkindedj.tutorial.resilience.solutions;
+package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial03_RetryBulkheadResilience_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial03_RetryBulkheadResilience_Solution.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 - 2026 Magnus Smith
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
-package org.higherkindedj.tutorial.resilience.solutions;
+package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial04_PathResilience_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial04_PathResilience_Solution.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 - 2026 Magnus Smith
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
-package org.higherkindedj.tutorial.resilience.solutions;
+package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Improve railway diagram alignment and apply shared CSS class

Replace inline \<pre style\> on every railway diagram in the transformers chapter, the Effect Path Overview, and the Focus-Effect capstone with the shared hkj-railway-diagram class so iOS Safari and Android webviews render box-drawing glyphs at consistent widths.

Audit and fix alignment column-by-column on each diagram: track dots, diagonals, ╳/┼ switches, ▼/│ siding arrows, and operator labels now share columns with the dots they describe.

Also includes the existing resilience tutorials reorganisation already on this branch.


## Type of change

- [ x] Documentation update

