### PR TITLE
Implement #515: mapValuesEachCollecting for persistent/third-party map values

### DIFF
--- a/hkj-book/src/optics/common_data_structure_traversals.md
+++ b/hkj-book/src/optics/common_data_structure_traversals.md
@@ -45,6 +45,7 @@ Higher-kinded-j provides factory methods in `Traversals` and dedicated utility c
 |-----------|--------|-------------|----------|
 | **Optional** | `Traversals.forOptional()` | 0 or 1 | Nullable fields, configuration values |
 | **Map Values** | `Traversals.forMapValues()` | 0 to N | Bulk value transforms, preserving keys |
+| **Persistent/3rd-party Map Values** | `Traversals.forMapValuesCollecting(...)` | 0 to N | Same, for `PMap`, Guava/Eclipse/Vavr maps |
 | **Tuple2 Pairs** | `TupleTraversals.both()` | Exactly 2 | Coordinate systems, min/max pairs |
 
 ---
@@ -268,6 +269,38 @@ ServiceRegistry updated = Traversals.modify(
     registry
 );
 ```
+
+### Persistent and Third-Party Maps: `forMapValuesCollecting()`
+
+`forMapValues()` is hard-wired to `java.util.HashMap`. To traverse the values of a *persistent* or *specialised* map — PCollections `PMap` / `PSortedMap`, Guava `ImmutableMap`, Eclipse Collections `ImmutableMap`, Vavr `io.vavr.collection.Map` — use `forMapValuesCollecting()`. It is the map-shaped companion to `forIterableCollecting()`, which does the same job for non-`Iterable` collections.
+
+For any map type that *implements* `java.util.Map` (PCollections maps, Guava `ImmutableMap`, Apache Commons map decorators, …), pass a single rebuild function:
+
+```java
+import org.pcollections.PMap;
+import org.pcollections.HashTreePMap;
+
+Traversal<PMap<String, Integer>, Integer> pmapValues =
+    Traversals.forMapValuesCollecting(HashTreePMap::from);
+
+PMap<String, Integer> scores =
+    HashTreePMap.<String, Integer>empty().plus("math", 90).plus("science", 95);
+PMap<String, Integer> updated =
+    Traversals.modify(pmapValues, score -> score + 10, scores);   // keys preserved
+```
+
+For map types that are *not* `java.util.Map` (Eclipse Collections `ImmutableMap`, Vavr `Map`), pass a view function as well — one that exposes the container as a JDK `Map`, plus one that rebuilds it:
+
+```java
+// Vavr HashMap
+Traversal<io.vavr.collection.HashMap<String, Integer>, Integer> vavrValues =
+    Traversals.forMapValuesCollecting(
+        io.vavr.collection.HashMap::toJavaMap, io.vavr.collection.HashMap::ofAll);
+```
+
+The same two overloads exist on `EachInstances` for use in the Focus DSL — `EachInstances.mapValuesEachCollecting(HashTreePMap::from)` — which is how `@GenerateFocus` widens `PMap` / `PSortedMap` fields into `TraversalPath`s. See [PCollections Optics](../tooling/pcollections_optics.md).
+
+> Like `forMapValues()`, the value transformation never touches keys. Sorted-map collectors (`TreePMap::from`, Vavr `TreeMap::ofAll`) re-apply natural ordering; custom comparators are not preserved.
 
 ---
 
@@ -538,7 +571,7 @@ Structure traversals extend the traversal pattern to common Java data types:
 | Structure | Traversal | Key Benefit |
 |-----------|-----------|-------------|
 | **Optional** | `forOptional()` | Null-safe composition without `.map()` chains |
-| **Map Values** | `forMapValues()` | Bulk value transformation preserving keys |
+| **Map Values** | `forMapValues()` / `forMapValuesCollecting()` | Bulk value transformation preserving keys, JDK or persistent maps |
 | **Tuple2 Pairs** | `both()` | Parallel operations on homogeneous pairs |
 
 These tools transform how you work with wrapped and paired values:

--- a/hkj-book/src/tooling/pcollections_optics.md
+++ b/hkj-book/src/tooling/pcollections_optics.md
@@ -29,7 +29,7 @@ Map generators focus on the value type (index 1). Keys are passed through unchan
 
 All seven generators run at the default priority and activate automatically once `org.pcollections:pcollections` is on your annotation processor's classpath.
 
-> The five collection-like generators (`PVector` / `PStack` / `PSet` / `PSortedSet` / `PBag`) also participate in `@GenerateFocus` navigator generation via `EachInstances.fromIterableCollecting`. The two map-value generators currently support `@GenerateTraversals` only; Focus DSL navigation through `PMap` / `PSortedMap` value fields would require a dedicated `mapValuesEachCollecting` helper that does not yet exist in `hkj-core`.
+> All seven generators participate in `@GenerateFocus` navigator generation. The five collection-like generators (`PVector` / `PStack` / `PSet` / `PSortedSet` / `PBag`) widen through [`EachInstances.fromIterableCollecting`](../optics/common_data_structure_traversals.md); the two map-value generators widen through [`EachInstances.mapValuesEachCollecting`](../optics/common_data_structure_traversals.md), the map-shaped companion to `fromIterableCollecting`. So `@GenerateFocus` on a record with a `PMap` or `PSortedMap` field produces a navigator returning a `TraversalPath` over the values.
 
 ---
 
@@ -99,12 +99,18 @@ import org.higherkindedj.optics.each.EachInstances;
 import org.higherkindedj.optics.each.Each;
 import org.pcollections.PVector;
 import org.pcollections.TreePVector;
+import org.pcollections.PMap;
+import org.pcollections.HashTreePMap;
 
 Each<PVector<String>, String> pvectorEach =
     EachInstances.fromIterableCollecting(TreePVector::from);
+
+// Persistent maps use the map-shaped companion helper.
+Each<PMap<String, Integer>, Integer> pmapValues =
+    EachInstances.mapValuesEachCollecting(HashTreePMap::from);
 ```
 
