### PR TITLE
Implement #459: MonadZero.filter with optimised List/Stream overrides

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/hkt/MonadZero.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/MonadZero.java
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -53,5 +56,49 @@ public interface MonadZero<F extends WitnessArity<TypeArity.Unary>>
   @Override
   default <A> Kind<F, A> empty() {
     return zero();
+  }
+
+  /**
+   * Filters a monadic value by a predicate. If the predicate returns {@code false} for the value,
+   * the result is {@link #zero()} (the empty/failure value for this monad).
+   *
+   * <p>This is the monadic equivalent of {@link java.util.stream.Stream#filter} and {@link
+   * java.util.Optional#filter}. Note the argument order: predicate first, then the monadic value —
+   * this matches the typeclass-style of {@link Monad#flatMap(java.util.function.Function, Kind)},
+   * not the instance-method style of {@code Stream.filter} / {@code Optional.filter}.
+   *
+   * <p>The default implementation is derived from {@link #flatMap(java.util.function.Function,
+   * Kind)} and {@link #of(Object)} / {@link #zero()}, and so adds no new algebraic obligations:
+   *
+   * <pre>{@code filter(p, ma)  ≡  flatMap(a -> p.test(a) ? of(a) : zero(), ma) }</pre>
+   *
+   * <p>Concrete instances are free to override with a more efficient implementation (e.g. {@code
+   * ListMonad} and {@code StreamMonad} avoid building per-element singleton/empty collections).
+   *
+   * <p><b>Examples:</b>
+   *
+   * <pre>{@code
+   * // Maybe: keep evens
+   * MonadZero<MaybeKind.Witness> mz = MaybeMonad.INSTANCE;
+   * mz.filter(x -> x % 2 == 0, mz.of(4));  // Just(4)
+   * mz.filter(x -> x % 2 == 0, mz.of(3));  // Nothing
+   *
+   * // List: keep positives
+   * MonadZero<ListKind.Witness> lz = ListMonad.INSTANCE;
+   * lz.filter(x -> x > 0, LIST.widen(List.of(-1, 2, -3, 4)));  // [2, 4]
+   * }</pre>
+   *
+   * @param predicate the condition to test; must not be null
+   * @param ma the monadic value to filter; must not be null
+   * @param <A> the type of the value within the monad
+   * @return a monadic value containing only the elements of {@code ma} that satisfy the predicate
+   *     (e.g. {@code ma} or {@link #zero()} for single-valued monads such as {@code Maybe} / {@code
+   *     Optional}; a possibly-smaller collection for {@code List} / {@code Stream})
+   * @throws NullPointerException if {@code predicate} or {@code ma} is null
+   */
+  default <A> Kind<F, A> filter(Predicate<? super A> predicate, Kind<F, A> ma) {
+    requireNonNull(predicate, "predicate for filter cannot be null");
+    requireNonNull(ma, "Kind ma for filter cannot be null");
+    return flatMap(a -> predicate.test(a) ? of(a) : zero(), ma);
   }
 }

--- a/hkj-book/src/functional/monad_zero.md
+++ b/hkj-book/src/functional/monad_zero.md
@@ -3,6 +3,7 @@
 ~~~admonish info title="What You'll Learn"
 - How MonadZero combines Monad and Alternative capabilities
 - The role of `zero()` as an absorbing element in monadic sequences
+- Filtering directly with `MonadZero.filter(predicate, ma)`
 - Enabling filtering in for-comprehensions with `when()`
 - Practical examples using List, Maybe, and Optional
 - Writing generic functions for monads with failure semantics
@@ -53,6 +54,12 @@ public interface MonadZero<F> extends Monad<F>, Alternative<F> {
     @Override
     default <A> Kind<F, A> empty() {
         return zero();
+    }
+
+    // Derived from flatMap + of / zero; overridden by List and Stream
+    // for an O(n) single-pass implementation.
+    default <A> Kind<F, A> filter(Predicate<? super A> predicate, Kind<F, A> ma) {
+        return flatMap(a -> predicate.test(a) ? of(a) : zero(), ma);
     }
 }
 ```
@@ -111,18 +118,39 @@ For different types, `zero()` has the natural "empty" semantics:
 
 ---
 
-## Writing Generic Functions
+## Filtering Directly with `filter`
 
-`MonadZero` allows you to write generic functions that work over any monad with a concept of "emptiness":
+`MonadZero` also exposes `filter(predicate, ma)` so you don't need a for-comprehension just to drop unwanted elements. The argument order matches `Monad.flatMap` (predicate first, then the monadic value), not the instance-method style of `Stream.filter` / `Optional.filter`:
 
 ```java
