### PR TITLE
Implement #460: Alternative.orElseAll(Iterable) collection fold

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/hkt/Alternative.java
+++ b/hkj-api/src/main/java/org/higherkindedj/hkt/Alternative.java
@@ -216,4 +216,70 @@ public interface Alternative<F extends WitnessArity<TypeArity.Unary>> extends Ap
 
     return result;
   }
+
+  /**
+   * Folds an {@link Iterable} of alternatives into a single value by repeatedly applying {@link
+   * #orElse(Kind, Supplier)}, starting from {@link #empty()}.
+   *
+   * <p>This is the {@code Alternative} analogue of folding a monoid, and the dynamically-sized
+   * counterpart to {@link #orElseAll(Kind, Supplier, Supplier...)}. It is useful when the
+   * alternatives are produced at runtime (e.g. mapping a {@code List} of strategies to their
+   * results) and the varargs form is not applicable.
+   *
+   * <p><b>Semantics by type:</b>
+   *
+   * <ul>
+   *   <li><b>Maybe/Optional:</b> Returns the first non-empty value, or {@code empty()} if all are
+   *       empty.
+   *   <li><b>List/Stream/VStream:</b> Concatenates all elements in order.
+   * </ul>
+   *
+   * <p><b>Note on evaluation:</b> The default implementation iterates the entire collection — for
+   * short-circuit types like {@code Maybe} and {@code Optional} it does not stop after the first
+   * non-empty value, and an infinite {@code Iterable} will not terminate. Concrete instances may
+   * provide stronger laziness; in particular, stream-like instances can override this method to
+   * traverse the iterable lazily so that a lazy {@code Iterable} stays lazy end-to-end. If you need
+   * lazy short-circuit evaluation of each candidate, use the varargs {@link #orElseAll(Kind,
+   * Supplier, Supplier...)} form or wrap each candidate in a {@code Supplier} yourself.
+   *
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
+   * Alternative<MaybeKind.Witness> alt = MaybeMonad.INSTANCE;
+   * List<Kind<MaybeKind.Witness, String>> candidates = searchStrategies.stream()
+   *     .map(s -> s.search(query))
+   *     .toList();
+   * Kind<MaybeKind.Witness, String> result = alt.orElseAll(candidates);
+   * // result is the first non-empty search result, or Nothing if all failed
+   * }</pre>
+   *
+   * <p>Concrete instances may override with a more efficient single-pass implementation (e.g.
+   * {@code ListMonad} and {@code StreamMonad} avoid the quadratic concatenation the derived form
+   * would produce).
+   *
+   * <p><b>Laws:</b>
+   *
+   * <pre>
+   * orElseAll([])              ≡ empty()                          -- identity
+   * orElseAll([x])             ≡ x                                -- singleton
+   * orElseAll([x, y])          ≡ orElse(x, () -&gt; y)               -- pairwise
+   * </pre>
+   *
+   * @param alternatives A non-null {@link Iterable} of alternative values.
+   * @param <A> The type of the value within the alternatives.
+   * @return A non-null {@link Kind Kind&lt;F, A&gt;} representing the combined result, or {@link
+   *     #empty()} if the iterable is empty.
+   * @throws NullPointerException if {@code alternatives} is null, or if it contains a null element
+   *     (lazy instances may defer this check until the result is consumed).
+   */
+  default <A> Kind<F, A> orElseAll(Iterable<Kind<F, A>> alternatives) {
+    requireNonNull(alternatives, "alternatives for orElseAll cannot be null");
+    Kind<F, A> result = empty();
+    for (Kind<F, A> alt : alternatives) {
+      requireNonNull(alt, "Element in alternatives for orElseAll cannot be null");
+      final Kind<F, A> next = alt;
+      result = orElse(result, () -> next);
+    }
+    return result;
+  }
 }