-`fromIterableCollecting` accepts any function that builds a persistent collection from a `List`, so the same form covers all the PCollections types. There is no library-specific factory class; the generic helper is the public API.
+`fromIterableCollecting` accepts any function that builds a persistent collection from a `List`; `mapValuesEachCollecting` does the same for any `java.util.Map` subtype, rebuilding the persistent map from a JDK `Map`. The same forms cover all the PCollections types — there is no library-specific factory class; the generic helpers are the public API.
 
 ---
 
@@ -121,7 +127,7 @@ For projects already on Eclipse Collections or Vavr, those existing generators r
 * **Activation is automatic** once PCollections is on the annotation processor classpath
 * **Reconstruction goes through `from(Collection)` / `from(Map)`**, so traversals round-trip cleanly through the persistent type
 * **Sorted variants assume natural ordering**; custom comparators are not preserved by generated code
-* **Use `EachInstances.fromIterableCollecting(TreePVector::from)`** for hand-written optics outside `@GenerateTraversals`
+* **Use `EachInstances.fromIterableCollecting(TreePVector::from)`** (collections) or **`EachInstances.mapValuesEachCollecting(HashTreePMap::from)`** (maps) for hand-written optics outside `@GenerateTraversals`
 ~~~
 
 ~~~admonish tip title="See Also"

--- a/hkj-core/src/main/java/org/higherkindedj/optics/each/EachInstances.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/each/EachInstances.java
@@ -438,4 +438,65 @@ public final class EachInstances {
       Function<List<A>, C> collector) {
     return () -> Traversals.forIterableCollecting(collector);
   }
