### PR TITLE
Validate PCollections × ListKind HKT compatibility (#440)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ eclipse-collections = "13.0.0"
 google-guava = "33.5.0-jre"
 apache-commons-collections4 = "4.5.0"
 vavr = "1.0.1"
+pcollections = "5.0.0"
 
 [libraries]
 # Core
@@ -132,6 +133,7 @@ eclipse-collections = { module = "org.eclipse.collections:eclipse-collections", 
 google-guava = { module = "com.google.guava:guava", version.ref = "google-guava" }
 apache-commons-collections4 = { module = "org.apache.commons:commons-collections4", version.ref = "apache-commons-collections4" }
 vavr = { module = "io.vavr:vavr", version.ref = "vavr" }
+pcollections = { module = "org.pcollections:pcollections", version.ref = "pcollections" }
 
 [plugins]
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/hkj-benchmarks/build.gradle.kts
+++ b/hkj-benchmarks/build.gradle.kts
@@ -15,6 +15,9 @@ dependencies {
   // Optional: Java Object Layout for allocation analysis
   jmhImplementation(libs.jol.core)
 
+  // PCollections — for HKT compatibility benchmarks (Phase 1)
+  jmhImplementation(libs.pcollections)
+
   // Test dependencies for benchmark assertions
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)
@@ -85,6 +88,17 @@ jmh {
 }
 
 tasks {
+  // Coerce a JMH JSON metric value to Double. JMH writes the literal string
+  // "NaN" / "Infinity" (instead of a JSON number) when a benchmark produced
+  // no usable measurement, which would otherwise crash a `value as Number` cast.
+  val asDouble = { v: Any? ->
+    when (v) {
+      is Number -> v.toDouble()
+      is String -> v.toDoubleOrNull() ?: Double.NaN
+      else -> Double.NaN
+    }
+  }
+
   // Short benchmarks for quick local feedback (default depths)
   register("shortBenchmark") {
     group = "benchmark"
@@ -146,11 +160,12 @@ tasks {
             val benchmark = (result["benchmark"] as String).substringAfterLast(".")
             @Suppress("UNCHECKED_CAST")
             val primaryMetric = result["primaryMetric"] as Map<String, Any>
-            val score = (primaryMetric["score"] as Number).toDouble()
-            val scoreError = (primaryMetric["scoreError"] as Number).toDouble()
+            val score = asDouble(primaryMetric["score"])
+            val scoreError = asDouble(primaryMetric["scoreError"])
             val scoreUnit = primaryMetric["scoreUnit"] as String
 
             val formattedScore = when {
+              score.isNaN() -> "NaN"
               score >= 1_000_000 -> "%.2f M".format(score / 1_000_000)
               score >= 1_000 -> "%.2f K".format(score / 1_000)
               else -> "%.2f".format(score)
@@ -199,14 +214,17 @@ tasks {
 
         results.sortedByDescending {
           @Suppress("UNCHECKED_CAST")
-          ((it["primaryMetric"] as Map<String, Any>)["score"] as Number).toDouble()
+          asDouble((it["primaryMetric"] as Map<String, Any>)["score"]).let {
+            if (it.isNaN()) Double.NEGATIVE_INFINITY else it
+          }
         }.forEach { result ->
           val benchmark = (result["benchmark"] as String)
             .removePrefix("org.higherkindedj.benchmarks.")
           @Suppress("UNCHECKED_CAST")
-          val score = ((result["primaryMetric"] as Map<String, Any>)["score"] as Number).toDouble()
+          val score = asDouble((result["primaryMetric"] as Map<String, Any>)["score"])
 
           val formattedScore = when {
+            score.isNaN() -> "NaN"
             score >= 1_000_000 -> "%,.0f M".format(score / 1_000_000)
             score >= 1_000 -> "%,.0f K".format(score / 1_000)
             else -> "%,.2f".format(score)

--- a/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/PCollectionsHktBenchmark.java
+++ b/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/PCollectionsHktBenchmark.java
@@ -1,0 +1,147 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListKindHelper;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalKindHelper;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+/**
+ * Phase 1 PCollections HKT compatibility benchmarks.
+ *
+ * <p>Compares {@code java.util.ArrayList} (the JDK reference) against PCollections {@link PVector}
+ * when both are widened into {@link ListKind} and processed through the existing HKT pipeline
+ * ({@link ListMonad}, {@link ListTraverse}). The goal is to quantify the cost of using persistent
+ * collections through the {@code java.util.List}-based widen/narrow boundary so that Phases 2 and 3
+ * can be evaluated against a baseline.
+ *
+ * <p>Run with: {@code ./gradlew :hkj-benchmarks:jmh -Pincludes=".*PCollectionsHktBenchmark.*"}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class PCollectionsHktBenchmark {
+
+  @Param({"10", "100", "1000"})
+  public int size;
+
+  private List<Integer> jdkList;
+  private PVector<Integer> pVector;
+
+  private Kind<ListKind.Witness, Integer> kindJdk;
+  private Kind<ListKind.Witness, Integer> kindPVector;
+
+  @Setup
+  public void setup() {
+    jdkList = new ArrayList<>(size);
+    PVector<Integer> v = TreePVector.empty();
+    for (int i = 0; i < size; i++) {
+      jdkList.add(i);
+      v = v.plus(i);
+    }
+    pVector = v;
+    kindJdk = ListKindHelper.LIST.widen(jdkList);
+    kindPVector = ListKindHelper.LIST.widen(pVector);
+  }
+
+  // ---------------------------------------------------------------------
+  // widen / narrow boundary cost
+  // ---------------------------------------------------------------------
+
+  @Benchmark
+  public List<Integer> widenNarrowJdk() {
+    Kind<ListKind.Witness, Integer> k = ListKindHelper.LIST.widen(jdkList);
+    return ListKindHelper.LIST.narrow(k);
+  }
+
+  @Benchmark
+  public List<Integer> widenNarrowPVector() {
+    Kind<ListKind.Witness, Integer> k = ListKindHelper.LIST.widen(pVector);
+    return ListKindHelper.LIST.narrow(k);
+  }
+
+  // ---------------------------------------------------------------------
+  // map
+  // ---------------------------------------------------------------------
+
+  @Benchmark
+  public Kind<ListKind.Witness, Integer> mapJdk() {
+    return ListMonad.INSTANCE.map(x -> x + 1, kindJdk);
+  }
+
+  @Benchmark
+  public Kind<ListKind.Witness, Integer> mapPVector() {
+    return ListMonad.INSTANCE.map(x -> x + 1, kindPVector);
+  }
+
+  // ---------------------------------------------------------------------
+  // flatMap
+  // ---------------------------------------------------------------------
+
+  @Benchmark
+  public Kind<ListKind.Witness, Integer> flatMapJdk() {
+    return ListMonad.INSTANCE.flatMap(x -> ListKindHelper.LIST.widen(List.of(x, x + 1)), kindJdk);
+  }
+
+  @Benchmark
+  public Kind<ListKind.Witness, Integer> flatMapPVector() {
+    return ListMonad.INSTANCE.flatMap(
+        x -> ListKindHelper.LIST.widen(TreePVector.from(List.of(x, x + 1))), kindPVector);
+  }
+
+  // ---------------------------------------------------------------------
+  // traverse with Optional applicative
+  // ---------------------------------------------------------------------
+
+  private static final Function<Integer, Kind<OptionalKind.Witness, Integer>> SAFE_INC =
+      i -> OptionalKindHelper.OPTIONAL.widen(Optional.of(i + 1));
+
+  @Benchmark
+  public Optional<List<Integer>> traverseJdk() {
+    Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> result =
+        ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, SAFE_INC, kindJdk);
+    return OptionalKindHelper.OPTIONAL.narrow(result).map(ListKindHelper.LIST::narrow);
+  }
+
+  @Benchmark
+  public Optional<List<Integer>> traversePVector() {
+    Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> result =
+        ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, SAFE_INC, kindPVector);
+    return OptionalKindHelper.OPTIONAL.narrow(result).map(ListKindHelper.LIST::narrow);
+  }
+
+  // ---------------------------------------------------------------------
+  // foldMap (sum)
+  // ---------------------------------------------------------------------
+
+  @Benchmark
+  public Integer foldMapJdk() {
+    return ListTraverse.INSTANCE.foldMap(Monoids.integerAddition(), i -> i, kindJdk);
+  }
+
+  @Benchmark
+  public Integer foldMapPVector() {
+    return ListTraverse.INSTANCE.foldMap(Monoids.integerAddition(), i -> i, kindPVector);
+  }
+}

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -250,6 +250,7 @@
   - [Compile-Time Checks](tooling/compile_checks.md)
   - [Diagnostics](tooling/diagnostics.md)
   - [Traversal Generator Plugins](tooling/generator_plugins.md)
+  - [PCollections Integration](tooling/pcollections_integration.md)
   - [Claude Code Skills](tooling/claude_code_skills.md)
   - [Testing With hkj-test](tooling/test_assertions.md)
 - [Spring Integration](spring/ch_intro.md)

--- a/hkj-book/src/benchmarks.md
+++ b/hkj-book/src/benchmarks.md
@@ -132,13 +132,15 @@ EitherBenchmark.leftMap                    thrpt   20  89.123 ± 1.234  ops/us
 
 | Signal | Meaning |
 |--------|---------|
-| Left/Nothing operations 5-10x faster than Right/Just | Instance reuse is working |
+| Left/Nothing operations 5-40x faster than Right/Just | Instance reuse is working |
 | VTask ~10-30% slower than IO for simple ops | Expected virtual thread overhead |
+| VTask blocking I/O 10x+ faster than platform threads at scale | Virtual thread scheduler scaling |
 | Deep chain (50+ steps) completes without error | Stack safety is intact |
 | VStream slower than Java Stream | Expected; virtual thread + pull overhead |
 | parEvalMap scales with concurrency for I/O | Parallel pipeline working correctly |
 | Scope joiners similar speed to Par.all | Minimal Scope abstraction cost |
 | Wrapper overhead < 15% | Acceptable Path wrapper cost |
+| PVector via ListKind 30-70% the throughput of ArrayList | Persistent collection iteration tax |
 
 ### Warning Signs
 
@@ -163,17 +165,24 @@ These types use **instance reuse**: `Left` and `Nothing` operations return the s
 | `leftMap` vs `rightMap` | Left 5-10x faster |
 | `nothingMap` vs `justMap` | Nothing 5-10x faster |
 | `leftLongChain` vs `rightLongChain` | Left 10-50x faster |
+| `constructNothing` vs `constructJust` | Singleton reuse can reach 30-40x |
+
+The "construct" pair is the strongest signal that allocation, not branching, dominates the gap. `constructNothing` returns the cached singleton, whereas `constructJust` allocates a fresh wrapper. On hot paths producing many `Just` or `Right` values, that allocation cost is real.
 
 ### VTask
 
-Virtual thread overhead is the dominant cost for simple operations. For real workloads involving I/O, this overhead is negligible.
+Virtual thread overhead is the dominant cost for simple operations. For real workloads involving I/O, this overhead is negligible, and the scheduling story flips dramatically in VTask's favour.
 
 | Comparison | Expected |
 |------------|----------|
 | Construction (succeed, delay) | Very fast (~100+ ops/us) |
 | VTask vs IO (simple execution) | VTask ~10-30% slower |
 | Deep chains (50+) | Completes without error |
-| High concurrency (1000+ tasks) | VTask scales better than platform threads |
+| Blocking I/O at concurrency 10 | Roughly equivalent to platform threads |
+| Blocking I/O at concurrency 100 | VTask ~3-4x faster |
+| Blocking I/O at concurrency 1000 | VTask 15-20x faster |
+
+The blocking I/O numbers come from `VTaskVsPlatformThreadsBenchmark`. Platform throughput collapses as concurrency grows because OS threads become the bottleneck; virtual thread throughput stays roughly flat because the scheduler parks blocked carriers freely. This is the strongest single argument for VTask in I/O-bound workloads.
 
 ### VStream
 
@@ -194,6 +203,30 @@ VStream's pull-based model adds overhead per element compared to Java Stream's p
 | VTaskPath vs raw VTask | 5-15% |
 | IOPath vs raw IO | 5-15% |
 | ForPath vs direct chaining | 10-25% |
+
+### PCollections via `ListKind`
+
+`PCollectionsHktBenchmark` measures `PVector` against `ArrayList` when both are processed through the standard `ListMonad`/`ListTraverse` pipeline. The widen/narrow boundary itself is free; the cost lives in iteration.
+
+| Comparison | Expected Ratio |
+|------------|---------------|
+| `widenNarrow` PVector vs ArrayList | Indistinguishable, both at the JMH ceiling |
+| `map` / `flatMap` / `foldMap` PVector vs ArrayList | PVector 30-40% the throughput |
+| `traverse` PVector vs ArrayList | PVector ~70% the throughput |
+
+The traverse case is the headline result. The more applicative work an operation does per element, the smaller the gap, because applicative `map2` and `Kind` boxing dominate the underlying iteration cost. See [PCollections Integration](tooling/pcollections_integration.md) for the full table and methodology.
+
+### Free Monad
+
+`Free` trades raw speed for program-as-data: a `Free` programme can be inspected, transformed, or interpreted multiple ways before it is run. That flexibility costs at least three orders of magnitude versus direct function composition.
+
+| Comparison | Expected Ratio |
+|------------|---------------|
+| `directComposition` vs `deepChainExecution` | Direct ~3-4 orders of magnitude faster |
+| `pureTrampolineIntegration` vs `flatMappedTrampolineIntegration` | Pure ~100x faster |
+| `programConstruction` vs `sequentialInterpretation` | Construction far cheaper than interpretation |
+
+If a workload is on a hot path and does not benefit from inspection or alternative interpreters, prefer direct composition. `Free` shines when the same programme is interpreted multiple ways, when the structure is analysed before execution, or when the alternatives would require substantial duplication.
 
 ---
 
@@ -282,10 +315,11 @@ After a successful run, reports are available at:
 
 The benchmarks consistently show that abstraction overhead is measured in **nanoseconds**. Real-world operations — database queries, HTTP calls, file reads — are measured in **milliseconds**. The overhead is three to four orders of magnitude smaller than any I/O operation.
 
-Abstraction overhead matters in exactly two scenarios:
+Abstraction overhead matters in exactly three scenarios:
 
-1. **Tight computational loops** processing millions of items per second with no I/O — use primitives directly
-2. **Very long chains** (hundreds of steps) creating GC pressure — break into named submethods
+1. **Tight computational loops** processing millions of items per second with no I/O. Use primitives directly.
+2. **Very long chains** (hundreds of steps) creating GC pressure. Break into named submethods.
+3. **Reflexive parallelism on trivial work.** `VTaskParBenchmark` shows `par*` variants running thousands of times slower than their sequential equivalents when the per-task work is negligible. Forking, joining, and synchronising all cost more than a few-nanosecond computation. Reach for `Par.zip`, `Par.map2`, or `Scope` only when each branch does enough work to amortise the structured-concurrency cost.
 
 For everything else, the type safety, composability, and testability benefits far outweigh the cost.
 

--- a/hkj-book/src/tooling/claude_code_skills.md
+++ b/hkj-book/src/tooling/claude_code_skills.md
@@ -203,5 +203,5 @@ Add to `.gitignore` only if your team prefers not to commit generated files. In 
 
 ---
 
-**Previous:** [Traversal Generator Plugins](generator_plugins.md)
+**Previous:** [PCollections Integration](pcollections_integration.md)
 **Next:** [Integration Guides](../spring/ch_intro.md)

--- a/hkj-book/src/tooling/generator_plugins.md
+++ b/hkj-book/src/tooling/generator_plugins.md
@@ -329,4 +329,4 @@ The `TraversalProcessor` will now discover your `NonEmptyListGenerator` via `Ser
 ---
 
 **Previous:** [Diagnostics](diagnostics.md)
-**Next:** [Claude Code Skills](claude_code_skills.md)
+**Next:** [PCollections Integration](pcollections_integration.md)

--- a/hkj-book/src/tooling/pcollections_integration.md
+++ b/hkj-book/src/tooling/pcollections_integration.md
@@ -1,0 +1,183 @@
+# PCollections Integration
+
+~~~admonish info title="What You'll Learn"
+- How PCollections persistent collections plug into Higher-Kinded-J via the existing `ListKind`
+- The performance characteristics of `PVector` versus `ArrayList` through the HKT pipeline
+- Which operations amortise PCollections' iteration cost and which expose it
+- How to add PCollections to your own project as an opt-in dependency
+~~~
+
+[PCollections](https://pcollections.org/) is a small, lightweight library of persistent immutable
+data structures whose types implement the standard `java.util` interfaces. `PVector` implements
+`List`, `PStack` implements `List`, `PSet` implements `Set`, and so on. That `java.util`
+compatibility makes PCollections a particularly easy fit for Higher-Kinded-J: any `PVector` or
+`PStack` can be widened directly into the existing `ListKind` and processed through `ListMonad`,
+`ListTraverse`, and `ListSelective` with no production code changes.
+
+This page describes the Phase 1 integration: a purely additive set of tests, benchmarks, and
+documentation that validate the compatibility hypothesis. No new HKT types or instances are
+introduced. Phase 2 adds optics generator plugins for `PVector`, `PStack`, `PSet`, `PBag`, and
+`PMap`; Phase 3 adds dedicated `Kind`/`Witness` types so persistent collections survive the entire
+HKT pipeline.
+
+---
+
+## What's in Phase 1
+
+| Artefact | Location |
+|----------|----------|
+| Version pin | `gradle/libs.versions.toml` (`pcollections = "5.0.0"`) |
+| Integration test | `hkj-core/src/test/.../list/pcollections/PCollectionsListIntegrationTest.java` |
+| jQwik property test | `hkj-core/src/test/.../list/pcollections/PCollectionsListPropertyTest.java` |
+| JMH benchmarks | `hkj-benchmarks/src/jmh/.../PCollectionsHktBenchmark.java` |
+| Runnable example | `hkj-examples/.../basic/pcollections/PCollectionsExample.java` |
+
+---
+
+## Adding PCollections to a Project That Already Uses Higher-Kinded-J
+
+PCollections is not a transitive dependency of `hkj-core`. Phase 1 wires it in only as a
+`testImplementation`. Application code that wants to use the integration must add it explicitly:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("org.pcollections:pcollections:5.0.0")
+    implementation("io.github.higher-kinded-j:hkj-core:<version>")
+}
+```
+
+If you also use the Java module system, add `requires org.pcollections;` to your `module-info.java`.
+
+---
+
+## Using PCollections Through `ListKind`
+
+Because `PVector` and `PStack` are `java.util.List` instances, the existing `ListKindHelper.LIST`
+helper widens them with no special API:
+
+```java
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+PVector<Integer> source = TreePVector.from(List.of(1, 2, 3));
+Kind<ListKind.Witness, Integer> kind = LIST.widen(source);
+
+Kind<ListKind.Witness, Integer> doubled = ListMonad.INSTANCE.map(x -> x * 2, kind);
+List<Integer> result = LIST.narrow(doubled); // java.util.List, not PVector
+```
+
+The same code accepts a `PStack`, an `ArrayList`, or any other `List` implementation. The
+widen/narrow boundary is structural rather than nominal.
+
+---
+
+## Phase 1 Caveat: Persistent Type Is Not Preserved End-to-End
+
+`ListMonad.of` and the standard `map`/`flatMap` implementations produce `java.util.List`
+instances internally, typically `Collections.singletonList` or a fresh `ArrayList`. That means a
+pipeline of the form:
+
+```java
+PVector<Integer> in = TreePVector.from(...);
+Kind<ListKind.Witness, Integer> out = ListMonad.INSTANCE.map(x -> x + 1, LIST.widen(in));
+List<Integer> narrowed = LIST.narrow(out); // not a PVector anymore
+```
+
+returns a JDK list, not a `PVector`. Round-tripping a `PVector` without any operation preserves
+the underlying instance (`narrowed == in`); only transformations widen back to `java.util.List`.
+Preserving the persistent type through the entire HKT pipeline is the goal of Phase 3.
+
+---
+
+## Performance Characteristics
+
+The headline finding from `PCollectionsHktBenchmark` is that **the widen/narrow boundary is free
+for both libraries**, and PCollections pays a structural iteration tax that **shrinks as the
+operation does more per-element work**.
+
+Throughput at size 1000, in operations per microsecond (higher is better):
+
+| Operation | `ArrayList` | `PVector` | `PVector / ArrayList` |
+|-----------|------------|-----------|-----------------------|
+| `widen` + `narrow` | 2.57 K | 2.57 K | 1.00 |
+| `traverse` (Optional applicative) | 0.10 | 0.07 | 0.70 |
+| `map` | 0.34 | 0.13 | 0.38 |
+| `foldMap` (sum monoid) | 0.44 | 0.14 | 0.32 |
+| `flatMap` | 0.07 | 0.02 | 0.29 |
+
+Two observations are worth flagging:
+
+- **The boundary is genuinely free.** Both `widen + narrow` benchmarks hit the same throughput
+  ceiling regardless of whether the underlying list is an `ArrayList` or a `TreePVector`,
+  confirming that `ListHolder` does not defensive-copy.
+- **`traverse` is the narrowest gap, not the widest.** Counterintuitively, the more "monadic" the
+  operation, the smaller the PCollections overhead becomes. `traverse` dominates the per-element
+  cost with applicative `map2` and `Kind` boxing, so the underlying iteration delta becomes a
+  small fraction of total time. This is good news: the operation shapes Higher-Kinded-J users
+  reach for most often are precisely the ones where PCollections costs least.
+
+`flatMap` shows the widest gap because each call also allocates a fresh `TreePVector` inside the
+lambda. That reconstruction cost is part of the measurement, not pure iteration overhead.
+
+To reproduce:
+
+```sh
+./gradlew :hkj-benchmarks:jmh -Pincludes=".*PCollectionsHktBenchmark.*"
+./gradlew :hkj-benchmarks:benchmarkReport
+```
+
+The fast-feedback configuration (one fork, one warmup, one measurement iteration) leaves error
+bars as `NaN`. For numbers worth citing externally, use `-Pjmh.warmupIterations=2
+-Pjmh.iterations=3`.
+
+---
+
+## What the Tests Cover
+
+`PCollectionsListIntegrationTest` exercises:
+
+- `widen`/`narrow` round-trips for `PVector` and `PStack`, including instance preservation
+- Functor `map` over `PVector` and `PStack`
+- Monad `flatMap` and `ap`, mixing `PVector` and `PStack` inputs
+- `Traverse` with the `Optional` applicative, covering both success and short-circuit cases
+- `Foldable.foldMap` with the sum and string monoids
+- `Selective.select` over a `PVector` of `Choice` values
+- `Alternative` (`empty`, `orElse`) composing PCollections lists with each other
+
+`PCollectionsListPropertyTest` uses jQwik to verify, across randomised inputs, that the standard
+laws hold for `PVector` widened through `ListKind`:
+
+- Functor identity and composition
+- Monad left identity, right identity, and associativity
+- Foldable: `foldMap` matches `stream().sum()`, and is a monoid homomorphism over concatenation
+
+---
+
+~~~admonish example title="See Example Code"
+[PCollectionsExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/basic/pcollections/PCollectionsExample.java)
+~~~
+
+~~~admonish info title="Key Takeaways"
+* **`PVector` and `PStack` work through `ListKind` with no production code changes**, because they implement `java.util.List`
+* **The widen/narrow boundary is free**, with no defensive copying in either direction
+* **PCollections pays a 2 to 3 times iteration tax** on `map`, `flatMap`, and `foldMap` compared to `ArrayList`
+* **The tax shrinks for richer operations**: `traverse` is only 30% slower because per-element applicative work dominates
+* **Operations return `java.util.List`**, not the original persistent type. Phase 3 is where end-to-end type preservation lands
+~~~
+
+~~~admonish tip title="See Also"
+- [Benchmarks and Performance](../benchmarks.md) - The full benchmark suite and how to read its output
+- [Traversal Generator Plugins](generator_plugins.md) - Phase 2 will add PCollections support to `@GenerateTraversals`
+- [List Type Class Instances](../monads/list_monad.md) - The instances PCollections piggy-backs on
+~~~
+
+---
+
+**Previous:** [Traversal Generator Plugins](generator_plugins.md)
+**Next:** [Claude Code Skills](claude_code_skills.md)

--- a/hkj-core/build.gradle.kts
+++ b/hkj-core/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
   testImplementation(libs.awaitility)
   testImplementation(libs.bundles.jqwik)
   testImplementation(libs.archunit.junit5)
+
+  // PCollections — validates java.util.List/Set HKT compatibility (Phase 1)
+  testImplementation(libs.pcollections)
 }
 
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/pcollections/PCollectionsListIntegrationTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/pcollections/PCollectionsListIntegrationTest.java
@@ -1,0 +1,304 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.list.pcollections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Alternative;
+import org.higherkindedj.hkt.Choice;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.hkt.Selective;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListSelective;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pcollections.ConsPStack;
+import org.pcollections.PStack;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+/**
+ * Validates that PCollections persistent data structures interoperate with the existing {@code
+ * ListKind} HKT infrastructure via {@code java.util.List} compatibility.
+ *
+ * <p>PCollections types ({@link PVector}, {@link PStack}) extend {@link java.util.List}, so the
+ * existing {@link org.higherkindedj.hkt.list.ListKindHelper#widen widen}/{@link
+ * org.higherkindedj.hkt.list.ListKindHelper#narrow narrow} pair accepts and produces them with no
+ * production code changes.
+ *
+ * <p>Note that operations such as {@code map}/{@code flatMap}/{@code of} return a {@code
+ * java.util.List} (currently a {@code Collections.singletonList} or {@code ArrayList}) and
+ * therefore lose the persistent type. Phase 1's purpose is to confirm that pipeline correctness
+ * holds; preserving persistent types end-to-end is the subject of later phases.
+ */
+@DisplayName("PCollections × ListKind integration (Phase 1)")
+class PCollectionsListIntegrationTest {
+
+  // ---------------------------------------------------------------------
+  // widen / narrow round-trips
+  // ---------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("widen / narrow round-trip")
+  class WidenNarrow {
+
+    @Test
+    @DisplayName("PVector widens and narrows preserving content and identity")
+    void pVectorRoundTrip() {
+      PVector<Integer> source = TreePVector.from(List.of(1, 2, 3, 4));
+      Kind<ListKind.Witness, Integer> widened = LIST.widen(source);
+      List<Integer> narrowed = LIST.narrow(widened);
+
+      assertThat(narrowed).containsExactly(1, 2, 3, 4);
+      // No defensive copy: the underlying List instance is preserved.
+      assertThat(narrowed).isSameAs(source);
+      assertThat(narrowed).isInstanceOf(PVector.class);
+    }
+
+    @Test
+    @DisplayName("PStack widens and narrows preserving content and identity")
+    void pStackRoundTrip() {
+      PStack<String> source = ConsPStack.from(List.of("a", "b", "c"));
+      Kind<ListKind.Witness, String> widened = LIST.widen(source);
+      List<String> narrowed = LIST.narrow(widened);
+
+      assertThat(narrowed).containsExactly("a", "b", "c");
+      assertThat(narrowed).isSameAs(source);
+      assertThat(narrowed).isInstanceOf(PStack.class);
+    }
+
+    @Test
+    @DisplayName("Empty PVector widens and narrows correctly")
+    void emptyPVectorRoundTrip() {
+      PVector<Integer> empty = TreePVector.empty();
+      Kind<ListKind.Witness, Integer> widened = LIST.widen(empty);
+
+      assertThat(LIST.narrow(widened)).isEmpty();
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Functor
+  // ---------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Functor operations via ListMonad")
+  class FunctorOps {
+
+    @Test
+    @DisplayName("map applies function to PVector elements")
+    void mapPVector() {
+      PVector<Integer> input = TreePVector.from(List.of(1, 2, 3));
+      Kind<ListKind.Witness, Integer> kind = LIST.widen(input);
+
+      Kind<ListKind.Witness, Integer> mapped = ListMonad.INSTANCE.map(x -> x * 10, kind);
+
+      assertThat(LIST.narrow(mapped)).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    @DisplayName("map applies function to PStack elements")
+    void mapPStack() {
+      PStack<String> input = ConsPStack.from(List.of("a", "b"));
+      Kind<ListKind.Witness, String> kind = LIST.widen(input);
+
+      Kind<ListKind.Witness, String> mapped = ListMonad.INSTANCE.map(String::toUpperCase, kind);
+
+      assertThat(LIST.narrow(mapped)).containsExactly("A", "B");
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Monad
+  // ---------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Monad operations via ListMonad")
+  class MonadOps {
+
+    @Test
+    @DisplayName("flatMap on PVector chains and flattens correctly")
+    void flatMapPVector() {
+      PVector<Integer> input = TreePVector.from(List.of(1, 2));
+      Kind<ListKind.Witness, Integer> kind = LIST.widen(input);
+
+      Function<Integer, Kind<ListKind.Witness, String>> dup =
+          i -> LIST.widen(TreePVector.from(List.of("v" + i, "v" + i)));
+
+      Kind<ListKind.Witness, String> result = ListMonad.INSTANCE.flatMap(dup, kind);
+
+      assertThat(LIST.narrow(result)).containsExactly("v1", "v1", "v2", "v2");
+    }
+
+    @Test
+    @DisplayName("ap with PVector of functions and PVector of values")
+    void apPVector() {
+      Kind<ListKind.Witness, Function<Integer, String>> ff =
+          LIST.widen(TreePVector.from(List.of(i -> "n" + i, i -> "x" + (i * 2))));
+      Kind<ListKind.Witness, Integer> fa = LIST.widen(TreePVector.from(List.of(1, 2)));
+
+      Kind<ListKind.Witness, String> result = ListMonad.INSTANCE.ap(ff, fa);
+
+      assertThat(LIST.narrow(result)).containsExactly("n1", "n2", "x2", "x4");
+    }
+
+    @Test
+    @DisplayName("Mixed PVector and PStack in flatMap")
+    void mixedPVectorPStack() {
+      Kind<ListKind.Witness, Integer> input = LIST.widen(TreePVector.from(List.of(1, 2, 3)));
+
+      Function<Integer, Kind<ListKind.Witness, Integer>> repeatViaPStack =
+          i -> LIST.widen(ConsPStack.from(List.of(i, i)));
+
+      Kind<ListKind.Witness, Integer> result = ListMonad.INSTANCE.flatMap(repeatViaPStack, input);
+
+      assertThat(LIST.narrow(result)).containsExactly(1, 1, 2, 2, 3, 3);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Traverse / Foldable
+  // ---------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Traverse and Foldable via ListTraverse")
+  class TraverseOps {
+
+    @Test
+    @DisplayName("traverse over PVector with Optional applicative — all present")
+    void traversePVectorAllPresent() {
+      Kind<ListKind.Witness, Integer> input = LIST.widen(TreePVector.from(List.of(1, 2, 3)));
+
+      Function<Integer, Kind<OptionalKind.Witness, Integer>> safeInc =
+          i -> OPTIONAL.widen(Optional.of(i + 1));
+
+      Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> result =
+          ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, safeInc, input);
+
+      Optional<List<Integer>> narrowed = OPTIONAL.narrow(result).map(LIST::narrow);
+      assertThat(narrowed).hasValue(List.of(2, 3, 4));
+    }
+
+    @Test
+    @DisplayName("traverse over PVector short-circuits on Optional.empty()")
+    void traversePVectorShortCircuits() {
+      Kind<ListKind.Witness, Integer> input = LIST.widen(TreePVector.from(List.of(1, 2, 3)));
+
+      Function<Integer, Kind<OptionalKind.Witness, Integer>> failOnTwo =
+          i -> OPTIONAL.widen(i == 2 ? Optional.empty() : Optional.of(i));
+
+      Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> result =
+          ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, failOnTwo, input);
+
+      assertThat(OPTIONAL.narrow(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("foldMap with sum monoid over PVector")
+    void foldMapSumPVector() {
+      Kind<ListKind.Witness, Integer> input = LIST.widen(TreePVector.from(List.of(1, 2, 3, 4)));
+
+      Integer sum = ListTraverse.INSTANCE.foldMap(Monoids.integerAddition(), i -> i, input);
+
+      assertThat(sum).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("foldMap with string concatenation over PStack")
+    void foldMapStringPStack() {
+      Kind<ListKind.Witness, String> input = LIST.widen(ConsPStack.from(List.of("a", "b", "c")));
+
+      String concat = ListTraverse.INSTANCE.foldMap(Monoids.string(), s -> s, input);
+
+      assertThat(concat).isEqualTo("abc");
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Selective
+  // ---------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Selective operations via ListSelective")
+  class SelectiveOps {
+
+    @Test
+    @DisplayName("select over PVector handles Right values directly")
+    void selectPVectorAllRight() {
+      PVector<Choice<Integer, String>> choices =
+          TreePVector.<Choice<Integer, String>>empty()
+              .plus(Selective.<Integer, String>right("A"))
+              .plus(Selective.<Integer, String>right("B"));
+
+      Kind<ListKind.Witness, Choice<Integer, String>> fab = LIST.widen(choices);
+      Kind<ListKind.Witness, Function<Integer, String>> ff =
+          LIST.widen(TreePVector.from(List.of(i -> "N" + i)));
+
+      Kind<ListKind.Witness, String> result = ListSelective.INSTANCE.select(fab, ff);
+
+      assertThat(LIST.narrow(result)).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("select over PVector applies functions to Left values")
+    void selectPVectorMixedChoices() {
+      PVector<Choice<Integer, String>> choices =
+          TreePVector.<Choice<Integer, String>>empty()
+              .plus(Selective.<Integer, String>left(1))
+              .plus(Selective.<Integer, String>right("X"))
+              .plus(Selective.<Integer, String>left(2));
+
+      Kind<ListKind.Witness, Choice<Integer, String>> fab = LIST.widen(choices);
+      Kind<ListKind.Witness, Function<Integer, String>> ff =
+          LIST.widen(TreePVector.from(List.of(i -> "N" + i)));
+
+      Kind<ListKind.Witness, String> result = ListSelective.INSTANCE.select(fab, ff);
+
+      assertThat(LIST.narrow(result)).containsExactly("N1", "X", "N2");
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Alternative
+  // ---------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Alternative operations via ListMonad")
+  class AlternativeOps {
+
+    private final Alternative<ListKind.Witness> alt = ListMonad.INSTANCE;
+
+    @Test
+    @DisplayName("orElse concatenates a PVector with a PStack alternative")
+    void orElseConcatenatesPVectorAndPStack() {
+      Kind<ListKind.Witness, Integer> primary = LIST.widen(TreePVector.from(List.of(1, 2)));
+      Kind<ListKind.Witness, Integer> fallback = LIST.widen(ConsPStack.from(List.of(3, 4)));
+
+      Kind<ListKind.Witness, Integer> result = alt.orElse(primary, () -> fallback);
+
+      assertThat(LIST.narrow(result)).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("empty() composes with PVector via orElse")
+    void emptyComposesWithPVector() {
+      Kind<ListKind.Witness, Integer> primary = alt.empty();
+      Kind<ListKind.Witness, Integer> fallback = LIST.widen(TreePVector.from(List.of(7, 8, 9)));
+
+      Kind<ListKind.Witness, Integer> result = alt.orElse(primary, () -> fallback);
+
+      assertThat(LIST.narrow(result)).containsExactly(7, 8, 9);
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/pcollections/PCollectionsListPropertyTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/pcollections/PCollectionsListPropertyTest.java
@@ -1,0 +1,175 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.list.pcollections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+
+import java.util.List;
+import java.util.function.Function;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.constraints.IntRange;
+import net.jqwik.api.constraints.Size;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+/**
+ * Property-based tests confirming that the standard {@link ListMonad} / {@link ListTraverse}
+ * Functor, Monad, and Foldable laws continue to hold when the underlying {@link java.util.List} is
+ * a PCollections {@link PVector}.
+ *
+ * <p>This is the property-test counterpart to {@link PCollectionsListIntegrationTest}: it exercises
+ * the same compatibility hypothesis across many randomised inputs.
+ */
+class PCollectionsListPropertyTest {
+
+  private final ListMonad monad = ListMonad.INSTANCE;
+  private final ListTraverse traverse = ListTraverse.INSTANCE;
+
+  // ---------------------------------------------------------------------
+  // Arbitraries
+  // ---------------------------------------------------------------------
+
+  @Provide
+  Arbitrary<PVector<Integer>> pvectorInts() {
+    return Arbitraries.integers()
+        .between(-50, 50)
+        .list()
+        .ofMinSize(0)
+        .ofMaxSize(20)
+        .map(TreePVector::from);
+  }
+
+  @Provide
+  Arbitrary<Function<Integer, Integer>> intToInt() {
+    return Arbitraries.of(
+        i -> i + 1, i -> i * 2, i -> -i, i -> i % 7, Function.<Integer>identity());
+  }
+
+  @Provide
+  Arbitrary<Function<Integer, Kind<ListKind.Witness, Integer>>> intToKindList() {
+    return Arbitraries.of(
+        (Function<Integer, Kind<ListKind.Witness, Integer>>)
+            i -> LIST.widen(TreePVector.from(List.of(i, i + 1))),
+        i -> LIST.widen(TreePVector.from(List.of(i * 10))),
+        i -> LIST.widen(TreePVector.<Integer>empty()),
+        i -> LIST.widen(TreePVector.from(List.of(i, -i, i * i))));
+  }
+
+  @Provide
+  Arbitrary<Function<Integer, Kind<ListKind.Witness, Integer>>> intToKindListSecondary() {
+    return Arbitraries.of(
+        (Function<Integer, Kind<ListKind.Witness, Integer>>)
+            i -> LIST.widen(TreePVector.from(List.of(i + 100))),
+        i -> LIST.widen(TreePVector.from(List.of(i, i))),
+        i -> LIST.widen(TreePVector.<Integer>empty()));
+  }
+
+  // ---------------------------------------------------------------------
+  // Functor laws
+  // ---------------------------------------------------------------------
+
+  @Property
+  @Label("Functor identity: map(id, pv) = pv")
+  void functorIdentity(@ForAll("pvectorInts") PVector<Integer> pv) {
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(pv);
+
+    Kind<ListKind.Witness, Integer> mapped = monad.map(Function.identity(), kind);
+
+    assertThat(LIST.narrow(mapped)).containsExactlyElementsOf(pv);
+  }
+
+  @Property
+  @Label("Functor composition: map(g . f, pv) = map(g, map(f, pv))")
+  void functorComposition(
+      @ForAll("pvectorInts") PVector<Integer> pv,
+      @ForAll("intToInt") Function<Integer, Integer> f,
+      @ForAll("intToInt") Function<Integer, Integer> g) {
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(pv);
+
+    Kind<ListKind.Witness, Integer> lhs = monad.map(f.andThen(g), kind);
+    Kind<ListKind.Witness, Integer> rhs = monad.map(g, monad.map(f, kind));
+
+    assertThat(LIST.narrow(lhs)).containsExactlyElementsOf(LIST.narrow(rhs));
+  }
+
+  // ---------------------------------------------------------------------
+  // Monad laws
+  // ---------------------------------------------------------------------
+
+  @Property
+  @Label("Monad left identity: flatMap(of(a), f) = f(a)")
+  void leftIdentity(
+      @ForAll @IntRange(min = -50, max = 50) int value,
+      @ForAll("intToKindList") Function<Integer, Kind<ListKind.Witness, Integer>> f) {
+
+    Kind<ListKind.Witness, Integer> lhs = monad.flatMap(f, monad.of(value));
+    Kind<ListKind.Witness, Integer> rhs = f.apply(value);
+
+    assertThat(LIST.narrow(lhs)).containsExactlyElementsOf(LIST.narrow(rhs));
+  }
+
+  @Property
+  @Label("Monad right identity: flatMap(pv, of) = pv")
+  void rightIdentity(@ForAll("pvectorInts") PVector<Integer> pv) {
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(pv);
+
+    Kind<ListKind.Witness, Integer> result = monad.flatMap(monad::of, kind);
+
+    assertThat(LIST.narrow(result)).containsExactlyElementsOf(pv);
+  }
+
+  @Property
+  @Label("Monad associativity: flatMap(flatMap(pv, f), g) = flatMap(pv, x -> flatMap(f(x), g))")
+  void associativity(
+      @ForAll("pvectorInts") @Size(max = 8) PVector<Integer> pv,
+      @ForAll("intToKindList") Function<Integer, Kind<ListKind.Witness, Integer>> f,
+      @ForAll("intToKindListSecondary") Function<Integer, Kind<ListKind.Witness, Integer>> g) {
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(pv);
+
+    Kind<ListKind.Witness, Integer> lhs = monad.flatMap(g, monad.flatMap(f, kind));
+    Kind<ListKind.Witness, Integer> rhs = monad.flatMap(x -> monad.flatMap(g, f.apply(x)), kind);
+
+    assertThat(LIST.narrow(lhs)).containsExactlyElementsOf(LIST.narrow(rhs));
+  }
+
+  // ---------------------------------------------------------------------
+  // Foldable laws
+  // ---------------------------------------------------------------------
+
+  @Property
+  @Label("foldMap with sum monoid equals java.util.stream sum")
+  void foldMapSumMatchesStream(@ForAll("pvectorInts") PVector<Integer> pv) {
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(pv);
+
+    int viaFoldMap = traverse.foldMap(Monoids.integerAddition(), i -> i, kind);
+    int viaStream = pv.stream().mapToInt(Integer::intValue).sum();
+
+    assertThat(viaFoldMap).isEqualTo(viaStream);
+  }
+
+  @Property
+  @Label(
+      "foldMap is a monoid homomorphism: foldMap(f) of (xs ++ ys) = foldMap(f, xs) <> foldMap(f, ys)")
+  void foldMapMonoidHomomorphism(
+      @ForAll("pvectorInts") PVector<Integer> xs, @ForAll("pvectorInts") PVector<Integer> ys) {
+    PVector<Integer> combined = xs.plusAll(ys);
+
+    int lhs = traverse.foldMap(Monoids.integerAddition(), i -> i, LIST.widen(combined));
+    int rhs =
+        traverse.foldMap(Monoids.integerAddition(), i -> i, LIST.widen(xs))
+            + traverse.foldMap(Monoids.integerAddition(), i -> i, LIST.widen(ys));
+
+    assertThat(lhs).isEqualTo(rhs);
+  }
+}

--- a/hkj-examples/build.gradle.kts
+++ b/hkj-examples/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
     // Eclipse Collections for cross-ecosystem portfolio risk example
     implementation(libs.eclipse.collections)
 
+    // PCollections for the persistent-collections HKT compatibility example (Phase 1)
+    implementation(libs.pcollections)
+
     // Testing dependencies for tutorials
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)

--- a/hkj-examples/src/main/java/module-info.java
+++ b/hkj-examples/src/main/java/module-info.java
@@ -17,6 +17,9 @@ module org.higherkindedj.examples {
   requires org.eclipse.collections.api;
   requires org.eclipse.collections.impl;
 
+  // PCollections for the persistent-collections HKT compatibility example
+  requires org.pcollections;
+
   // Export spec interface examples for external types
   exports org.higherkindedj.example.optics.external;
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/pcollections/PCollectionsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/pcollections/PCollectionsExample.java
@@ -1,0 +1,114 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.basic.pcollections;
+
+import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
+import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoids;
+import org.higherkindedj.hkt.list.ListKind;
+import org.higherkindedj.hkt.list.ListMonad;
+import org.higherkindedj.hkt.list.ListTraverse;
+import org.higherkindedj.hkt.optional.OptionalKind;
+import org.higherkindedj.hkt.optional.OptionalMonad;
+import org.pcollections.ConsPStack;
+import org.pcollections.PStack;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+/**
+ * Demonstrates that PCollections persistent data structures interoperate with the existing {@code
+ * ListKind} HKT pipeline through their {@link java.util.List} compatibility.
+ *
+ * <p>Run with:
+ *
+ * <pre>{@code
+ * ./gradlew :hkj-examples:run -PmainClass=org.higherkindedj.example.basic.pcollections.PCollectionsExample
+ * }</pre>
+ *
+ * <p>Phase 1 caveat: although a {@link PVector} or {@link PStack} can be widened directly into
+ * {@link ListKind}, operations like {@code map} and {@code flatMap} return a JDK {@link List}.
+ * Preserving the persistent type end-to-end is the subject of later phases.
+ */
+public final class PCollectionsExample {
+
+  private PCollectionsExample() {}
+
+  public static void main(String[] args) {
+    System.out.println("=== PCollections × Higher-Kinded-J (Phase 1) ===\n");
+
+    widenAndMap();
+    flatMapAcrossPVectorAndPStack();
+    traverseValidatesEntireVector();
+    foldMapAggregates();
+  }
+
+  /** Wrap a {@link PVector} as a {@code Kind<ListKind.Witness, A>} and map a function over it. */
+  private static void widenAndMap() {
+    System.out.println("--- Functor: map over a PVector ---");
+
+    PVector<Integer> prices = TreePVector.from(List.of(100, 250, 999));
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(prices);
+
+    Kind<ListKind.Witness, String> formatted =
+        ListMonad.INSTANCE.map(p -> String.format("£%.2f", p / 100.0), kind);
+
+    System.out.println("source PVector  : " + prices);
+    System.out.println("after map (List): " + LIST.narrow(formatted));
+    System.out.println();
+  }
+
+  /** flatMap can mix PVector and PStack inputs without any code change. */
+  private static void flatMapAcrossPVectorAndPStack() {
+    System.out.println("--- Monad: flatMap mixing PVector and PStack ---");
+
+    Kind<ListKind.Witness, Integer> orders = LIST.widen(TreePVector.from(List.of(1, 2, 3)));
+
+    Function<Integer, Kind<ListKind.Witness, String>> expandViaPStack =
+        id -> LIST.widen(ConsPStack.from(List.of("order-" + id + "-A", "order-" + id + "-B")));
+
+    Kind<ListKind.Witness, String> expanded = ListMonad.INSTANCE.flatMap(expandViaPStack, orders);
+
+    System.out.println("orders   : " + LIST.narrow(orders));
+    System.out.println("expanded : " + LIST.narrow(expanded));
+    System.out.println();
+  }
+
+  /** traverse over a PVector with the Optional applicative gives all-or-nothing validation. */
+  private static void traverseValidatesEntireVector() {
+    System.out.println("--- Traverse: validate every element of a PVector ---");
+
+    Kind<ListKind.Witness, Integer> goodInputs = LIST.widen(TreePVector.from(List.of(1, 2, 3, 4)));
+    Kind<ListKind.Witness, Integer> badInputs = LIST.widen(TreePVector.from(List.of(1, 2, -3, 4)));
+
+    Function<Integer, Kind<OptionalKind.Witness, Integer>> mustBePositive =
+        i -> OPTIONAL.widen(i > 0 ? Optional.of(i) : Optional.empty());
+
+    Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> good =
+        ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, mustBePositive, goodInputs);
+    Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> bad =
+        ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, mustBePositive, badInputs);
+
+    System.out.println("good : " + OPTIONAL.narrow(good).map(LIST::narrow));
+    System.out.println("bad  : " + OPTIONAL.narrow(bad).map(LIST::narrow));
+    System.out.println();
+  }
+
+  /** foldMap aggregates a PVector into a monoid. */
+  private static void foldMapAggregates() {
+    System.out.println("--- Foldable: foldMap with sum monoid ---");
+
+    PVector<Integer> nums = TreePVector.from(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    Kind<ListKind.Witness, Integer> kind = LIST.widen(nums);
+
+    int total = ListTraverse.INSTANCE.foldMap(Monoids.integerAddition(), i -> i, kind);
+
+    System.out.println("PVector       : " + nums);
+    System.out.println("foldMap (sum) : " + total);
+    System.out.println();
+  }
+}


### PR DESCRIPTION
Adds tests, JMH benchmarks, a runnable example, and a documentation page that validate PCollections persistent collections (PVector, PStack) work through the existing ListKind / ListMonad / ListTraverse / ListSelective / Alternative infrastructure via java.util.List compatibility, with no production code changes.

- pcollections 5.0.0 pinned in libs.versions.toml; wired in as testImplementation (hkj-core), jmhImplementation (hkj-benchmarks), and implementation (hkj-examples) plus 'requires org.pcollections;' in the examples module-info.
- PCollectionsListIntegrationTest exercises widen/narrow round-trips, Functor, Monad (flatMap, ap), Traverse with Optional applicative, Foldable.foldMap, Selective.select, and Alternative.orElse over PVector and PStack, including mixed-flavour pipelines.
- PCollectionsListPropertyTest uses jQwik to verify Functor identity / composition, Monad left identity / right identity / associativity, and Foldable monoid-homomorphism laws across randomised PVector inputs.
- PCollectionsHktBenchmark compares ArrayList against PVector through the HKT pipeline (widen/narrow, map, flatMap, traverse, foldMap) at sizes 10/100/1000.
- PCollectionsExample demonstrates the four pipeline shapes.
- New hkj-book/src/tooling/pcollections_integration.md page wired into the Tooling chapter; benchmarks.md updated with five empirical findings from the full suite (VTask blocking I/O scaling, traverse amortising the PCollections iteration tax, Maybe singleton-reuse ratio, Free monad cost, parallelism-on-trivial-work warning).
- benchmarkReport / benchmarkSummary tasks made tolerant of JMH NaN scores so single-iteration runs don't crash the report.

Fixes #440 