--- a/hkj-book/src/functional/alternative.md
+++ b/hkj-book/src/functional/alternative.md
@@ -109,6 +109,33 @@ Kind<MaybeKind.Witness, String> config = alt.orElseAll(
 );
 ```
 
+**Folding a dynamic collection with `orElseAll(Iterable)`:**
+
+When the number of alternatives is only known at runtime, pass them as an
+`Iterable`. This is the analogue of Haskell's `asum`/`msum`:
+
+```java
+// Try each registered search strategy and return the first non-empty result.
+List<Kind<MaybeKind.Witness, Result>> candidates = searchStrategies.stream()
+    .map(s -> s.search(query))
+    .toList();
+
+Kind<MaybeKind.Witness, Result> result = alt.orElseAll(candidates);
+// Just(...) of the first strategy that returned a result, or Nothing if all failed.
+```
+
+For `List`, `Stream`, and `VStream` the same call concatenates every input
+into a single result; concrete instances override the default with a
+single-pass implementation to avoid quadratic concatenation.
+
+Unlike the varargs `orElseAll`, the default `Iterable` implementation does not
+short-circuit on the first non-empty value — every element of the iterable
+is iterated and combined into the result. Concrete instances may provide
+stronger laziness: the `StreamMonad` override, for example, traverses the
+iterable lazily so that a lazy `Iterable` stays lazy end-to-end. If you need
+lazy short-circuit evaluation of each candidate, prefer the varargs form or
+wrap each candidate in a `Supplier`.
+
 #### 2. Non-Deterministic Computation with List
 
 Represent all possible outcomes:
@@ -294,7 +321,8 @@ For a complete, runnable example demonstrating Alternative with configuration lo
 
 This example demonstrates:
 - Basic `orElse()` fallback patterns
-- `orElseAll()` for multiple fallback sources
+- `orElseAll()` for multiple fallback sources, both as varargs (lazy
+  short-circuit) and over an `Iterable` (dynamic collections)
 - `guard()` for conditional validation
 - Lazy evaluation benefits
 - Parser combinator patterns using Alternative

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
@@ -8,6 +8,7 @@ import static org.higherkindedj.hkt.util.validation.Operation.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -228,6 +229,32 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
     result.addAll(listA);
     result.addAll(listB);
 
+    return LIST.widen(result);
+  }
+
+  /**
+   * Concatenates an iterable of lists into a single list in one pass.
+   *
+   * <p>Overrides the default {@link org.higherkindedj.hkt.Alternative#orElseAll(Iterable)} to avoid
+   * the quadratic concatenation the derived form would produce (each iteration would copy the
+   * accumulated result alongside the next element). This implementation walks the input once and
+   * appends each element list to a single result {@link ArrayList}.
+   *
+   * @param alternatives the iterable of lists to concatenate; must not be null, and must not
+   *     contain null elements
+   * @param <A> the element type
+   * @return a single list containing every element of every input list, in iteration order
+   * @throws NullPointerException if {@code alternatives} is null or contains a null element
+   */
+  @Override
+  public <A> Kind<ListKind.Witness, A> orElseAll(Iterable<Kind<ListKind.Witness, A>> alternatives) {
+    Objects.requireNonNull(alternatives, "alternatives for orElseAll cannot be null");
+
+    List<A> result = new ArrayList<>();
+    for (Kind<ListKind.Witness, A> alt : alternatives) {
+      Validation.kind().requireNonNull(alt, OR_ELSE_ALL, "element in alternatives");
+      result.addAll(LIST.narrow(alt));
+    }
     return LIST.widen(result);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamMonad.java
@@ -6,11 +6,13 @@ import static org.higherkindedj.hkt.stream.StreamKindHelper.STREAM;
 import static org.higherkindedj.hkt.util.validation.Operation.*;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadZero;
 import org.higherkindedj.hkt.util.validation.Validation;
@@ -312,5 +314,37 @@ public class StreamMonad implements MonadZero<StreamKind.Witness> {
                     }));
 
     return STREAM.widen(concatenated);
+  }
+
+  /**
+   * Concatenates an iterable of streams into a single stream.
+   *
+   * <p>Overrides the default {@link org.higherkindedj.hkt.Alternative#orElseAll(Iterable)} for two
+   * reasons: deeply nested {@link Stream#concat(Stream, Stream)} chains (which the derived form
+   * produces) are documented to risk {@code StackOverflowError} for long inputs, and a single
+   * {@link Stream#flatMap(Function)} preserves the lazy evaluation semantics of {@code Stream}
+   * end-to-end.
+   *
+   * @param alternatives the iterable of streams to concatenate; must not be null, and must not
+   *     contain null elements
+   * @param <A> the element type
+   * @return a single stream that lazily emits every element of every input stream in iteration
+   *     order
+   * @throws NullPointerException if {@code alternatives} is null, or any element is null when
+   *     reached during stream consumption
+   */
+  @Override
+  public <A> Kind<StreamKind.Witness, A> orElseAll(
+      Iterable<Kind<StreamKind.Witness, A>> alternatives) {
+    Objects.requireNonNull(alternatives, "alternatives for orElseAll cannot be null");
+
+    Stream<A> result =
+        StreamSupport.stream(alternatives.spliterator(), false)
+            .flatMap(
+                alt -> {
+                  Validation.kind().requireNonNull(alt, OR_ELSE_ALL, "element in alternatives");
+                  return STREAM.narrow(alt);
+                });
+    return STREAM.widen(result);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
@@ -50,6 +50,7 @@ public enum Operation {
   TO_EITHER("toEither"),
   MATCH("match"),
   OR_ELSE("orElse"),
+  OR_ELSE_ALL("orElseAll"),
   OR_ELSE_GET("orElseGet"),
   OR_EITHER("orEither"),
   RECOVER_FUNCTION("recoverFunction"),

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/list/ListAlternativeTest.java
@@ -5,6 +5,7 @@ package org.higherkindedj.hkt.list;
 import static org.assertj.core.api.Assertions.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.higherkindedj.hkt.Alternative;
@@ -175,6 +176,92 @@ class ListAlternativeTest {
 
       List<Integer> resultList = LIST.narrow(result);
       assertThat(resultList).containsExactly(1, 2, 3, 4);
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll(Iterable) Tests")
+  class OrElseAllIterableTests {
+
+    @Test
+    @DisplayName("orElseAll(empty iterable) returns empty list")
+    void orElseAllEmptyIterableReturnsEmpty() {
+      Kind<ListKind.Witness, Integer> result = alternative.orElseAll(List.of());
+      assertThat(LIST.narrow(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) concatenates all lists in order")
+    void orElseAllIterableConcatenates() {
+      List<Kind<ListKind.Witness, Integer>> lists =
+          Arrays.asList(
+              LIST.widen(Arrays.asList(1, 2)),
+              LIST.widen(Arrays.asList(3)),
+              LIST.widen(Arrays.asList(4, 5)));
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElseAll(lists);
+
+      assertThat(LIST.narrow(result)).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) skips empty lists")
+    void orElseAllIterableSkipsEmpty() {
+      List<Kind<ListKind.Witness, Integer>> lists =
+          Arrays.asList(
+              alternative.empty(),
+              LIST.widen(Arrays.asList(1, 2)),
+              alternative.empty(),
+              LIST.widen(Arrays.asList(3)),
+              alternative.empty());
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElseAll(lists);
+
+      assertThat(LIST.narrow(result)).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) with singleton returns that list")
+    void orElseAllIterableSingleton() {
+      Kind<ListKind.Witness, Integer> single = LIST.widen(Arrays.asList(7, 8, 9));
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElseAll(List.of(single));
+
+      assertThat(LIST.narrow(result)).containsExactly(7, 8, 9);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) handles large input without quadratic blow-up")
+    void orElseAllIterableLargeInput() {
+      List<Kind<ListKind.Witness, Integer>> lists = new ArrayList<>();
+      for (int i = 0; i < 10_000; i++) {
+        lists.add(LIST.widen(Arrays.asList(i)));
+      }
+
+      Kind<ListKind.Witness, Integer> result = alternative.orElseAll(lists);
+
+      List<Integer> resultList = LIST.narrow(result);
+      assertThat(resultList).hasSize(10_000);
+      assertThat(resultList.get(0)).isEqualTo(0);
+      assertThat(resultList.get(9_999)).isEqualTo(9_999);
+    }
+
+    @Test
+    @DisplayName("orElseAll(null iterable) throws NullPointerException")
+    void orElseAllNullIterableThrows() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> alternative.orElseAll((Iterable<Kind<ListKind.Witness, Integer>>) null))
+          .withMessageContaining("alternatives");
+    }
+
+    @Test
+    @DisplayName("orElseAll(iterable with null element) throws NullPointerException")
+    void orElseAllNullElementThrows() {
+      List<Kind<ListKind.Witness, Integer>> lists = new ArrayList<>();
+      lists.add(LIST.widen(Arrays.asList(1)));
+      lists.add(null);
+
+      assertThatNullPointerException().isThrownBy(() -> alternative.orElseAll(lists));
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/maybe/MaybeAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/maybe/MaybeAlternativeTest.java
@@ -4,6 +4,9 @@ package org.higherkindedj.hkt.maybe;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.higherkindedj.hkt.Alternative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Unit;
@@ -184,6 +187,85 @@ class MaybeAlternativeTest extends MaybeTestBase {
       Maybe<Integer> maybe = narrowToMaybe(result);
       assertThat(maybe.isJust()).isTrue();
       assertThat(maybe.get()).isEqualTo(99);
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll(Iterable) Tests")
+  class OrElseAllIterableTests {
+
+    @Test
+    @DisplayName("orElseAll(empty iterable) returns empty()")
+    void orElseAllEmptyIterableReturnsEmpty() {
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElseAll(List.of());
+      assertThat(narrowToMaybe(result).isNothing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) returns first Just")
+    void orElseAllIterableReturnsFirstJust() {
+      List<Kind<MaybeKind.Witness, Integer>> candidates =
+          Arrays.asList(alternative.empty(), alternative.of(42), alternative.of(7));
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElseAll(candidates);
+
+      Maybe<Integer> maybe = narrowToMaybe(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) returns Nothing when all empty")
+    void orElseAllIterableAllEmpty() {
+      List<Kind<MaybeKind.Witness, Integer>> candidates =
+          Arrays.asList(alternative.empty(), alternative.empty(), alternative.empty());
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElseAll(candidates);
+
+      assertThat(narrowToMaybe(result).isNothing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) with singleton returns that element")
+    void orElseAllIterableSingleton() {
+      Kind<MaybeKind.Witness, Integer> just = alternative.of(99);
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElseAll(List.of(just));
+
+      assertThat(narrowToMaybe(result).get()).isEqualTo(99);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) accepts arbitrary Iterable, not just List")
+    void orElseAllAcceptsArbitraryIterable() {
+      List<Kind<MaybeKind.Witness, Integer>> backing = new ArrayList<>();
+      backing.add(alternative.empty());
+      backing.add(alternative.of(123));
+      Iterable<Kind<MaybeKind.Witness, Integer>> iter = backing::iterator;
+
+      Kind<MaybeKind.Witness, Integer> result = alternative.orElseAll(iter);
+
+      assertThat(narrowToMaybe(result).get()).isEqualTo(123);
+    }
+
+    @Test
+    @DisplayName("orElseAll(null iterable) throws NullPointerException")
+    void orElseAllNullIterableThrows() {
+      assertThatNullPointerException()
+          .isThrownBy(
+              () -> alternative.orElseAll((Iterable<Kind<MaybeKind.Witness, Integer>>) null))
+          .withMessageContaining("alternatives");
+    }
+
+    @Test
+    @DisplayName("orElseAll(iterable with null element) throws NullPointerException")
+    void orElseAllNullElementThrows() {
+      List<Kind<MaybeKind.Witness, Integer>> candidates = new ArrayList<>();
+      candidates.add(alternative.empty());
+      candidates.add(null);
+      candidates.add(alternative.of(1));
+
+      assertThatNullPointerException().isThrownBy(() -> alternative.orElseAll(candidates));
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/optional/OptionalAlternativeTest.java
@@ -5,6 +5,9 @@ package org.higherkindedj.hkt.optional;
 import static org.assertj.core.api.Assertions.*;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.higherkindedj.hkt.Alternative;
 import org.higherkindedj.hkt.Kind;
@@ -186,6 +189,71 @@ class OptionalAlternativeTest {
       Optional<Integer> optional = OPTIONAL.narrow(result);
       assertThat(optional).isPresent();
       assertThat(optional.get()).isEqualTo(99);
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll(Iterable) Tests")
+  class OrElseAllIterableTests {
+
+    @Test
+    @DisplayName("orElseAll(empty iterable) returns Optional.empty()")
+    void orElseAllEmptyIterableReturnsEmpty() {
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElseAll(List.of());
+      assertThat(OPTIONAL.narrow(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) returns first present")
+    void orElseAllIterableReturnsFirstPresent() {
+      List<Kind<OptionalKind.Witness, Integer>> candidates =
+          Arrays.asList(alternative.empty(), alternative.of(42), alternative.of(7));
+
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElseAll(candidates);
+
+      Optional<Integer> optional = OPTIONAL.narrow(result);
+      assertThat(optional).isPresent();
+      assertThat(optional.get()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) returns Optional.empty() when all empty")
+    void orElseAllIterableAllEmpty() {
+      List<Kind<OptionalKind.Witness, Integer>> candidates =
+          Arrays.asList(alternative.empty(), alternative.empty(), alternative.empty());
+
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElseAll(candidates);
+
+      assertThat(OPTIONAL.narrow(result)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) with singleton returns that element")
+    void orElseAllIterableSingleton() {
+      Kind<OptionalKind.Witness, Integer> present = alternative.of(99);
+
+      Kind<OptionalKind.Witness, Integer> result = alternative.orElseAll(List.of(present));
+
+      assertThat(OPTIONAL.narrow(result).get()).isEqualTo(99);
+    }
+
+    @Test
+    @DisplayName("orElseAll(null iterable) throws NullPointerException")
+    void orElseAllNullIterableThrows() {
+      assertThatNullPointerException()
+          .isThrownBy(
+              () -> alternative.orElseAll((Iterable<Kind<OptionalKind.Witness, Integer>>) null))
+          .withMessageContaining("alternatives");
+    }
+
+    @Test
+    @DisplayName("orElseAll(iterable with null element) throws NullPointerException")
+    void orElseAllNullElementThrows() {
+      List<Kind<OptionalKind.Witness, Integer>> candidates = new ArrayList<>();
+      candidates.add(alternative.empty());
+      candidates.add(null);
+
+      assertThatNullPointerException().isThrownBy(() -> alternative.orElseAll(candidates));
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/stream/StreamAlternativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/stream/StreamAlternativeTest.java
@@ -5,6 +5,7 @@ package org.higherkindedj.hkt.stream;
 import static org.assertj.core.api.Assertions.*;
 import static org.higherkindedj.hkt.stream.StreamKindHelper.STREAM;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -193,6 +194,102 @@ class StreamAlternativeTest {
       Stream<Integer> resultStream = STREAM.narrow(result);
       List<Integer> list = resultStream.collect(Collectors.toList());
       assertThat(list).containsExactly(1, 2, 3, 4);
+    }
+  }
+
+  @Nested
+  @DisplayName("orElseAll(Iterable) Tests")
+  class OrElseAllIterableTests {
+
+    @Test
+    @DisplayName("orElseAll(empty iterable) returns empty stream")
+    void orElseAllEmptyIterableReturnsEmpty() {
+      Kind<StreamKind.Witness, Integer> result = alternative.orElseAll(List.of());
+      assertThat(STREAM.narrow(result).collect(Collectors.toList())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) concatenates all streams in order")
+    void orElseAllIterableConcatenates() {
+      List<Kind<StreamKind.Witness, Integer>> streams =
+          Arrays.asList(
+              STREAM.widen(Stream.of(1, 2)),
+              STREAM.widen(Stream.of(3)),
+              STREAM.widen(Stream.of(4, 5)));
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+
+      assertThat(STREAM.narrow(result).collect(Collectors.toList())).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) skips empty streams")
+    void orElseAllIterableSkipsEmpty() {
+      List<Kind<StreamKind.Witness, Integer>> streams =
+          Arrays.asList(
+              alternative.empty(),
+              STREAM.widen(Stream.of(1, 2)),
+              alternative.empty(),
+              STREAM.widen(Stream.of(3)));
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+
+      assertThat(STREAM.narrow(result).collect(Collectors.toList())).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) preserves laziness — does not consume source streams eagerly")
+    void orElseAllIterablePreservesLaziness() {
+      boolean[] consumed = {false};
+      Stream<Integer> peeking = Stream.of(1, 2, 3).peek(x -> consumed[0] = true);
+      List<Kind<StreamKind.Witness, Integer>> streams =
+          Arrays.asList(STREAM.widen(peeking), STREAM.widen(Stream.of(4)));
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+
+      assertThat(consumed[0]).isFalse();
+      List<Integer> collected = STREAM.narrow(result).collect(Collectors.toList());
+      assertThat(consumed[0]).isTrue();
+      assertThat(collected).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) handles a long iterable without StackOverflowError")
+    void orElseAllIterableLongInput() {
+      List<Kind<StreamKind.Witness, Integer>> streams = new ArrayList<>();
+      for (int i = 0; i < 5_000; i++) {
+        streams.add(STREAM.widen(Stream.of(i)));
+      }
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+
+      List<Integer> collected = STREAM.narrow(result).collect(Collectors.toList());
+      assertThat(collected).hasSize(5_000);
+      assertThat(collected.get(0)).isEqualTo(0);
+      assertThat(collected.get(4_999)).isEqualTo(4_999);
+    }
+
+    @Test
+    @DisplayName("orElseAll(null iterable) throws NullPointerException")
+    void orElseAllNullIterableThrows() {
+      assertThatNullPointerException()
+          .isThrownBy(
+              () -> alternative.orElseAll((Iterable<Kind<StreamKind.Witness, Integer>>) null))
+          .withMessageContaining("alternatives");
+    }
+
+    @Test
+    @DisplayName("orElseAll(iterable with null element) throws NullPointerException on consumption")
+    void orElseAllNullElementThrows() {
+      List<Kind<StreamKind.Witness, Integer>> streams = new ArrayList<>();
+      streams.add(STREAM.widen(Stream.of(1)));
+      streams.add(null);
+
+      Kind<StreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+      // Validation is deferred until the resulting stream is consumed, which is correct for the
+      // lazy contract — but the consumer is guaranteed to see the failure.
+      assertThatNullPointerException()
+          .isThrownBy(() -> STREAM.narrow(result).collect(Collectors.toList()));
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamTypeClassTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/vstream/VStreamTypeClassTest.java
@@ -3,9 +3,12 @@
 package org.higherkindedj.hkt.vstream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -459,6 +462,61 @@ class VStreamTypeClassTest {
           alternative.orElse(a, () -> alternative.orElse(b, () -> c));
 
       assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("orElseAll(empty iterable) returns empty stream")
+    void orElseAllEmptyIterableReturnsEmpty() {
+      Kind<VStreamKind.Witness, Integer> result = alternative.orElseAll(List.of());
+      assertThat(VSTREAM.narrow(result).toList().run()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) concatenates all streams in order")
+    void orElseAllIterableConcatenates() {
+      List<Kind<VStreamKind.Witness, Integer>> streams =
+          Arrays.asList(
+              VSTREAM.widen(VStream.of(1, 2)),
+              VSTREAM.widen(VStream.of(3)),
+              VSTREAM.widen(VStream.of(4, 5)));
+
+      Kind<VStreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("orElseAll(Iterable) skips empty streams")
+    void orElseAllIterableSkipsEmpty() {
+      List<Kind<VStreamKind.Witness, Integer>> streams =
+          Arrays.asList(
+              alternative.empty(),
+              VSTREAM.widen(VStream.of(1, 2)),
+              alternative.empty(),
+              VSTREAM.widen(VStream.of(3)));
+
+      Kind<VStreamKind.Witness, Integer> result = alternative.orElseAll(streams);
+
+      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("orElseAll(null iterable) throws NullPointerException")
+    void orElseAllNullIterableThrows() {
+      assertThatNullPointerException()
+          .isThrownBy(
+              () -> alternative.orElseAll((Iterable<Kind<VStreamKind.Witness, Integer>>) null))
+          .withMessageContaining("alternatives");
+    }
+
+    @Test
+    @DisplayName("orElseAll(iterable with null element) throws NullPointerException")
+    void orElseAllNullElementThrows() {
+      List<Kind<VStreamKind.Witness, Integer>> streams = new ArrayList<>();
+      streams.add(VSTREAM.widen(VStream.of(1)));
+      streams.add(null);
+
+      assertThatNullPointerException().isThrownBy(() -> alternative.orElseAll(streams));
     }
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java
@@ -4,6 +4,8 @@ package org.higherkindedj.example.basic.alternative;
 
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
+import java.util.List;
+import java.util.function.Function;
 import org.higherkindedj.hkt.Alternative;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.maybe.Maybe;
@@ -23,7 +25,8 @@ import org.higherkindedj.hkt.maybe.MaybeMonad;
  *   <li><b>orElse()</b>: Combining alternatives with lazy evaluation
  *   <li><b>empty()</b>: Representing the absence of configuration
  *   <li><b>guard()</b>: Conditional validation
- *   <li><b>orElseAll()</b>: Chaining multiple fallback sources
+ *   <li><b>orElseAll()</b>: Chaining multiple fallback sources, either as a static varargs list or
+ *       as a runtime-built {@link Iterable}
  * </ul>
  */
 public class AlternativeConfigExample {
@@ -36,6 +39,7 @@ public class AlternativeConfigExample {
 
     demonstrateBasicOrElse();
     demonstrateOrElseChain();
+    demonstrateOrElseAllIterable();
     demonstrateGuard();
     demonstrateLazyEvaluation();
     demonstrateParserCombinator();
@@ -85,9 +89,46 @@ public class AlternativeConfigExample {
     System.out.println();
   }
 
+  /**
+   * Demonstrates orElseAll(Iterable) for folding a runtime-built collection of alternatives — the
+   * {@code asum}/{@code msum} analogue.
+   *
+   * <p>Unlike the varargs form in {@link #demonstrateOrElseChain()}, the set of sources here is not
+   * known at compile time. We treat each {@link ConfigSource} as a strategy, look it up at runtime,
+   * and fold the resulting candidates with a single call.
+   */
+  private static void demonstrateOrElseAllIterable() {
+    System.out.println("3. orElseAll(Iterable) - Dynamic Source Registry");
+    System.out.println("------------------------------------------------");
+
+    String key = "API_KEY";
+
+    // A registry of sources, as you might receive from SPI, a config file, or a
+    // priority list constructed at startup. The number and order are not fixed.
+    List<Function<String, Kind<MaybeKind.Witness, ConfigValue>>> registry =
+        List.of(
+            AlternativeConfigExample::readFromEnvironment,
+            AlternativeConfigExample::readFromSystemProperty,
+            AlternativeConfigExample::readFromConfigFile,
+            AlternativeConfigExample::readFromDatabase,
+            AlternativeConfigExample::getDefaultValue);
+
+    // Map each strategy to its candidate result, then fold with orElseAll(Iterable).
+    List<Kind<MaybeKind.Witness, ConfigValue>> candidates =
+        registry.stream().map(source -> source.apply(key)).toList();
+
+    Kind<MaybeKind.Witness, ConfigValue> config = alt.orElseAll(candidates);
+
+    Maybe<ConfigValue> result = MAYBE.narrow(config);
+    if (result.isJust()) {
+      System.out.println("  ✓ Loaded: " + result.get());
+    }
+    System.out.println();
+  }
+
   /** Demonstrates guard() for conditional validation. */
   private static void demonstrateGuard() {
-    System.out.println("3. guard() - Conditional Validation");
+    System.out.println("4. guard() - Conditional Validation");
     System.out.println("-----------------------------------");
 
     String key = "MAX_CONNECTIONS";
@@ -117,7 +158,7 @@ public class AlternativeConfigExample {
 
   /** Demonstrates lazy evaluation - fallback not computed unless needed. */
   private static void demonstrateLazyEvaluation() {
-    System.out.println("4. Lazy Evaluation - Efficiency");
+    System.out.println("5. Lazy Evaluation - Efficiency");
     System.out.println("-------------------------------");
 
     boolean[] expensiveCallExecuted = {false};
@@ -142,7 +183,7 @@ public class AlternativeConfigExample {
 
   /** Demonstrates using Alternative for simple parser combinators. */
   private static void demonstrateParserCombinator() {
-    System.out.println("5. Parser Combinator Pattern");
+    System.out.println("6. Parser Combinator Pattern");
     System.out.println("----------------------------");
 
     String input1 = "true";


### PR DESCRIPTION
Add a default orElseAll(Iterable<Kind<F, A>>) to Alternative, the dynamically-sized counterpart to the existing varargs orElseAll and the analogue of Haskell's asum/msum. It folds an iterable of alternatives via orElse starting from empty(), so semantics match the varargs form: first non-empty for Maybe/Optional, concatenation for List/Stream/VStream.

Picked orElseAll(Iterable) as an overload rather than introducing a new name (combineAll, asum, etc.). Overload resolution is unambiguous against the existing (Kind, Supplier, Supplier...) signature, the name is consistent with the established varargs form, and combineAll would have collided with Monoid.combineAll.

Override on ListMonad and StreamMonad to avoid the O(n^2) result-list copying and deeply-nested Stream.concat chains the derived form would produce — the latter is documented to risk StackOverflowError on long inputs. ListMonad walks the iterable once into a single ArrayList; StreamMonad delegates to a single Stream.flatMap over the iterable's spliterator, preserving lazy evaluation end-to-end. VStream uses the default since VStream.concat already fuses via Step transitions.

Add OR_ELSE_ALL to the validation Operation enum to align with the existing OR_ELSE / FILTER pattern used by the optimised overrides.

Add OrElseAllIterableTests covering: empty iterable returns empty(), singleton returns the element, first-success for short-circuit types, full concatenation for collection types, large-input stress for the ListMonad override (10k elements), long-input stress and laziness preservation for the StreamMonad override (5k elements, peek probe), null-iterable and null-element validation. Also extend VStreamTypeClassTest with the same suite of cases.

Document the Iterable overload in hkj-book/src/functional/alternative.md alongside the varargs form, including a note that the Iterable form does not short-circuit on the first non-empty value because each element has already been evaluated by the caller.

 Fixes #460 