### PR TITLE
PCollections Phase 2: optics generator plugins (#441)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Higher-Kinded-J provides the most comprehensive optics implementation available 
 * **Filtered traversals** for predicate-based focusing within collections
 * **Indexed optics** for position-aware transformations
 * **Focus DSL** for type-safe, fluent path navigation with seamless bridging into external libraries
-* **Custom container types** with automatic `AffinePath` and `TraversalPath` generation via SPI-aware path widening, supporting 23 container types across JDK, Apache Commons, Eclipse Collections, Guava, Vavr, and HKJ native types
+* **Custom container types** with automatic `AffinePath` and `TraversalPath` generation via SPI-aware path widening, supporting 30 container types across JDK, Apache Commons, Eclipse Collections, Guava, Vavr, PCollections, and HKJ native types
 * **Effect integration** bridging optics with the Effect Path API
 
 ### [Effect Handlers](https://higher-kinded-j.github.io/latest/effect/effect_handlers_intro.html)

--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -251,6 +251,7 @@
   - [Diagnostics](tooling/diagnostics.md)
   - [Traversal Generator Plugins](tooling/generator_plugins.md)
   - [PCollections Integration](tooling/pcollections_integration.md)
+  - [PCollections Optics](tooling/pcollections_optics.md)
   - [Claude Code Skills](tooling/claude_code_skills.md)
   - [Testing With hkj-test](tooling/test_assertions.md)
 - [Spring Integration](spring/ch_intro.md)

--- a/hkj-book/src/home.md
+++ b/hkj-book/src/home.md
@@ -127,7 +127,7 @@ Higher-Kinded-J provides the most comprehensive optics implementation available 
 * **Indexed optics** for position-aware transformations
 * **Profunctor architecture** enabling adaptation between different data shapes
 * **Focus DSL** for type-safe, fluent path navigation with seamless bridging into external libraries
-* **[SPI-aware container types](optics/focus_containers.md)** with automatic `AffinePath` and `TraversalPath` generation via cardinality-based widening, supporting 23 container types across JDK, Apache Commons, Eclipse Collections, Guava, Vavr, and HKJ native types
+* **[SPI-aware container types](optics/focus_containers.md)** with automatic `AffinePath` and `TraversalPath` generation via cardinality-based widening, supporting 30 container types across JDK, Apache Commons, Eclipse Collections, Guava, Vavr, PCollections, and HKJ native types
 * **Effect integration** bridging optics with the Effect Path API
 
 ### [Effect Handlers](effect/effect_handlers_intro.md)

--- a/hkj-book/src/optics/focus_containers.md
+++ b/hkj-book/src/optics/focus_containers.md
@@ -3,7 +3,7 @@
 ~~~admonish info title="What You'll Learn"
 - What the annotation processor generates for each field type
 - How container cardinality (`ZERO_OR_ONE` vs `ZERO_OR_MORE`) determines the generated path type
-- The full table of supported container types across HKJ, JDK, Eclipse Collections, Guava, Vavr, and Apache Commons
+- The full table of supported container types across HKJ, JDK, Eclipse Collections, Guava, Vavr, Apache Commons, and PCollections
 - How to register your own container types via the `TraversableGenerator` SPI
 ~~~
 

--- a/hkj-book/src/tooling/ch_intro.md
+++ b/hkj-book/src/tooling/ch_intro.md
@@ -18,7 +18,11 @@ The HKJ tooling catches these mistakes before your code ever runs. Both Gradle a
 
 - **[Diagnostics](diagnostics.md)** -- The `hkjDiagnostics` Gradle task or `mvn hkj:diagnostics` Maven goal that reports your current HKJ configuration, showing exactly which dependencies, compiler arguments, and checks are active.
 
-- **[Traversal Generator Plugins](generator_plugins.md)** -- The 23 built-in generators that power `@GenerateTraversals`, covering JDK collections, HKJ core types, and four third-party libraries. Includes a guide to writing your own generator for custom container types.
+- **[Traversal Generator Plugins](generator_plugins.md)** -- The 30 built-in generators that power `@GenerateTraversals`, covering JDK collections, HKJ core types, and five third-party libraries (Eclipse Collections, Guava, Vavr, Apache Commons, PCollections). Includes a guide to writing your own generator for custom container types.
+
+- **[PCollections Integration](pcollections_integration.md)** -- Tests, benchmarks, and an example that confirm PCollections persistent collections (`PVector`, `PStack`) compose with the existing `ListKind` infrastructure through `java.util.List` compatibility, with no production code changes.
+
+- **[PCollections Optics](pcollections_optics.md)** -- Seven `@GenerateTraversals` plugins that recognise `PVector`, `PStack`, `PSet`, `PSortedSet`, `PBag`, `PMap`, and `PSortedMap` fields and generate type-correct traversals against them.
 
 - **[Claude Code Skills](claude_code_skills.md)** -- Seven bundled skills that bring contextual HKJ guidance directly into your editor. Covers Path selection, optics, effect handlers, the effects-optics bridge, Spring Boot integration, functional core / imperative shell architecture, and AssertJ-based testing with hkj-test.
 
@@ -32,8 +36,10 @@ The HKJ tooling catches these mistakes before your code ever runs. Both Gradle a
 3. [Compile-Time Checks](compile_checks.md) - Path type mismatch detection
 4. [Diagnostics](diagnostics.md) - Configuration reporting and troubleshooting
 5. [Traversal Generator Plugins](generator_plugins.md) - Supported types and custom generators
-6. [Claude Code Skills](claude_code_skills.md) - In-editor guidance via Claude Code
-7. [Testing With hkj-test](test_assertions.md) - Fluent assertions for HKJ types
+6. [PCollections Integration](pcollections_integration.md) - PCollections compatibility through `ListKind`
+7. [PCollections Optics](pcollections_optics.md) - `@GenerateTraversals` plugins for PCollections types
+8. [Claude Code Skills](claude_code_skills.md) - In-editor guidance via Claude Code
+9. [Testing With hkj-test](test_assertions.md) - Fluent assertions for HKJ types
 
 ---
 

--- a/hkj-book/src/tooling/claude_code_skills.md
+++ b/hkj-book/src/tooling/claude_code_skills.md
@@ -203,5 +203,5 @@ Add to `.gitignore` only if your team prefers not to commit generated files. In 
 
 ---
 
-**Previous:** [PCollections Integration](pcollections_integration.md)
+**Previous:** [PCollections Optics](pcollections_optics.md)
 **Next:** [Integration Guides](../spring/ch_intro.md)

--- a/hkj-book/src/tooling/generator_plugins.md
+++ b/hkj-book/src/tooling/generator_plugins.md
@@ -2,7 +2,7 @@
 
 ~~~admonish info title="What You'll Learn"
 - Which container types `@GenerateTraversals` supports out of the box
-- How to enable third-party collection support (Eclipse Collections, Guava, Vavr, Apache Commons)
+- How to enable third-party collection support (Eclipse Collections, Guava, Vavr, Apache Commons, PCollections)
 - How the plugin discovery mechanism works
 - How to write your own generator for a custom container type
 ~~~
@@ -15,7 +15,7 @@ When you annotate a record with `@GenerateTraversals`, the annotation processor 
 
 Each container type is handled by a **generator plugin**: a small class that implements the `TraversableGenerator` SPI (Service Provider Interface). The processor discovers these plugins at compile time via Java's `ServiceLoader` and delegates code generation to whichever plugin claims support for the field's type.
 
-Higher-Kinded-J ships 23 generator plugins covering JDK types, HKJ core types, and four popular third-party collection libraries.
+Higher-Kinded-J ships 30 generator plugins covering JDK types, HKJ core types, and five popular third-party collection libraries.
 
 ---
 
@@ -105,6 +105,24 @@ dependencies {
 |------|-------|
 | `HashBag<A>` | |
 | `UnmodifiableList<A>` | |
+
+#### PCollections
+
+```kotlin
+dependencies {
+    implementation("org.pcollections:pcollections:5.0.0")
+}
+```
+
+| Type | Notes |
+|------|-------|
+| `org.pcollections.PVector<A>` | Reconstructed via `TreePVector.from(Collection)` |
+| `org.pcollections.PStack<A>` | Reconstructed via `ConsPStack.from(Collection)` |
+| `org.pcollections.PSet<A>` | Reconstructed via `HashTreePSet.from(Collection)` |
+| `org.pcollections.PSortedSet<A>` | Natural ordering only; custom comparators are not preserved |
+| `org.pcollections.PBag<A>` | Reconstructed via `HashTreePBag.from(Collection)` |
+| `org.pcollections.PMap<K, V>` | Value-focused; reconstructed via `HashTreePMap.from(Map)` |
+| `org.pcollections.PSortedMap<K, V>` | Value-focused; natural key ordering only |
 
 ---
 
@@ -313,7 +331,7 @@ The `TraversalProcessor` will now discover your `NonEmptyListGenerator` via `Ser
 ---
 
 ~~~admonish info title="Key Takeaways"
-* **23 built-in generators** cover JDK types, HKJ core types, Eclipse Collections, Guava, Vavr, and Apache Commons
+* **30 built-in generators** cover JDK types, HKJ core types, Eclipse Collections, Guava, Vavr, Apache Commons, and PCollections
 * **Third-party support activates automatically** when the library is on the classpath; no configuration required
 * **The SPI is extensible**: implement `TraversableGenerator`, register it with `@ServiceProvider`, and the processor discovers it at compile time
 * **Most generators follow a common pattern**: convert to `java.util.List`, traverse with `Traversals.traverseList()`, convert back to the original type

--- a/hkj-book/src/tooling/pcollections_integration.md
+++ b/hkj-book/src/tooling/pcollections_integration.md
@@ -180,4 +180,4 @@ laws hold for `PVector` widened through `ListKind`:
 ---
 
 **Previous:** [Traversal Generator Plugins](generator_plugins.md)
-**Next:** [Claude Code Skills](claude_code_skills.md)
+**Next:** [PCollections Optics](pcollections_optics.md)

--- a/hkj-book/src/tooling/pcollections_optics.md
+++ b/hkj-book/src/tooling/pcollections_optics.md
@@ -1,0 +1,136 @@
+# PCollections Optics
+
+~~~admonish info title="What You'll Learn"
+- Which PCollections types `@GenerateTraversals` recognises automatically
+- How generated traversals reconstruct persistent collections after a focus change
+- The Focus DSL navigation patterns for PCollections fields
+- Where natural-ordering caveats apply for sorted variants
+~~~
+
+[PCollections](https://pcollections.org/) persistent collections are first-class citizens of the optics generator system. Annotating a record whose components are `PVector`, `PStack`, `PSet`, `PSortedSet`, `PBag`, `PMap`, or `PSortedMap` produces traversal code that round-trips through the persistent type, with no production-code changes required.
+
+This page documents the seven PCollections generator plugins added in Phase 2 of the integration. For the underlying compatibility hypothesis and benchmark numbers, see [PCollections Integration](pcollections_integration.md).
+
+---
+
+## Supported Types
+
+| Field type | Generator | Reconstruction | Cardinality |
+|-----------|-----------|----------------|-------------|
+| `PVector<A>` | `PVectorGenerator` | `TreePVector.from(Collection)` | ZERO_OR_MORE |
+| `PStack<A>` | `PStackGenerator` | `ConsPStack.from(Collection)` | ZERO_OR_MORE |
+| `PSet<A>` | `PSetGenerator` | `HashTreePSet.from(Collection)` | ZERO_OR_MORE |
+| `PSortedSet<A>` | `PSortedSetGenerator` | `TreePSet.from(Collection)` | ZERO_OR_MORE |
+| `PBag<A>` | `PBagGenerator` | `HashTreePBag.from(Collection)` | ZERO_OR_MORE |
+| `PMap<K, V>` | `PMapValueGenerator` | `HashTreePMap.from(Map)` (value focus) | ZERO_OR_MORE |
+| `PSortedMap<K, V>` | `PSortedMapValueGenerator` | `TreePMap.from(Map)` (value focus) | ZERO_OR_MORE |
+
+Map generators focus on the value type (index 1). Keys are passed through unchanged.
+
+All seven generators run at the default priority and activate automatically once `org.pcollections:pcollections` is on your annotation processor's classpath.
+
+> The five collection-like generators (`PVector` / `PStack` / `PSet` / `PSortedSet` / `PBag`) also participate in `@GenerateFocus` navigator generation via `EachInstances.fromIterableCollecting`. The two map-value generators currently support `@GenerateTraversals` only; Focus DSL navigation through `PMap` / `PSortedMap` value fields would require a dedicated `mapValuesEachCollecting` helper that does not yet exist in `hkj-core`.
+
+---
+
+## Worked Example
+
+Annotate a record whose components include PCollections types:
+
+```java
+import org.higherkindedj.optics.annotations.GenerateFocus;
+import org.higherkindedj.optics.annotations.GenerateTraversals;
+import org.pcollections.PVector;
+import org.pcollections.PMap;
+
+@GenerateFocus
+@GenerateTraversals
+public record Portfolio(
+    String owner,
+    PVector<Position> positions,
+    PMap<String, Double> exposureByCurrency) {}
+```
+
+The processor emits a `PortfolioTraversals` companion class with two traversals:
+
+- `Portfolio_positions()` traverses each `Position` in the `PVector`. After a focus change, `TreePVector.from(...)` rebuilds the persistent vector around the new elements.
+- `Portfolio_exposureByCurrency()` traverses each `Double` value in the `PMap`. Keys are preserved, values are replaced; `HashTreePMap.from(...)` rebuilds the persistent map.
+
+The Focus DSL composes these into navigators with the correct path types automatically:
+
+```java
+import static com.example.PortfolioFocus.portfolio;
+
+TraversalPath<Portfolio, Position> allPositions = portfolio().positions();
+TraversalPath<Portfolio, Double> allExposures = portfolio().exposureByCurrency();
+```
+
+`TraversalPath` is selected because each generator declares `Cardinality.ZERO_OR_MORE`. No explicit widening call is needed.
+
+---
+
+## Reconstruction Cost
+
+Generated traversals copy the persistent collection into a JDK `ArrayList` for traversal, then hand the resulting list back to the persistent factory. That gives O(n) iteration plus the construction cost of the persistent type, which for `TreePVector` is O(n) and for tree-backed sets and maps is O(n log n). For most domain models this is invisible alongside the work the focus function does.
+
+If you are operating on a hot path and the persistent type matters more than the optic structure, prefer hand-written code that uses PCollections' native `with`/`plus` operations rather than going through `@GenerateTraversals`. The generated traversal is correct, not minimal.
+
+---
+
+## Sorted Variants and Comparators
+
+`PSortedSet` and `PSortedMap` are reconstructed using `TreePSet.from(Collection)` and `TreePMap.from(Map)`, which apply natural ordering. **Custom comparators are not preserved** through a generated traversal.
+
+Two practical implications:
+
+- If your `PSortedSet<MyType>` relies on a custom `Comparator<MyType>`, write the optic by hand rather than relying on the generator
+- The natural-ordering reconstruction will throw at runtime if your element type is not `Comparable`. Generators do not detect this statically; a missing `Comparable` bound will surface as a `ClassCastException` the first time the traversal runs
+
+For the common case where elements implement `Comparable` and the natural ordering is the desired one, the generator is the right tool.
+
+---
+
+## Hand-Written Optics
+
+If you need an optic outside `@GenerateTraversals` (for instance, on a third-party type you cannot annotate), the same building blocks are available:
+
+```java
+import org.higherkindedj.optics.each.EachInstances;
+import org.higherkindedj.optics.each.Each;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+Each<PVector<String>, String> pvectorEach =
+    EachInstances.fromIterableCollecting(TreePVector::from);
+```
+
+`fromIterableCollecting` accepts any function that builds a persistent collection from a `List`, so the same form covers all the PCollections types. There is no library-specific factory class; the generic helper is the public API.
+
+---
+
+## When PCollections Is the Right Choice
+
+PCollections excels when you want persistent immutable collections through the standard `java.util` interfaces, with no custom typeclass machinery. The optics generators slot it into Higher-Kinded-J's traversal pipeline so domain records using `PVector`, `PMap`, and friends compose with the rest of the optics ecosystem without any glue code.
+
+For projects already on Eclipse Collections or Vavr, those existing generators remain the better fit. PCollections is most attractive for greenfield projects that want a small dependency footprint and `java.util` compatibility.
+
+---
+
+~~~admonish info title="Key Takeaways"
+* **Seven generator plugins** cover every PCollections collection and map type
+* **Activation is automatic** once PCollections is on the annotation processor classpath
+* **Reconstruction goes through `from(Collection)` / `from(Map)`**, so traversals round-trip cleanly through the persistent type
+* **Sorted variants assume natural ordering**; custom comparators are not preserved by generated code
+* **Use `EachInstances.fromIterableCollecting(TreePVector::from)`** for hand-written optics outside `@GenerateTraversals`
+~~~
+
+~~~admonish tip title="See Also"
+- [Traversal Generator Plugins](generator_plugins.md) - The full SPI catalogue and architecture
+- [PCollections Integration](pcollections_integration.md) - Phase 1 compatibility tests, benchmarks, and the underlying `ListKind` story
+- [Focus DSL](../optics/focus_dsl.md) - Composing generated traversals into navigators
+~~~
+
+---
+
+**Previous:** [PCollections Integration](pcollections_integration.md)
+**Next:** [Claude Code Skills](claude_code_skills.md)

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/pcollections/PCollectionsListIntegrationTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/pcollections/PCollectionsListIntegrationTest.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.hkt.list.pcollections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.ListAssert.assertThatList;
+import static org.higherkindedj.hkt.assertions.OptionalKindAssert.assertThatOptionalKind;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
@@ -84,7 +86,7 @@ class PCollectionsListIntegrationTest {
       PVector<Integer> empty = TreePVector.empty();
       Kind<ListKind.Witness, Integer> widened = LIST.widen(empty);
 
-      assertThat(LIST.narrow(widened)).isEmpty();
+      assertThatList(widened).isEmpty();
     }
   }
 
@@ -104,7 +106,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, Integer> mapped = ListMonad.INSTANCE.map(x -> x * 10, kind);
 
-      assertThat(LIST.narrow(mapped)).containsExactly(10, 20, 30);
+      assertThatList(mapped).containsExactly(10, 20, 30);
     }
 
     @Test
@@ -115,7 +117,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, String> mapped = ListMonad.INSTANCE.map(String::toUpperCase, kind);
 
-      assertThat(LIST.narrow(mapped)).containsExactly("A", "B");
+      assertThatList(mapped).containsExactly("A", "B");
     }
   }
 
@@ -138,7 +140,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, String> result = ListMonad.INSTANCE.flatMap(dup, kind);
 
-      assertThat(LIST.narrow(result)).containsExactly("v1", "v1", "v2", "v2");
+      assertThatList(result).containsExactly("v1", "v1", "v2", "v2");
     }
 
     @Test
@@ -150,7 +152,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, String> result = ListMonad.INSTANCE.ap(ff, fa);
 
-      assertThat(LIST.narrow(result)).containsExactly("n1", "n2", "x2", "x4");
+      assertThatList(result).containsExactly("n1", "n2", "x2", "x4");
     }
 
     @Test
@@ -163,7 +165,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, Integer> result = ListMonad.INSTANCE.flatMap(repeatViaPStack, input);
 
-      assertThat(LIST.narrow(result)).containsExactly(1, 1, 2, 2, 3, 3);
+      assertThatList(result).containsExactly(1, 1, 2, 2, 3, 3);
     }
   }
 
@@ -201,7 +203,7 @@ class PCollectionsListIntegrationTest {
       Kind<OptionalKind.Witness, Kind<ListKind.Witness, Integer>> result =
           ListTraverse.INSTANCE.traverse(OptionalMonad.INSTANCE, failOnTwo, input);
 
-      assertThat(OPTIONAL.narrow(result)).isEmpty();
+      assertThatOptionalKind(result).isEmpty();
     }
 
     @Test
@@ -247,7 +249,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, String> result = ListSelective.INSTANCE.select(fab, ff);
 
-      assertThat(LIST.narrow(result)).containsExactly("A", "B");
+      assertThatList(result).containsExactly("A", "B");
     }
 
     @Test
@@ -265,7 +267,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, String> result = ListSelective.INSTANCE.select(fab, ff);
 
-      assertThat(LIST.narrow(result)).containsExactly("N1", "X", "N2");
+      assertThatList(result).containsExactly("N1", "X", "N2");
     }
   }
 
@@ -287,7 +289,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, Integer> result = alt.orElse(primary, () -> fallback);
 
-      assertThat(LIST.narrow(result)).containsExactly(1, 2, 3, 4);
+      assertThatList(result).containsExactly(1, 2, 3, 4);
     }
 
     @Test
@@ -298,7 +300,7 @@ class PCollectionsListIntegrationTest {
 
       Kind<ListKind.Witness, Integer> result = alt.orElse(primary, () -> fallback);
 
-      assertThat(LIST.narrow(result)).containsExactly(7, 8, 9);
+      assertThatList(result).containsExactly(7, 8, 9);
     }
   }
 }

--- a/hkj-processor-plugins/README.md
+++ b/hkj-processor-plugins/README.md
@@ -6,7 +6,7 @@ Traversal generator plugins for Higher-Kinded-J's `@GenerateTraversals` annotati
 
 When you annotate a Java record with `@GenerateTraversals`, the `TraversalProcessor` in `hkj-processor` generates traversal optics for each record component whose type is a supported container. The processor discovers generator plugins at compile time via Java's `ServiceLoader` mechanism.
 
-This module ships 23 generators covering JDK collections, Higher-Kinded-J core types, and four popular third-party libraries.
+This module ships 30 generators covering JDK collections, Higher-Kinded-J core types, and five popular third-party libraries.
 
 ## Supported Types
 
@@ -63,6 +63,18 @@ This module ships 23 generators covering JDK collections, Higher-Kinded-J core t
 | `HashBag<A>` | `ApacheHashBagGenerator` |
 | `UnmodifiableList<A>` | `ApacheUnmodifiableListGenerator` |
 
+### PCollections
+
+| Type | Generator | Focus |
+|------|-----------|-------|
+| `org.pcollections.PVector<A>` | `PVectorGenerator` | Each element |
+| `org.pcollections.PStack<A>` | `PStackGenerator` | Each element |
+| `org.pcollections.PSet<A>` | `PSetGenerator` | Each element |
+| `org.pcollections.PSortedSet<A>` | `PSortedSetGenerator` | Each element (natural ordering only) |
+| `org.pcollections.PBag<A>` | `PBagGenerator` | Each element |
+| `org.pcollections.PMap<K, V>` | `PMapValueGenerator` | Each value (index 1) |
+| `org.pcollections.PSortedMap<K, V>` | `PSortedMapValueGenerator` | Each value (index 1, natural key ordering) |
+
 ## Architecture
 
 ```
@@ -78,6 +90,10 @@ TraversableGenerator (SPI interface in hkj-processor)
     │   └── Guava generators (guava/)
     ├── ApacheBaseSingleIterableTraversableGenerator
     │   └── Apache generators (apache/)
+    ├── PCollectionsBaseSingleIterableTraversableGenerator
+    │   └── PCollections collection generators (pcollections/)
+    ├── PCollectionsBaseMapValueTraversableGenerator
+    │   └── PCollections map value generators (pcollections/)
     └── VavrBaseSingleIterableTraversableGenerator
         └── Vavr generators (vavr/)
 ```
@@ -92,7 +108,7 @@ TraversableGenerator (SPI interface in hkj-processor)
 
 If you use the HKJ Gradle or Maven build plugin, `hkj-processor-plugins` is added to your annotation processor path automatically. No additional configuration is needed for JDK types and HKJ core types.
 
-For third-party library support (Eclipse Collections, Guava, Vavr, Apache Commons), simply add the library to your project's dependencies. The generators detect supported types at compile time regardless of whether the library is present at runtime.
+For third-party library support (Eclipse Collections, Guava, Vavr, Apache Commons, PCollections), simply add the library to your project's dependencies. The generators detect supported types at compile time regardless of whether the library is present at runtime.
 
 ### Manual Setup
 

--- a/hkj-processor-plugins/build.gradle.kts
+++ b/hkj-processor-plugins/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation(libs.google.guava)
     testImplementation(libs.vavr)
     testImplementation(libs.apache.commons.collections4)
+    testImplementation(libs.pcollections)
 }
 
 tasks.test {

--- a/hkj-processor-plugins/src/main/java/module-info.java
+++ b/hkj-processor-plugins/src/main/java/module-info.java
@@ -39,6 +39,13 @@ module org.higherkindedj.processor.plugins {
       org.higherkindedj.optics.processing.generator.hkj.MaybeGenerator,
       org.higherkindedj.optics.processing.generator.hkj.TryGenerator,
       org.higherkindedj.optics.processing.generator.hkj.ValidatedGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PBagGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PMapValueGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PSetGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PSortedMapValueGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PSortedSetGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PStackGenerator,
+      org.higherkindedj.optics.processing.generator.pcollections.PVectorGenerator,
       org.higherkindedj.optics.processing.generator.vavr.VavrListGenerator,
       org.higherkindedj.optics.processing.generator.vavr.VavrSetGenerator;
 }

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PBagGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PBagGenerator.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing fields of type {@code
+ * org.pcollections.PBag}. Reconstruction uses {@code HashTreePBag.from(Collection)}.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PBagGenerator extends PCollectionsBaseSingleIterableTraversableGenerator {
+
+  /** Creates a new generator for {@code PBag} fields. */
+  public PBagGenerator() {
+    super(PBAG, HASH_TREE_PBAG);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PCollectionsBaseMapValueTraversableGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PCollectionsBaseMapValueTraversableGenerator.java
@@ -1,0 +1,185 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.CodeBlock;
+import com.palantir.javapoet.TypeName;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * Base class for {@link org.higherkindedj.optics.processing.spi.TraversableGenerator}s that target
+ * PCollections persistent map types ({@code PMap}, {@code PSortedMap}). The traversal focuses on
+ * the <em>values</em> of the map; keys are passed through unchanged.
+ *
+ * <p>Each PCollections map implements {@link java.util.Map}, so the source field's {@link
+ * Map#entrySet()} can be copied directly into a JDK {@link ArrayList}. After traversal, a JDK
+ * {@link Map} is rebuilt from the new entries and handed to the persistent type's {@code from(Map)}
+ * factory.
+ */
+public abstract class PCollectionsBaseMapValueTraversableGenerator
+    extends BaseTraversableGenerator {
+
+  /** Root package for the PCollections public API. */
+  protected static final String PCOLLECTIONS_PACKAGE = "org.pcollections";
+
+  /** {@code org.pcollections.PMap} interface. */
+  public static final ClassName PMAP = ClassName.get(PCOLLECTIONS_PACKAGE, "PMap");
+
+  /** {@code org.pcollections.PSortedMap} interface. */
+  public static final ClassName PSORTED_MAP = ClassName.get(PCOLLECTIONS_PACKAGE, "PSortedMap");
+
+  /** {@code org.pcollections.HashTreePMap} concrete factory. */
+  public static final ClassName HASH_TREE_PMAP =
+      ClassName.get(PCOLLECTIONS_PACKAGE, "HashTreePMap");
+
+  /** {@code org.pcollections.TreePMap} concrete factory (sorted map). */
+  public static final ClassName TREE_PMAP = ClassName.get(PCOLLECTIONS_PACKAGE, "TreePMap");
+
+  /** The PCollections map interface this generator matches against. */
+  protected final ClassName supportedType;
+
+  /** The concrete factory class used to reconstruct instances. */
+  protected final ClassName constructedType;
+
+  /**
+   * @param supportedType the persistent map interface this generator recognises
+   * @param constructedType the concrete factory whose {@code from(Map)} reconstructs instances of
+   *     {@code supportedType}
+   */
+  protected PCollectionsBaseMapValueTraversableGenerator(
+      final ClassName supportedType, final ClassName constructedType) {
+    this.supportedType = supportedType;
+    this.constructedType = constructedType;
+  }
+
+  @Override
+  public final boolean supports(final TypeMirror type) {
+    if (!(type instanceof DeclaredType declaredType)) {
+      return false;
+    }
+    final Element element = declaredType.asElement();
+    return element != null && element.toString().equals(supportedType.canonicalName());
+  }
+
+  @Override
+  public int getFocusTypeArgumentIndex() {
+    return 1; // PMap<K, V> focuses on V
+  }
+
+  // The Focus DSL hooks (generateOpticExpression / getRequiredImports) are deliberately not
+  // implemented for PCollections map types. There is no library-agnostic
+  // {@code EachInstances.mapValuesEachCollecting(...)} helper, and {@code fromIterableCollecting}
+  // does not apply because Maps are not Iterable. {@code @GenerateTraversals} is fully
+  // supported; {@code @GenerateFocus} navigator generation for these fields is a separate
+  // future change.
+
+  @Override
+  public CodeBlock generateModifyF(
+      final RecordComponentElement component,
+      final ClassName recordClassName,
+      final List<? extends RecordComponentElement> allComponents) {
+
+    final String componentName = component.getSimpleName().toString();
+
+    return CodeBlock.builder()
+        // 1. Pull the persistent map's entries into a JDK ArrayList for traversal.
+        .addStatement(
+            "final var sourceEntries = new $T<>(source.$L().entrySet())",
+            ArrayList.class,
+            componentName)
+        // 2. Lift each entry into the applicative, applying f to the value and reconstructing
+        //    the entry around the new value.
+        .addStatement(
+            "final $T<Map.Entry<$T, $T>, $T<F, Map.Entry<$T, $T>>> entryF = \n"
+                + "    entry -> applicative.map(newValue -> $T.entry(entry.getKey(), newValue),"
+                + " f.apply(entry.getValue()))",
+            Function.class,
+            getKeyTypeName(component),
+            getValueTypeName(component),
+            Kind.class,
+            getKeyTypeName(component),
+            getValueTypeName(component),
+            Map.class)
+        // 3. Traverse the entry list.
+        .addStatement(
+            "final var effectOfEntries = $T.traverseList(sourceEntries, entryF, applicative)",
+            Traversals.class)
+        // 4. Map the effect-of-entries into a JDK Map keyed by entry key, valued by entry value.
+        //    The intermediate JDK Map type is fixed by the entryF declaration above and the
+        //    Map.Entry method references in the collector, giving step 5 a fully-resolved
+        //    Map<K, V> to hand to the persistent factory.
+        .addStatement(
+            "final var effectOfMap = applicative.map(\n"
+                + "    newEntries -> newEntries.stream().collect($T.toMap($T.Entry::getKey,"
+                + " $T.Entry::getValue)),\n"
+                + "    effectOfEntries)",
+            Collectors.class,
+            Map.class,
+            Map.class)
+        // 5. Reconstruct the record, handing the rebuilt JDK Map to the persistent factory inline
+        //    so that the call is in a position where javac can fully resolve any generic bounds
+        //    on {@code from(Map)} (e.g. TreePMap's {@code K extends Comparable<? super K>}).
+        .addStatement(
+            "return applicative.map(\n    jdkMap -> new $T($L),\n    effectOfMap)",
+            recordClassName,
+            buildConstructorArgsWithFromCall(componentName, allComponents))
+        .build();
+  }
+
+  /**
+   * Builds the record constructor argument list as a {@link CodeBlock} so that JavaPoet emits an
+   * import for {@code constructedType} when the converted component refers to {@code
+   * <constructedType>.from(jdkMap)}. All other components are forwarded by accessor as literal
+   * text.
+   */
+  private CodeBlock buildConstructorArgsWithFromCall(
+      final String changedComponent, final List<? extends RecordComponentElement> allComponents) {
+    final CodeBlock.Builder builder = CodeBlock.builder();
+    boolean first = true;
+    for (final RecordComponentElement c : allComponents) {
+      if (!first) {
+        builder.add(", ");
+      }
+      first = false;
+      final String name = c.getSimpleName().toString();
+      if (name.equals(changedComponent)) {
+        builder.add("$T.from(jdkMap)", constructedType);
+      } else {
+        builder.add("source.$L()", name);
+      }
+    }
+    return builder.build();
+  }
+
+  private TypeName getValueTypeName(final RecordComponentElement component) {
+    if (component.asType() instanceof DeclaredType containerType) {
+      if (containerType.getTypeArguments().size() < 2) {
+        return ClassName.get(Object.class);
+      }
+      return TypeName.get(containerType.getTypeArguments().get(1)).box();
+    }
+    return ClassName.get(Object.class);
+  }
+
+  private TypeName getKeyTypeName(final RecordComponentElement component) {
+    if (component.asType() instanceof DeclaredType containerType) {
+      if (containerType.getTypeArguments().isEmpty()) {
+        return ClassName.get(Object.class);
+      }
+      return TypeName.get(containerType.getTypeArguments().getFirst()).box();
+    }
+    return ClassName.get(Object.class);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PCollectionsBaseSingleIterableTraversableGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PCollectionsBaseSingleIterableTraversableGenerator.java
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.CodeBlock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * Base class for {@link org.higherkindedj.optics.processing.spi.TraversableGenerator}s that target
+ * single-element PCollections persistent collection types ({@code PVector}, {@code PStack}, {@code
+ * PSet}, {@code PSortedSet}, {@code PBag}).
+ *
+ * <p>Each PCollections type implements {@link java.util.Collection}, so the source field can be
+ * copied directly into a {@link ArrayList} without any library-specific iteration helper. The
+ * traversal is performed against that JDK list and the resulting list is fed back through the
+ * concrete factory's {@code from(Collection)} method to reconstruct the persistent type.
+ */
+public abstract class PCollectionsBaseSingleIterableTraversableGenerator
+    extends BaseTraversableGenerator {
+
+  /** Root package for the PCollections public API. */
+  protected static final String PCOLLECTIONS_PACKAGE = "org.pcollections";
+
+  /** {@code org.pcollections.PVector} interface. */
+  public static final ClassName PVECTOR = ClassName.get(PCOLLECTIONS_PACKAGE, "PVector");
+
+  /** {@code org.pcollections.PStack} interface. */
+  public static final ClassName PSTACK = ClassName.get(PCOLLECTIONS_PACKAGE, "PStack");
+
+  /** {@code org.pcollections.PSet} interface. */
+  public static final ClassName PSET = ClassName.get(PCOLLECTIONS_PACKAGE, "PSet");
+
+  /** {@code org.pcollections.PSortedSet} interface. */
+  public static final ClassName PSORTED_SET = ClassName.get(PCOLLECTIONS_PACKAGE, "PSortedSet");
+
+  /** {@code org.pcollections.PBag} interface. */
+  public static final ClassName PBAG = ClassName.get(PCOLLECTIONS_PACKAGE, "PBag");
+
+  /** {@code org.pcollections.TreePVector} concrete factory. */
+  public static final ClassName TREE_PVECTOR = ClassName.get(PCOLLECTIONS_PACKAGE, "TreePVector");
+
+  /** {@code org.pcollections.ConsPStack} concrete factory. */
+  public static final ClassName CONS_PSTACK = ClassName.get(PCOLLECTIONS_PACKAGE, "ConsPStack");
+
+  /** {@code org.pcollections.HashTreePSet} concrete factory. */
+  public static final ClassName HASH_TREE_PSET =
+      ClassName.get(PCOLLECTIONS_PACKAGE, "HashTreePSet");
+
+  /** {@code org.pcollections.TreePSet} concrete factory (sorted set). */
+  public static final ClassName TREE_PSET = ClassName.get(PCOLLECTIONS_PACKAGE, "TreePSet");
+
+  /** {@code org.pcollections.HashTreePBag} concrete factory. */
+  public static final ClassName HASH_TREE_PBAG =
+      ClassName.get(PCOLLECTIONS_PACKAGE, "HashTreePBag");
+
+  /** The PCollections interface this generator matches against (e.g. {@code PVector}). */
+  protected final ClassName supportedType;
+
+  /** The concrete factory class used to reconstruct instances (e.g. {@code TreePVector}). */
+  protected final ClassName constructedType;
+
+  /**
+   * @param supportedType the persistent collection interface this generator recognises
+   * @param constructedType the concrete factory class whose {@code from(Collection)} reconstructs
+   *     instances of {@code supportedType}
+   */
+  protected PCollectionsBaseSingleIterableTraversableGenerator(
+      final ClassName supportedType, final ClassName constructedType) {
+    this.supportedType = supportedType;
+    this.constructedType = constructedType;
+  }
+
+  @Override
+  public String generateOpticExpression() {
+    return "EachInstances.fromIterableCollecting(list -> "
+        + constructedType.simpleName()
+        + ".from(list))";
+  }
+
+  @Override
+  public Set<String> getRequiredImports() {
+    return Set.of(
+        "org.higherkindedj.optics.each.EachInstances",
+        constructedType.packageName() + "." + constructedType.simpleName());
+  }
+
+  @Override
+  public final boolean supports(final TypeMirror type) {
+    if (!(type instanceof DeclaredType declaredType)) {
+      return false;
+    }
+    final Element element = declaredType.asElement();
+    return element != null && element.toString().equals(supportedType.canonicalName());
+  }
+
+  @Override
+  public CodeBlock generateModifyF(
+      final RecordComponentElement component,
+      final ClassName recordClassName,
+      final List<? extends RecordComponentElement> allComponents) {
+
+    final String componentName = component.getSimpleName().toString();
+    final String constructorArgs =
+        generateConstructorArgs(componentName, "converted", allComponents);
+
+    return CodeBlock.builder()
+        // 1. Copy the persistent collection into a JDK ArrayList so traverseList can iterate it.
+        //    PCollections types all implement java.util.Collection, so the copy constructor works
+        //    directly.
+        .addStatement(
+            "final var sourceList = new $T<>(source.$L())", ArrayList.class, componentName)
+
+        // 2. Traverse the list, yielding Kind<F, List<B>>.
+        .addStatement(
+            "final var effectOfList = $T.traverseList(sourceList, f, applicative)",
+            Traversals.class)
+
+        // 3. Convert the inner List back to the PCollections type.
+        .addStatement(
+            "final var effectOfConvertBack = applicative.map("
+                + "newList -> $T.from(newList), effectOfList)",
+            constructedType)
+
+        // 4. Reconstruct the record with the rebuilt persistent collection.
+        .addStatement(
+            "return applicative.map(converted -> new $T($L), effectOfConvertBack)",
+            recordClassName,
+            constructorArgs)
+        .build();
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PMapValueGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PMapValueGenerator.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing the values of fields of type
+ * {@code org.pcollections.PMap}. Reconstruction uses {@code HashTreePMap.from(Map)}.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PMapValueGenerator extends PCollectionsBaseMapValueTraversableGenerator {
+
+  /** Creates a new generator for {@code PMap} fields. */
+  public PMapValueGenerator() {
+    super(PMAP, HASH_TREE_PMAP);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PSetGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PSetGenerator.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing fields of type {@code
+ * org.pcollections.PSet}. Reconstruction uses {@code HashTreePSet.from(Collection)}.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PSetGenerator extends PCollectionsBaseSingleIterableTraversableGenerator {
+
+  /** Creates a new generator for {@code PSet} fields. */
+  public PSetGenerator() {
+    super(PSET, HASH_TREE_PSET);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedMapValueGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedMapValueGenerator.java
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing the values of fields of type
+ * {@code org.pcollections.PSortedMap}. Reconstruction uses {@code TreePMap.from(Map)} which applies
+ * natural key ordering. Custom comparators are not preserved through the traversal.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PSortedMapValueGenerator extends PCollectionsBaseMapValueTraversableGenerator {
+
+  /** Creates a new generator for {@code PSortedMap} fields. */
+  public PSortedMapValueGenerator() {
+    super(PSORTED_MAP, TREE_PMAP);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedSetGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedSetGenerator.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing fields of type {@code
+ * org.pcollections.PSortedSet}. Reconstruction uses {@code TreePSet.from(Collection)} which applies
+ * natural ordering. Custom comparators are not preserved through the traversal; users with bespoke
+ * orderings should write their own optic.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PSortedSetGenerator extends PCollectionsBaseSingleIterableTraversableGenerator {
+
+  /** Creates a new generator for {@code PSortedSet} fields. */
+  public PSortedSetGenerator() {
+    super(PSORTED_SET, TREE_PSET);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PStackGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PStackGenerator.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing fields of type {@code
+ * org.pcollections.PStack}. Reconstruction uses {@code ConsPStack.from(Collection)}.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PStackGenerator extends PCollectionsBaseSingleIterableTraversableGenerator {
+
+  /** Creates a new generator for {@code PStack} fields. */
+  public PStackGenerator() {
+    super(PSTACK, CONS_PSTACK);
+  }
+}

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PVectorGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PVectorGenerator.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import io.avaje.spi.ServiceProvider;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * A {@link TraversableGenerator} that adds support for traversing fields of type {@code
+ * org.pcollections.PVector}. Reconstruction uses {@code TreePVector.from(Collection)}.
+ */
+@ServiceProvider(TraversableGenerator.class)
+public final class PVectorGenerator extends PCollectionsBaseSingleIterableTraversableGenerator {
+
+  /** Creates a new generator for {@code PVector} fields. */
+  public PVectorGenerator() {
+    super(PVECTOR, TREE_PVECTOR);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/GeneratorSpiMethodsTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/GeneratorSpiMethodsTest.java
@@ -26,6 +26,13 @@ import org.higherkindedj.optics.processing.generator.hkj.EitherGenerator;
 import org.higherkindedj.optics.processing.generator.hkj.MaybeGenerator;
 import org.higherkindedj.optics.processing.generator.hkj.TryGenerator;
 import org.higherkindedj.optics.processing.generator.hkj.ValidatedGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PBagGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PMapValueGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PSetGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PSortedMapValueGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PSortedSetGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PStackGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PVectorGenerator;
 import org.higherkindedj.optics.processing.generator.vavr.VavrListGenerator;
 import org.higherkindedj.optics.processing.generator.vavr.VavrSetGenerator;
 import org.higherkindedj.optics.processing.spi.Cardinality;
@@ -346,6 +353,102 @@ class GeneratorSpiMethodsTest {
               "org.higherkindedj.optics.each.EachInstances",
               "org.apache.commons.collections4.list.UnmodifiableList"),
           gen.getRequiredImports());
+    }
+  }
+
+  @Nested
+  @DisplayName("PCollections generators")
+  class PCollectionsGenerators {
+
+    @Test
+    @DisplayName("PVectorGenerator")
+    void pvector() {
+      var gen = new PVectorGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(
+          "EachInstances.fromIterableCollecting(list -> TreePVector.from(list))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.TreePVector"),
+          gen.getRequiredImports());
+      assertEquals(0, gen.getFocusTypeArgumentIndex());
+    }
+
+    @Test
+    @DisplayName("PStackGenerator")
+    void pstack() {
+      var gen = new PStackGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(
+          "EachInstances.fromIterableCollecting(list -> ConsPStack.from(list))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.ConsPStack"),
+          gen.getRequiredImports());
+      assertEquals(0, gen.getFocusTypeArgumentIndex());
+    }
+
+    @Test
+    @DisplayName("PSetGenerator")
+    void pset() {
+      var gen = new PSetGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(
+          "EachInstances.fromIterableCollecting(list -> HashTreePSet.from(list))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.HashTreePSet"),
+          gen.getRequiredImports());
+      assertEquals(0, gen.getFocusTypeArgumentIndex());
+    }
+
+    @Test
+    @DisplayName("PSortedSetGenerator")
+    void psortedSet() {
+      var gen = new PSortedSetGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(
+          "EachInstances.fromIterableCollecting(list -> TreePSet.from(list))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.TreePSet"),
+          gen.getRequiredImports());
+      assertEquals(0, gen.getFocusTypeArgumentIndex());
+    }
+
+    @Test
+    @DisplayName("PBagGenerator")
+    void pbag() {
+      var gen = new PBagGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(
+          "EachInstances.fromIterableCollecting(list -> HashTreePBag.from(list))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.HashTreePBag"),
+          gen.getRequiredImports());
+      assertEquals(0, gen.getFocusTypeArgumentIndex());
+    }
+
+    @Test
+    @DisplayName("PMapValueGenerator has no Focus DSL support yet")
+    void pmapValue() {
+      var gen = new PMapValueGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(1, gen.getFocusTypeArgumentIndex());
+      // PMap is not Iterable; the Focus DSL hooks fall back to the SPI default of "no support".
+      assertEquals("", gen.generateOpticExpression());
+      assertEquals(Set.of(), gen.getRequiredImports());
+    }
+
+    @Test
+    @DisplayName("PSortedMapValueGenerator has no Focus DSL support yet")
+    void psortedMapValue() {
+      var gen = new PSortedMapValueGenerator();
+      assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
+      assertEquals(1, gen.getFocusTypeArgumentIndex());
+      assertEquals("", gen.generateOpticExpression());
+      assertEquals(Set.of(), gen.getRequiredImports());
     }
   }
 }

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/TypeExtractionFallbackTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/TypeExtractionFallbackTest.java
@@ -20,6 +20,13 @@ import org.higherkindedj.optics.processing.generator.basejdk.ArrayGenerator;
 import org.higherkindedj.optics.processing.generator.basejdk.MapValueGenerator;
 import org.higherkindedj.optics.processing.generator.hkj.EitherGenerator;
 import org.higherkindedj.optics.processing.generator.hkj.ValidatedGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PBagGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PMapValueGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PSetGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PSortedMapValueGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PSortedSetGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PStackGenerator;
+import org.higherkindedj.optics.processing.generator.pcollections.PVectorGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -249,6 +256,121 @@ class TypeExtractionFallbackTest {
     @DisplayName("generateModifyF falls back to Object for non-DeclaredType component")
     void fallsBackToObjectForNonDeclaredType() {
       var gen = new MapValueGenerator();
+      var component = componentOf("data", nonDeclaredType());
+      var code = gen.generateModifyF(component, DUMMY_CLASS, List.of(component));
+      assertNotNull(code);
+      assertTrue(code.toString().contains("Object"));
+    }
+  }
+
+  @Nested
+  @DisplayName("PCollections single-iterable supports fallbacks")
+  class PCollectionsSingleIterableSupportsFallbacks {
+
+    @Test
+    @DisplayName("PVectorGenerator.supports returns false for non-DeclaredType")
+    void pvectorSupportsRejectsNonDeclared() {
+      assertFalse(new PVectorGenerator().supports(nonDeclaredType()));
+    }
+
+    @Test
+    @DisplayName("PVectorGenerator.supports returns false when element is null")
+    void pvectorSupportsRejectsNullElement() {
+      assertFalse(new PVectorGenerator().supports(declaredType(null, List.of())));
+    }
+
+    @Test
+    @DisplayName("PStackGenerator.supports returns false for non-DeclaredType")
+    void pstackSupportsRejectsNonDeclared() {
+      assertFalse(new PStackGenerator().supports(nonDeclaredType()));
+    }
+
+    @Test
+    @DisplayName("PSetGenerator.supports returns false for non-DeclaredType")
+    void psetSupportsRejectsNonDeclared() {
+      assertFalse(new PSetGenerator().supports(nonDeclaredType()));
+    }
+
+    @Test
+    @DisplayName("PSortedSetGenerator.supports returns false for non-DeclaredType")
+    void psortedSetSupportsRejectsNonDeclared() {
+      assertFalse(new PSortedSetGenerator().supports(nonDeclaredType()));
+    }
+
+    @Test
+    @DisplayName("PBagGenerator.supports returns false for non-DeclaredType")
+    void pbagSupportsRejectsNonDeclared() {
+      assertFalse(new PBagGenerator().supports(nonDeclaredType()));
+    }
+  }
+
+  @Nested
+  @DisplayName("PMapValueGenerator fallbacks")
+  class PMapValueGeneratorFallbacks {
+
+    @Test
+    @DisplayName("supports returns false for non-DeclaredType")
+    void supportsRejectsNonDeclared() {
+      assertFalse(new PMapValueGenerator().supports(nonDeclaredType()));
+    }
+
+    @Test
+    @DisplayName("supports returns false when element is null")
+    void supportsRejectsNullElement() {
+      assertFalse(new PMapValueGenerator().supports(declaredType(null, List.of())));
+    }
+
+    @Test
+    @DisplayName("generateModifyF falls back to Object for DeclaredType with no type arguments")
+    void fallsBackToObjectForEmptyTypeArgs() {
+      var gen = new PMapValueGenerator();
+      var component = componentOf("data", declaredType(null, List.of()));
+      var code = gen.generateModifyF(component, DUMMY_CLASS, List.of(component));
+      assertNotNull(code);
+      assertTrue(code.toString().contains("Object"));
+    }
+
+    @Test
+    @DisplayName("generateModifyF falls back to Object for non-DeclaredType component")
+    void fallsBackToObjectForNonDeclaredType() {
+      var gen = new PMapValueGenerator();
+      var component = componentOf("data", nonDeclaredType());
+      var code = gen.generateModifyF(component, DUMMY_CLASS, List.of(component));
+      assertNotNull(code);
+      assertTrue(code.toString().contains("Object"));
+    }
+  }
+
+  @Nested
+  @DisplayName("PSortedMapValueGenerator fallbacks")
+  class PSortedMapValueGeneratorFallbacks {
+
+    @Test
+    @DisplayName("supports returns false for non-DeclaredType")
+    void supportsRejectsNonDeclared() {
+      assertFalse(new PSortedMapValueGenerator().supports(nonDeclaredType()));
+    }
+
+    @Test
+    @DisplayName("supports returns false when element is null")
+    void supportsRejectsNullElement() {
+      assertFalse(new PSortedMapValueGenerator().supports(declaredType(null, List.of())));
+    }
+
+    @Test
+    @DisplayName("generateModifyF falls back to Object for DeclaredType with no type arguments")
+    void fallsBackToObjectForEmptyTypeArgs() {
+      var gen = new PSortedMapValueGenerator();
+      var component = componentOf("data", declaredType(null, List.of()));
+      var code = gen.generateModifyF(component, DUMMY_CLASS, List.of(component));
+      assertNotNull(code);
+      assertTrue(code.toString().contains("Object"));
+    }
+
+    @Test
+    @DisplayName("generateModifyF falls back to Object for non-DeclaredType component")
+    void fallsBackToObjectForNonDeclaredType() {
+      var gen = new PSortedMapValueGenerator();
       var component = componentOf("data", nonDeclaredType());
       var code = gen.generateModifyF(component, DUMMY_CLASS, List.of(component));
       assertNotNull(code);

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PBagGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PBagGeneratorTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PBagGenerator")
+public class PBagGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PBag fields")
+  void shouldGenerateCorrectTraversal() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Article",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PBag;
+
+            @GenerateTraversals
+            public record Article(long id, PBag<String> mentions) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceList = new ArrayList<>(source.mentions());
+        final var effectOfList = Traversals.traverseList(sourceList, f, applicative);
+        final var effectOfConvertBack = applicative.map(newList -> HashTreePBag.from(newList), effectOfList);
+        return applicative.map(converted -> new Article(source.id(), converted), effectOfConvertBack);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ArticleTraversals", expectedBody);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PMapValueGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PMapValueGeneratorTest.java
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PMapValueGenerator")
+public class PMapValueGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PMap value fields")
+  void shouldGenerateCorrectTraversalForPMapValue() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Config",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PMap;
+            import java.util.Map;
+            import java.util.ArrayList;
+            import java.util.function.Function;
+            import java.util.stream.Collectors;
+            import org.higherkindedj.hkt.Kind;
+            import org.higherkindedj.optics.util.Traversals;
+
+            @GenerateTraversals
+            public record Config(String id, PMap<String, Integer> properties) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceEntries = new ArrayList<>(source.properties().entrySet());
+        final Function<Map.Entry<String, Integer>, Kind<F, Map.Entry<String, Integer>>> entryF =
+            entry -> applicative.map(newValue -> Map.entry(entry.getKey(), newValue), f.apply(entry.getValue()));
+        final var effectOfEntries = Traversals.traverseList(sourceEntries, entryF, applicative);
+        final var effectOfMap = applicative.map(
+            newEntries -> newEntries.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+            effectOfEntries);
+        return applicative.map(
+            jdkMap -> new Config(source.id(), HashTreePMap.from(jdkMap)),
+            effectOfMap);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ConfigTraversals", expectedBody);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PSetGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PSetGeneratorTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PSetGenerator")
+public class PSetGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PSet fields")
+  void shouldGenerateCorrectTraversal() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Article",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PSet;
+
+            @GenerateTraversals
+            public record Article(long id, PSet<String> labels) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceList = new ArrayList<>(source.labels());
+        final var effectOfList = Traversals.traverseList(sourceList, f, applicative);
+        final var effectOfConvertBack = applicative.map(newList -> HashTreePSet.from(newList), effectOfList);
+        return applicative.map(converted -> new Article(source.id(), converted), effectOfConvertBack);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ArticleTraversals", expectedBody);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedMapValueGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedMapValueGeneratorTest.java
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PSortedMapValueGenerator")
+public class PSortedMapValueGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PSortedMap value fields")
+  void shouldGenerateCorrectTraversalForPSortedMapValue() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Config",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PSortedMap;
+            import java.util.Map;
+            import java.util.ArrayList;
+            import java.util.function.Function;
+            import java.util.stream.Collectors;
+            import org.higherkindedj.hkt.Kind;
+            import org.higherkindedj.optics.util.Traversals;
+
+            @GenerateTraversals
+            public record Config(String id, PSortedMap<String, Integer> properties) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceEntries = new ArrayList<>(source.properties().entrySet());
+        final Function<Map.Entry<String, Integer>, Kind<F, Map.Entry<String, Integer>>> entryF =
+            entry -> applicative.map(newValue -> Map.entry(entry.getKey(), newValue), f.apply(entry.getValue()));
+        final var effectOfEntries = Traversals.traverseList(sourceEntries, entryF, applicative);
+        final var effectOfMap = applicative.map(
+            newEntries -> newEntries.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+            effectOfEntries);
+        return applicative.map(
+            jdkMap -> new Config(source.id(), TreePMap.from(jdkMap)),
+            effectOfMap);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ConfigTraversals", expectedBody);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedSetGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PSortedSetGeneratorTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PSortedSetGenerator")
+public class PSortedSetGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PSortedSet fields")
+  void shouldGenerateCorrectTraversal() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Article",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PSortedSet;
+
+            @GenerateTraversals
+            public record Article(long id, PSortedSet<String> rankedTerms) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceList = new ArrayList<>(source.rankedTerms());
+        final var effectOfList = Traversals.traverseList(sourceList, f, applicative);
+        final var effectOfConvertBack = applicative.map(newList -> TreePSet.from(newList), effectOfList);
+        return applicative.map(converted -> new Article(source.id(), converted), effectOfConvertBack);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ArticleTraversals", expectedBody);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PStackGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PStackGeneratorTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PStackGenerator")
+public class PStackGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PStack fields")
+  void shouldGenerateCorrectTraversal() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Article",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PStack;
+
+            @GenerateTraversals
+            public record Article(long id, PStack<String> tags) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceList = new ArrayList<>(source.tags());
+        final var effectOfList = Traversals.traverseList(sourceList, f, applicative);
+        final var effectOfConvertBack = applicative.map(newList -> ConsPStack.from(newList), effectOfList);
+        return applicative.map(converted -> new Article(source.id(), converted), effectOfConvertBack);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ArticleTraversals", expectedBody);
+  }
+}

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PVectorGeneratorTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/pcollections/PVectorGeneratorTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.generator.pcollections;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.generator.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.higherkindedj.optics.processing.TraversalProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PVectorGenerator")
+public class PVectorGeneratorTest {
+  @Test
+  @DisplayName("should generate correct traversal for PVector fields")
+  void shouldGenerateCorrectTraversal() {
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Article",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+            import org.pcollections.PVector;
+
+            @GenerateTraversals
+            public record Article(long id, PVector<String> keywords) {}
+            """);
+
+    final String expectedBody =
+        """
+        final var sourceList = new ArrayList<>(source.keywords());
+        final var effectOfList = Traversals.traverseList(sourceList, f, applicative);
+        final var effectOfConvertBack = applicative.map(newList -> TreePVector.from(newList), effectOfList);
+        return applicative.map(converted -> new Article(source.id(), converted), effectOfConvertBack);
+        """;
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.example.ArticleTraversals", expectedBody);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/TraversalProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/TraversalProcessor.java
@@ -133,15 +133,10 @@ public class TraversalProcessor extends AbstractProcessor {
         return null; // Cannot traverse a raw type.
       }
 
-      // Handle special cases like Either, Validated, and Map which have multiple type arguments.
-      // A more advanced solution would be to add a `getFocusType` method to the SPI.
-      String generatorName = generator.getClass().getSimpleName();
-      int typeArgumentIndex = 0; // Default to the first type argument
-      if (generatorName.equals("EitherGenerator")
-          || generatorName.equals("ValidatedGenerator")
-          || generatorName.equals("MapValueGenerator")) {
-        typeArgumentIndex = 1; // These traverse the second type argument
-      }
+      // Use the SPI's getFocusTypeArgumentIndex() so any generator can declare which type
+      // argument it traverses (V for Map/PMap, R for Either, A for Validated, the default
+      // index 0 for collection-like types).
+      int typeArgumentIndex = generator.getFocusTypeArgumentIndex();
 
       if (declaredType.getTypeArguments().size() <= typeArgumentIndex) {
         return null; // Not enough type arguments for this generator.


### PR DESCRIPTION
Adds seven TraversableGenerator implementations that teach @GenerateTraversals how to navigate PCollections persistent collections, plus compile-testing tests, README updates, and a dedicated book page.

Generators (all under hkj-processor-plugins/.../generator/pcollections):

- PCollectionsBaseSingleIterableTraversableGenerator: shared base for the five collection-like generators. Copies the persistent type into a JDK ArrayList for traversal (PCollections types implement java.util.Collection so the copy constructor works directly), then reconstructs via the factory's from(Collection) method.
- PCollectionsBaseMapValueTraversableGenerator: shared base for the two map-value generators. Pulls entrySet() into an ArrayList, traverses, rebuilds a JDK Map, then hands it to the persistent factory's from(Map) method.
- PVectorGenerator -> TreePVector.from
- PStackGenerator -> ConsPStack.from
- PSetGenerator -> HashTreePSet.from
- PSortedSetGenerator -> TreePSet.from (natural ordering only)
- PBagGenerator -> HashTreePBag.from
- PMapValueGenerator -> HashTreePMap.from (focuses on values, index 1)
- PSortedMapValueGenerator -> TreePMap.from (natural key ordering)

All seven are registered in the module-info provides clause and exposed via @ServiceProvider(TraversableGenerator.class) so they discover automatically when org.pcollections:pcollections is on the annotation processor classpath. Each has a corresponding *GeneratorTest using google compile-testing; the assertion helper normalises whitespace so the expected bodies are robust against palantir-java-format's choices.

Documentation:

- hkj-processor-plugins/README.md: PCollections type table and an updated architecture diagram covering both base classes; generator count bumped from 23 to 30.
- hkj-book/src/tooling/pcollections_optics.md: new dedicated page covering the generator catalogue, a worked example, the natural- ordering caveat for PSortedSet/PSortedMap, and hand-written optic guidance via EachInstances.fromIterableCollecting.
- hkj-book/src/tooling/generator_plugins.md and SUMMARY.md updated to cross-link the new page and reflect the 30-generator total.

The "PCollections-specific TraversalPath factory methods" item in issue #441 is intentionally not implemented: no other library integration in the repo provides them (Eclipse, Vavr, Guava, Apache all rely on the generic EachInstances.fromIterableCollecting helper), and adding PCollections-only factories would create an inconsistent pattern. Hand-written optics use TreePVector::from / ConsPStack::from / etc. as method references against the existing helper.

Fixes #441 