+
+  // ===== Generic Map Values =====
+
+  /**
+   * Creates an {@link Each} instance for the values of an arbitrary map-shaped container, given a
+   * function that exposes it as a {@code java.util.Map} and a function that reconstructs it.
+   *
+   * <p>Use this overload for map types that do <em>not</em> implement {@link Map} — for example
+   * Eclipse Collections {@code ImmutableMap} or Vavr {@code io.vavr.collection.Map}. For types that
+   * already extend {@link Map} prefer the single-argument {@link
+   * #mapValuesEachCollecting(Function)}.
+   *
+   * <pre>{@code
+   * // Vavr HashMap
+   * Each<io.vavr.collection.HashMap<String, Integer>, Integer> vavrValues =
+   *     EachInstances.mapValuesEachCollecting(
+   *         io.vavr.collection.HashMap::toJavaMap, io.vavr.collection.HashMap::ofAll);
+   * }</pre>
+   *
+   * @param view A function exposing the map-shaped container as a {@code java.util.Map}.
+   * @param rebuild A function that converts a {@code Map} back into the container type {@code M}.
+   * @param <M> The map-shaped container type.
+   * @param <K> The key type of the map.
+   * @param <V> The value type of the map.
+   * @return An {@code Each} instance for the values of the container.
+   */
+  public static <M, K, V> Each<M, V> mapValuesEachCollecting(
+      Function<M, Map<K, V>> view, Function<Map<K, V>, M> rebuild) {
+    return () -> Traversals.forMapValuesCollecting(view, rebuild);
+  }
+
+  /**
+   * Creates an {@link Each} instance for the values of a {@link Map}-implementing container, given
+   * a function that reconstructs the container from a {@code java.util.Map}. Companion to {@link
+   * #fromIterableCollecting} for non-{@code Iterable} containers.
+   *
+   * <p>The bound {@code M extends Map} keeps the helper applicable to any persistent or specialised
+   * map whose interface inherits from {@link Map}: PCollections {@code PMap} / {@code PSortedMap},
+   * Guava {@code ImmutableMap}, Apache Commons map decorators, etc. For map types that are not
+   * {@code java.util.Map}s, use {@link #mapValuesEachCollecting(Function, Function)}.
+   *
+   * <pre>{@code
+   * // PCollections HashTreePMap
+   * Each<PMap<String, Integer>, Integer> pmapValues =
+   *     EachInstances.mapValuesEachCollecting(HashTreePMap::from);
+   *
+   * // Guava ImmutableMap
+   * Each<ImmutableMap<String, Integer>, Integer> guavaValues =
+   *     EachInstances.mapValuesEachCollecting(ImmutableMap::copyOf);
+   * }</pre>
+   *
+   * @param collector A function that converts a {@code Map} back into the map type {@code M}.
+   * @param <M> The map type, which must be {@code Map<K, V>}.
+   * @param <K> The key type of the map.
+   * @param <V> The value type of the map.
+   * @return An {@code Each} instance for the values of the map.
+   */
+  public static <M extends Map<K, V>, K, V> Each<M, V> mapValuesEachCollecting(
+      Function<Map<K, V>, M> collector) {
+    return () -> Traversals.forMapValuesCollecting(collector);
+  }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/optics/util/Traversals.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/util/Traversals.java
@@ -400,6 +400,79 @@ public final class Traversals {
   }
 
   /**
+   * Creates a {@code Traversal} that focuses on every value of an arbitrary map-shaped container,
+   * reconstructing it via the provided collector.
+   *
+   * <p>The traversal exposes the source as a {@code java.util.Map} via {@code view}, applies the
+   * effectful function to each value while keeping the keys unchanged, then hands the rebuilt JDK
+   * map to {@code rebuild} to produce a fresh instance of the container type {@code M}.
+   *
+   * <p>Use this overload for map types that do <em>not</em> implement {@link Map} — for example
+   * Eclipse Collections {@code ImmutableMap} or Vavr {@code io.vavr.collection.Map}. For types that
+   * already extend {@link Map} (PCollections {@code PMap}, Guava {@code ImmutableMap}, …) prefer
+   * the single-argument {@link #forMapValuesCollecting(Function)}.
+   *
+   * <pre>{@code
+   * // Vavr HashMap
+   * Traversal<io.vavr.collection.HashMap<String, Integer>, Integer> vavrValues =
+   *     Traversals.forMapValuesCollecting(
+   *         io.vavr.collection.HashMap::toJavaMap, io.vavr.collection.HashMap::ofAll);
+   * }</pre>
+   *
+   * @param view A function exposing the map-shaped container as a {@code java.util.Map}.
+   * @param rebuild A function that converts a {@code Map} back into the container type {@code M}.
+   * @param <M> The map-shaped container type.
+   * @param <K> The type of the map's keys.
+   * @param <V> The type of the map's values.
+   * @return A {@code Traversal} for all values of the container.
+   */
+  public static <M, K, V> Traversal<M, V> forMapValuesCollecting(
+      final Function<M, Map<K, V>> view, final Function<Map<K, V>, M> rebuild) {
+    return new Traversal<>() {
+      @Override
+      public <F extends WitnessArity<TypeArity.Unary>> Kind<F, M> modifyF(
+          final Function<V, Kind<F, V>> f, final M source, final Applicative<F> applicative) {
+        final Kind<F, Map<K, V>> traversed = traverseMapValues(view.apply(source), f, applicative);
+        return applicative.map(rebuild, traversed);
+      }
+    };
+  }
+
+  /**
+   * Creates a {@code Traversal} that focuses on every value of a {@link Map}-implementing
+   * container, reconstructing it via the provided collector. Companion to {@link
+   * #forIterableCollecting} for non-{@code Iterable} containers.
+   *
+   * <p>The traversal applies the effectful function to each value of {@code source} while keeping
+   * the keys unchanged, then hands the rebuilt JDK map to {@code collector} to produce a fresh
+   * instance of {@code M}. The bound {@code M extends Map} keeps the helper applicable to any
+   * persistent or specialised map whose interface inherits from {@link Map}: PCollections {@code
+   * PMap} / {@code PSortedMap}, Guava {@code ImmutableMap}, Apache Commons map decorators, etc. For
+   * map types that are not {@code java.util.Map}s, use {@link #forMapValuesCollecting(Function,
+   * Function)}.
+   *
+   * <pre>{@code
+   * // PCollections HashTreePMap
+   * Traversal<PMap<String, Integer>, Integer> pmapValues =
+   *     Traversals.forMapValuesCollecting(HashTreePMap::from);
+   *
+   * // Guava ImmutableMap
+   * Traversal<ImmutableMap<String, Integer>, Integer> guavaValues =
+   *     Traversals.forMapValuesCollecting(ImmutableMap::copyOf);
+   * }</pre>
+   *
+   * @param collector A function that converts a {@code Map} back into the map type {@code M}.
+   * @param <M> The map type, which must be {@code Map<K, V>}.
+   * @param <K> The type of the map's keys.
+   * @param <V> The type of the map's values.
+   * @return A {@code Traversal} for all values of the map.
+   */
+  public static <M extends Map<K, V>, K, V> Traversal<M, V> forMapValuesCollecting(
+      final Function<Map<K, V>, M> collector) {
+    return forMapValuesCollecting(m -> m, collector);
+  }
+
+  /**
    * Applies an effectful function to each element of a {@link List} and collects the results in a
    * single effect.
    *

--- a/hkj-core/src/test/java/org/higherkindedj/optics/each/EachInstancesTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/each/EachInstancesTest.java
@@ -1278,4 +1278,77 @@ class EachInstancesTest {
       assertThat(each.supportsIndexed()).isFalse();
     }
   }
+
+  // ===== mapValuesEachCollecting Factory =====
+
+  /** A map-shaped container that is deliberately NOT a {@link java.util.Map}. */
+  record FrozenMap<K, V>(Map<K, V> entries) {}
+
+  @Nested
+  @DisplayName("mapValuesEachCollecting Factory")
+  class MapValuesEachCollectingTests {
+
+    @Test
+    @DisplayName("two-arg overload should traverse the values of a non-Map container")
+    void twoArg_traverses() {
+      Each<FrozenMap<String, Integer>, Integer> each =
+          EachInstances.mapValuesEachCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source =
+          new FrozenMap<>(new LinkedHashMap<>(Map.of("a", 1, "b", 2, "c", 3)));
+
+      List<Integer> values = Traversals.getAll(each.each(), source);
+
+      assertThat(values).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("two-arg overload should modify values and preserve keys")
+    void twoArg_modifies() {
+      Each<FrozenMap<String, Integer>, Integer> each =
+          EachInstances.mapValuesEachCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source = new FrozenMap<>(Map.of("x", 10, "y", 20));
+
+      FrozenMap<String, Integer> modified = Traversals.modify(each.each(), n -> n + 1, source);
+
+      assertThat(modified.entries()).containsOnly(Map.entry("x", 11), Map.entry("y", 21));
+    }
+
+    @Test
+    @DisplayName("two-arg overload should handle an empty container")
+    void twoArg_empty() {
+      Each<FrozenMap<String, Integer>, Integer> each =
+          EachInstances.mapValuesEachCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source = new FrozenMap<>(new HashMap<>());
+
+      assertThat(Traversals.getAll(each.each(), source)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("single-arg overload should traverse and modify a Map subtype")
+    void singleArg_traversesAndModifies() {
+      Each<TreeMap<String, Integer>, Integer> each =
+          EachInstances.mapValuesEachCollecting(map -> new TreeMap<>(map));
+      TreeMap<String, Integer> source = new TreeMap<>(Map.of("a", 1, "b", 2));
+
+      assertThat(Traversals.getAll(each.each(), source)).containsExactlyInAnyOrder(1, 2);
+      TreeMap<String, Integer> modified = Traversals.modify(each.each(), n -> n * 100, source);
+      assertThat(modified).containsExactly(Map.entry("a", 100), Map.entry("b", 200));
+    }
+
+    @Test
+    @DisplayName("single-arg overload should handle an empty Map")
+    void singleArg_empty() {
+      Each<TreeMap<String, Integer>, Integer> each =
+          EachInstances.mapValuesEachCollecting(map -> new TreeMap<>(map));
+      assertThat(Traversals.getAll(each.each(), new TreeMap<>())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("supportsIndexed() should return false")
+    void supportsIndexedReturnsFalse() {
+      Each<TreeMap<String, Integer>, Integer> each =
+          EachInstances.mapValuesEachCollecting(map -> new TreeMap<>(map));
+      assertThat(each.supportsIndexed()).isFalse();
+    }
+  }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/optics/util/TraversalsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/util/TraversalsTest.java
@@ -3622,4 +3622,122 @@ class TraversalsTest {
       assertThat(outer).isEmpty();
     }
   }
+
+  // =============================================================================
+  // forMapValuesCollecting Tests
+  // =============================================================================
+
+  /** A map-shaped container that is deliberately NOT a {@link java.util.Map}. */
+  record FrozenMap<K, V>(Map<K, V> entries) {}
+
+  @Nested
+  @DisplayName("forMapValuesCollecting Tests")
+  class ForMapValuesCollectingTests {
+
+    @Test
+    @DisplayName("two-arg overload should traverse the values of a non-Map container")
+    void twoArg_getAll() {
+      Traversal<FrozenMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source =
+          new FrozenMap<>(new LinkedHashMap<>(Map.of("a", 1, "b", 2, "c", 3)));
+
+      List<Integer> values = Traversals.getAll(traversal, source);
+
+      assertThat(values).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("two-arg overload should modify values and preserve keys")
+    void twoArg_modifyPreservesKeys() {
+      Traversal<FrozenMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source = new FrozenMap<>(Map.of("x", 10, "y", 20));
+
+      FrozenMap<String, Integer> modified = Traversals.modify(traversal, n -> n + 1, source);
+
+      assertThat(modified.entries()).containsOnly(Map.entry("x", 11), Map.entry("y", 21));
+    }
+
+    @Test
+    @DisplayName("two-arg overload should handle an empty container")
+    void twoArg_empty() {
+      Traversal<FrozenMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source = new FrozenMap<>(new HashMap<>());
+
+      FrozenMap<String, Integer> modified = Traversals.modify(traversal, n -> n + 1, source);
+
+      assertThat(Traversals.getAll(traversal, source)).isEmpty();
+      assertThat(modified.entries()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("two-arg overload should compose with filtered")
+    void twoArg_composesWithFiltered() {
+      Traversal<FrozenMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(FrozenMap::entries, FrozenMap::new);
+      Traversal<FrozenMap<String, Integer>, Integer> evenOnly =
+          traversal.andThen(Traversals.filtered(n -> n % 2 == 0));
+
+      FrozenMap<String, Integer> source =
+          new FrozenMap<>(new LinkedHashMap<>(Map.of("a", 1, "b", 2, "c", 3, "d", 4)));
+
+      assertThat(Traversals.getAll(evenOnly, source)).containsExactlyInAnyOrder(2, 4);
+    }
+
+    @Test
+    @DisplayName("two-arg overload should propagate failure in Optional context")
+    void twoArg_failurePropagates() {
+      Traversal<FrozenMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(FrozenMap::entries, FrozenMap::new);
+      FrozenMap<String, Integer> source =
+          new FrozenMap<>(new LinkedHashMap<>(Map.of("a", 1, "b", 2, "c", 3)));
+
+      Kind<OptionalKind.Witness, FrozenMap<String, Integer>> result =
+          traversal.modifyF(
+              n ->
+                  OptionalKindHelper.OPTIONAL.widen(
+                      n == 2 ? Optional.empty() : Optional.of(n * 10)),
+              source,
+              OptionalMonad.INSTANCE);
+
+      assertThat(OPTIONAL.narrow(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("single-arg overload should traverse values of a Map subtype")
+    void singleArg_getAll() {
+      Traversal<TreeMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(map -> new TreeMap<>(map));
+      TreeMap<String, Integer> source = new TreeMap<>(Map.of("a", 1, "b", 2));
+
+      assertThat(Traversals.getAll(traversal, source)).containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    @DisplayName("single-arg overload should modify values and preserve keys")
+    void singleArg_modify() {
+      Traversal<TreeMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(map -> new TreeMap<>(map));
+      TreeMap<String, Integer> source = new TreeMap<>(Map.of("a", 1, "b", 2));
+
+      TreeMap<String, Integer> modified = Traversals.modify(traversal, n -> n * 100, source);
+
+      assertThat(modified).containsExactly(Map.entry("a", 100), Map.entry("b", 200));
+    }
+
+    @Test
+    @DisplayName("single-arg overload should handle an empty Map")
+    void singleArg_empty() {
+      Traversal<TreeMap<String, Integer>, Integer> traversal =
+          Traversals.forMapValuesCollecting(map -> new TreeMap<>(map));
+      TreeMap<String, Integer> source = new TreeMap<>();
+
+      TreeMap<String, Integer> modified = Traversals.modify(traversal, n -> n * 100, source);
+
+      assertThat(Traversals.getAll(traversal, source)).isEmpty();
+      assertThat(modified).isEmpty();
+    }
+  }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/EachInstancesExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/EachInstancesExample.java
@@ -65,6 +65,7 @@ public class EachInstancesExample {
     demonstrateTryEach();
     demonstrateValidatedEach();
     demonstrateIndexedTraversal();
+    demonstrateMapValuesEachCollecting();
     demonstrateFocusDslIntegration();
     demonstrateCustomEach();
   }
@@ -413,6 +414,42 @@ public class EachInstancesExample {
     for (Product product : allProducts.getAll(discounted)) {
       System.out.printf("  %s: £%.2f%n", product.name(), product.price());
     }
+
+    System.out.println();
+  }
+
+  /** A map-shaped container that is not a {@link Map}, used to show the two-argument overload. */
+  private record CurrencyExposure(Map<String, Integer> byCurrency) {}
+
+  /**
+   * Demonstrates {@link EachInstances#mapValuesEachCollecting} — the companion to {@code
+   * fromIterableCollecting} for map-shaped containers. The single-argument overload works for any
+   * {@code java.util.Map} subtype (persistent maps such as PCollections {@code PMap}, Guava {@code
+   * ImmutableMap}, …); the two-argument overload additionally covers map types that are not {@code
+   * java.util.Map}, such as Eclipse Collections {@code ImmutableMap} or Vavr {@code
+   * io.vavr.collection.Map}.
+   */
+  private static void demonstrateMapValuesEachCollecting() {
+    System.out.println("--- Generic Map Values Each (mapValuesEachCollecting) ---");
+
+    // Single-argument overload: M extends Map. Here a TreeMap stands in for a persistent/sorted map
+    // such as PCollections TreePMap (which would use `TreePMap::from`).
+    Each<TreeMap<String, Integer>, Integer> sortedValues =
+        EachInstances.mapValuesEachCollecting(map -> new TreeMap<>(map));
+    TreeMap<String, Integer> prices = new TreeMap<>(Map.of("eur", 100, "gbp", 120, "usd", 110));
+    TreeMap<String, Integer> withVat =
+        Traversals.modify(sortedValues.each(), p -> Math.round(p * 1.2f), prices);
+    System.out.println("Prices: " + prices);
+    System.out.println("With VAT (keys preserved): " + withVat);
+
+    // Two-argument overload: arbitrary map-shaped container that is not a java.util.Map.
+    Each<CurrencyExposure, Integer> exposureValues =
+        EachInstances.mapValuesEachCollecting(CurrencyExposure::byCurrency, CurrencyExposure::new);
+    CurrencyExposure exposure = new CurrencyExposure(Map.of("eur", 5, "usd", 3));
+    CurrencyExposure doubled = Traversals.modify(exposureValues.each(), v -> v * 2, exposure);
+    System.out.println("Exposure: " + exposure.byCurrency());
+    System.out.println("Doubled exposure: " + doubled.byCurrency());
+    System.out.println("Supports indexed: " + exposureValues.supportsIndexed());
 
     System.out.println();
   }

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PCollectionsBaseMapValueTraversableGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/pcollections/PCollectionsBaseMapValueTraversableGenerator.java
@@ -8,6 +8,7 @@ import com.palantir.javapoet.TypeName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
@@ -78,12 +79,21 @@ public abstract class PCollectionsBaseMapValueTraversableGenerator
     return 1; // PMap<K, V> focuses on V
   }
 
-  // The Focus DSL hooks (generateOpticExpression / getRequiredImports) are deliberately not
-  // implemented for PCollections map types. There is no library-agnostic
-  // {@code EachInstances.mapValuesEachCollecting(...)} helper, and {@code fromIterableCollecting}
-  // does not apply because Maps are not Iterable. {@code @GenerateTraversals} is fully
-  // supported; {@code @GenerateFocus} navigator generation for these fields is a separate
-  // future change.
+  @Override
+  public String generateOpticExpression() {
+    // Each PCollections map implements java.util.Map, so the single-argument
+    // mapValuesEachCollecting overload (bound M extends Map) applies directly.
+    return "EachInstances.mapValuesEachCollecting(map -> "
+        + constructedType.simpleName()
+        + ".from(map))";
+  }
+
+  @Override
+  public Set<String> getRequiredImports() {
+    return Set.of(
+        "org.higherkindedj.optics.each.EachInstances",
+        constructedType.packageName() + "." + constructedType.simpleName());
+  }
 
   @Override
   public CodeBlock generateModifyF(

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/GeneratorSpiMethodsTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/GeneratorSpiMethodsTest.java
@@ -431,24 +431,31 @@ class GeneratorSpiMethodsTest {
     }
 
     @Test
-    @DisplayName("PMapValueGenerator has no Focus DSL support yet")
+    @DisplayName("PMapValueGenerator")
     void pmapValue() {
       var gen = new PMapValueGenerator();
       assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
       assertEquals(1, gen.getFocusTypeArgumentIndex());
-      // PMap is not Iterable; the Focus DSL hooks fall back to the SPI default of "no support".
-      assertEquals("", gen.generateOpticExpression());
-      assertEquals(Set.of(), gen.getRequiredImports());
+      assertEquals(
+          "EachInstances.mapValuesEachCollecting(map -> HashTreePMap.from(map))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.HashTreePMap"),
+          gen.getRequiredImports());
     }
 
     @Test
-    @DisplayName("PSortedMapValueGenerator has no Focus DSL support yet")
+    @DisplayName("PSortedMapValueGenerator")
     void psortedMapValue() {
       var gen = new PSortedMapValueGenerator();
       assertEquals(Cardinality.ZERO_OR_MORE, gen.getCardinality());
       assertEquals(1, gen.getFocusTypeArgumentIndex());
-      assertEquals("", gen.generateOpticExpression());
-      assertEquals(Set.of(), gen.getRequiredImports());
+      assertEquals(
+          "EachInstances.mapValuesEachCollecting(map -> TreePMap.from(map))",
+          gen.generateOpticExpression());
+      assertEquals(
+          Set.of("org.higherkindedj.optics.each.EachInstances", "org.pcollections.TreePMap"),
+          gen.getRequiredImports());
     }
   }
 }

--- a/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/ThirdPartySpiWideningTest.java
+++ b/hkj-processor-plugins/src/test/java/org/higherkindedj/optics/processing/generator/ThirdPartySpiWideningTest.java
@@ -129,4 +129,55 @@ class ThirdPartySpiWideningTest {
       assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", "ImmutableList::copyOf");
     }
   }
+
+  @Nested
+  @DisplayName("PCollections")
+  class PCollections {
+
+    @Test
+    @DisplayName("PMap field should widen to TraversalPath via mapValuesEachCollecting")
+    void pmapNavigator() {
+      var outer =
+          JavaFileObjects.forSourceString(
+              "com.example.Portfolio",
+              """
+              package com.example;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.pcollections.PMap;
+              @GenerateFocus(widenCollections = true)
+              public record Portfolio(String owner, PMap<String, Integer> exposureByCurrency) {}
+              """);
+
+      Compilation compilation = javac().withProcessors(new FocusProcessor()).compile(outer);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.PortfolioFocus",
+          "EachInstances.mapValuesEachCollecting(map -> HashTreePMap.from(map))");
+    }
+
+    @Test
+    @DisplayName("PSortedMap field should widen to TraversalPath via TreePMap factory")
+    void psortedMapNavigator() {
+      var outer =
+          JavaFileObjects.forSourceString(
+              "com.example.Ledger",
+              """
+              package com.example;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.pcollections.PSortedMap;
+              @GenerateFocus(widenCollections = true)
+              public record Ledger(String id, PSortedMap<String, Integer> balances) {}
+              """);
+
+      Compilation compilation = javac().withProcessors(new FocusProcessor()).compile(outer);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.LedgerFocus",
+          "EachInstances.mapValuesEachCollecting(map -> TreePMap.from(map))");
+    }
+  }
 }


### PR DESCRIPTION
Adds the map-shaped companion to forIterableCollecting:

- Traversals.forMapValuesCollecting(Function<Map<K,V>, M>) — single-arg overload bounded M extends Map, for PCollections PMap/PSortedMap, Guava ImmutableMap, etc.
- Traversals.forMapValuesCollecting(Function<M, Map<K,V>>, Function<Map<K,V>, M>) — general two-arg overload (unbounded M) for map types that are not java.util.Map, e.g. Eclipse Collections ImmutableMap or Vavr Map.
- EachInstances.mapValuesEachCollecting mirrors both overloads for the Focus DSL.
- PCollectionsBaseMapValueTraversableGenerator now emits the Focus DSL optic expression + imports, so @GenerateFocus on PMap/PSortedMap fields produces a TraversalPath navigator.

Tests: full coverage for both overloads in TraversalsTest and EachInstancesTest (get/modify/empty/compose/failure-propagation, supportsIndexed), updated GeneratorSpiMethodsTest cases, and compile-test navigator coverage for PMap and PSortedMap in ThirdPartySpiWideningTest. Example added to EachInstancesExample; book pages cross-linked.

Fixes #515 