### PR TITLE
Implement polymorphic optics (#508), supersedes #259

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -83,6 +83,7 @@
       - [Advanced Prism Patterns: Recipes](optics/advanced_prism_patterns_recipes.md)
     - [Profunctor Optics](optics/profunctor_optics.md)
       - [Profunctor Optics: Recipes](optics/profunctor_optics_recipes.md)
+    - [Polymorphic Optics](optics/polymorphic_optics.md)
   - [Java-Friendly APIs](optics/ch4_intro.md)
     - [Focus DSL](optics/focus_dsl.md)
       - [Navigation and Composition](optics/focus_navigation.md)

--- a/hkj-book/src/optics/ch3_intro.md
+++ b/hkj-book/src/optics/ch3_intro.md
@@ -78,6 +78,7 @@ When position matters:
 - **At and Ixed** – Type classes for indexed access. `At` handles keys that may or may not exist (like Map entries); `Ixed` handles indices that should exist (like List positions).
 - **Advanced Prism Patterns** – Beyond basic sum types: `nearly` matches values close to a target, `doesNotMatch` inverts a Prism's focus, and complex hierarchies compose cleanly.
 - **Profunctor Optics** – Transform the input and output types of optics. Adapt an optic for a different representation without rewriting it.
+- **Polymorphic Optics** – A small escape hatch for the rare cases where the type change is the operation, not an adapter around it. Polymorphic factories for generic wrappers, plus typeclass-driven leaves over `Functor` and `Traverse`.
 ~~~
 
 ---
@@ -91,6 +92,7 @@ When position matters:
 5. [Indexed Access](indexed_access.md) - At and Ixed type classes for indexed access patterns
 6. [Advanced Prism Patterns](advanced_prism_patterns.md) - `nearly`, `doesNotMatch`, and complex matching
 7. [Profunctor Optics](profunctor_optics.md) - Type adaptation with contramap, map, and dimap
+8. [Polymorphic Optics](polymorphic_optics.md) - Type-changing optics for generic wrappers and HKT-typed leaves
 
 ---
 

--- a/hkj-book/src/optics/polymorphic_optics.md
+++ b/hkj-book/src/optics/polymorphic_optics.md
@@ -1,0 +1,243 @@
+# Polymorphic Optics: Type-Changing Updates
+
+## *A small escape hatch for when the type change is the operation*
+
+~~~admonish info title="What You'll Learn"
+- Why the everyday optics in higher-kinded-j are deliberately monomorphic
+- When to reach for the polymorphic surface in `org.higherkindedj.optics.poly`
+- Building polymorphic lenses and isos with `PolyOptics.polyLens` and `PolyOptics.polyIso`
+- The runners: `modifyF`, `modify`, `set`, and `get`
+- Turning a `Functor` or `Traverse` instance into a polymorphic optic with `Optics.mapped` and `Optics.traversed`
+- Composing a monomorphic head with a polymorphic leaf via `Optic#andThen`
+- When to prefer the profunctor adapters (`contramap`, `map`, `dimap`) instead
+~~~
+
+~~~admonish title="Hands On Practice"
+[Tutorial21_PolymorphicOptics.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_PolymorphicOptics.java)
+~~~
+
+~~~admonish title="Example Code"
+[PolyOpticsExample](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/poly/PolyOpticsExample.java)
+~~~
+
+---
+
+## Why monomorphic by default
+
+The base [`Optic`](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-api/src/main/java/org/higherkindedj/optics/Optic.java) interface in higher-kinded-j already carries four type parameters:
+
+```java
+public interface Optic<S, T, A, B> { ... }
+```
+
+Every shipped optic ([`Lens`](lenses.md), [`Prism`](prisms.md), [`Iso`](iso.md), [`Affine`](affine.md), [`Traversal`](traversals.md), [`Setter`](setters.md)) deliberately fixes `S = T` and `A = B`:
+
+```java
+public interface Lens<S, A> extends Optic<S, S, A, A> { ... }
+```
+
+That choice keeps the public surface short and predictable. `Lens<User, String>` reads at a glance; `Lens<User, User, String, String>` does not. Java has no type alias, so paying for four parameters in every signature is a real cost on every line of every API.
+
+The vast majority of "I want to change types" needs in Java are not a call for polymorphic optics at all. They are a call for the [profunctor adapters](profunctor_optics.md), which let you reuse a monomorphic optic with a different source or target type.
+
+~~~admonish tip title="Reach for the adapters first"
+If you are bridging an external DTO to your internal record, a wrapper type to a raw value, or a V1 schema to a V2 schema, the right tool is `lens.contramap(...)`, `lens.map(...)`, or `lens.dimap(...)`. See [Profunctor Optics](profunctor_optics.md) and [Profunctor Optics: Recipes](profunctor_optics_recipes.md).
+~~~
+
+---
+
+## When polymorphic optics are the right tool
+
+There is one scenario where the type change is the operation, not an adapter around it: working with a generic container or wrapper, where modifying the inside changes the outside.
+
+```java
+record Box<A>(A value) {}
+
+// We want a single optic that turns a Box<String> into a Box<Integer>.
+// Profunctor adapters cannot express this, because the result type is Box<Integer>,
+// not Box<String> with a different view.
+```
+
+Higher-kinded-j keeps this advanced surface separate, in the package `org.higherkindedj.optics.poly`, with two small classes:
+
+| Class | Purpose |
+|-------|---------|
+| `PolyOptics` | Factories (`polyLens`, `polyIso`) and runners (`modifyF`, `modify`, `set`, `get`) over the raw `Optic` interface |
+| `Optics` | Typeclass-driven factories: `mapped(Functor)` for a polymorphic Setter, `traversed(Traverse)` for a polymorphic Traversal |
+
+---
+
+## Building polymorphic lenses and isos
+
+### `PolyOptics.polyLens`
+
+A polymorphic lens needs a getter and a type-changing setter. The setter receives the original whole alongside the new part so other fields can be preserved:
+
+```java
+record Tagged<A>(String tag, A value) {}
+
+Optic<Tagged<String>, Tagged<Integer>, String, Integer> value =
+    PolyOptics.polyLens(Tagged::value, (t, n) -> new Tagged<>(t.tag(), n));
+
+Tagged<Integer> result =
+    PolyOptics.modify(value, Integer::parseInt, new Tagged<>("answer", "42"));
+// result == new Tagged<>("answer", 42)
+```
+
+### `PolyOptics.polyIso`
+
+An iso is a lossless two-way conversion. Because the wrapper has no other fields, the reverse direction does not need the original source:
+
+```java
+record UserId<A>(A raw) {}
+
+Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+    PolyOptics.polyIso(UserId::raw, UserId::new);
+
+UserId<Integer> numeric = PolyOptics.modify(raw, Integer::parseInt, new UserId<>("123"));
+// numeric == new UserId<>(123)
+```
+
+---
+
+## The runners
+
+The runners are static helpers in `PolyOptics` that hide the `Const` and `Identity` applicative tricks otherwise needed to use a polymorphic optic:
+
+| Runner | Purpose |
+|--------|---------|
+| `modifyF(optic, f, source, applicative)` | Effectful modification under any `Applicative` |
+| `modify(optic, f, source)` | Pure modification (Identity applicative) |
+| `set(optic, value, source)` | Replace the focused part with a new value |
+| `get(optic, source)` | Extract the focused part, lens-like only |
+
+`get` only works for lens-shaped polymorphic optics (those built from `polyLens`, `polyIso`, and their compositions). If you point it at a prism / traversal-shaped optic, an `UnsupportedOperationException` points you back at `modifyF` with an appropriate applicative.
+
+---
+
+## Typeclass-driven polymorphic optics
+
+The `Optics` class turns an HKJ typeclass instance into a polymorphic optic over its contents. This is the one place polymorphism gives us something the monomorphic surface cannot: composing a leaf step that <em>changes element type</em>.
+
+### `Optics.mapped(Functor)`
+
+`mapped` is a polymorphic <b>Setter</b>. It supports pure type-changing modification under the Identity applicative (via `PolyOptics.modify` and `PolyOptics.set`):
+
+```java
+Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> elems =
+    Optics.mapped(ListMonad.INSTANCE);
+
+Kind<ListKind.Witness, Integer> ints =
+    PolyOptics.modify(elems, Integer::parseInt, LIST.widen(List.of("1", "2", "3")));
+// ints narrows to List.of(1, 2, 3)
+```
+
+If you call `modifyF` with a non-Identity applicative on a `mapped(Functor)` optic, it raises a clear error pointing at `traversed(Traverse)` instead.
+
+### `Optics.traversed(Traverse)`
+
+`traversed` is a polymorphic <b>Traversal</b>. It runs under any `Applicative`, so you can short-circuit on `Either`, accumulate errors with `Validated`, run async, and so on:
+
+```java
+Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+    Optics.traversed(ListTraverse.INSTANCE);
+
+ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+    s -> {
+      try { return VALIDATED.widen(Validated.valid(Integer.parseInt(s))); }
+      catch (NumberFormatException e) {
+        return VALIDATED.widen(Validated.invalid(List.of("bad: " + s)));
+      }
+    };
+
+Kind<ValidatedKind.Witness<List<String>>, Kind<ListKind.Witness, Integer>> result =
+    PolyOptics.modifyF(trav, parseValidated,
+        LIST.widen(List.of("1", "x", "2", "y")), validatedApp);
+
+// VALIDATED.narrow(result).getError() == List.of("bad: x", "bad: y")
+```
+
+### Choosing between `mapped` and `traversed`
+
+| Situation | Use |
+|-----------|-----|
+| Pure type-changing map | `Optics.mapped(Functor)` |
+| Effectful traversal under any Applicative | `Optics.traversed(Traverse)` |
+| Need to accumulate errors with Validated | `Optics.traversed(Traverse)` |
+| Need to short-circuit on Either / Try | `Optics.traversed(Traverse)` |
+
+---
+
+## Composing monomorphic heads with polymorphic leaves
+
+The whole point of a separate polymorphic surface is that it composes with the existing monomorphic optics via `Optic#andThen`. A typical shape is "a polymorphic lens onto a collection field, then a polymorphic traversal over the elements":
+
+```java
+record Page<A>(int number, List<A> rows) {}
+
+Optic<Page<String>, Page<Integer>, List<String>, List<Integer>> rowsLens =
+    PolyOptics.polyLens(Page::rows, (p, rs) -> new Page<>(p.number(), rs));
+
+// Bridge plain List <-> Kind<ListKind.Witness, ?>.
+Optic<List<String>, List<Integer>,
+      Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>>
+    listAsKind = PolyOptics.polyIso(LIST::widen, LIST::narrow);
+
+Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+    allRows = Optics.traversed(ListTraverse.INSTANCE);
+
+Optic<Page<String>, Page<Integer>, String, Integer> pageRows =
+    rowsLens.andThen(listAsKind).andThen(allRows);
+
+Page<Integer> result =
+    PolyOptics.modify(pageRows, Integer::parseInt, new Page<>(1, List.of("1", "2", "3")));
+// result == new Page<>(1, List.of(1, 2, 3))
+```
+
+The same composition under `Validated` accumulates errors across the rows; under `Either` it short-circuits on the first failure.
+
+---
+
+## When NOT to use polymorphic optics
+
+Most "I want to change types" needs are <em>not</em> a call for polymorphic optics. Reach for the simpler tools first.
+
+| Need | Tool |
+|------|------|
+| Reuse an optic with a different source or target type | `lens.contramap`, `lens.map`, `lens.dimap` (see [Profunctor Optics](profunctor_optics.md)) |
+| Bridge an external DTO to your internal record | Profunctor `dimap` |
+| Map a wrapper to its raw value | A monomorphic [`Iso`](iso.md) |
+| Update coupled fields atomically | [`Lens.paired`](coupled_fields.md) |
+| Accumulate validation errors across a record | The Effect Path API + a monomorphic traversal |
+| Type-changing update of a generic wrapper | `PolyOptics.polyLens` / `polyIso` |
+| Type-changing element map over an HKT | `Optics.mapped` / `Optics.traversed` |
+
+---
+
+## Summary
+
+~~~admonish info title="Key Takeaways"
+* **Monomorphic by default** — The everyday optics keep two type parameters because four is too noisy in Java without type aliases.
+* **Profunctor adapters first** — Most type-change needs are best solved by `dimap` / `map` / `contramap` on the existing optics.
+* **`PolyOptics` is an escape hatch** — Reach for it when authoring a generic wrapper whose type change is the operation.
+* **Typeclass-driven leaves** — `Optics.mapped` and `Optics.traversed` lift `Functor` and `Traverse` instances into polymorphic optics that compose with monomorphic heads via `Optic#andThen`.
+* **`mapped` is a Setter; `traversed` is a Traversal** — Use `mapped` for pure modifications; `traversed` for any applicative.
+~~~
+
+~~~admonish info title="Hands-On Learning"
+Practice polymorphic optics in [Tutorial 21: Polymorphic Optics](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_PolymorphicOptics.java) (7 exercises plus a diagnostic, ~12 minutes).
+~~~
+
+~~~admonish tip title="See Also"
+- [Profunctor Optics](profunctor_optics.md) — The first place to look when you want to reuse an optic with a different type.
+- [Profunctor Optics: Recipes](profunctor_optics_recipes.md) — Wrapper types, V1 / V2 migration, and API integration patterns.
+- [Composition Rules](composition_rules.md) — How `andThen` chooses the result optic across the family.
+- [Lenses](lenses.md), [Isomorphisms](iso.md), [Traversals](traversals.md) — The monomorphic optics that polymorphic leaves compose with.
+~~~
+
+---
+
+**Previous:** [Profunctor Optics: Recipes](profunctor_optics_recipes.md)
+**Next:** [Java-Friendly APIs](ch4_intro.md)

--- a/hkj-book/src/optics/profunctor_optics.md
+++ b/hkj-book/src/optics/profunctor_optics.md
@@ -351,6 +351,7 @@ public class ApiIntegration {
 
 ~~~admonish tip title="See Also"
 - [Profunctor Optics: Recipes](profunctor_optics_recipes.md), wrapper-type recipes, V1/V2 migration adapters, and a complete runnable example.
+- [Polymorphic Optics](polymorphic_optics.md), the type-changing escape hatch for the smaller set of cases where `dimap` cannot express the operation.
 ~~~
 
 ---

--- a/hkj-book/src/optics/profunctor_optics_recipes.md
+++ b/hkj-book/src/optics/profunctor_optics_recipes.md
@@ -400,4 +400,4 @@ This profunctor capability makes higher-kinded-j optics incredibly flexible and 
 ---
 
 **Previous:** [Profunctor Optics](profunctor_optics.md)
-**Next:** [Java-Friendly APIs](ch4_intro.md)
+**Next:** [Polymorphic Optics](polymorphic_optics.md)

--- a/hkj-core/src/main/java/module-info.java
+++ b/hkj-core/src/main/java/module-info.java
@@ -55,6 +55,7 @@ module org.higherkindedj.core {
   exports org.higherkindedj.optics.free;
   exports org.higherkindedj.optics.fluent;
   exports org.higherkindedj.optics.focus;
+  exports org.higherkindedj.optics.poly;
   exports org.higherkindedj.hkt.vtask;
   exports org.higherkindedj.hkt.vstream;
   exports org.higherkindedj.hkt.context;

--- a/hkj-core/src/main/java/org/higherkindedj/optics/poly/Optics.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/poly/Optics.java
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.poly;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Traverse;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.optics.Optic;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Typeclass-driven factories for polymorphic optics.
+ *
+ * <p>These factories turn an HKJ {@link Functor} or {@link Traverse} instance into a polymorphic
+ * optic over its contents. They are the one place in the optics surface where polymorphism gives us
+ * something the monomorphic optics cannot: composing a leaf step that <em>changes element type</em>
+ * with the existing {@code Lens} / {@code Prism} / {@code Iso} / {@code Affine} / {@code Traversal}
+ * heads, via {@link Optic#andThen}.
+ *
+ * <h2>Quick Tour</h2>
+ *
+ * <pre>{@code
+ * // mapped: a polymorphic Setter into the elements of any unary Functor.
+ * // Use with PolyOptics.modify / set (i.e. under the Identity applicative).
+ * Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> elems =
+ *     Optics.mapped(ListFunctor.INSTANCE);
+ *
+ * Kind<ListKind.Witness, Integer> ints =
+ *     PolyOptics.modify(elems, Integer::parseInt, LIST.widen(List.of("1", "2", "3")));
+ *
+ * // traversed: a polymorphic Traversal into the elements of any unary Traverse.
+ * // Works under any Applicative; here we accumulate validation errors.
+ * Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+ *     Optics.traversed(ListTraverse.INSTANCE);
+ *
+ * Kind<ValidatedKind.Witness<List<String>>, Kind<ListKind.Witness, Integer>> result =
+ *     PolyOptics.modifyF(trav, parseValidated, LIST.widen(input), validatedApp);
+ * }</pre>
+ *
+ * @see PolyOptics low-level factories and runners over the raw {@link Optic} interface
+ */
+@NullMarked
+public final class Optics {
+
+  private Optics() {}
+
+  /**
+   * Returns a polymorphic optic into the elements of any unary {@link Functor}.
+   *
+   * <p>The returned optic is a <b>polymorphic Setter</b>: it supports pure type-changing
+   * modification under the Identity applicative ({@link PolyOptics#modify} and {@link
+   * PolyOptics#set}). It does <em>not</em> support arbitrary effectful traversal; if you need to
+   * thread an effect through the elements, use {@link #traversed(Traverse)} instead.
+   *
+   * <p>The optic composes with the monomorphic optics in {@link org.higherkindedj.optics} via
+   * {@link Optic#andThen}, allowing a monomorphic head ({@code Lens<User, List<String>>}, say) to
+   * be followed by this polymorphic leaf to express "map every element, possibly changing type".
+   *
+   * @param functor the {@link Functor} instance for {@code F}
+   * @param <F> the unary HKT witness
+   * @param <A> the original element type
+   * @param <B> the resulting element type
+   * @return a polymorphic Setter into the elements of {@code F}
+   */
+  public static <F extends WitnessArity<TypeArity.Unary>, A, B>
+      Optic<Kind<F, A>, Kind<F, B>, A, B> mapped(Functor<F> functor) {
+    return new Optic<>() {
+      @Override
+      public <G extends WitnessArity<TypeArity.Unary>> Kind<G, Kind<F, B>> modifyF(
+          Function<A, Kind<G, B>> f, Kind<F, A> source, Applicative<G> app) {
+        // mapped is a polymorphic Setter: it requires the Identity applicative.
+        // Under Identity, f returns Kind<IdKind.Witness, B> = Id<B>, so we can recover B
+        // by narrowing. For any other Applicative the optic is not sound; we raise a clear error.
+        Function<A, B> pure =
+            a -> {
+              Kind<G, B> gb = f.apply(a);
+              if (!(gb instanceof Id<?> id)) {
+                throw new UnsupportedOperationException(
+                    "Optics.mapped(Functor) is a polymorphic Setter and only supports pure "
+                        + "modification under IdMonad (use PolyOptics.modify or PolyOptics.set). "
+                        + "For effectful traversal, use Optics.traversed(Traverse) with a Traverse "
+                        + "instance for "
+                        + functor.getClass().getSimpleName()
+                        + ".");
+              }
+              @SuppressWarnings("unchecked")
+              B b = (B) id.value();
+              return b;
+            };
+        Kind<F, B> mappedF = functor.map(pure, source);
+        return app.of(mappedF);
+      }
+    };
+  }
+
+  /**
+   * Returns a polymorphic optic into the elements of any unary {@link Traverse}.
+   *
+   * <p>This is a <b>polymorphic Traversal</b>: it can run under any {@link Applicative}, so it
+   * supports both pure modification (via {@link PolyOptics#modify}) and effectful traversal (via
+   * {@link PolyOptics#modifyF}). Common applicatives include {@code Validated} for error
+   * accumulation, {@code Either} for short-circuiting, and {@code IdMonad} for pure mapping.
+   *
+   * <p>The optic composes with the monomorphic optics in {@link org.higherkindedj.optics} via
+   * {@link Optic#andThen}, allowing a monomorphic head to be followed by this polymorphic leaf.
+   *
+   * @param traverse the {@link Traverse} instance for {@code F}
+   * @param <F> the unary HKT witness
+   * @param <A> the original element type
+   * @param <B> the resulting element type
+   * @return a polymorphic Traversal into the elements of {@code F}
+   */
+  public static <F extends WitnessArity<TypeArity.Unary>, A, B>
+      Optic<Kind<F, A>, Kind<F, B>, A, B> traversed(Traverse<F> traverse) {
+    return new Optic<>() {
+      @Override
+      public <G extends WitnessArity<TypeArity.Unary>> Kind<G, Kind<F, B>> modifyF(
+          Function<A, Kind<G, B>> f, Kind<F, A> source, Applicative<G> app) {
+        return traverse.traverse(app, f::apply, source);
+      }
+    };
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/poly/PolyConst.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/poly/PolyConst.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.poly;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Package-private {@code Const} functor used by {@link PolyOptics#get} to extract the focused part
+ * of a lens-shaped polymorphic optic without performing a modification.
+ *
+ * <p>The Const functor wraps a value of type {@code C} and ignores its phantom parameter. {@code
+ * map} preserves the wrapped value (since the function is never applied), which is exactly the
+ * behaviour we need to surface the captured focus through an optic's {@code modifyF}.
+ *
+ * <p>{@code ap} is intentionally unsupported; this Const is only used for lens / iso shaped
+ * polymorphic optics whose {@code modifyF} call uses {@code map} (and never {@code ap} or {@code
+ * of}). If a caller passes an optic whose shape requires {@code ap} or {@code of} (for example, a
+ * prism that fails to match), a clear exception is raised pointing them at {@link
+ * PolyOptics#modifyF}.
+ *
+ * @param <C> The type of the captured value.
+ * @param <A> The phantom type parameter (ignored).
+ */
+@NullMarked
+record PolyConst<C, A>(C value) implements Kind<PolyConst.Witness<C>, A> {
+
+  /** Witness type for the {@link PolyConst} functor. */
+  static final class Witness<C> implements WitnessArity<TypeArity.Unary> {
+    private Witness() {}
+  }
+
+  @SuppressWarnings("unchecked")
+  static <C, A> PolyConst<C, A> narrow(Kind<Witness<C>, A> kind) {
+    return (PolyConst<C, A>) Objects.requireNonNull(kind, "kind");
+  }
+
+  /**
+   * Returns an {@link Applicative} for {@code PolyConst} suitable for capturing the focus of a
+   * lens-shaped polymorphic optic.
+   *
+   * <p>{@code map} returns a Const containing the previously captured value; {@code of} and {@code
+   * ap} throw, because they imply an optic shape (prism / traversal) that {@link PolyOptics#get}
+   * does not support.
+   */
+  static <C> Applicative<Witness<C>> applicative() {
+    return new Applicative<>() {
+      @Override
+      public <A> Kind<Witness<C>, A> of(A value) {
+        throw new UnsupportedOperationException(
+            "PolyOptics.get is lens-like only. The optic invoked Applicative.of, "
+                + "which means it has prism / traversal shape (it can fail to focus). "
+                + "Use PolyOptics.modifyF with an appropriate Applicative instead.");
+      }
+
+      @Override
+      public <A, B> Kind<Witness<C>, B> map(
+          Function<? super A, ? extends B> f, Kind<Witness<C>, A> fa) {
+        return new PolyConst<>(narrow(fa).value());
+      }
+
+      @Override
+      public <A, B> Kind<Witness<C>, B> ap(
+          Kind<Witness<C>, ? extends Function<A, B>> ff, Kind<Witness<C>, A> fa) {
+        throw new UnsupportedOperationException(
+            "PolyOptics.get is lens-like only. The optic invoked Applicative.ap, "
+                + "which means it has traversal shape (it focuses on multiple parts). "
+                + "Use PolyOptics.modifyF with an appropriate Applicative instead.");
+      }
+    };
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/poly/PolyOptics.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/poly/PolyOptics.java
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.poly;
+
+import static org.higherkindedj.hkt.id.IdKindHelper.ID;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdMonad;
+import org.higherkindedj.optics.Optic;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Factories and runners for polymorphic ({@code S, T, A, B}) optics over the existing {@link Optic}
+ * interface.
+ *
+ * <p>Most users should keep using the monomorphic {@code Lens}, {@code Prism}, {@code Iso}, {@code
+ * Affine}, {@code Traversal}, and {@code Setter} types in {@link org.higherkindedj.optics}. Reach
+ * for {@link PolyOptics} only when you need a type-changing update, typically when authoring a
+ * generic wrapper or container, or when composing in a leaf step that changes element type.
+ *
+ * <h2>Quick Tour</h2>
+ *
+ * <pre>{@code
+ * // Generic wrapper
+ * record Box<A>(A value) {}
+ *
+ * Optic<Box<String>, Box<Integer>, String, Integer> contents =
+ *     PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+ *
+ * Box<Integer> bi = PolyOptics.modify(contents, Integer::parseInt, new Box<>("42"));
+ * // bi == new Box<>(42)
+ *
+ * String s = PolyOptics.get(contents, new Box<>("hello"));
+ * // s == "hello"
+ * }</pre>
+ *
+ * @see Optics typeclass-driven polymorphic factories ({@code mapped}, {@code traversed})
+ */
+@NullMarked
+public final class PolyOptics {
+
+  private PolyOptics() {}
+
+  // ---------------------------------------------------------------------------------------------
+  // Construction
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Creates a lens-shaped polymorphic optic from a getter and a type-changing setter.
+   *
+   * <p>The setter receives the original source {@code S} together with a new part {@code B} and
+   * returns a new whole {@code T}. This lets the part change type and, in turn, the whole.
+   *
+   * @param get function extracting the focused part {@code A} from the source {@code S}
+   * @param set function building a new whole {@code T} from the original source and a new part
+   * @param <S> the original whole type
+   * @param <T> the resulting whole type
+   * @param <A> the original part type
+   * @param <B> the resulting part type
+   * @return a polymorphic optic with lens semantics
+   */
+  public static <S, T, A, B> Optic<S, T, A, B> polyLens(
+      Function<? super S, ? extends A> get, BiFunction<? super S, ? super B, ? extends T> set) {
+    return new Optic<>() {
+      @Override
+      public <F extends WitnessArity<TypeArity.Unary>> Kind<F, T> modifyF(
+          Function<A, Kind<F, B>> f, S source, Applicative<F> app) {
+        Kind<F, B> fb = f.apply(get.apply(source));
+        return app.map(b -> set.apply(source, b), fb);
+      }
+    };
+  }
+
+  /**
+   * Creates an isomorphism-shaped polymorphic optic from a forward and a reverse conversion.
+   *
+   * <p>An iso represents a lossless, two-way conversion that may change types. The forward
+   * direction extracts the part {@code A}; the reverse direction reconstructs the whole {@code T}
+   * from a new part {@code B} <em>without</em> referring to the original source.
+   *
+   * @param get forward conversion {@code S -> A}
+   * @param reverseGet reverse conversion {@code B -> T}
+   * @param <S> the original whole type
+   * @param <T> the resulting whole type
+   * @param <A> the original part type
+   * @param <B> the resulting part type
+   * @return a polymorphic optic with iso semantics
+   */
+  public static <S, T, A, B> Optic<S, T, A, B> polyIso(
+      Function<? super S, ? extends A> get, Function<? super B, ? extends T> reverseGet) {
+    return new Optic<>() {
+      @Override
+      public <F extends WitnessArity<TypeArity.Unary>> Kind<F, T> modifyF(
+          Function<A, Kind<F, B>> f, S source, Applicative<F> app) {
+        Kind<F, B> fb = f.apply(get.apply(source));
+        return app.map(reverseGet::apply, fb);
+      }
+    };
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Runners
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Modifies the focused part using an effectful function under any {@link Applicative}.
+   *
+   * <p>This is the most general runner; the specialised {@link #modify}, {@link #set}, and {@link
+   * #get} runners delegate to it through {@link IdMonad} or a Const applicative.
+   *
+   * @param optic the polymorphic optic
+   * @param f effectful transformation {@code A -> Kind<F, B>}
+   * @param source the source whole
+   * @param applicative the {@link Applicative} for context {@code F}
+   * @param <F> the applicative witness
+   * @param <S> the original whole type
+   * @param <T> the resulting whole type
+   * @param <A> the original part type
+   * @param <B> the resulting part type
+   * @return the resulting whole {@code T} wrapped in {@code F}
+   */
+  public static <F extends WitnessArity<TypeArity.Unary>, S, T, A, B> Kind<F, T> modifyF(
+      Optic<S, T, A, B> optic, Function<A, Kind<F, B>> f, S source, Applicative<F> applicative) {
+    return optic.modifyF(f, source, applicative);
+  }
+
+  /**
+   * Modifies the focused part with a pure function, returning the resulting whole.
+   *
+   * <p>Internally runs {@link #modifyF} under {@link IdMonad}.
+   *
+   * @param optic the polymorphic optic
+   * @param f pure transformation {@code A -> B}
+   * @param source the source whole
+   * @return the resulting whole with the part transformed
+   */
+  public static <S, T, A, B> T modify(
+      Optic<S, T, A, B> optic, Function<? super A, ? extends B> f, S source) {
+    Function<A, Kind<IdKind.Witness, B>> lifted = a -> Id.of(f.apply(a));
+    Kind<IdKind.Witness, T> result = optic.modifyF(lifted, source, IdMonad.instance());
+    return ID.narrow(result).value();
+  }
+
+  /**
+   * Sets the focused part to a new value, returning the resulting whole.
+   *
+   * <p>Equivalent to {@code modify(optic, ignored -> value, source)}.
+   *
+   * @param optic the polymorphic optic
+   * @param value the new value for the focused part
+   * @param source the source whole
+   * @return the resulting whole with the part replaced
+   */
+  public static <S, T, A, B> T set(Optic<S, T, A, B> optic, B value, S source) {
+    return modify(optic, ignored -> value, source);
+  }
+
+  /**
+   * Extracts the focused part from a lens-shaped polymorphic optic.
+   *
+   * <p>This runner is <b>lens-like only</b>; it works with optics built by {@link #polyLens} and
+   * {@link #polyIso}, and with their compositions. If the supplied optic has prism or traversal
+   * shape (it can fail to focus, or focuses on more than one part), an {@link
+   * UnsupportedOperationException} is raised pointing the caller at {@link #modifyF}.
+   *
+   * @param optic the polymorphic optic
+   * @param source the source whole
+   * @return the focused part
+   * @throws UnsupportedOperationException if the optic has non-lens shape
+   */
+  public static <S, T, A, B> A get(Optic<S, T, A, B> optic, S source) {
+    Applicative<PolyConst.Witness<A>> capture = PolyConst.applicative();
+    Function<A, Kind<PolyConst.Witness<A>, B>> f = PolyConst::new;
+    Kind<PolyConst.Witness<A>, T> result = optic.modifyF(f, source, capture);
+    return PolyConst.narrow(result).value();
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/poly/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/poly/package-info.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+/**
+ * Polymorphic optics: a small, intentionally narrow surface for type-changing optics.
+ *
+ * <p>The everyday optics in {@link org.higherkindedj.optics} ({@code Lens}, {@code Prism}, {@code
+ * Iso}, {@code Affine}, {@code Traversal}, {@code Setter}) are <b>monomorphic</b>: they specialise
+ * the four-parameter {@link org.higherkindedj.optics.Optic Optic} to {@code S = T} and {@code A =
+ * B}. That covers the overwhelming majority of practical use cases and keeps the public API short
+ * and easy to read.
+ *
+ * <p>This package is the escape hatch for the few cases where a type-changing optic is genuinely
+ * the right tool, without forcing every user to pay the cost of four type parameters.
+ *
+ * <h2>When to reach for this package</h2>
+ *
+ * <ul>
+ *   <li>You are authoring a generic wrapper or container type ({@code Box<A>}, {@code Tagged<T,
+ *       A>}, ...) and want a polymorphic optic into its contents.
+ *   <li>You want to compose monomorphic optics with a leaf step that changes element type, for
+ *       example mapping {@code List<String>} to {@code List<Integer>} as part of a larger optic
+ *       chain.
+ * </ul>
+ *
+ * <h2>When you do not need this package</h2>
+ *
+ * <p>If you are bridging API/DTO formats, adapting wrapper types to existing optics, or migrating
+ * between {@code V1} and {@code V2} of a record, the {@code contramap} / {@code map} / {@code
+ * dimap} profunctor adapters on the existing monomorphic optics are very likely all you need. See
+ * the <em>Profunctor Optics</em> chapter of the documentation.
+ *
+ * <h2>What is here</h2>
+ *
+ * <ul>
+ *   <li>{@link org.higherkindedj.optics.poly.PolyOptics} factories ({@code polyLens}, {@code
+ *       polyIso}) and runners ({@code modifyF}, {@code modify}, {@code set}, {@code get}) over the
+ *       raw {@link org.higherkindedj.optics.Optic Optic} interface.
+ *   <li>{@link org.higherkindedj.optics.poly.Optics} typeclass-driven factories ({@code mapped},
+ *       {@code traversed}) that turn a {@link org.higherkindedj.hkt.Functor Functor} or {@link
+ *       org.higherkindedj.hkt.Traverse Traverse} instance into a polymorphic optic over its
+ *       contents.
+ * </ul>
+ */
+@NullMarked
+package org.higherkindedj.optics.poly;
+
+import org.jspecify.annotations.NullMarked;

--- a/hkj-core/src/test/java/org/higherkindedj/optics/poly/OpticsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/poly/OpticsTest.java
@@ -1,0 +1,286 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.poly;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.maybe.MaybeTraverse;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.hkt.validated.ValidatedMonad;
+import org.higherkindedj.optics.Optic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Optics: typeclass-driven polymorphic factories")
+class OpticsTest {
+
+  // ---------------------------------------------------------------------------------------------
+  // Optics.mapped
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Optics.mapped(Functor)")
+  class MappedTests {
+
+    @Test
+    @DisplayName("changes element type of a List under PolyOptics.modify")
+    void mappedOverList() {
+      Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+          elems = Optics.mapped(ListMonad.INSTANCE);
+
+      Kind<ListKind.Witness, Integer> result =
+          PolyOptics.modify(elems, Integer::parseInt, LIST.widen(List.of("1", "2", "3")));
+
+      assertThat(LIST.narrow(result)).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("changes the inner of a Maybe under PolyOptics.modify")
+    void mappedOverMaybe() {
+      Optic<Kind<MaybeKind.Witness, String>, Kind<MaybeKind.Witness, Integer>, String, Integer>
+          inner = Optics.mapped(MaybeMonad.INSTANCE);
+
+      Kind<MaybeKind.Witness, Integer> some =
+          PolyOptics.modify(inner, String::length, MAYBE.widen(Maybe.just("hello")));
+      assertThat(MAYBE.narrow(some)).isEqualTo(Maybe.just(5));
+
+      Kind<MaybeKind.Witness, Integer> none =
+          PolyOptics.modify(inner, String::length, MAYBE.widen(Maybe.nothing()));
+      assertThat(MAYBE.narrow(none)).isEqualTo(Maybe.nothing());
+    }
+
+    @Test
+    @DisplayName("changes the Right of an Either under PolyOptics.modify")
+    void mappedOverEither() {
+      Optic<
+              Kind<EitherKind.Witness<String>, String>,
+              Kind<EitherKind.Witness<String>, Integer>,
+              String,
+              Integer>
+          inner = Optics.mapped(EitherMonad.<String>instance());
+
+      Kind<EitherKind.Witness<String>, Integer> right =
+          PolyOptics.modify(inner, String::length, EITHER.widen(Either.right("hello")));
+      assertThat(EITHER.narrow(right)).isEqualTo(Either.right(5));
+
+      Kind<EitherKind.Witness<String>, Integer> left =
+          PolyOptics.modify(inner, String::length, EITHER.widen(Either.left("oops")));
+      assertThat(EITHER.narrow(left)).isEqualTo(Either.left("oops"));
+    }
+
+    @Test
+    @DisplayName("rejects non-Identity Applicatives with a clear error")
+    void rejectsNonIdentityApplicative() {
+      Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+          elems = Optics.mapped(ListMonad.INSTANCE);
+
+      Function<String, Kind<MaybeKind.Witness, Integer>> tryParse =
+          s -> MAYBE.widen(Maybe.just(Integer.parseInt(s)));
+
+      assertThatThrownBy(
+              () ->
+                  PolyOptics.modifyF(
+                      elems, tryParse, LIST.widen(List.of("1")), MaybeMonad.INSTANCE))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Optics.traversed(Traverse)");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Optics.traversed
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Optics.traversed(Traverse)")
+  class TraversedTests {
+
+    @Test
+    @DisplayName("pure type-changing modify under Identity")
+    void traversedPureModify() {
+      Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+          Optics.traversed(ListTraverse.INSTANCE);
+
+      Kind<ListKind.Witness, Integer> result =
+          PolyOptics.modify(trav, String::length, LIST.widen(List.of("a", "bb", "ccc")));
+
+      assertThat(LIST.narrow(result)).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("accumulates errors across a list under Validated")
+    void traversedAccumulatesErrors() {
+      Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+          Optics.traversed(ListTraverse.INSTANCE);
+
+      ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+      Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+          s -> {
+            try {
+              return VALIDATED.widen(Validated.valid(Integer.parseInt(s)));
+            } catch (NumberFormatException e) {
+              return VALIDATED.widen(Validated.invalid(List.of("bad: " + s)));
+            }
+          };
+
+      // All valid
+      Kind<ValidatedKind.Witness<List<String>>, Kind<ListKind.Witness, Integer>> good =
+          PolyOptics.modifyF(
+              trav, parseValidated, LIST.widen(List.of("1", "2", "3")), validatedApp);
+      assertThat(VALIDATED.narrow(good).isValid()).isTrue();
+      assertThat(LIST.narrow(VALIDATED.narrow(good).get())).containsExactly(1, 2, 3);
+
+      // Mixed: errors are accumulated.
+      Kind<ValidatedKind.Witness<List<String>>, Kind<ListKind.Witness, Integer>> mixed =
+          PolyOptics.modifyF(
+              trav, parseValidated, LIST.widen(List.of("1", "x", "2", "y")), validatedApp);
+      Validated<List<String>, Kind<ListKind.Witness, Integer>> narrowed = VALIDATED.narrow(mixed);
+      assertThat(narrowed.isInvalid()).isTrue();
+      assertThat(narrowed.getError()).containsExactly("bad: x", "bad: y");
+    }
+
+    @Test
+    @DisplayName("short-circuits over a Maybe traverse")
+    void traversedOverMaybeShortCircuits() {
+      Optic<Kind<MaybeKind.Witness, String>, Kind<MaybeKind.Witness, Integer>, String, Integer>
+          trav = Optics.traversed(MaybeTraverse.INSTANCE);
+
+      Function<String, Kind<EitherKind.Witness<String>, Integer>> safeParse =
+          s -> {
+            try {
+              return EITHER.widen(Either.right(Integer.parseInt(s)));
+            } catch (NumberFormatException e) {
+              return EITHER.widen(Either.left("bad: " + s));
+            }
+          };
+
+      Kind<EitherKind.Witness<String>, Kind<MaybeKind.Witness, Integer>> ok =
+          PolyOptics.modifyF(trav, safeParse, MAYBE.widen(Maybe.just("9")), EitherMonad.instance());
+      assertThat(EITHER.narrow(ok).isRight()).isTrue();
+      assertThat(MAYBE.narrow(EITHER.narrow(ok).getRight())).isEqualTo(Maybe.just(9));
+
+      Kind<EitherKind.Witness<String>, Kind<MaybeKind.Witness, Integer>> bad =
+          PolyOptics.modifyF(
+              trav, safeParse, MAYBE.widen(Maybe.just("nope")), EitherMonad.instance());
+      assertThat(EITHER.narrow(bad)).isEqualTo(Either.left("bad: nope"));
+
+      // Empty Maybe never invokes the function: result is an Either.right(Maybe.nothing()).
+      Kind<EitherKind.Witness<String>, Kind<MaybeKind.Witness, Integer>> empty =
+          PolyOptics.modifyF(trav, safeParse, MAYBE.widen(Maybe.nothing()), EitherMonad.instance());
+      assertThat(EITHER.narrow(empty).isRight()).isTrue();
+      assertThat(MAYBE.narrow(EITHER.narrow(empty).getRight())).isEqualTo(Maybe.nothing());
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Composition: monomorphic head + polymorphic leaf
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("composition with monomorphic heads")
+  class CompositionTests {
+
+    // A monomorphic-shaped head followed by a type-changing leaf via Optic#andThen.
+    record Page<A>(int number, List<A> rows) {}
+
+    @Test
+    @DisplayName("polyLens head + Optics.traversed leaf transforms List<String> into List<Integer>")
+    void monoHeadPolyLeaf() {
+      Optic<Page<String>, Page<Integer>, List<String>, List<Integer>> rowsLens =
+          PolyOptics.polyLens(Page::rows, (p, rs) -> new Page<>(p.number(), rs));
+
+      Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+          allRows = Optics.traversed(ListTraverse.INSTANCE);
+
+      // Bridge plain List <-> Kind<ListKind.Witness, ?> via a polyIso.
+      Optic<
+              List<String>,
+              List<Integer>,
+              Kind<ListKind.Witness, String>,
+              Kind<ListKind.Witness, Integer>>
+          listAsKind = PolyOptics.polyIso(LIST::widen, LIST::narrow);
+
+      Optic<Page<String>, Page<Integer>, String, Integer> pageRows =
+          rowsLens.andThen(listAsKind).andThen(allRows);
+
+      Page<Integer> result =
+          PolyOptics.modify(pageRows, Integer::parseInt, new Page<>(1, List.of("1", "2", "3")));
+
+      assertThat(result).isEqualTo(new Page<>(1, List.of(1, 2, 3)));
+    }
+
+    @Test
+    @DisplayName("modifyF under Validated composes through the bridge to accumulate errors")
+    void modifyFComposes() {
+      Optic<Page<String>, Page<Integer>, List<String>, List<Integer>> rowsLens =
+          PolyOptics.polyLens(Page::rows, (p, rs) -> new Page<>(p.number(), rs));
+
+      Optic<
+              List<String>,
+              List<Integer>,
+              Kind<ListKind.Witness, String>,
+              Kind<ListKind.Witness, Integer>>
+          listAsKind = PolyOptics.polyIso(LIST::widen, LIST::narrow);
+
+      Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+          allRows = Optics.traversed(ListTraverse.INSTANCE);
+
+      Optic<Page<String>, Page<Integer>, String, Integer> pageRows =
+          rowsLens.andThen(listAsKind).andThen(allRows);
+
+      ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+      Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+          s -> {
+            try {
+              return VALIDATED.widen(Validated.valid(Integer.parseInt(s)));
+            } catch (NumberFormatException e) {
+              return VALIDATED.widen(Validated.invalid(List.of("bad: " + s)));
+            }
+          };
+
+      Kind<ValidatedKind.Witness<List<String>>, Page<Integer>> result =
+          PolyOptics.modifyF(
+              pageRows, parseValidated, new Page<>(1, List.of("a", "b", "3")), validatedApp);
+
+      assertThat(VALIDATED.narrow(result).getError()).containsExactly("bad: a", "bad: b");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Constructor accessibility
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("API hygiene")
+  class HygieneTests {
+    @Test
+    @DisplayName("Optics is not instantiable")
+    void notInstantiable() throws Exception {
+      var ctor = Optics.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      var instance = ctor.newInstance();
+      assertThat(instance).isNotNull();
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/poly/PolyOpticsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/poly/PolyOpticsTest.java
@@ -1,0 +1,336 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.poly;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
+import static org.higherkindedj.hkt.id.IdKindHelper.ID;
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.id.Id;
+import org.higherkindedj.hkt.id.IdKind;
+import org.higherkindedj.hkt.id.IdMonad;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.hkt.validated.ValidatedMonad;
+import org.higherkindedj.optics.Optic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PolyOptics: factories and runners")
+class PolyOpticsTest {
+
+  // Generic wrapper used as the canonical "polymorphic container" example.
+  record Box<A>(A value) {}
+
+  // Simple two-field polymorphic record for the polyLens "preserve other fields" test.
+  record Tagged<A>(String tag, A value) {}
+
+  // Iso fixture: lossless wrapper around a single value.
+  record UserId<A>(A raw) {}
+
+  // ---------------------------------------------------------------------------------------------
+  // polyLens
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("polyLens")
+  class PolyLensTests {
+
+    @Test
+    @DisplayName("changes the part type and threads it through to the whole")
+    void changesPartType() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      Box<Integer> result = PolyOptics.modify(contents, Integer::parseInt, new Box<>("42"));
+
+      assertThat(result).isEqualTo(new Box<>(42));
+    }
+
+    @Test
+    @DisplayName("preserves other fields when the part type changes")
+    void preservesOtherFields() {
+      Optic<Tagged<String>, Tagged<Integer>, String, Integer> value =
+          PolyOptics.polyLens(Tagged::value, (t, n) -> new Tagged<>(t.tag(), n));
+
+      Tagged<Integer> result =
+          PolyOptics.modify(value, Integer::parseInt, new Tagged<>("answer", "42"));
+
+      assertThat(result).isEqualTo(new Tagged<>("answer", 42));
+    }
+
+    @Test
+    @DisplayName("modifyF threads the new part through any Applicative")
+    void modifyFUnderEither() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      Function<String, Kind<EitherKind.Witness<String>, Integer>> safeParse =
+          s -> {
+            try {
+              return EITHER.widen(Either.right(Integer.parseInt(s)));
+            } catch (NumberFormatException e) {
+              return EITHER.widen(Either.left("bad number: " + s));
+            }
+          };
+
+      Kind<EitherKind.Witness<String>, Box<Integer>> ok =
+          PolyOptics.modifyF(contents, safeParse, new Box<>("42"), EitherMonad.instance());
+      assertThat(EITHER.narrow(ok)).isEqualTo(Either.right(new Box<>(42)));
+
+      Kind<EitherKind.Witness<String>, Box<Integer>> err =
+          PolyOptics.modifyF(contents, safeParse, new Box<>("nope"), EitherMonad.instance());
+      assertThat(EITHER.narrow(err)).isEqualTo(Either.left("bad number: nope"));
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // polyIso
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("polyIso")
+  class PolyIsoTests {
+
+    @Test
+    @DisplayName("converts a generic wrapper to its raw value and back, changing element type")
+    void roundTripChangingType() {
+      Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+          PolyOptics.polyIso(UserId::raw, UserId::new);
+
+      UserId<Integer> result = PolyOptics.modify(raw, Integer::parseInt, new UserId<>("123"));
+      assertThat(result).isEqualTo(new UserId<>(123));
+    }
+
+    @Test
+    @DisplayName("set replaces the part irrespective of the original")
+    void setReplacesPart() {
+      Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+          PolyOptics.polyIso(UserId::raw, UserId::new);
+
+      UserId<Integer> result = PolyOptics.set(raw, 7, new UserId<>("ignored"));
+      assertThat(result).isEqualTo(new UserId<>(7));
+    }
+
+    @Test
+    @DisplayName("modifyF reconstructs through the reverseGet, threading the applicative")
+    void modifyFThroughMaybe() {
+      Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+          PolyOptics.polyIso(UserId::raw, UserId::new);
+
+      Function<String, Kind<MaybeKind.Witness, Integer>> tryParse =
+          s -> {
+            try {
+              return MAYBE.widen(Maybe.just(Integer.parseInt(s)));
+            } catch (NumberFormatException e) {
+              return MAYBE.widen(Maybe.nothing());
+            }
+          };
+
+      Kind<MaybeKind.Witness, UserId<Integer>> ok =
+          PolyOptics.modifyF(raw, tryParse, new UserId<>("42"), MaybeMonad.INSTANCE);
+      assertThat(MAYBE.narrow(ok)).isEqualTo(Maybe.just(new UserId<>(42)));
+
+      Kind<MaybeKind.Witness, UserId<Integer>> nothing =
+          PolyOptics.modifyF(raw, tryParse, new UserId<>("nope"), MaybeMonad.INSTANCE);
+      assertThat(MAYBE.narrow(nothing)).isEqualTo(Maybe.nothing());
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Runners: get / set / modify / modifyF
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("get")
+  class GetTests {
+
+    @Test
+    @DisplayName("extracts the focused part of a polyLens")
+    void getFromPolyLens() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      assertThat(PolyOptics.get(contents, new Box<>("hello"))).isEqualTo("hello");
+    }
+
+    @Test
+    @DisplayName("extracts the focused part of a polyIso")
+    void getFromPolyIso() {
+      Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+          PolyOptics.polyIso(UserId::raw, UserId::new);
+
+      assertThat(PolyOptics.get(raw, new UserId<>("u-1"))).isEqualTo("u-1");
+    }
+
+    @Test
+    @DisplayName("rejects optics whose modifyF requires Applicative.of (prism-shaped)")
+    void rejectsPrismShapedOptic() {
+      // A hand-crafted prism-like optic: it calls Applicative.of when the predicate fails.
+      Optic<String, String, String, String> nonEmpty =
+          new Optic<>() {
+            @Override
+            public <F extends WitnessArity<TypeArity.Unary>> Kind<F, String> modifyF(
+                Function<String, Kind<F, String>> f, String s, Applicative<F> app) {
+              return s.isEmpty() ? app.of(s) : app.map(x -> x, f.apply(s));
+            }
+          };
+
+      assertThatThrownBy(() -> PolyOptics.get(nonEmpty, ""))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Applicative.of");
+    }
+
+    @Test
+    @DisplayName("rejects optics whose modifyF requires Applicative.ap (traversal-shaped)")
+    void rejectsTraversalShapedOptic() {
+      // A toy "two-element" traversal: focuses on a pair and combines via ap.
+      Optic<List<String>, List<String>, String, String> twoOf =
+          new Optic<>() {
+            @Override
+            public <F extends WitnessArity<TypeArity.Unary>> Kind<F, List<String>> modifyF(
+                Function<String, Kind<F, String>> f, List<String> source, Applicative<F> app) {
+              Kind<F, String> a = f.apply(source.get(0));
+              Kind<F, String> b = f.apply(source.get(1));
+              BiFunction<String, String, List<String>> combine = List::of;
+              return app.map2(a, b, combine);
+            }
+          };
+
+      assertThatThrownBy(() -> PolyOptics.get(twoOf, List.of("x", "y")))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Applicative.ap");
+    }
+  }
+
+  @Nested
+  @DisplayName("set / modify")
+  class SetModifyTests {
+
+    @Test
+    @DisplayName("set replaces the value")
+    void setReplaces() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      assertThat(PolyOptics.set(contents, 99, new Box<>("ignored"))).isEqualTo(new Box<>(99));
+    }
+
+    @Test
+    @DisplayName("modify applies a pure transformation under Identity")
+    void modifyAppliesFunction() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      assertThat(PolyOptics.modify(contents, String::length, new Box<>("hello")))
+          .isEqualTo(new Box<>(5));
+    }
+  }
+
+  @Nested
+  @DisplayName("modifyF")
+  class ModifyFTests {
+
+    @Test
+    @DisplayName("delegates to the optic's own modifyF (Identity case)")
+    void delegatesToOpticIdentity() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      Kind<IdKind.Witness, Box<Integer>> result =
+          PolyOptics.modifyF(
+              contents, s -> Id.of(s.length()), new Box<>("abcd"), IdMonad.instance());
+      assertThat(ID.narrow(result).value()).isEqualTo(new Box<>(4));
+    }
+
+    @Test
+    @DisplayName("accumulates errors under Validated")
+    void accumulatesUnderValidated() {
+      Optic<Box<String>, Box<Integer>, String, Integer> contents =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+      Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+          s -> {
+            try {
+              return VALIDATED.widen(Validated.valid(Integer.parseInt(s)));
+            } catch (NumberFormatException e) {
+              return VALIDATED.widen(Validated.invalid(List.of("bad: " + s)));
+            }
+          };
+
+      Kind<ValidatedKind.Witness<List<String>>, Box<Integer>> ok =
+          PolyOptics.modifyF(contents, parseValidated, new Box<>("9"), validatedApp);
+      assertThat(VALIDATED.narrow(ok)).isEqualTo(Validated.valid(new Box<>(9)));
+
+      Kind<ValidatedKind.Witness<List<String>>, Box<Integer>> bad =
+          PolyOptics.modifyF(contents, parseValidated, new Box<>("nope"), validatedApp);
+      assertThat(VALIDATED.narrow(bad).getError()).containsExactly("bad: nope");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Composition with the base Optic#andThen
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("composition via Optic#andThen")
+  class CompositionTests {
+
+    record Outer<A>(Box<A> inner) {}
+
+    @Test
+    @DisplayName("composes two polymorphic lenses into a deeper polymorphic lens")
+    void composeTwoPolyLenses() {
+      Optic<Outer<String>, Outer<Integer>, Box<String>, Box<Integer>> outerLens =
+          PolyOptics.polyLens(Outer::inner, (o, b) -> new Outer<>(b));
+
+      Optic<Box<String>, Box<Integer>, String, Integer> innerLens =
+          PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+      Optic<Outer<String>, Outer<Integer>, String, Integer> combined = outerLens.andThen(innerLens);
+
+      Outer<Integer> result =
+          PolyOptics.modify(combined, Integer::parseInt, new Outer<>(new Box<>("123")));
+      assertThat(result).isEqualTo(new Outer<>(new Box<>(123)));
+
+      assertThat(PolyOptics.get(combined, new Outer<>(new Box<>("hello")))).isEqualTo("hello");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Constructor accessibility (covers the private no-arg ctor)
+  // ---------------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("API hygiene")
+  class HygieneTests {
+    @Test
+    @DisplayName("PolyOptics is not instantiable")
+    void notInstantiable() throws Exception {
+      var ctor = PolyOptics.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      var instance = ctor.newInstance();
+      assertThat(instance).isNotNull();
+    }
+  }
+}

--- a/hkj-examples/EXAMPLES-GUIDE.md
+++ b/hkj-examples/EXAMPLES-GUIDE.md
@@ -282,6 +282,7 @@ Examples demonstrating various traversal patterns over collections and data stru
 | [FreeMonadOpticDSLExample.java](src/main/java/org/higherkindedj/example/optics/fluent/FreeMonadOpticDSLExample.java) | Free monad optic DSL patterns | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.fluent.FreeMonadOpticDSLExample` | [Free Monad DSL](https://higher-kinded-j.github.io/latest/optics/free_monad_dsl.html) |
 | [OpticInterpretersExample.java](src/main/java/org/higherkindedj/example/optics/fluent/OpticInterpretersExample.java) | Shows optic interpreter patterns | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.fluent.OpticInterpretersExample` | [Interpreters](https://higher-kinded-j.github.io/latest/optics/interpreters.html) |
 | [OpticProfunctorExample.java](src/main/java/org/higherkindedj/example/optics/profunctor/OpticProfunctorExample.java) | Demonstrates profunctor optics | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.profunctor.OpticProfunctorExample` | [Profunctor Optics](https://higher-kinded-j.github.io/latest/optics/profunctor_optics.html) |
+| [PolyOpticsExample.java](src/main/java/org/higherkindedj/example/optics/poly/PolyOpticsExample.java) | Polymorphic optics for generic wrappers and Functor/Traverse leaves | `./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.optics.poly.PolyOpticsExample` | [Polymorphic Optics](https://higher-kinded-j.github.io/latest/optics/polymorphic_optics.html) |
 
 ### Cookbook Recipes
 
@@ -435,6 +436,7 @@ Interactive tutorial examples for learning Higher-Kinded-J concepts.
 | [Tutorial01_ForStateBasics.java](src/test/java/org/higherkindedj/tutorial/expression/Tutorial01_ForStateBasics.java) | ForState comprehension basics with lens-based state | Run via test runner | [ForState Comprehension](https://higher-kinded-j.github.io/latest/functional/forstate_comprehension.html) |
 | [Tutorial04_EnhancedOpticsIntegration.java](src/test/java/org/higherkindedj/tutorial/expression/Tutorial04_EnhancedOpticsIntegration.java) | Enhanced optics: traverseOver, modifyThrough, modifyVia, updateVia, through(Iso) | Run via test runner | [Optics in Comprehensions](https://higher-kinded-j.github.io/latest/functional/for_optics.html) |
 | [Tutorial02_MTLBasics.java](src/test/java/org/higherkindedj/tutorial/mtl/Tutorial02_MTLBasics.java) | MTL pattern basics: MonadReader, MonadState, MonadWriter | Run via test runner | [MTL Capabilities](https://higher-kinded-j.github.io/latest/transformers/mtl_capabilities.html) |
+| [Tutorial21_PolymorphicOptics.java](src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_PolymorphicOptics.java) | Polymorphic optics: polyLens, polyIso, mapped/traversed factories, monomorphic + polymorphic composition | Run via test runner | [Polymorphic Optics](https://higher-kinded-j.github.io/latest/optics/polymorphic_optics.html) |
 
 ---
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/poly/PolyOpticsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/poly/PolyOpticsExample.java
@@ -1,0 +1,174 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics.poly;
+
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+
+import java.util.List;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.hkt.validated.ValidatedMonad;
+import org.higherkindedj.optics.Optic;
+import org.higherkindedj.optics.poly.Optics;
+import org.higherkindedj.optics.poly.PolyOptics;
+
+/**
+ * Demonstrates the polymorphic optics surface in {@link org.higherkindedj.optics.poly}.
+ *
+ * <p>The example walks through three small scenarios in increasing order of richness:
+ *
+ * <ol>
+ *   <li>Building a polymorphic lens for a generic wrapper.
+ *   <li>Building a polymorphic iso for a single-field wrapper and changing its element type.
+ *   <li>Composing a monomorphic head ({@code polyLens}) with a typeclass-driven leaf ({@link
+ *       Optics#traversed}) to parse a list of strings into a list of integers, accumulating errors
+ *       with {@code Validated}.
+ * </ol>
+ *
+ * <p>Run with: {@code ./gradlew :hkj-examples:run -PmainClass=
+ * org.higherkindedj.example.optics.poly.PolyOpticsExample}.
+ */
+public final class PolyOpticsExample {
+
+  // -------------------------------------------------------------------------
+  // Domain model
+  // -------------------------------------------------------------------------
+
+  /** A generic single-field wrapper that we can operate on with a polymorphic lens. */
+  public record Box<A>(A value) {}
+
+  /** A generic ID wrapper used to demonstrate polyIso changing the underlying type. */
+  public record UserId<A>(A raw) {}
+
+  /** A page of rows used to demonstrate composition of monomorphic head + polymorphic leaf. */
+  public record Page<A>(int number, List<A> rows) {}
+
+  private PolyOpticsExample() {}
+
+  // -------------------------------------------------------------------------
+  // Scenario 1: polyLens over a generic Box
+  // -------------------------------------------------------------------------
+
+  static void scenario1_polyLensOverBox() {
+    Optic<Box<String>, Box<Integer>, String, Integer> contents =
+        PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+    Box<String> stringBox = new Box<>("42");
+    Box<Integer> intBox = PolyOptics.modify(contents, Integer::parseInt, stringBox);
+
+    System.out.println("Scenario 1: polyLens over Box<A>");
+    System.out.println("  before: " + stringBox);
+    System.out.println("  after : " + intBox);
+    System.out.println("  get   : " + PolyOptics.get(contents, stringBox));
+    System.out.println();
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: polyIso over a UserId wrapper
+  // -------------------------------------------------------------------------
+
+  static void scenario2_polyIsoOverUserId() {
+    Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+        PolyOptics.polyIso(UserId::raw, UserId::new);
+
+    UserId<String> textual = new UserId<>("123");
+    UserId<Integer> numeric = PolyOptics.modify(raw, Integer::parseInt, textual);
+
+    System.out.println("Scenario 2: polyIso over UserId<A>");
+    System.out.println("  before: " + textual);
+    System.out.println("  after : " + numeric);
+    System.out.println("  set   : " + PolyOptics.set(raw, 7, textual));
+    System.out.println();
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: monomorphic head + polymorphic leaf via Optics.traversed
+  // -------------------------------------------------------------------------
+
+  static void scenario3_traversedLeafAccumulatesErrors() {
+    // Lens-shaped polymorphic head onto Page::rows.
+    Optic<Page<String>, Page<Integer>, List<String>, List<Integer>> rowsLens =
+        PolyOptics.polyLens(Page::rows, (p, rs) -> new Page<>(p.number(), rs));
+
+    // Bridge plain List <-> Kind<ListKind.Witness, ?> so we can reach Optics.traversed.
+    Optic<
+            List<String>,
+            List<Integer>,
+            Kind<ListKind.Witness, String>,
+            Kind<ListKind.Witness, Integer>>
+        listAsKind = PolyOptics.polyIso(LIST::widen, LIST::narrow);
+
+    // Polymorphic leaf: traversed list elements that may change type.
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        allRows = Optics.traversed(ListTraverse.INSTANCE);
+
+    Optic<Page<String>, Page<Integer>, String, Integer> pageRows =
+        rowsLens.andThen(listAsKind).andThen(allRows);
+
+    Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+        s -> {
+          try {
+            return VALIDATED.widen(Validated.valid(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return VALIDATED.widen(Validated.invalid(List.of("bad row: " + s)));
+          }
+        };
+
+    ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+    Page<String> validInput = new Page<>(1, List.of("1", "2", "3"));
+    Page<String> mixedInput = new Page<>(2, List.of("1", "x", "3", "y"));
+
+    Kind<ValidatedKind.Witness<List<String>>, Page<Integer>> ok =
+        PolyOptics.modifyF(pageRows, parseValidated, validInput, validatedApp);
+    Kind<ValidatedKind.Witness<List<String>>, Page<Integer>> mixed =
+        PolyOptics.modifyF(pageRows, parseValidated, mixedInput, validatedApp);
+
+    System.out.println("Scenario 3: monomorphic head + polymorphic leaf (Validated)");
+    System.out.println("  valid  : " + VALIDATED.narrow(ok));
+    System.out.println("  errors : " + VALIDATED.narrow(mixed).getError());
+    System.out.println();
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 4: Optics.mapped under Either (a Functor application)
+  // -------------------------------------------------------------------------
+
+  static void scenario4_mappedOverEither() {
+    Optic<
+            Kind<EitherKind.Witness<String>, String>,
+            Kind<EitherKind.Witness<String>, Integer>,
+            String,
+            Integer>
+        rightContent = Optics.mapped(EitherMonad.<String>instance());
+
+    Kind<EitherKind.Witness<String>, Integer> right =
+        PolyOptics.modify(rightContent, String::length, EITHER.widen(Either.right("hello")));
+    Kind<EitherKind.Witness<String>, Integer> left =
+        PolyOptics.modify(rightContent, String::length, EITHER.widen(Either.left("missing")));
+
+    System.out.println("Scenario 4: Optics.mapped over Either<String, ?>");
+    System.out.println("  right : " + EITHER.narrow(right));
+    System.out.println("  left  : " + EITHER.narrow(left));
+    System.out.println();
+  }
+
+  public static void main(String[] args) {
+    System.out.println("== PolyOptics Example ==");
+    System.out.println();
+    scenario1_polyLensOverBox();
+    scenario2_polyIsoOverUserId();
+    scenario3_traversedLeafAccumulatesErrors();
+    scenario4_mappedOverEither();
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/README.md
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/README.md
@@ -223,6 +223,14 @@ Navigating custom container types with Affines:
 - `some(Affine)` composition on path types
 - Composing container-widened paths with standard lens paths
 
+### Tutorial 21: Polymorphic Optics (~12 minutes)
+Type-changing optics for generic wrappers and HKT-typed leaves:
+- `PolyOptics.polyLens` and `polyIso` factories for type-changing updates
+- `PolyOptics.modify`, `set`, `get`, and `modifyF` runners
+- `Optics.mapped(Functor)` as a polymorphic Setter
+- `Optics.traversed(Traverse)` as a polymorphic Traversal under any Applicative
+- Composing monomorphic heads with polymorphic leaves via `Optic#andThen`
+
 ## MTL Tutorial Series
 
 ### Tutorial 02: MTL Basics (~35 minutes)

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_PolymorphicOptics.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_PolymorphicOptics.java
@@ -1,0 +1,463 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+
+import java.util.List;
+import java.util.function.Function;
+import org.assertj.core.api.Assertions;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.hkt.validated.ValidatedMonad;
+import org.higherkindedj.optics.Optic;
+import org.higherkindedj.optics.poly.Optics;
+import org.higherkindedj.optics.poly.PolyOptics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tutorial 21: Polymorphic Optics — Type-Changing Updates Without Boilerplate.
+ *
+ * <p>Pain → Promise. Most of the time we update a record field with a value of the <em>same</em>
+ * type ({@code Lens<User, String>}, {@code Prism<Result, Failure>}). Occasionally we want to change
+ * the focused type along the way: parse {@code Box<String>} into {@code Box<Integer>}, or map every
+ * element of {@code List<String>} to {@code List<Integer>} as a leaf step in a longer optic chain.
+ * Hand-rolling that is messy:
+ *
+ * <pre>
+ *   Box&lt;Integer&gt; result = new Box&lt;&gt;(Integer.parseInt(box.value()));   // tedious for every wrapper
+ *   List&lt;Integer&gt; ints   = strings.stream().map(Integer::parseInt).toList(); // can't compose
+ * </pre>
+ *
+ * <p>Higher-Kinded-J solves this with a small <b>polymorphic optics</b> surface in {@link
+ * org.higherkindedj.optics.poly}:
+ *
+ * <pre>
+ *   Optic&lt;Box&lt;String&gt;, Box&lt;Integer&gt;, String, Integer&gt; contents =
+ *       PolyOptics.polyLens(Box::value, (b, n) -&gt; new Box&lt;&gt;(n));
+ *   Box&lt;Integer&gt; result = PolyOptics.modify(contents, Integer::parseInt, new Box&lt;&gt;("42"));
+ * </pre>
+ *
+ * <p>Java idiom anchors:
+ *
+ * <ul>
+ *   <li>{@code PolyOptics.polyLens} ↔ a {@code with*} method whose return type is allowed to differ
+ *       from its input type.
+ *   <li>{@code PolyOptics.polyIso} ↔ a pair of conversion functions ({@code S -> A} and {@code B ->
+ *       T}) that change types lossless-ly.
+ *   <li>{@code Optics.mapped(Functor)} ↔ {@code Stream.map} for any unary HKT, lifted into an optic
+ *       that composes with {@code andThen}.
+ *   <li>{@code Optics.traversed(Traverse)} ↔ {@code List.stream().map(...).collect(...)} but under
+ *       any {@link org.higherkindedj.hkt.Applicative} (so you can accumulate validation errors,
+ *       short-circuit on Either, run async, ...).
+ * </ul>
+ *
+ * <p>Key concepts:
+ *
+ * <ul>
+ *   <li>The base {@link Optic} interface already carries four type parameters ({@code S, T, A, B});
+ *       polymorphic optics simply <em>use</em> them.
+ *   <li>The everyday monomorphic {@code Lens}, {@code Prism}, {@code Iso}, {@code Affine}, {@code
+ *       Traversal}, and {@code Setter} stay unchanged. Polymorphic optics live in their own package
+ *       as a deliberate escape hatch.
+ *   <li>For most "type-changing" needs (DTO/V1↔V2 adapters, wrapper integration), the existing
+ *       {@code dimap} / {@code map} / {@code contramap} <em>profunctor</em> adapters are the right
+ *       tool. Polymorphic optics are for the smaller set of cases where the type change <em>is</em>
+ *       the operation, not an adapter around it.
+ * </ul>
+ *
+ * <p>Estimated time: 12-15 minutes.
+ *
+ * <p>This tutorial uses tiered hints (Nudge / Strategy / Spoiler) — read only as far as you need.
+ *
+ * <p>Replace each placeholder with the correct code to make the tests pass.
+ */
+@DisplayName("Tutorial 21: Polymorphic Optics")
+public class Tutorial21_PolymorphicOptics {
+
+  /** Helper for incomplete exercises that throws a clear exception. */
+  private static <T> T answerRequired() {
+    throw new RuntimeException("Answer required");
+  }
+
+  // ─── Domain model ───────────────────────────────────────────────────────
+
+  /** A generic single-field wrapper. The whole point of this tutorial is to change its A. */
+  public record Box<A>(A value) {}
+
+  /** A generic ID wrapper used to demonstrate polyIso. */
+  public record UserId<A>(A raw) {}
+
+  /** A page of rows. The "head" of our composition will be a polymorphic lens onto rows. */
+  public record Page<A>(int number, List<A> rows) {}
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Exercise 1: polyLens over a generic wrapper
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 1: Build a polymorphic lens.
+   *
+   * <p>{@link PolyOptics#polyLens} takes a getter and a type-changing setter and returns an {@link
+   * Optic} with four type parameters. We then use {@link PolyOptics#modify} to apply a pure
+   * type-changing function.
+   *
+   * <p>Task: produce a {@code Box<Integer>} by parsing the inner value of a {@code Box<String>}.
+   *
+   * <pre>
+   *   // Nudge:    polyLens needs a getter (Box -&gt; A) and a type-changing setter (Box, B) -&gt; new Box.
+   *   // Strategy: PolyOptics.polyLens(Box::value, (b, n) -&gt; new Box&lt;&gt;(n)).
+   *   // Spoiler:  PolyOptics.modify(contents, Integer::parseInt, input)
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 1: polyLens turns Box<String> into Box<Integer>")
+  void exercise1_polyLens() {
+    Box<String> input = new Box<>("42");
+
+    // TODO: build a polymorphic lens that focuses on Box::value and rebuilds with a new value.
+    Optic<Box<String>, Box<Integer>, String, Integer> contents = answerRequired();
+
+    // TODO: use PolyOptics.modify with Integer::parseInt to produce a Box<Integer>.
+    Box<Integer> output = answerRequired();
+
+    assertThat(output).isEqualTo(new Box<>(42));
+    assertThat(input).isEqualTo(new Box<>("42")); // original unchanged
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Exercise 2: PolyOptics.get over a polyLens
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 2: Extracting the focus of a polymorphic lens.
+   *
+   * <p>{@link PolyOptics#get} works for any optic built from {@code polyLens} or {@code polyIso}
+   * (and their compositions). It internally uses a Const applicative; if you point it at a prism /
+   * traversal-shaped optic it will throw a clear error.
+   *
+   * <p>Task: extract the focused {@code String} from a {@code Box<String>} via your polymorphic
+   * lens.
+   *
+   * <pre>
+   *   // Nudge:    The same polymorphic lens you built in Exercise 1 supports get.
+   *   // Strategy: PolyOptics.get(contents, input).
+   *   // Spoiler:  PolyOptics.get(contents, input)
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 2: PolyOptics.get extracts the focused part")
+  void exercise2_polyLensGet() {
+    Box<String> input = new Box<>("hello");
+    Optic<Box<String>, Box<Integer>, String, Integer> contents =
+        PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+    // TODO: extract the focused String using PolyOptics.get.
+    String focused = answerRequired();
+
+    assertThat(focused).isEqualTo("hello");
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Exercise 3: polyIso for a single-field wrapper
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 3: Build a polymorphic iso.
+   *
+   * <p>An iso is a lossless two-way conversion. Because the wrapper has only one field, we can
+   * reconstruct the whole from the new part directly without referring to the original source.
+   * That's exactly what {@link PolyOptics#polyIso} expects.
+   *
+   * <p>Task: build a polymorphic iso between {@code UserId<String>} and {@code UserId<Integer>}.
+   *
+   * <pre>
+   *   // Nudge:    polyIso takes a forward getter and a reverseGet that builds a new whole from a part.
+   *   // Strategy: PolyOptics.polyIso(UserId::raw, UserId::new).
+   *   // Spoiler:  PolyOptics.modify(raw, Integer::parseInt, input)
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 3: polyIso converts UserId<String> to UserId<Integer>")
+  void exercise3_polyIso() {
+    UserId<String> input = new UserId<>("123");
+
+    // TODO: build a polymorphic iso for UserId.
+    Optic<UserId<String>, UserId<Integer>, String, Integer> raw = answerRequired();
+
+    // TODO: produce a UserId<Integer> by parsing the raw String.
+    UserId<Integer> output = answerRequired();
+
+    assertThat(output).isEqualTo(new UserId<>(123));
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Exercise 4: Optics.mapped over a Functor
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 4: A polymorphic Setter into the contents of any Functor.
+   *
+   * <p>{@link Optics#mapped(org.higherkindedj.hkt.Functor)} returns a polymorphic optic into the
+   * elements of any unary {@link org.higherkindedj.hkt.Functor}. It is a polymorphic <b>Setter</b>:
+   * it supports pure modifications via {@link PolyOptics#modify}. For effectful traversal use
+   * {@code Optics.traversed} (Exercise 5).
+   *
+   * <p>Task: change the element type of a {@code List<String>} into {@code List<Integer>} using
+   * {@code Optics.mapped} and {@code PolyOptics.modify}.
+   *
+   * <pre>
+   *   // Nudge:    Optics.mapped wants a Functor instance; ListMonad.INSTANCE is a Functor.
+   *   // Strategy: Optics.mapped(ListMonad.INSTANCE).
+   *   // Spoiler:  PolyOptics.modify(elems, Integer::parseInt, LIST.widen(input))
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 4: Optics.mapped changes the elements of a List under modify")
+  void exercise4_mappedOverList() {
+    List<String> input = List.of("1", "2", "3");
+
+    // TODO: build a polymorphic Setter for the elements of any List Functor.
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> elems =
+        answerRequired();
+
+    // TODO: apply PolyOptics.modify with Integer::parseInt to obtain a Kind<ListKind.Witness,
+    // Integer>.
+    Kind<ListKind.Witness, Integer> result = answerRequired();
+
+    assertThat(LIST.narrow(result)).containsExactly(1, 2, 3);
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Exercise 5: Optics.traversed under Validated
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 5: A polymorphic Traversal that accumulates errors.
+   *
+   * <p>{@link Optics#traversed(org.higherkindedj.hkt.Traverse)} returns a polymorphic optic that
+   * runs under <em>any</em> {@link org.higherkindedj.hkt.Applicative}, including {@code Validated}
+   * (which accumulates errors via the supplied {@code Semigroup}).
+   *
+   * <p>Task: parse a {@code List<String>} into a {@code Kind<ValidatedKind.Witness<List<String>>,
+   * Kind<ListKind.Witness, Integer>>} that accumulates "bad: x" / "bad: y" errors.
+   *
+   * <pre>
+   *   // Nudge:    Use Optics.traversed(ListTraverse.INSTANCE) and PolyOptics.modifyF.
+   *   // Strategy: ValidatedMonad.instance(Semigroups.list()) is the Applicative you want.
+   *   // Spoiler:  PolyOptics.modifyF(trav, parseValidated, LIST.widen(input), validatedApp)
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 5: Optics.traversed accumulates errors under Validated")
+  void exercise5_traversedUnderValidated() {
+    List<String> input = List.of("1", "x", "2", "y");
+
+    Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+        s -> {
+          try {
+            return VALIDATED.widen(Validated.valid(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return VALIDATED.widen(Validated.invalid(List.of("bad: " + s)));
+          }
+        };
+
+    ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+    // TODO: build a polymorphic traversal over List elements.
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+        answerRequired();
+
+    // TODO: run modifyF with the validated parser and assert that errors accumulate.
+    Kind<ValidatedKind.Witness<List<String>>, Kind<ListKind.Witness, Integer>> result =
+        answerRequired();
+
+    Validated<List<String>, Kind<ListKind.Witness, Integer>> narrowed = VALIDATED.narrow(result);
+    assertThat(narrowed.isInvalid()).isTrue();
+    assertThat(narrowed.getError()).containsExactly("bad: x", "bad: y");
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Exercise 6: Composition — monomorphic head + polymorphic leaf
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 6: Compose a polyLens head with an Optics.traversed leaf.
+   *
+   * <p>The shipped optics compose via {@link Optic#andThen}. We focus a {@code Page<String>} onto
+   * its rows with a {@code polyLens}, bridge the plain {@code List} to its HKT shape with a {@code
+   * polyIso}, and traverse with {@code Optics.traversed} to change element type.
+   *
+   * <p>Task: complete the composition so that calling {@code PolyOptics.modify} on {@code
+   * Page<String>} returns a {@code Page<Integer>} with each row parsed.
+   *
+   * <pre>
+   *   // Nudge:    Three pieces compose with andThen: rowsLens, listAsKind, allRows.
+   *   // Strategy: rowsLens.andThen(listAsKind).andThen(allRows).
+   *   // Spoiler:  PolyOptics.modify(pageRows, Integer::parseInt, input)
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 6: monomorphic head + polymorphic leaf transforms a whole record")
+  void exercise6_compose() {
+    Page<String> input = new Page<>(1, List.of("1", "2", "3"));
+
+    Optic<Page<String>, Page<Integer>, List<String>, List<Integer>> rowsLens =
+        PolyOptics.polyLens(Page::rows, (p, rs) -> new Page<>(p.number(), rs));
+
+    Optic<
+            List<String>,
+            List<Integer>,
+            Kind<ListKind.Witness, String>,
+            Kind<ListKind.Witness, Integer>>
+        listAsKind = PolyOptics.polyIso(LIST::widen, LIST::narrow);
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        allRows = Optics.traversed(ListTraverse.INSTANCE);
+
+    // TODO: compose the three optics into a single optic Page<String> -> Page<Integer>.
+    Optic<Page<String>, Page<Integer>, String, Integer> pageRows = answerRequired();
+
+    // TODO: use PolyOptics.modify with Integer::parseInt to obtain the new page.
+    Page<Integer> output = answerRequired();
+
+    assertThat(output).isEqualTo(new Page<>(1, List.of(1, 2, 3)));
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Diagnostic: when NOT to use polymorphic optics
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Diagnostic exercise: when NOT to reach for {@link PolyOptics}.
+   *
+   * <p>Most "I want to change types" needs are <em>not</em> calls for polymorphic optics. If you
+   * are mapping between an external DTO and your internal record, the right tool is the monomorphic
+   * optic plus its {@code dimap} / {@code map} / {@code contramap} profunctor adapters. Polymorphic
+   * optics are for the smaller case where the type change <em>is</em> the operation (typically over
+   * a generic container the user authored).
+   *
+   * <p>The code below tries to use {@link Optics#mapped} under {@link MaybeMonad} as if it were a
+   * full traversal — but {@code mapped} is a polymorphic <b>Setter</b> and only supports pure
+   * modification under the Identity applicative. The right tool for the failable case is {@link
+   * Optics#traversed} with a {@code Traverse} instance.
+   *
+   * <p>Lesson: <em>different tools for different jobs</em>. {@code Optics.mapped(Functor)} is the
+   * Setter; {@code Optics.traversed(Traverse)} is the Traversal.
+   */
+  @Test
+  @DisplayName("Diagnostic: mapped(Functor) is a Setter; use traversed(Traverse) for effects")
+  void diagnostic_mappedVsTraversed() {
+    // The wrong attempt: pass a Maybe-returning function into Optics.mapped.
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        wrongChoice = Optics.mapped(ListMonad.INSTANCE);
+
+    Function<String, Kind<MaybeKind.Witness, Integer>> tryParse =
+        s -> {
+          try {
+            return MAYBE.widen(Maybe.just(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return MAYBE.widen(Maybe.nothing());
+          }
+        };
+
+    Assertions.assertThatThrownBy(
+            () ->
+                PolyOptics.modifyF(
+                    wrongChoice, tryParse, LIST.widen(List.of("1")), MaybeMonad.INSTANCE))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Optics.traversed(Traverse)");
+
+    // The right shape: traversed(Traverse) under any Applicative.
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        rightChoice = Optics.traversed(ListTraverse.INSTANCE);
+
+    Kind<MaybeKind.Witness, Kind<ListKind.Witness, Integer>> result =
+        PolyOptics.modifyF(
+            rightChoice, tryParse, LIST.widen(List.of("1", "2")), MaybeMonad.INSTANCE);
+
+    assertThat(MAYBE.narrow(result).isJust()).isTrue();
+    assertThat(LIST.narrow(MAYBE.narrow(result).get())).containsExactly(1, 2);
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Bonus: short-circuit with Either via Optics.traversed
+  // ═════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Exercise 7: Optics.traversed short-circuits over an Either Applicative.
+   *
+   * <p>Same {@code traversed} optic as Exercise 5, but under {@link EitherMonad} the first error
+   * stops the traversal.
+   *
+   * <p>Task: parse a list that contains a bad token, observing the short-circuit.
+   *
+   * <pre>
+   *   // Nudge:    Use the same Optics.traversed(ListTraverse.INSTANCE) leaf.
+   *   // Strategy: EitherMonad.&lt;String&gt;instance() is the Applicative.
+   *   // Spoiler:  PolyOptics.modifyF(trav, safeParse, LIST.widen(input), EitherMonad.instance())
+   * </pre>
+   */
+  @Test
+  @DisplayName("Exercise 7: traversed short-circuits under Either")
+  void exercise7_traversedShortCircuits() {
+    List<String> input = List.of("1", "nope", "2");
+
+    Function<String, Kind<EitherKind.Witness<String>, Integer>> safeParse =
+        s -> {
+          try {
+            return EITHER.widen(Either.right(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return EITHER.widen(Either.left("bad: " + s));
+          }
+        };
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+        Optics.traversed(ListTraverse.INSTANCE);
+
+    // TODO: run modifyF under EitherMonad and observe the short-circuit on the first failure.
+    Kind<EitherKind.Witness<String>, Kind<ListKind.Witness, Integer>> result = answerRequired();
+
+    assertThat(EITHER.narrow(result)).isEqualTo(Either.left("bad: nope"));
+  }
+
+  /**
+   * Congratulations! You have completed Tutorial 21: Polymorphic Optics.
+   *
+   * <p>You now understand:
+   *
+   * <ul>
+   *   <li>How to build a type-changing lens with {@link PolyOptics#polyLens}.
+   *   <li>How to build a type-changing iso with {@link PolyOptics#polyIso}.
+   *   <li>The difference between {@link Optics#mapped} (Setter under Identity) and {@link
+   *       Optics#traversed} (Traversal under any Applicative).
+   *   <li>How to compose monomorphic heads with polymorphic leaves via {@link Optic#andThen}.
+   *   <li>When <em>not</em> to use polymorphic optics: profunctor adapters ({@code dimap} / {@code
+   *       map} / {@code contramap}) cover the common DTO/wrapper cases.
+   * </ul>
+   *
+   * <p>Next steps:
+   *
+   * <ul>
+   *   <li>Read the Profunctor Optics chapter to see when monomorphic optics + adapters are the
+   *       right tool.
+   *   <li>Combine polymorphic optics with the Effect Path API for failable type-changing pipelines.
+   * </ul>
+   */
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial21_PolymorphicOptics_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial21_PolymorphicOptics_Solution.java
@@ -1,0 +1,306 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.tutorial.solutions.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+
+import java.util.List;
+import java.util.function.Function;
+import org.assertj.core.api.Assertions;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.maybe.MaybeKind;
+import org.higherkindedj.hkt.maybe.MaybeMonad;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.hkt.validated.ValidatedMonad;
+import org.higherkindedj.optics.Optic;
+import org.higherkindedj.optics.poly.Optics;
+import org.higherkindedj.optics.poly.PolyOptics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Solutions for Tutorial 21: Polymorphic Optics.
+ *
+ * <p>The solutions are working code; each {@code @Test} carries a teaching block in the <em>Why
+ * this is idiomatic / Alternative / Common wrong attempt</em> format established by the Foundations
+ * journey. Read the working answer first, then the commentary.
+ */
+@DisplayName("Tutorial 21: Polymorphic Optics — Solutions")
+public class Tutorial21_PolymorphicOptics_Solution {
+
+  public record Box<A>(A value) {}
+
+  public record UserId<A>(A raw) {}
+
+  public record Page<A>(int number, List<A> rows) {}
+
+  /**
+   * Why this is idiomatic: {@code polyLens} is the natural lens shape for a generic wrapper — the
+   * getter is just the accessor, and the setter rebuilds the wrapper with a value of a <em>possibly
+   * different</em> type. {@code PolyOptics.modify} runs the optic under the Identity applicative so
+   * the call site reads like a plain {@code with} method.
+   *
+   * <p>Alternative: write {@code new Box<>(Integer.parseInt(box.value()))} inline. Same answer, but
+   * it does not compose into a longer optic chain.
+   *
+   * <p>Common wrong attempt: reach for a monomorphic {@code Lens<Box<String>, String>}. That lens
+   * cannot return a {@code Box<Integer>} because its types are fixed at construction.
+   */
+  @Test
+  @DisplayName("Exercise 1: polyLens turns Box<String> into Box<Integer>")
+  void exercise1_polyLens() {
+    Box<String> input = new Box<>("42");
+
+    // SOLUTION: build a polymorphic lens with a type-changing setter.
+    Optic<Box<String>, Box<Integer>, String, Integer> contents =
+        PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+    Box<Integer> output = PolyOptics.modify(contents, Integer::parseInt, input);
+
+    assertThat(output).isEqualTo(new Box<>(42));
+    assertThat(input).isEqualTo(new Box<>("42"));
+  }
+
+  /**
+   * Why this is idiomatic: {@code PolyOptics.get} re-uses the polymorphic optic we already have for
+   * {@code modify} and {@code set}. We do not need a separate "getter" data type.
+   *
+   * <p>Alternative: call {@code Box::value} directly. That is fine for a single field, but it does
+   * not compose with deeper polymorphic chains the way an optic does.
+   *
+   * <p>Common wrong attempt: pass a prism / traversal-shaped optic into {@code get}. {@code get} is
+   * documented as lens-like only and raises a clear {@code UnsupportedOperationException} pointing
+   * at {@code modifyF} in that case.
+   */
+  @Test
+  @DisplayName("Exercise 2: PolyOptics.get extracts the focused part")
+  void exercise2_polyLensGet() {
+    Box<String> input = new Box<>("hello");
+    Optic<Box<String>, Box<Integer>, String, Integer> contents =
+        PolyOptics.polyLens(Box::value, (b, n) -> new Box<>(n));
+
+    String focused = PolyOptics.get(contents, input);
+
+    assertThat(focused).isEqualTo("hello");
+  }
+
+  /**
+   * Why this is idiomatic: a single-field wrapper has no "other fields" to preserve, so the iso
+   * form is more honest than a lens — {@code reverseGet} only needs the new part.
+   *
+   * <p>Alternative: write a {@code polyLens(UserId::raw, (u, n) -> new UserId<>(n))}. Equivalent
+   * for one-field records, but iso is the right shape and signals the lossless symmetry.
+   *
+   * <p>Common wrong attempt: hand-roll a {@code Iso<UserId<String>, String>} (monomorphic). It
+   * cannot widen the underlying type because both type parameters are fixed.
+   */
+  @Test
+  @DisplayName("Exercise 3: polyIso converts UserId<String> to UserId<Integer>")
+  void exercise3_polyIso() {
+    UserId<String> input = new UserId<>("123");
+
+    Optic<UserId<String>, UserId<Integer>, String, Integer> raw =
+        PolyOptics.polyIso(UserId::raw, UserId::new);
+
+    UserId<Integer> output = PolyOptics.modify(raw, Integer::parseInt, input);
+
+    assertThat(output).isEqualTo(new UserId<>(123));
+  }
+
+  /**
+   * Why this is idiomatic: {@code Optics.mapped} surfaces the existing {@code Functor} instance as
+   * an optic that composes with the rest of the optics ecosystem via {@code Optic#andThen}. Use it
+   * when the operation is a pure type-changing map.
+   *
+   * <p>Alternative: {@code list.stream().map(Integer::parseInt).toList()}. Same outcome for one
+   * step; the optic shines when the map is one leaf in a longer chain over a record.
+   *
+   * <p>Common wrong attempt: pass an effectful function (returning {@code Maybe}, {@code Either},
+   * ...) into {@code mapped}. {@code mapped} is a polymorphic Setter under Identity; for effectful
+   * traversal use {@code traversed} (Exercise 5).
+   */
+  @Test
+  @DisplayName("Exercise 4: Optics.mapped changes the elements of a List under modify")
+  void exercise4_mappedOverList() {
+    List<String> input = List.of("1", "2", "3");
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> elems =
+        Optics.mapped(ListMonad.INSTANCE);
+
+    Kind<ListKind.Witness, Integer> result =
+        PolyOptics.modify(elems, Integer::parseInt, LIST.widen(input));
+
+    assertThat(LIST.narrow(result)).containsExactly(1, 2, 3);
+  }
+
+  /**
+   * Why this is idiomatic: a {@code Traverse} instance plus {@code Validated} together give us
+   * "parse every element, accumulate every error" with no manual error book-keeping. Threading an
+   * {@link Optic} through it means the same step composes with monomorphic optics on either side.
+   *
+   * <p>Alternative: a hand-written loop that builds a {@code List<String>} of errors and a {@code
+   * List<Integer>} of values. Verbose, and does not interoperate with the Effect Path API.
+   *
+   * <p>Common wrong attempt: use {@code Optics.mapped} (the Setter) here. It only supports the
+   * Identity applicative, so {@code Validated} cannot accumulate.
+   */
+  @Test
+  @DisplayName("Exercise 5: Optics.traversed accumulates errors under Validated")
+  void exercise5_traversedUnderValidated() {
+    List<String> input = List.of("1", "x", "2", "y");
+
+    Function<String, Kind<ValidatedKind.Witness<List<String>>, Integer>> parseValidated =
+        s -> {
+          try {
+            return VALIDATED.widen(Validated.valid(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return VALIDATED.widen(Validated.invalid(List.of("bad: " + s)));
+          }
+        };
+
+    ValidatedMonad<List<String>> validatedApp = ValidatedMonad.instance(Semigroups.list());
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+        Optics.traversed(ListTraverse.INSTANCE);
+
+    Kind<ValidatedKind.Witness<List<String>>, Kind<ListKind.Witness, Integer>> result =
+        PolyOptics.modifyF(trav, parseValidated, LIST.widen(input), validatedApp);
+
+    Validated<List<String>, Kind<ListKind.Witness, Integer>> narrowed = VALIDATED.narrow(result);
+    assertThat(narrowed.isInvalid()).isTrue();
+    assertThat(narrowed.getError()).containsExactly("bad: x", "bad: y");
+  }
+
+  /**
+   * Why this is idiomatic: composing the three pieces with {@code Optic#andThen} keeps every step
+   * type-safe end-to-end. The middle "iso" is just a bridge between the plain {@code List} surface
+   * and the HKT shape that {@code Optics.traversed} expects — it is not magic, it is a lossless
+   * reinterpretation.
+   *
+   * <p>Alternative: skip the polymorphic head and operate on rows directly with a stream. The optic
+   * version composes with anything else in your record ({@code Page::number}, etc.) and supports
+   * {@code modifyF} under any applicative for free.
+   *
+   * <p>Common wrong attempt: drop the {@code listAsKind} bridge and try to call {@code
+   * Optics.traversed(...)} on a plain {@code List}. The traversed optic is parameterised by {@code
+   * Kind<F, A>}; the bridge is what allows the plain {@code List} produced by the lens to flow into
+   * it.
+   */
+  @Test
+  @DisplayName("Exercise 6: monomorphic head + polymorphic leaf transforms a whole record")
+  void exercise6_compose() {
+    Page<String> input = new Page<>(1, List.of("1", "2", "3"));
+
+    Optic<Page<String>, Page<Integer>, List<String>, List<Integer>> rowsLens =
+        PolyOptics.polyLens(Page::rows, (p, rs) -> new Page<>(p.number(), rs));
+
+    Optic<
+            List<String>,
+            List<Integer>,
+            Kind<ListKind.Witness, String>,
+            Kind<ListKind.Witness, Integer>>
+        listAsKind = PolyOptics.polyIso(LIST::widen, LIST::narrow);
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        allRows = Optics.traversed(ListTraverse.INSTANCE);
+
+    Optic<Page<String>, Page<Integer>, String, Integer> pageRows =
+        rowsLens.andThen(listAsKind).andThen(allRows);
+
+    Page<Integer> output = PolyOptics.modify(pageRows, Integer::parseInt, input);
+
+    assertThat(output).isEqualTo(new Page<>(1, List.of(1, 2, 3)));
+  }
+
+  /**
+   * Why this is idiomatic: the diagnostic shows the exact symptom of choosing the wrong tool — a
+   * clear runtime exception that names the right tool. The follow-up uses {@code traversed} under
+   * {@code MaybeMonad} and works.
+   *
+   * <p>Alternative: simply remember the rule: {@code mapped(Functor)} for pure Setter, {@code
+   * traversed(Traverse)} for full Traversal under any applicative.
+   *
+   * <p>Common wrong attempt: assume {@code mapped} is "more general" because Functor is a weaker
+   * abstraction. In our optic surface, the more powerful applicative-compatible factory needs the
+   * stronger {@code Traverse} instance. The error message points the way.
+   */
+  @Test
+  @DisplayName("Diagnostic: mapped(Functor) is a Setter; use traversed(Traverse) for effects")
+  void diagnostic_mappedVsTraversed() {
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        wrongChoice = Optics.mapped(ListMonad.INSTANCE);
+
+    Function<String, Kind<MaybeKind.Witness, Integer>> tryParse =
+        s -> {
+          try {
+            return MAYBE.widen(Maybe.just(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return MAYBE.widen(Maybe.nothing());
+          }
+        };
+
+    Assertions.assertThatThrownBy(
+            () ->
+                PolyOptics.modifyF(
+                    wrongChoice, tryParse, LIST.widen(List.of("1")), MaybeMonad.INSTANCE))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Optics.traversed(Traverse)");
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer>
+        rightChoice = Optics.traversed(ListTraverse.INSTANCE);
+
+    Kind<MaybeKind.Witness, Kind<ListKind.Witness, Integer>> result =
+        PolyOptics.modifyF(
+            rightChoice, tryParse, LIST.widen(List.of("1", "2")), MaybeMonad.INSTANCE);
+
+    assertThat(MAYBE.narrow(result).isJust()).isTrue();
+    assertThat(LIST.narrow(MAYBE.narrow(result).get())).containsExactly(1, 2);
+  }
+
+  /**
+   * Why this is idiomatic: switching from {@code Validated} to {@code Either} is a one-line change
+   * to the applicative; the optic itself is unchanged. That is the payoff of building traversals on
+   * top of {@code Applicative}.
+   *
+   * <p>Alternative: hand-write a loop that parses elements and bails on the first failure. Same
+   * outcome, more boilerplate, no composition.
+   *
+   * <p>Common wrong attempt: expect {@code Either} to accumulate errors. {@code Either} is a
+   * fail-fast applicative; for accumulation use {@code Validated}.
+   */
+  @Test
+  @DisplayName("Exercise 7: traversed short-circuits under Either")
+  void exercise7_traversedShortCircuits() {
+    List<String> input = List.of("1", "nope", "2");
+
+    Function<String, Kind<EitherKind.Witness<String>, Integer>> safeParse =
+        s -> {
+          try {
+            return EITHER.widen(Either.right(Integer.parseInt(s)));
+          } catch (NumberFormatException e) {
+            return EITHER.widen(Either.left("bad: " + s));
+          }
+        };
+
+    Optic<Kind<ListKind.Witness, String>, Kind<ListKind.Witness, Integer>, String, Integer> trav =
+        Optics.traversed(ListTraverse.INSTANCE);
+
+    Kind<EitherKind.Witness<String>, Kind<ListKind.Witness, Integer>> result =
+        PolyOptics.modifyF(trav, safeParse, LIST.widen(input), EitherMonad.instance());
+
+    assertThat(EITHER.narrow(result)).isEqualTo(Either.left("bad: nope"));
+  }
+}


### PR DESCRIPTION
Adds a small, narrowly scoped polymorphic-optics surface in org.higherkindedj.optics.poly that complements the existing monomorphic optics rather than duplicating them, plus complete tests, an example, a tutorial pair, and book documentation.

Library code (hkj-core)
- PolyOptics: polyLens / polyIso factories and modifyF / modify / set / get runners over the existing Optic<S, T, A, B> interface.
- Optics: typeclass-driven mapped(Functor) and traversed(Traverse) leaves that compose with monomorphic optics via Optic#andThen.
- Package-private PolyConst applicative used by get; raises clear errors for prism / traversal-shaped optics.
- module-info exports the new package.

Tests (hkj-core)
- PolyOpticsTest and OpticsTest cover every public method, every error path, and composition with monomorphic optics, including a diagnostic for choosing between mapped (Setter) and traversed (Traversal).

Example and tutorial pair
- PolyOpticsExample walks four scenarios end-to-end.
- Tutorial21_PolymorphicOptics with seven tiered-hint exercises plus a diagnostic, following the existing tutorial style guide.
- Tutorial21_PolymorphicOptics_Solution with per-exercise teaching commentary in the Why-this-is-idiomatic / Alternative / Common-wrong- attempt format.

Documentation
- New hkj-book/src/optics/polymorphic_optics.md page that opens by pointing readers at the profunctor adapters for the common DTO / wrapper cases and reserves the polymorphic surface for the smaller set of cases where the type change is the operation.
- SUMMARY.md, ch3_intro.md, profunctor_optics.md and profunctor_optics_recipes.md cross-linked.
- Tutorials README.md and EXAMPLES-GUIDE.md updated.

Closes #508 