-// A generic "filter" that works with List, Maybe, Optional, or Stream
-public static <F, A> Kind<F, A> filterM(
-    MonadZero<F> mz, Kind<F, A> fa, Predicate<A> predicate) {
-    return mz.flatMap(
-        a -> predicate.test(a) ? mz.of(a) : mz.zero(),
-        fa
-    );
+// List: keep positives
+MonadZero<ListKind.Witness> lz = ListMonad.INSTANCE;
+Kind<ListKind.Witness, Integer> positives =
+    lz.filter(x -> x > 0, LIST.widen(List.of(-1, 2, -3, 4)));   // [2, 4]
+
+// Maybe: keep even values
+MonadZero<MaybeKind.Witness> mz = MaybeMonad.INSTANCE;
+mz.filter(x -> x % 2 == 0, mz.of(4));   // Just(4)
+mz.filter(x -> x % 2 == 0, mz.of(3));   // Nothing
+```
+
+The default implementation is derived from `flatMap` + `of` / `zero` and adds no new algebraic obligations:
+
+```
+filter(p, ma)  ≡  flatMap(a -> p.test(a) ? of(a) : zero(), ma)
+```
+
+`ListMonad` and `StreamMonad` override `filter` to avoid the per-element singleton/empty allocations the derived form would produce — `ListMonad` walks once into a single result list, `StreamMonad` delegates to `Stream.filter` to preserve laziness.
+
+---
+
+## Writing Generic Functions
+
+`MonadZero` lets you write generic functions that work over any monad with a concept of "emptiness". Since `filter` is now part of the interface, generic filtering is just a method call:
+
+```java
+public static <F, A extends Number> Kind<F, A> keepPositive(MonadZero<F> mz, Kind<F, A> fa) {
+    return mz.filter(a -> a.doubleValue() > 0, fa);
 }
 ```
 
@@ -130,7 +158,8 @@ public static <F, A> Kind<F, A> filterM(
 
 ~~~admonish info title="Key Takeaways"
 * **`zero()` is the absorbing element** that terminates a computational path, like multiplying by zero
-* **`.when()` in for-comprehensions** is the primary use case, enabling mid-chain filtering
+* **`filter(predicate, ma)`** drops values that fail the predicate by short-circuiting to `zero()`
+* **`.when()` in for-comprehensions** is built on `filter` and is the idiomatic form for mid-chain guards
 * **Requires `MonadZero`**, not just `Monad`; use `For.from(monadZero, ...)` to unlock filtering
 * **Works uniformly** across List, Maybe, Optional, and Stream
 ~~~

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/expression/For.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/expression/For.java
@@ -702,9 +702,7 @@ public final class For {
      * @return The current builder step, with the filter applied.
      */
     public FilterableSteps1<M, A> when(Predicate<A> filter) {
-      Kind<M, A> newComputation =
-          monad.flatMap(a -> filter.test(a) ? monad.of(a) : monad.zero(), this.computation);
-      return new FilterableSteps1<>(monad, newComputation);
+      return new FilterableSteps1<>(monad, monad.filter(filter, this.computation));
     }
 
     /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/expression/ForPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/expression/ForPath.java
@@ -847,9 +847,7 @@ public final class ForPath {
      * @return this step with the filter applied
      */
     public MaybePathSteps1<A> when(Predicate<A> predicate) {
-      Kind<MaybeKind.Witness, A> newComp =
-          MONAD.flatMap(a -> predicate.test(a) ? MONAD.of(a) : MONAD.zero(), computation);
-      return new MaybePathSteps1<>(newComp);
+      return new MaybePathSteps1<>(MONAD.filter(predicate, computation));
     }
 
     /**
@@ -982,9 +980,7 @@ public final class ForPath {
     }
 
     public OptionalPathSteps1<A> when(Predicate<A> predicate) {
-      Kind<OptionalKind.Witness, A> newComp =
-          MONAD.flatMap(a -> predicate.test(a) ? MONAD.of(a) : MONAD.zero(), computation);
-      return new OptionalPathSteps1<>(newComp);
+      return new OptionalPathSteps1<>(MONAD.filter(predicate, computation));
     }
 
     public <T extends WitnessArity<TypeArity.Unary>, C, B>
@@ -1418,9 +1414,7 @@ public final class ForPath {
     }
 
     public NonDetPathSteps1<A> when(Predicate<A> predicate) {
-      Kind<ListKind.Witness, A> newComp =
-          MONAD.flatMap(a -> predicate.test(a) ? MONAD.of(a) : MONAD.zero(), computation);
-      return new NonDetPathSteps1<>(newComp);
+      return new NonDetPathSteps1<>(MONAD.filter(predicate, computation));
     }
 
     public <T extends WitnessArity<TypeArity.Unary>, C, B> NonDetPathSteps2<A, Kind<T, B>> traverse(

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/expression/ForState.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/expression/ForState.java
@@ -707,9 +707,7 @@ public final class ForState {
     @Override
     public FilterableSteps<M, S> when(Predicate<S> predicate) {
       Objects.requireNonNull(predicate, "predicate must not be null");
-      Kind<M, S> newState =
-          monad.flatMap(s -> predicate.test(s) ? monad.of(s) : monad.zero(), state);
-      return new ForStateFilterableStepsImpl<>(monad, newState);
+      return new ForStateFilterableStepsImpl<>(monad, monad.filter(predicate, state));
     }
 
     @Override
@@ -867,8 +865,7 @@ public final class ForState {
       Objects.requireNonNull(path, "path must not be null");
       Affine<S, T> affine = path.toAffine();
       // Short-circuit to zero if the affine target is absent in the current state.
-      Kind<M, S> guarded =
-          monad.flatMap(s -> affine.getOptional(s).isPresent() ? monad.of(s) : monad.zero(), state);
+      Kind<M, S> guarded = monad.filter(s -> affine.getOptional(s).isPresent(), state);
       // Synthesise a Lens<S, T> backed by the affine. Pre-condition: getOptional(s) is non-empty
       // because of the guard above; this is enforced by the short-circuit and by AffinePath
       // semantics (set always produces a structure where getOptional returns the new value).

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadZero;
@@ -148,6 +149,34 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
   @Override
   public <T> Kind<ListKind.Witness, T> zero() {
     return LIST.widen(Collections.emptyList());
+  }
+
+  /**
+   * Filters a list by retaining only the elements that satisfy {@code predicate}.
+   *
+   * <p>Overrides the default {@code flatMap}-based implementation on {@link MonadZero} to avoid
+   * allocating per-element singleton/empty lists. Walks the input list once and appends matching
+   * elements to a single result list.
+   *
+   * @param predicate the element predicate; must not be null
+   * @param ma the input list; must not be null
+   * @param <A> the element type
+   * @return a list containing only the elements of {@code ma} for which {@code predicate} holds
+   */
+  @Override
+  public <A> Kind<ListKind.Witness, A> filter(
+      Predicate<? super A> predicate, Kind<ListKind.Witness, A> ma) {
+    Validation.function().require(predicate, "predicate", FILTER);
+    Validation.kind().requireNonNull(ma, FILTER);
+
+    List<A> input = LIST.narrow(ma);
+    List<A> result = new ArrayList<>(input.size());
+    for (A a : input) {
+      if (predicate.test(a)) {
+        result.add(a);
+      }
+    }
+    return LIST.widen(result);
   }
 
   // --- Alternative Methods ---

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamMonad.java
@@ -7,6 +7,7 @@ import static org.higherkindedj.hkt.util.validation.Operation.*;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -232,6 +233,29 @@ public class StreamMonad implements MonadZero<StreamKind.Witness> {
   @Override
   public <T> Kind<StreamKind.Witness, T> zero() {
     return STREAM.widen(Stream.empty());
+  }
+
+  /**
+   * Filters a stream by retaining only the elements that satisfy {@code predicate}.
+   *
+   * <p>Overrides the default {@code flatMap}-based implementation on {@link MonadZero} to delegate
+   * directly to {@link Stream#filter(Predicate)}, preserving the underlying stream's lazy
+   * evaluation semantics.
+   *
+   * @param predicate the element predicate; must not be null
+   * @param ma the input stream; must not be null
+   * @param <A> the element type
+   * @return a stream containing only the elements of {@code ma} for which {@code predicate} holds.
+   *     Evaluation remains lazy.
+   */
+  @Override
+  public <A> Kind<StreamKind.Witness, A> filter(
+      Predicate<? super A> predicate, Kind<StreamKind.Witness, A> ma) {
+    Validation.function().require(predicate, "predicate", FILTER);
+    Validation.kind().requireNonNull(ma, FILTER);
+
+    Stream<A> input = STREAM.narrow(ma);
+    return STREAM.widen(input.filter(predicate));
   }
 
   // --- Alternative Methods ---

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
@@ -10,6 +10,7 @@ public enum Operation {
   MAP_4("map4"),
   MAP_5("map5"),
   FLAT_MAP("flatMap"),
+  FILTER("filter"),
   FOLD_MAP("foldMap"),
   TRAVERSE("traverse"),
   HANDLE_ERROR_WITH("handleErrorWith"),

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListMonadTest.java
@@ -560,4 +560,67 @@ class ListMonadTest extends ListTestBase {
       assertThatList(flattened).containsExactly(1, 11, 21, 2, 12, 22);
     }
   }
+
+  @Nested
+  @DisplayName("MonadZero filter Tests")
+  class FilterTests {
+
+    @Test
+    @DisplayName("filter retains elements that satisfy the predicate")
+    void filterRetainsElementsThatSatisfyThePredicate() {
+      var input = listOf(-1, 2, -3, 4);
+
+      var result = ListMonad.INSTANCE.filter(x -> x > 0, input);
+
+      assertThatList(result).containsExactly(2, 4);
+    }
+
+    @Test
+    @DisplayName("filter with always-true predicate returns the same list")
+    void filterWithAlwaysTrueReturnsSameList() {
+      var input = listOf(1, 2, 3);
+
+      var result = ListMonad.INSTANCE.filter(x -> true, input);
+
+      assertThatList(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("filter with always-false predicate returns zero (empty list)")
+    void filterWithAlwaysFalseReturnsZero() {
+      var input = listOf(1, 2, 3);
+
+      var result = ListMonad.INSTANCE.filter(x -> false, input);
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("filter on zero (empty list) is zero")
+    void filterOnZeroIsZero() {
+      Kind<ListKind.Witness, Integer> empty = ListMonad.INSTANCE.zero();
+
+      var result = ListMonad.INSTANCE.filter(x -> x > 0, empty);
+
+      assertThatList(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("filter throws NullPointerException when predicate is null")
+    void filterThrowsWhenPredicateIsNull() {
+      var input = listOf(1, 2, 3);
+
+      org.assertj.core.api.Assertions.assertThatThrownBy(
+              () -> ListMonad.INSTANCE.filter(null, input))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("filter throws NullPointerException when ma is null")
+    void filterThrowsWhenMaIsNull() {
+      org.assertj.core.api.Assertions.assertThatThrownBy(
+              () -> ListMonad.INSTANCE.filter(x -> true, null))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalMonadTest.java
@@ -446,6 +446,54 @@ class OptionalMonadTest extends OptionalTestBase {
 
       assertThatOptionalKind(zeroKind).isEmpty();
     }
+
+    @Test
+    @DisplayName("filter keeps a present value matching the predicate")
+    void filterKeepsMatchingPresent() {
+      var input = presentOf(4);
+
+      var result = OptionalMonad.INSTANCE.filter(x -> ((Integer) x) % 2 == 0, input);
+
+      assertThatOptionalKind(result).isPresent().contains(4);
+    }
+
+    @Test
+    @DisplayName("filter drops a present value not matching the predicate")
+    void filterDropsNonMatchingPresent() {
+      var input = presentOf(3);
+
+      var result = OptionalMonad.INSTANCE.filter(x -> ((Integer) x) % 2 == 0, input);
+
+      assertThatOptionalKind(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("filter on empty stays empty")
+    void filterOnEmptyStaysEmpty() {
+      Kind<OptionalKind.Witness, Integer> empty = emptyOptional();
+
+      var result = OptionalMonad.INSTANCE.filter(x -> true, empty);
+
+      assertThatOptionalKind(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("filter throws NullPointerException when predicate is null")
+    void filterThrowsWhenPredicateIsNull() {
+      var input = presentOf(1);
+
+      org.assertj.core.api.Assertions.assertThatThrownBy(
+              () -> OptionalMonad.INSTANCE.filter(null, input))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("filter throws NullPointerException when ma is null")
+    void filterThrowsWhenMaIsNull() {
+      org.assertj.core.api.Assertions.assertThatThrownBy(
+              () -> OptionalMonad.INSTANCE.filter(x -> true, null))
+          .isInstanceOf(NullPointerException.class);
+    }
   }
 
   @Nested

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/stream/StreamMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/stream/StreamMonadTest.java
@@ -558,5 +558,84 @@ class StreamMonadTest extends StreamTestBase {
 
       assertThatStream(zero).isEmpty();
     }
+
+    @Test
+    @DisplayName("filter retains elements that satisfy the predicate")
+    void filterRetainsMatching() {
+      Kind<StreamKind.Witness, Integer> input = streamOf(-1, 2, -3, 4);
+
+      var result = streamMonad.filter(x -> x > 0, input);
+
+      assertThatStream(result).containsExactly(2, 4);
+    }
+
+    @Test
+    @DisplayName("filter with always-true predicate is identity")
+    void filterWithAlwaysTrueIsIdentity() {
+      Kind<StreamKind.Witness, Integer> input = streamOf(1, 2, 3);
+
+      var result = streamMonad.filter(x -> true, input);
+
+      assertThatStream(result).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("filter with always-false predicate yields zero")
+    void filterWithAlwaysFalseYieldsZero() {
+      Kind<StreamKind.Witness, Integer> input = streamOf(1, 2, 3);
+
+      var result = streamMonad.filter(x -> false, input);
+
+      assertThatStream(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("filter on zero is zero")
+    void filterOnZeroIsZero() {
+      Kind<StreamKind.Witness, Integer> empty = streamMonad.zero();
+
+      var result = streamMonad.filter(x -> x > 0, empty);
+
+      assertThatStream(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("filter is lazy: predicate not invoked before terminal operation")
+    void filterIsLazy() {
+      var calls = new int[] {0};
+      Kind<StreamKind.Witness, Integer> input = streamOf(1, 2, 3);
+
+      var result =
+          streamMonad.filter(
+              x -> {
+                calls[0]++;
+                return x > 1;
+              },
+              input);
+
+      // No terminal operation yet — predicate must not have run.
+      assertThat(calls[0]).isZero();
+
+      // Consume: predicate now runs once per element.
+      List<Integer> out = STREAM.narrow(result).collect(Collectors.toList());
+      assertThat(out).containsExactly(2, 3);
+      assertThat(calls[0]).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("filter throws NullPointerException when predicate is null")
+    void filterThrowsWhenPredicateIsNull() {
+      Kind<StreamKind.Witness, Integer> input = streamOf(1, 2, 3);
+
+      org.assertj.core.api.Assertions.assertThatThrownBy(() -> streamMonad.filter(null, input))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("filter throws NullPointerException when ma is null")
+    void filterThrowsWhenMaIsNull() {
+      org.assertj.core.api.Assertions.assertThatThrownBy(() -> streamMonad.filter(x -> true, null))
+          .isInstanceOf(NullPointerException.class);
+    }
   }
 }


### PR DESCRIPTION
Add a default `filter(Predicate, Kind)` to `MonadZero`, derived from `flatMap` + `of` / `zero` so it adds no new algebraic obligations. Argument order matches `Monad.flatMap` (predicate first), not `Stream.filter` / `Optional.filter`, for consistency with the typeclass API.

Override `filter` in `ListMonad` and `StreamMonad` to avoid the per-element singleton/empty allocations the derived form would produce — `ListMonad` walks once into a single result list, `StreamMonad` delegates to `Stream.filter` to preserve laziness.

Refactor the duplicated `flatMap(a -> p.test(a) ? of(a) : zero(), ma)` pattern out of the comprehension builders (`For.when`, `ForState.when`, `ForState.zoom` affine guard, `ForPath.{Maybe,Optional,NonDet}.when`) to call `filter` directly.

Add `FILTER` to the validation `Operation` enum and tests covering the identity, annihilation, zero-propagation, and null-argument cases on `ListMonad`, `StreamMonad` (including a laziness assertion), and `OptionalMonad` (exercising the default impl).

Document MonadZero.filter in the user guide

Update hkj-book/src/functional/monad_zero.md to surface the new filter operation: interface signature, direct usage examples, the derivation law, a note on the List/Stream overrides, and a simpler generic-function example that calls filter instead of inlining the flatMap-based pattern.

 Fixes #459 