### PR TITLE
Standardise the org.higherkindedj.hkt.util.validation package

### DIFF
--- a/hkj-core/src/main/java/org/higherkindedj/hkt/constant/ConstApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/constant/ConstApplicative.java
@@ -4,7 +4,6 @@ package org.higherkindedj.hkt.constant;
 
 import static org.higherkindedj.hkt.constant.ConstKindHelper.CONST;
 import static org.higherkindedj.hkt.util.validation.Operation.AP;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 import static org.higherkindedj.hkt.util.validation.Operation.MAP_2;
 
 import java.util.function.BiFunction;
@@ -105,8 +104,7 @@ public final class ConstApplicative<M> implements Applicative<ConstKind.Witness<
   public <A, B> Kind<ConstKind.Witness<M>, B> map(
       Function<? super A, ? extends B> f, Kind<ConstKind.Witness<M>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     // Since A is phantom in Const<M, A>, we can safely change the type parameter
     // The actual value (type M) remains unchanged

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/context/ContextFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/context/ContextFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.context;
 
 import static org.higherkindedj.hkt.context.ContextKindHelper.CONTEXT;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -67,8 +66,7 @@ public class ContextFunctor<R> implements Functor<ContextKind.Witness<R>> {
   public <A, B> Kind<ContextKind.Witness<R>, B> map(
       Function<? super A, ? extends B> f, Kind<ContextKind.Witness<R>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Context<R, A> contextA = CONTEXT.narrow(fa);
     Context<R, B> contextB = contextA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/context/ContextKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/context/ContextKindHelper.java
@@ -82,11 +82,7 @@ public enum ContextKindHelper implements ContextConverterOps {
   @SuppressWarnings("unchecked")
   public <R, A> Context<R, A> narrow(@Nullable Kind<ContextKind.Witness<R>, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            CONTEXT_CLASS,
-            ContextHolder.class,
-            holder -> ((ContextHolder<R, A>) holder).context());
+        .narrowHolder(kind, CONTEXT_CLASS, ContextHolder.class, ContextHolder::context);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/coyoneda/CoyonedaFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/coyoneda/CoyonedaFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.coyoneda;
 
 import static org.higherkindedj.hkt.coyoneda.CoyonedaKindHelper.COYONEDA;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -88,8 +87,7 @@ public class CoyonedaFunctor<F extends WitnessArity<TypeArity.Unary>>
   @Override
   public <A, B> Kind<CoyonedaKind.Witness<F>, B> map(
       Function<? super A, ? extends B> f, Kind<CoyonedaKind.Witness<F>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Coyoneda<F, A> coyoneda = COYONEDA.narrow(fa);
     Coyoneda<F, B> mapped = coyoneda.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.either;
 
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -54,8 +53,7 @@ public class EitherFunctor<L> implements Functor<EitherKind.Witness<L>> {
   @Override
   public <A, B> Kind<EitherKind.Witness<L>, B> map(
       Function<? super A, ? extends B> f, Kind<EitherKind.Witness<L>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Either<L, A> eitherA = EITHER.narrow(fa);
     Either<L, B> resultEither = eitherA.map(f); // Delegates to Either's right-biased map

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherTraverse.java
@@ -65,8 +65,7 @@ public final class EitherTraverse<E> implements Traverse<EitherKind.Witness<E>> 
   @Override
   public <A, B> Kind<EitherKind.Witness<E>, B> map(
       Function<? super A, ? extends B> f, Kind<EitherKind.Witness<E>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Either<E, A> either = EITHER.narrow(fa);
     Either<E, B> resultEither = either.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either_t/EitherTMonad.java
@@ -82,8 +82,7 @@ public class EitherTMonad<F extends WitnessArity<TypeArity.Unary>, L>
   public <R_IN, R_OUT> Kind<EitherTKind.Witness<F, L>, R_OUT> map(
       Function<? super R_IN, ? extends R_OUT> f, Kind<EitherTKind.Witness<F, L>, R_IN> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     EitherT<F, L, R_IN> eitherT = EITHER_T.narrow(fa);
     Kind<F, Either<L, R_OUT>> newValue = outerMonad.map(either -> either.map(f), eitherT.value());

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/eitherf/EitherFFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/eitherf/EitherFFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.eitherf;
 
 import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -77,8 +76,7 @@ public final class EitherFFunctor<
   @Override
   public <A, B> Kind<EitherFKind.Witness<F, G>, B> map(
       Function<? super A, ? extends B> f, Kind<EitherFKind.Witness<F, G>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     EitherF<F, G, A> eitherF = EitherFKindHelper.EITHERF.narrow(fa);
     EitherF<F, G, B> mapped =

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/error/ErrorOpFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/error/ErrorOpFunctor.java
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.error;
 
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
-
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
@@ -39,8 +37,7 @@ public final class ErrorOpFunctor<E> implements Functor<ErrorOpKind.Witness<E>> 
   @SuppressWarnings("unchecked")
   public <A, B> Kind<ErrorOpKind.Witness<E>, B> map(
       Function<? super A, ? extends B> f, Kind<ErrorOpKind.Witness<E>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
     // Safe cast: A is phantom in ErrorOp.Raise (the record holds only the error E, never a
     // value of type A). Changing A to B has no runtime effect — the data is unchanged.
     ErrorOp<E, A> op = ErrorOpKindHelper.ERROR_OP.narrow(fa);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free/FreeFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free/FreeFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.free;
 
 import static org.higherkindedj.hkt.free.FreeKindHelper.FREE;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -49,8 +48,7 @@ public class FreeFunctor<F extends WitnessArity<TypeArity.Unary>>
   @Override
   public <A, B> Kind<FreeKind.Witness<F>, B> map(
       Function<? super A, ? extends @Nullable B> f, Kind<FreeKind.Witness<F>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Free<F, A> freeA = FREE.narrow(fa);
     Free<F, B> resultFree = freeA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free/FreeKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free/FreeKindHelper.java
@@ -63,7 +63,6 @@ public enum FreeKindHelper {
   @SuppressWarnings("unchecked")
   public <F extends WitnessArity<TypeArity.Unary>, A> Free<F, A> narrow(
       @Nullable Kind<FreeKind.Witness<F>, A> kind) {
-    return Validation.kind()
-        .narrowWithPattern(kind, Free.class, FreeHolder.class, holder -> holder.free());
+    return Validation.kind().narrowHolder(kind, Free.class, FreeHolder.class, FreeHolder::free);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free_ap/FreeAp.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free_ap/FreeAp.java
@@ -2,7 +2,12 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.free_ap;
 
-import static java.util.Objects.requireNonNull;
+import static org.higherkindedj.hkt.util.validation.Operation.AP;
+import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
+import static org.higherkindedj.hkt.util.validation.Operation.FOLD_MAP;
+import static org.higherkindedj.hkt.util.validation.Operation.LIFT_F;
+import static org.higherkindedj.hkt.util.validation.Operation.MAP;
+import static org.higherkindedj.hkt.util.validation.Operation.MAP_2;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -13,6 +18,7 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.Natural;
 import org.higherkindedj.hkt.TypeArity;
 import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.util.validation.Validation;
 
 /**
  * Free Applicative functor for independent/parallel composition.
@@ -119,7 +125,7 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    */
   record Lift<F extends WitnessArity<TypeArity.Unary>, A>(Kind<F, A> fa) implements FreeAp<F, A> {
     public Lift {
-      requireNonNull(fa, "Lifted Kind cannot be null");
+      Validation.KIND.requireNonNull(fa, CONSTRUCTION, "Lift.fa");
     }
   }
 
@@ -138,8 +144,8 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
   record Ap<F extends WitnessArity<TypeArity.Unary>, X, A>(
       FreeAp<F, Function<X, A>> ff, FreeAp<F, X> fa) implements FreeAp<F, A> {
     public Ap {
-      requireNonNull(ff, "Function FreeAp cannot be null");
-      requireNonNull(fa, "Value FreeAp cannot be null");
+      Validation.FUNCTION.require(ff, "ff", CONSTRUCTION);
+      Validation.FUNCTION.require(fa, "fa", CONSTRUCTION);
     }
   }
 
@@ -165,7 +171,7 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    * @throws NullPointerException if fa is null
    */
   static <F extends WitnessArity<TypeArity.Unary>, A> FreeAp<F, A> lift(Kind<F, A> fa) {
-    requireNonNull(fa, "Kind to lift cannot be null");
+    Validation.KIND.requireNonNull(fa, LIFT_F);
     return new Lift<>(fa);
   }
 
@@ -178,7 +184,7 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    * @throws NullPointerException if f is null
    */
   default <B> FreeAp<F, B> map(Function<? super A, ? extends B> f) {
-    requireNonNull(f, "Map function cannot be null");
+    Validation.FUNCTION.require(f, "f", MAP);
     return ap(pure(f));
   }
 
@@ -194,7 +200,7 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    * @throws NullPointerException if ff is null
    */
   default <B> FreeAp<F, B> ap(FreeAp<F, ? extends Function<? super A, ? extends B>> ff) {
-    requireNonNull(ff, "Function FreeAp cannot be null");
+    Validation.FUNCTION.require(ff, "ff", AP);
     // Need to handle the variance carefully
     @SuppressWarnings("unchecked")
     FreeAp<F, Function<A, B>> safeFF = (FreeAp<F, Function<A, B>>) (FreeAp<F, ?>) ff;
@@ -215,8 +221,8 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    */
   default <B, C> FreeAp<F, C> map2(
       FreeAp<F, B> fb, BiFunction<? super A, ? super B, ? extends C> combine) {
-    requireNonNull(fb, "Second FreeAp cannot be null");
-    requireNonNull(combine, "Combine function cannot be null");
+    Validation.FUNCTION.require(fb, "fb", MAP_2);
+    Validation.FUNCTION.require(combine, "combine", MAP_2);
     return fb.ap(this.map(a -> b -> combine.apply(a, b)));
   }
 
@@ -250,8 +256,8 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    */
   default <G extends WitnessArity<TypeArity.Unary>> Kind<G, A> foldMap(
       Natural<F, G> transform, Applicative<G> applicative) {
-    requireNonNull(transform, "Natural transformation cannot be null");
-    requireNonNull(applicative, "Applicative cannot be null");
+    Validation.FUNCTION.require(transform, "transform", FOLD_MAP);
+    Validation.FUNCTION.require(applicative, "applicative", FOLD_MAP);
     return interpretFreeAp(this, transform, applicative);
   }
 
@@ -337,7 +343,7 @@ public sealed interface FreeAp<F extends WitnessArity<TypeArity.Unary>, A>
    * @throws NullPointerException if applicative is null
    */
   default Kind<F, A> retract(Applicative<F> applicative) {
-    requireNonNull(applicative, "Applicative cannot be null");
+    Validation.FUNCTION.require(applicative, "applicative", FOLD_MAP);
     return foldMap(Natural.identity(), applicative);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free_ap/FreeApApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free_ap/FreeApApplicative.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.free_ap;
 
 import static org.higherkindedj.hkt.free_ap.FreeApKindHelper.FREE_AP;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 import static org.higherkindedj.hkt.util.validation.Operation.MAP_2;
 
 import java.util.function.BiFunction;
@@ -81,8 +80,7 @@ public class FreeApApplicative<F extends WitnessArity<TypeArity.Unary>> extends 
   @Override
   public <A, B> Kind<FreeApKind.Witness<F>, B> map(
       Function<? super A, ? extends B> f, Kind<FreeApKind.Witness<F>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     FreeAp<F, A> freeAp = FREE_AP.narrow(fa);
     FreeAp<F, B> mapped = freeAp.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free_ap/FreeApFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free_ap/FreeApFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.free_ap;
 
 import static org.higherkindedj.hkt.free_ap.FreeApKindHelper.FREE_AP;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -62,8 +61,7 @@ public class FreeApFunctor<F extends WitnessArity<TypeArity.Unary>>
   @Override
   public <A, B> Kind<FreeApKind.Witness<F>, B> map(
       Function<? super A, ? extends B> f, Kind<FreeApKind.Witness<F>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     FreeAp<F, A> freeAp = FREE_AP.narrow(fa);
     FreeAp<F, B> mapped = freeAp.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.future;
 
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -72,8 +71,7 @@ public class CompletableFutureFunctor implements Functor<CompletableFutureKind.W
   public <A, B> Kind<CompletableFutureKind.Witness, B> map(
       Function<? super A, ? extends @Nullable B> f, Kind<CompletableFutureKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     CompletableFuture<A> futureA = FUTURE.narrow(fa);
     CompletableFuture<B> futureB = futureA.thenApply(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureKindHelper.java
@@ -69,11 +69,11 @@ public enum CompletableFutureKindHelper implements CompletableFutureConverterOps
   @SuppressWarnings("unchecked")
   public <A> CompletableFuture<A> narrow(@Nullable Kind<CompletableFutureKind.Witness, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
+        .narrowHolder(
             kind,
             COMPLETABLE_FUTURE_CLASS,
             CompletableFutureHolder.class,
-            holder -> ((CompletableFutureHolder<A>) holder).future());
+            CompletableFutureHolder::future);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdMonad.java
@@ -88,8 +88,7 @@ public class IdMonad implements Monad<IdKind.Witness> {
   public <A, B> Kind<IdKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<IdKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return ID.narrow(fa).map(f);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdTraverse.java
@@ -67,8 +67,7 @@ public enum IdTraverse implements Traverse<IdKind.Witness> {
   public <A, B> Kind<IdKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<IdKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return ID.narrow(fa).map(f);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.io;
 
 import static org.higherkindedj.hkt.io.IOKindHelper.*;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.*;
@@ -49,8 +48,7 @@ public class IOFunctor implements Functor<IOKind.Witness> {
   public <A, B> Kind<IOKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<IOKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     IO<A> ioA = IO_OP.narrow(fa);
     IO<B> ioB = ioA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyKindHelper.java
@@ -63,8 +63,7 @@ public enum LazyKindHelper implements LazyConverterOps {
   @SuppressWarnings("unchecked")
   public <A> Lazy<A> narrow(@Nullable Kind<LazyKind.Witness, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind, LAZY_CLASS, LazyHolder.class, holder -> ((LazyHolder<A>) holder).lazyInstance());
+        .narrowHolder(kind, LAZY_CLASS, LazyHolder.class, LazyHolder::lazyInstance);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyMonad.java
@@ -57,8 +57,7 @@ public class LazyMonad
   public <A, B> Kind<LazyKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<LazyKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Lazy<A> lazyA = LAZY.narrow(fa);
     Lazy<B> lazyB = lazyA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.list;
 
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,8 +71,7 @@ class ListFunctor implements Functor<ListKind.Witness> {
   public <A, B> Kind<ListKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<ListKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     List<A> listA = LIST.narrow(fa);
     List<B> listB = new ArrayList<>(listA.size());

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKindHelper.java
@@ -64,9 +64,7 @@ public enum ListKindHelper implements ListConverterOps {
   @Override
   @SuppressWarnings("unchecked")
   public <A> List<A> narrow(@Nullable Kind<ListKind.Witness, A> kind) {
-    return Validation.kind()
-        .narrowWithPattern(
-            kind, LIST_CLASS, ListHolder.class, holder -> ((ListHolder<A>) holder).list());
+    return Validation.kind().narrowHolder(kind, LIST_CLASS, ListHolder.class, ListHolder::list);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListMonad.java
@@ -102,8 +102,7 @@ public class ListMonad implements MonadZero<ListKind.Witness> {
   public <A, B> Kind<ListKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<ListKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return ListFunctor.INSTANCE.map(f, fa);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListTraverse.java
@@ -48,8 +48,7 @@ public enum ListTraverse implements Traverse<ListKind.Witness> {
   public <A, B> Kind<ListKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<ListKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return ListFunctor.INSTANCE.map(f, fa);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.maybe;
 
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -59,8 +58,7 @@ public class MaybeFunctor implements Functor<MaybeKind.Witness> {
   public <A, B> Kind<MaybeKind.Witness, B> map(
       Function<? super A, ? extends @Nullable B> f, Kind<MaybeKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Maybe<A> maybeA = MAYBE.narrow(fa);
     Maybe<B> resultMaybe = maybeA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeTraverse.java
@@ -27,8 +27,7 @@ public enum MaybeTraverse implements Traverse<MaybeKind.Witness> {
   public <A, B> Kind<MaybeKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<MaybeKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return MAYBE.widen(MAYBE.narrow(fa).map(f));
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTMonad.java
@@ -79,8 +79,7 @@ public class MaybeTMonad<F extends WitnessArity<TypeArity.Unary>>
   public <A, B> Kind<MaybeTKind.Witness<F>, B> map(
       Function<? super A, ? extends B> f, Kind<MaybeTKind.Witness<F>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     MaybeT<F, A> maybeT = MAYBE_T.narrow(fa);
     Kind<F, Maybe<B>> newValue = outerMonad.map(maybe -> maybe.map(f), maybeT.value());

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.optional;
 
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.*;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -76,8 +75,7 @@ public class OptionalFunctor implements Functor<OptionalKind.Witness> {
   public <A, B> Kind<OptionalKind.Witness, B> map(
       Function<? super A, ? extends @Nullable B> f, Kind<OptionalKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Optional<A> optionalA = OPTIONAL.narrow(fa);
     // Optional.map correctly handles f returning null by creating Optional.empty()

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalKindHelper.java
@@ -71,10 +71,6 @@ public enum OptionalKindHelper implements OptionalConverterOps {
   @SuppressWarnings("unchecked")
   public <A> Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            OPTIONAL_CLASS,
-            OptionalHolder.class,
-            holder -> ((OptionalHolder<A>) holder).optional());
+        .narrowHolder(kind, OPTIONAL_CLASS, OptionalHolder.class, OptionalHolder::optional);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalMonad.java
@@ -117,8 +117,7 @@ public class OptionalMonad extends OptionalFunctor
   public <A, B> Kind<OptionalKind.Witness, B> map(
       Function<? super A, ? extends @Nullable B> f, Kind<OptionalKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Optional<A> optionalA = OPTIONAL.narrow(fa);
     // Optional.map correctly handles f returning null by creating Optional.empty()

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalTraverse.java
@@ -75,8 +75,7 @@ public enum OptionalTraverse implements Traverse<OptionalKind.Witness> {
   public <A, B> Kind<OptionalKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<OptionalKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return OPTIONAL.widen(OPTIONAL.narrow(fa).map(f));
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTMonad.java
@@ -81,8 +81,7 @@ public class OptionalTMonad<F extends WitnessArity<TypeArity.Unary>>
   public <A, B> Kind<OptionalTKind.Witness<F>, B> map(
       Function<? super A, ? extends @Nullable B> f, Kind<OptionalTKind.Witness<F>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     OptionalT<F, A> optionalT = OPTIONAL_T.narrow(fa);
     Kind<F, Optional<B>> newValue = outerMonad.map(opt -> opt.map(f), optionalT.value());

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.reader;
 
 import static org.higherkindedj.hkt.reader.ReaderKindHelper.READER;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -50,8 +49,7 @@ public class ReaderFunctor<R> implements Functor<ReaderKind.Witness<R>> {
   public <A, B> Kind<ReaderKind.Witness<R>, B> map(
       Function<? super A, ? extends B> f, Kind<ReaderKind.Witness<R>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Reader<R, A> readerA = READER.narrow(fa);
     Reader<R, B> readerB = readerA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderKindHelper.java
@@ -79,11 +79,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
   @SuppressWarnings("unchecked")
   public <R, A> Reader<R, A> narrow(@Nullable Kind<ReaderKind.Witness<R>, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            READER_CLASS,
-            ReaderHolder.class,
-            holder -> ((ReaderHolder<R, A>) holder).reader());
+        .narrowHolder(kind, READER_CLASS, ReaderHolder.class, ReaderHolder::reader);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTMonad.java
@@ -134,8 +134,7 @@ public class ReaderTMonad<F extends WitnessArity<TypeArity.Unary>, R_ENV>
   public <A, B> Kind<ReaderTKind.Witness<F, R_ENV>, B> map(
       Function<? super A, ? extends B> f, Kind<ReaderTKind.Witness<F, R_ENV>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     ReaderT<F, R_ENV, A> faT = READER_T.narrow(fa);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.state;
 
 import static org.higherkindedj.hkt.state.StateKindHelper.STATE;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -61,8 +60,7 @@ public class StateFunctor<S> implements Functor<StateKind.Witness<S>> {
   public <A, B> Kind<StateKind.Witness<S>, B> map(
       Function<? super A, ? extends B> f, Kind<StateKind.Witness<S>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     State<S, A> stateA = STATE.narrow(fa);
     State<S, B> stateB = stateA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateKindHelper.java
@@ -78,11 +78,7 @@ public enum StateKindHelper implements StateConverterOps {
   @SuppressWarnings("unchecked")
   public <S, A> State<S, A> narrow(@Nullable Kind<StateKind.Witness<S>, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            STATE_CLASS,
-            StateHolder.class,
-            holder -> ((StateHolder<S, A>) holder).stateInstance());
+        .narrowHolder(kind, STATE_CLASS, StateHolder.class, StateHolder::stateInstance);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_op/StateOpFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_op/StateOpFunctor.java
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.state_op;
 
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
-
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Kind;
@@ -34,8 +32,7 @@ public final class StateOpFunctor<S> implements Functor<StateOpKind.Witness<S>> 
   @Override
   public <A, B> Kind<StateOpKind.Witness<S>, B> map(
       Function<? super A, ? extends B> f, Kind<StateOpKind.Witness<S>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
     StateOp<S, A> op = StateOpKindHelper.STATE_OP.narrow(fa);
     return StateOpKindHelper.STATE_OP.widen(op.mapK(f));
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTMonad.java
@@ -95,8 +95,7 @@ public class StateTMonad<S, F extends WitnessArity<TypeArity.Unary>>
   @Override
   public <A, B> Kind<StateTKind.Witness<S, F>, B> map(
       Function<? super A, ? extends B> f, Kind<StateTKind.Witness<S, F>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     StateT<S, F, A> stateT = StateTKind.narrow(fa);
     Function<S, Kind<F, StateTuple<S, B>>> newRunFn =

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.stream;
 
 import static org.higherkindedj.hkt.stream.StreamKindHelper.STREAM;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -112,8 +111,7 @@ class StreamFunctor implements Functor<StreamKind.Witness> {
   public <A, B> Kind<StreamKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<StreamKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Stream<A> streamA = STREAM.narrow(fa);
     Stream<B> streamB = streamA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamKindHelper.java
@@ -84,8 +84,7 @@ public enum StreamKindHelper implements StreamConverterOps {
   @SuppressWarnings("unchecked")
   public <A> Stream<A> narrow(@Nullable Kind<StreamKind.Witness, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind, STREAM_CLASS, StreamHolder.class, holder -> ((StreamHolder<A>) holder).stream());
+        .narrowHolder(kind, STREAM_CLASS, StreamHolder.class, StreamHolder::stream);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamMonad.java
@@ -161,8 +161,7 @@ public class StreamMonad implements MonadZero<StreamKind.Witness> {
   public <A, B> Kind<StreamKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<StreamKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return StreamFunctor.INSTANCE.map(f, fa);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamTraverse.java
@@ -169,8 +169,7 @@ public enum StreamTraverse implements Traverse<StreamKind.Witness> {
   public <A, B> Kind<StreamKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<StreamKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return StreamFunctor.INSTANCE.map(f, fa);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trampoline/TrampolineFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trampoline/TrampolineFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.trampoline;
 
 import static org.higherkindedj.hkt.trampoline.TrampolineKindHelper.TRAMPOLINE;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -61,8 +60,7 @@ public class TrampolineFunctor implements Functor<TrampolineKind.Witness> {
   public <A, B> Kind<TrampolineKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<TrampolineKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Trampoline<A> trampolineA = TRAMPOLINE.narrow(fa);
     Trampoline<B> resultTrampoline = trampolineA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trampoline/TrampolineKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trampoline/TrampolineKindHelper.java
@@ -67,11 +67,7 @@ public enum TrampolineKindHelper implements TrampolineConverterOps {
   @SuppressWarnings("unchecked")
   public <A> Trampoline<A> narrow(@Nullable Kind<TrampolineKind.Witness, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            TRAMPOLINE_CLASS,
-            TrampolineHolder.class,
-            holder -> ((TrampolineHolder<A>) holder).trampoline());
+        .narrowHolder(kind, TRAMPOLINE_CLASS, TrampolineHolder.class, TrampolineHolder::trampoline);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryFunctor.java
@@ -3,7 +3,6 @@
 package org.higherkindedj.hkt.trymonad;
 
 import static org.higherkindedj.hkt.trymonad.TryKindHelper.TRY;
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.Functor;
@@ -35,8 +34,7 @@ public class TryFunctor implements Functor<TryKind.Witness> {
   public <A, B> Kind<TryKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<TryKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Try<A> tryA = TRY.narrow(fa);
     Try<B> resultTry = tryA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryKindHelper.java
@@ -63,9 +63,7 @@ public enum TryKindHelper implements TryConverterOps {
   @Override
   @SuppressWarnings("unchecked")
   public <A> Try<A> narrow(@Nullable Kind<TryKind.Witness, A> kind) {
-    return Validation.kind()
-        .narrowWithPattern(
-            kind, TRY_CLASS, TryHolder.class, holder -> ((TryHolder<A>) holder).tryInstance());
+    return Validation.kind().narrowHolder(kind, TRY_CLASS, TryHolder.class, TryHolder::tryInstance);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryTraverse.java
@@ -42,8 +42,7 @@ public enum TryTraverse implements Traverse<TryKind.Witness> {
   public <A, B> Kind<TryKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<TryKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return TRY.widen(TRY.narrow(fa).map(f));
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/FunctionValidator.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/FunctionValidator.java
@@ -6,6 +6,7 @@ import static java.util.Objects.isNull;
 import static org.higherkindedj.hkt.util.validation.Operation.FLAT_MAP;
 import static org.higherkindedj.hkt.util.validation.Operation.FOLD_MAP;
 import static org.higherkindedj.hkt.util.validation.Operation.HANDLE_ERROR_WITH;
+import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 import static org.higherkindedj.hkt.util.validation.Operation.TRAVERSE;
 
 import java.util.Objects;
@@ -18,10 +19,20 @@ import org.higherkindedj.hkt.WitnessArity;
 import org.higherkindedj.hkt.exception.KindUnwrapException;
 
 /**
- * Handles function parameter validations in monad operations.
+ * Handles parameter validations in monad operations.
  *
- * <p>This validator ensures consistent error messaging for function parameters across all monad
- * operations, preventing confusion about which operation failed and why.
+ * <p>Despite the name, this validator is used for any reference parameter that participates in a
+ * monad/functor/applicative operation — functions, monoids, error values, optics, applicatives,
+ * etc. The error message format is parameter-name-led so it reads correctly for any of these:
+ *
+ * <ul>
+ *   <li>{@code require(f, "f", FLAT_MAP)} → {@code "f for flatMap cannot be null"}
+ *   <li>{@code require(monoid, "monoid", OF)} → {@code "monoid for of cannot be null"}
+ *   <li>{@code require(optic, "optic", LIFT_F)} → {@code "optic for liftF cannot be null"}
+ * </ul>
+ *
+ * <p>The class name is retained for source compatibility; if a more neutral name is wanted, an
+ * alias may be introduced in a future release.
  */
 public enum FunctionValidator {
   FUNCTION_VALIDATOR;
@@ -34,21 +45,22 @@ public enum FunctionValidator {
    * @param operation The operation name
    * @param <T> The function type
    * @return The validated function
-   * @throws NullPointerException with context-specific message if function is null Example usage:
+   * @throws NullPointerException with context-specific message if the parameter is null
+   *     <p>Example usage:
    *     <pre>
-   * Validation.functionValidator().require(fn, "runStateTFn", CONSTRUCTION);
-   * // Error: "function runStateTFn for construction cannot be null"
-   *  </pre>
+   * Validation.function().require(fn, "runStateTFn", CONSTRUCTION);
+   * // Error: "runStateTFn for construction cannot be null"
+   *     </pre>
    */
-  public <T> T require(T function, String functionName, Operation operation) {
-    Objects.requireNonNull(functionName, "functionName cannot be null");
+  public <T> T require(T parameter, String parameterName, Operation operation) {
+    Objects.requireNonNull(parameterName, "parameterName cannot be null");
     Objects.requireNonNull(operation, "operation cannot be null");
 
-    if (function == null) {
+    if (parameter == null) {
       throw new NullPointerException(
-          new FunctionContext(functionName, operation.toString()).nullParameterMessage());
+          new FunctionContext(parameterName, operation.toString()).nullParameterMessage());
     }
-    return function;
+    return parameter;
   }
 
   /**
@@ -81,6 +93,24 @@ public enum FunctionValidator {
 
   // ==================== Bulk Validation Helpers ====================
   // These methods reduce boilerplate by combining multiple validations into single calls.
+
+  /**
+   * Validates all parameters for a map operation in a single call.
+   *
+   * <p>This combines function and Kind validation, reducing boilerplate in Functor implementations.
+   *
+   * @param f the mapping function (must be non-null)
+   * @param fa the input Kind (must be non-null)
+   * @param <F> the functor type constructor
+   * @param <A> input type
+   * @param <B> output type
+   * @throws NullPointerException if f or fa is null
+   */
+  public <F extends WitnessArity<?>, A, B> void validateMap(
+      Function<? super A, ? extends B> f, Kind<F, A> fa) {
+    require(f, "f", MAP);
+    Validation.kind().requireNonNull(fa, MAP);
+  }
 
   /**
    * Validates all parameters for a flatMap operation in a single call.
@@ -162,6 +192,11 @@ public enum FunctionValidator {
     require(handler, "handler", HANDLE_ERROR_WITH);
   }
 
+  /**
+   * Context record for parameter validation. Despite the legacy field name {@code functionName},
+   * this carries the name of any reference parameter (function, monoid, error, etc.) — the
+   * generated message is parameter-name-led, e.g. {@code "f for flatMap cannot be null"}.
+   */
   public record FunctionContext(String functionName, String operation) {
 
     public FunctionContext {
@@ -170,7 +205,7 @@ public enum FunctionValidator {
     }
 
     public String nullParameterMessage() {
-      return String.format("Function %s for %s cannot be null", functionName, operation);
+      return String.format("%s for %s cannot be null", functionName, operation);
     }
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/KindValidator.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/KindValidator.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.hkt.util.validation;
 
 import static org.higherkindedj.hkt.util.validation.Operation.AP;
+import static org.higherkindedj.hkt.util.validation.Operation.NARROW;
+import static org.higherkindedj.hkt.util.validation.Operation.WIDEN;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -41,7 +43,7 @@ public enum KindValidator {
       Class<T> targetType,
       Function<? super Kind<F, A>, ? extends T> narrower) {
 
-    var context = new KindContext(targetType, "narrow");
+    var context = new KindContext(targetType, NARROW.toString());
 
     return switch (kind) {
       case null -> throw new KindUnwrapException(context.nullParameterMessage());
@@ -72,7 +74,7 @@ public enum KindValidator {
   public <F extends WitnessArity<?>, A, T> T narrowWithTypeCheck(
       @Nullable Kind<F, A> kind, Class<T> targetType) {
 
-    var context = new KindContext(targetType, "narrow");
+    var context = new KindContext(targetType, NARROW.toString());
 
     return switch (kind) {
       case null -> throw new KindUnwrapException(context.nullParameterMessage());
@@ -86,22 +88,54 @@ public enum KindValidator {
   }
 
   /**
-   * Specialized narrowing for holder-based Kind implementations using pattern matching. This
-   * provides a consistent approach for types that wrap their concrete implementation in an internal
-   * holder record.
+   * Specialized narrowing for holder-based Kind implementations.
    *
-   * <p>Example usage:
+   * <p>Most KindHelpers wrap their concrete implementation in an internal record (e.g. {@code
+   * OptionalHolder}, {@code LazyHolder}). Pass a method reference to the holder's accessor to
+   * extract the wrapped value with one line:
    *
    * <pre>{@code
-   * public <A> SomeType<A> narrow(@Nullable Kind<...> kind) {
-   *   return Validation.kind().narrowWithPattern(
-   *     kind,
-   *     SOME_CLASS,
-   *     SomeHolder.class,
-   *     holder -> holder.value()
-   *   );
+   * public <A> Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind) {
+   *   return Validation.KIND.narrowHolder(kind, Optional.class, OptionalHolder.class,
+   *                                       OptionalHolder::optional);
    * }
    * }</pre>
+   *
+   * <p>This is the preferred holder-narrow entry point. {@link #narrowWithPattern} is retained as a
+   * deprecated alias.
+   *
+   * @param kind The Kind to narrow, may be null
+   * @param targetType The target type class for error messaging
+   * @param holderType The holder type class for pattern matching
+   * @param accessor Function to extract the value from the holder (typically a method reference)
+   * @param <F> The witness type of the Kind
+   * @param <A> The value type of the Kind
+   * @param <T> The target type to narrow to
+   * @param <H> The holder type
+   * @return The narrowed result
+   * @throws KindUnwrapException if kind is null or not of the expected holder type
+   */
+  public <F extends WitnessArity<?>, A, T, H extends Kind<F, A>> T narrowHolder(
+      @Nullable Kind<F, A> kind,
+      Class<T> targetType,
+      Class<H> holderType,
+      Function<? super H, ? extends T> accessor) {
+
+    var context = new KindContext(targetType, NARROW.toString());
+
+    return switch (kind) {
+      case null -> throw new KindUnwrapException(context.nullParameterMessage());
+      default -> {
+        if (!holderType.isInstance(kind)) {
+          throw new KindUnwrapException(context.invalidTypeMessage(kind));
+        }
+        yield accessor.apply(holderType.cast(kind));
+      }
+    };
+  }
+
+  /**
+   * Specialized narrowing for holder-based Kind implementations using pattern matching.
    *
    * @param kind The Kind to narrow, may be null
    * @param targetType The target type class for error messaging
@@ -113,14 +147,18 @@ public enum KindValidator {
    * @param <H> The holder type
    * @return The narrowed result
    * @throws KindUnwrapException if kind is null or not of the expected holder type
+   * @deprecated since 0.4.4, scheduled for removal in 0.5.0. Use {@link #narrowHolder(Kind, Class,
+   *     Class, Function)} instead — the new name better reflects what the method does and is paired
+   *     with a clearer Javadoc example.
    */
+  @Deprecated(since = "0.4.4", forRemoval = true)
   public <F extends WitnessArity<?>, A, T, H extends Kind<F, A>> T narrowWithPattern(
       @Nullable Kind<F, A> kind,
       Class<T> targetType,
       Class<H> holderType,
       Function<? super H, ? extends T> extractor) {
 
-    var context = new KindContext(targetType, "narrow");
+    var context = new KindContext(targetType, NARROW.toString());
 
     return switch (kind) {
       case null -> throw new KindUnwrapException(context.nullParameterMessage());
@@ -144,7 +182,7 @@ public enum KindValidator {
    */
   public <T> T requireForWiden(T input, Class<T> inputType) {
     if (input == null) {
-      var context = new KindContext(inputType, "widen");
+      var context = new KindContext(inputType, WIDEN.toString());
       throw new NullPointerException(context.nullInputMessage());
     }
     return input;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Operation.java
@@ -94,7 +94,9 @@ public enum Operation {
   LOCAL("local"),
   FROM_RUNNABLE("fromRunnable"),
   AND_THEN("andThen"),
-  COMPOSE("compose");
+  COMPOSE("compose"),
+  WIDEN("widen"),
+  NARROW("narrow");
 
   Operation(String label) {
     this.label = label;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/TransformerValidator.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/TransformerValidator.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.hkt.util.validation;
 
 import java.util.Objects;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Functor;
 import org.higherkindedj.hkt.Monad;
 import org.higherkindedj.hkt.TypeArity;
 import org.higherkindedj.hkt.WitnessArity;
@@ -24,32 +26,75 @@ public enum TransformerValidator {
    *
    * @param monad The outer monad to validate
    * @param transformerClass The class of the transformer (e.g., StateT.class, OptionalT.class)
-   * @param methodName The method name for error context (e.g., "construction", "lift", "map")
+   * @param operation The {@link Operation} for error context (e.g., {@code CONSTRUCTION}, {@code
+   *     LIFT_F}, {@code MAP})
    * @param <F> The monad witness type
    * @return The validated monad
    * @throws NullPointerException with context-specific message if monad is null
    *     <p>Example usage:
    *     <pre>
    * // In constructor
-   * DomainValidator.requireOuterMonad(monadF, StateT.class, "construction");
+   * Validation.transformer().requireOuterMonad(monadF, StateT.class, CONSTRUCTION);
    * // Error: "Outer Monad cannot be null for StateT construction"
    *
    * // In factory method
-   * DomainValidator.requireOuterMonad(outerMonad, OptionalT.class, "lift");
-   * // Error: "Outer Monad cannot be null for OptionalT.lift"
+   * Validation.transformer().requireOuterMonad(outerMonad, OptionalT.class, LIFT_F);
+   * // Error: "Outer Monad cannot be null for OptionalT liftF"
    * </pre>
    */
   public <F extends WitnessArity<TypeArity.Unary>> Monad<F> requireOuterMonad(
-      Monad<F> monad, Class<?> transformerClass, Operation methodName) {
+      Monad<F> monad, Class<?> transformerClass, Operation operation) {
 
     Objects.requireNonNull(transformerClass, "transformerClass cannot be null");
-    Objects.requireNonNull(methodName, "methodName cannot be null");
+    Objects.requireNonNull(operation, "operation cannot be null");
 
     String transformerName = transformerClass.getSimpleName();
-    String context = transformerName + " " + methodName;
+    String context = transformerName + " " + operation;
 
     var domainContext = new DomainContext("Outer Monad", context);
     return Objects.requireNonNull(monad, domainContext.nullParameterMessage());
+  }
+
+  /**
+   * Validates the outer applicative for transformer construction.
+   *
+   * @param applicative The outer applicative to validate
+   * @param transformerClass The class of the transformer
+   * @param operation The {@link Operation} for error context
+   * @param <F> The applicative witness type
+   * @return The validated applicative
+   * @throws NullPointerException if applicative is null
+   */
+  public <F extends WitnessArity<TypeArity.Unary>> Applicative<F> requireOuterApplicative(
+      Applicative<F> applicative, Class<?> transformerClass, Operation operation) {
+
+    Objects.requireNonNull(transformerClass, "transformerClass cannot be null");
+    Objects.requireNonNull(operation, "operation cannot be null");
+
+    String context = transformerClass.getSimpleName() + " " + operation;
+    var domainContext = new DomainContext("Outer Applicative", context);
+    return Objects.requireNonNull(applicative, domainContext.nullParameterMessage());
+  }
+
+  /**
+   * Validates the outer functor for transformer construction.
+   *
+   * @param functor The outer functor to validate
+   * @param transformerClass The class of the transformer
+   * @param operation The {@link Operation} for error context
+   * @param <F> The functor witness type
+   * @return The validated functor
+   * @throws NullPointerException if functor is null
+   */
+  public <F extends WitnessArity<TypeArity.Unary>> Functor<F> requireOuterFunctor(
+      Functor<F> functor, Class<?> transformerClass, Operation operation) {
+
+    Objects.requireNonNull(transformerClass, "transformerClass cannot be null");
+    Objects.requireNonNull(operation, "operation cannot be null");
+
+    String context = transformerClass.getSimpleName() + " " + operation;
+    var domainContext = new DomainContext("Outer Functor", context);
+    return Objects.requireNonNull(functor, domainContext.nullParameterMessage());
   }
 
   /**
@@ -61,29 +106,30 @@ public enum TransformerValidator {
    * @param component The component to validate
    * @param componentName The name of the component (e.g., "inner Optional", "state function")
    * @param transformerClass The class of the transformer (e.g., OptionalT.class, StateT.class)
-   * @param methodName The method name for context (e.g., "fromOptional", "create")
+   * @param operation The {@link Operation} for context (e.g., {@code FROM_OPTIONAL}, {@code
+   *     CONSTRUCTION})
    * @param <T> The component type
    * @return The validated component
    * @throws NullPointerException with descriptive message if component is null
    *     <p>Example usage:
    *     <pre>
-   * DomainValidator.requireTransformerComponent(
+   * Validation.transformer().requireTransformerComponent(
    *     optional,
    *     "inner Optional",
    *     OptionalT.class,
-   *     "fromOptional"
+   *     FROM_OPTIONAL
    * );
    * // Error: "inner Optional cannot be null for OptionalT.fromOptional"
    * </pre>
    */
   public <T> T requireTransformerComponent(
-      T component, String componentName, Class<?> transformerClass, Operation methodName) {
+      T component, String componentName, Class<?> transformerClass, Operation operation) {
 
     Objects.requireNonNull(transformerClass, "transformerClass cannot be null");
-    Objects.requireNonNull(methodName, "methodName cannot be null");
+    Objects.requireNonNull(operation, "operation cannot be null");
 
     String transformerName = transformerClass.getSimpleName();
-    String fullContext = transformerName + "." + methodName;
+    String fullContext = transformerName + "." + operation;
 
     var context = DomainContext.transformer(fullContext);
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Validation.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/util/validation/Validation.java
@@ -2,20 +2,57 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.util.validation;
 
+/**
+ * Entry point for the validation utilities.
+ *
+ * <p>Two equivalent access styles are supported. The static fields are preferred for new code
+ * because they shave a pair of parentheses off the call site:
+ *
+ * <pre>{@code
+ * Validation.KIND.requireNonNull(ma, FLAT_MAP);   // preferred
+ * Validation.kind().requireNonNull(ma, FLAT_MAP); // also fine
+ * }</pre>
+ *
+ * <p><b>Exception contract.</b> The validators are intentionally split between two exception types:
+ *
+ * <ul>
+ *   <li>{@link NullPointerException} — thrown by precondition checks on parameters supplied by the
+ *       caller (functions, monoids, error values, transformer components, outer monads, and {@link
+ *       KindValidator#requireNonNull} on {@link org.higherkindedj.hkt.Kind} parameters).
+ *   <li>{@link org.higherkindedj.hkt.exception.KindUnwrapException} — thrown by Kind unwrap
+ *       operations such as {@link KindValidator#narrow}, {@link KindValidator#narrowWithTypeCheck},
+ *       {@link KindValidator#narrowHolder}, {@link KindValidator#narrowWithPattern}, and {@link
+ *       FunctionValidator#requireNonNullResult} (which signals a bind-style violation where a user
+ *       function returned a null Kind).
+ * </ul>
+ */
 public interface Validation {
+
+  /** Validator for core sum-type values and errors (Either, Validated, ...). */
+  CoreTypeValidator CORE = CoreTypeValidator.CORE_TYPE_VALIDATOR;
+
+  /** Validator for function and other reference parameters in monad/functor operations. */
+  FunctionValidator FUNCTION = FunctionValidator.FUNCTION_VALIDATOR;
+
+  /** Validator for {@link org.higherkindedj.hkt.Kind} parameters and narrow/widen operations. */
+  KindValidator KIND = KindValidator.KIND_VALIDATOR;
+
+  /** Validator for monad transformer outer instances and inner components. */
+  TransformerValidator TRANSFORMER = TransformerValidator.TRANSFORMER_VALIDATOR;
+
   static CoreTypeValidator coreType() {
-    return CoreTypeValidator.CORE_TYPE_VALIDATOR;
+    return CORE;
   }
 
   static FunctionValidator function() {
-    return FunctionValidator.FUNCTION_VALIDATOR;
+    return FUNCTION;
   }
 
   static KindValidator kind() {
-    return KindValidator.KIND_VALIDATOR;
+    return KIND;
   }
 
   static TransformerValidator transformer() {
-    return TransformerValidator.TRANSFORMER_VALIDATOR;
+    return TRANSFORMER;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedMonad.java
@@ -61,8 +61,7 @@ public class ValidatedMonad<E> implements MonadError<ValidatedKind.Witness<E>, E
   public <A, B> Kind<ValidatedKind.Witness<E>, B> map(
       Function<? super A, ? extends B> f, Kind<ValidatedKind.Witness<E>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Validated<E, A> validated = VALIDATED.narrow(fa);
     Validated<E, B> result = validated.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedTraverse.java
@@ -38,8 +38,7 @@ public final class ValidatedTraverse<E> implements Traverse<ValidatedKind.Witnes
   public <A, B> Kind<ValidatedKind.Witness<E>, B> map(
       Function<? super A, ? extends B> f, Kind<ValidatedKind.Witness<E>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return VALIDATED.widen(VALIDATED.narrow(fa).map(f));
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamFunctor.java
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.vstream;
 
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
 
 import java.util.function.Function;
@@ -59,8 +58,7 @@ public class VStreamFunctor implements Functor<VStreamKind.Witness> {
   public <A, B> Kind<VStreamKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<VStreamKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     VStream<A> stream = VSTREAM.narrow(fa);
     VStream<B> mapped = stream.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamTraverse.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamTraverse.java
@@ -66,8 +66,7 @@ public enum VStreamTraverse implements Traverse<VStreamKind.Witness> {
   public <A, B> Kind<VStreamKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<VStreamKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     return VStreamFunctor.INSTANCE.map(f, fa);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/Resource.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/Resource.java
@@ -2,10 +2,16 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.vtask;
 
+import static org.higherkindedj.hkt.util.validation.Operation.AP;
+import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
+import static org.higherkindedj.hkt.util.validation.Operation.FLAT_MAP;
+import static org.higherkindedj.hkt.util.validation.Operation.MAP;
+
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.higherkindedj.hkt.util.validation.Validation;
 
 /**
  * A functional resource type that guarantees cleanup via the bracket pattern.
@@ -93,8 +99,8 @@ public final class Resource<A> {
    * @throws NullPointerException if acquire or release is null
    */
   public static <A> Resource<A> make(Callable<A> acquire, Consumer<A> release) {
-    Objects.requireNonNull(acquire, "acquire must not be null");
-    Objects.requireNonNull(release, "release must not be null");
+    Validation.function().require(acquire, "acquire", CONSTRUCTION);
+    Validation.function().require(release, "release", CONSTRUCTION);
     return new Resource<>(acquire, release);
   }
 
@@ -109,7 +115,7 @@ public final class Resource<A> {
    * @throws NullPointerException if acquire is null
    */
   public static <A extends AutoCloseable> Resource<A> fromAutoCloseable(Callable<A> acquire) {
-    Objects.requireNonNull(acquire, "acquire must not be null");
+    Validation.function().require(acquire, "acquire", CONSTRUCTION);
     return new Resource<>(
         acquire,
         resource -> {
@@ -156,13 +162,13 @@ public final class Resource<A> {
    * @throws NullPointerException if f is null
    */
   public <B> VTask<B> use(Function<? super A, ? extends VTask<B>> f) {
-    Objects.requireNonNull(f, "f must not be null");
+    Validation.function().require(f, "f", FLAT_MAP);
 
     return () -> {
       A resource = acquire.call();
       try {
         VTask<B> task = f.apply(resource);
-        Objects.requireNonNull(task, "function must not return null");
+        Objects.requireNonNull(task, "f returned null in Resource.use, which is not allowed");
         return task.execute();
       } finally {
         release.accept(resource);
@@ -181,7 +187,7 @@ public final class Resource<A> {
    * @throws NullPointerException if f is null
    */
   public <B> VTask<B> useSync(Function<? super A, ? extends B> f) {
-    Objects.requireNonNull(f, "f must not be null");
+    Validation.function().require(f, "f", MAP);
     return use(a -> VTask.succeed(f.apply(a)));
   }
 
@@ -199,7 +205,7 @@ public final class Resource<A> {
    * @throws NullPointerException if f is null
    */
   public <B> Resource<B> map(Function<? super A, ? extends B> f) {
-    Objects.requireNonNull(f, "f must not be null");
+    Validation.function().require(f, "f", MAP);
 
     // Use a holder to capture the original resource for release
     @SuppressWarnings("unchecked")
@@ -232,7 +238,7 @@ public final class Resource<A> {
    * @throws NullPointerException if f is null
    */
   public <B> Resource<B> flatMap(Function<? super A, ? extends Resource<B>> f) {
-    Objects.requireNonNull(f, "f must not be null");
+    Validation.function().require(f, "f", FLAT_MAP);
 
     // Holders to capture the outer resource and inner release for proper cleanup
     @SuppressWarnings("unchecked")
@@ -246,7 +252,8 @@ public final class Resource<A> {
           outerHolder[0] = a;
           try {
             Resource<B> resourceB = f.apply(a);
-            Objects.requireNonNull(resourceB, "function must not return null");
+            Objects.requireNonNull(
+                resourceB, "f returned null in Resource.flatMap, which is not allowed");
             innerReleaseHolder[0] = resourceB.release;
             return resourceB.acquire.call();
           } catch (Throwable t) {
@@ -302,7 +309,7 @@ public final class Resource<A> {
    * @throws NullPointerException if other is null
    */
   public <B> Resource<Par.Tuple2<A, B>> and(Resource<B> other) {
-    Objects.requireNonNull(other, "other must not be null");
+    Validation.function().require(other, "other", AP);
 
     return new Resource<>(
         () -> {
@@ -352,8 +359,8 @@ public final class Resource<A> {
    * @throws NullPointerException if second or third is null
    */
   public <B, C> Resource<Par.Tuple3<A, B, C>> and(Resource<B> second, Resource<C> third) {
-    Objects.requireNonNull(second, "second must not be null");
-    Objects.requireNonNull(third, "third must not be null");
+    Validation.function().require(second, "second", AP);
+    Validation.function().require(third, "third", AP);
 
     return new Resource<>(
         () -> {
@@ -422,7 +429,7 @@ public final class Resource<A> {
    * @throws NullPointerException if finalizer is null
    */
   public Resource<A> withFinalizer(Runnable finalizer) {
-    Objects.requireNonNull(finalizer, "finalizer must not be null");
+    Validation.function().require(finalizer, "finalizer", CONSTRUCTION);
 
     return new Resource<>(
         acquire,
@@ -444,7 +451,7 @@ public final class Resource<A> {
    * @return a Resource with failure cleanup added
    */
   public Resource<A> onFailure(Consumer<? super A> onFailure) {
-    Objects.requireNonNull(onFailure, "onFailure must not be null");
+    Validation.function().require(onFailure, "onFailure", CONSTRUCTION);
 
     return new Resource<>(acquire, release);
     // Note: Full implementation would track failure state in use()

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/VTaskFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/VTaskFunctor.java
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.vtask;
 
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 import static org.higherkindedj.hkt.vtask.VTaskKindHelper.VTASK;
 
 import java.util.function.Function;
@@ -53,8 +52,7 @@ public class VTaskFunctor implements Functor<VTaskKind.Witness> {
   public <A, B> Kind<VTaskKind.Witness, B> map(
       Function<? super A, ? extends B> f, Kind<VTaskKind.Witness, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     VTask<A> vtaskA = VTASK.narrow(fa);
     VTask<B> vtaskB = vtaskA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterFunctor.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterFunctor.java
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.writer;
 
-import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 import static org.higherkindedj.hkt.writer.WriterKindHelper.WRITER;
 
 import java.util.function.Function;
@@ -45,8 +44,7 @@ public class WriterFunctor<W> implements Functor<WriterKind.Witness<W>> {
   public <A, B> Kind<WriterKind.Witness<W>, B> map(
       Function<? super A, ? extends B> f, Kind<WriterKind.Witness<W>, A> fa) {
 
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     Writer<W, A> writerA = WRITER.narrow(fa);
     Writer<W, B> writerB = writerA.map(f);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterKindHelper.java
@@ -89,11 +89,7 @@ public enum WriterKindHelper implements WriterConverterOps {
   @SuppressWarnings("unchecked")
   public <W, A> Writer<W, A> narrow(@Nullable Kind<WriterKind.Witness<W>, A> kind) {
     return Validation.kind()
-        .narrowWithPattern(
-            kind,
-            WRITER_CLASS,
-            WriterHolder.class,
-            holder -> ((WriterHolder<W, A>) holder).writer());
+        .narrowHolder(kind, WRITER_CLASS, WriterHolder.class, WriterHolder::writer);
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer_t/WriterTMonad.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer_t/WriterTMonad.java
@@ -78,8 +78,7 @@ public class WriterTMonad<F extends WitnessArity<TypeArity.Unary>, W>
   @Override
   public <A, B> Kind<WriterTKind.Witness<F, W>, B> map(
       Function<? super A, ? extends B> f, Kind<WriterTKind.Witness<F, W>, A> fa) {
-    Validation.function().require(f, "f", MAP);
-    Validation.kind().requireNonNull(fa, MAP);
+    Validation.function().validateMap(f, fa);
 
     WriterT<F, W, A> writerT = WRITER_T.narrow(fa);
     Kind<F, Pair<B, W>> mapped =

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/either_t/EitherTMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/either_t/EitherTMonadTest.java
@@ -279,7 +279,7 @@ class EitherTMonadTest
 
       assertThatThrownBy(() -> eitherTMonad.ap(ff, fa))
           .isInstanceOf(NullPointerException.class)
-          .hasMessage("Function mapper for map cannot be null");
+          .hasMessage("mapper for map cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/future/CompletableFutureMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/future/CompletableFutureMonadTest.java
@@ -360,7 +360,7 @@ class CompletableFutureMonadTest {
       assertThatThrownBy(() -> futureMonad.handleErrorWith(failedKind, null))
           .isInstanceOf(NullPointerException.class)
           .message()
-          .isEqualTo("Function handler for handleErrorWith cannot be null");
+          .isEqualTo("handler for handleErrorWith cannot be null");
     }
 
     @Test
@@ -1091,7 +1091,7 @@ class CompletableFutureMonadTest {
       Kind<CompletableFutureKind.Witness, Integer> input = futureMonad.of(1);
       assertThatThrownBy(() -> futureMonad.flatMap(null, input))
           .isInstanceOf(NullPointerException.class)
-          .hasMessage("Function f for flatMap cannot be null");
+          .hasMessage("f for flatMap cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/io/IOFunctorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/io/IOFunctorTest.java
@@ -272,7 +272,7 @@ class IOFunctorTest extends IOTestBase {
     void mapValidatesNullMapper() {
       assertThatThrownBy(() -> functor.map(null, validKind))
           .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("Function f for map cannot be null");
+          .hasMessageContaining("f for map cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/io/IOMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/io/IOMonadTest.java
@@ -484,7 +484,7 @@ class IOMonadTest extends IOTestBase {
     void flatMapValidatesNullFunction() {
       assertThatThrownBy(() -> monad.flatMap(null, validKind))
           .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("Function f for flatMap cannot be null");
+          .hasMessageContaining("f for flatMap cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/lazy/LazyFunctorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/lazy/LazyFunctorTest.java
@@ -144,7 +144,7 @@ class LazyFunctorTest extends LazyTestBase {
     void mapShouldThrowNPEForNullMapper() {
       assertThatNullPointerException()
           .isThrownBy(() -> functor.map(null, validKind))
-          .withMessageContaining("Function f for map cannot be null");
+          .withMessageContaining("f for map cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/lazy/LazyTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/lazy/LazyTest.java
@@ -412,7 +412,7 @@ class LazyTest extends LazyTestBase {
 
       assertThatNullPointerException()
           .isThrownBy(() -> lazy.flatMap(null))
-          .withMessageContaining("Function f for flatMap cannot be null");
+          .withMessageContaining("f for flatMap cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/maybe/MaybeMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/maybe/MaybeMonadTest.java
@@ -301,7 +301,7 @@ class MaybeMonadTest extends MaybeTestBase {
       Function<Integer, Kind<MaybeKind.Witness, String>> testValidFlatMapper =
           i -> MAYBE.widen(Maybe.just("flat:" + i));
       return Stream.of(
-          Arguments.of("Function f", testValidKind, null),
+          Arguments.of("f for", testValidKind, null),
           Arguments.of("Kind", null, testValidFlatMapper));
     }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state/StateFunctorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state/StateFunctorTest.java
@@ -108,7 +108,7 @@ class StateFunctorTest extends StateTestBase<Integer> {
     void mapShouldValidateMapperIsNonNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> functor.map(null, validKind))
-          .withMessageContaining("Function f for map cannot be null");
+          .withMessageContaining("f for map cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state/StateMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state/StateMonadTest.java
@@ -202,7 +202,7 @@ class StateMonadTest extends StateTestBase<Integer> {
     void flatMapShouldValidateMapperIsNonNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> monad.flatMap(null, validKind))
-          .withMessageContaining("Function f for flatMap cannot be null");
+          .withMessageContaining("f for flatMap cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state/StateTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state/StateTest.java
@@ -264,7 +264,7 @@ class StateTest extends StateTestBase<Integer> {
     void modifyThrowsForNullFunction() {
       assertThatNullPointerException()
           .isThrownBy(() -> State.modify(null))
-          .withMessageContaining("Function f for modify cannot be null");
+          .withMessageContaining("f for modify cannot be null");
     }
 
     @Test
@@ -294,7 +294,7 @@ class StateTest extends StateTestBase<Integer> {
     void inspectThrowsForNullFunction() {
       assertThatNullPointerException()
           .isThrownBy(() -> State.inspect(null))
-          .withMessageContaining("Function f for inspect cannot be null");
+          .withMessageContaining("f for inspect cannot be null");
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/test/patterns/FlexibleValidationConfig.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/test/patterns/FlexibleValidationConfig.java
@@ -178,7 +178,7 @@ public final class FlexibleValidationConfig {
       if (mapHasClassContext && mapContextClass != null) {
         assertThatThrownBy(() -> applicative.map(null, validKind))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("Function " + mapFunctionName + " for map cannot be null");
+            .hasMessageContaining(mapFunctionName + " for map cannot be null");
 
         assertThatThrownBy(() -> applicative.map(validMapper, null))
             .isInstanceOf(NullPointerException.class)
@@ -186,7 +186,7 @@ public final class FlexibleValidationConfig {
       } else {
         assertThatThrownBy(() -> applicative.map(null, validKind))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("Function " + mapFunctionName + " for map cannot be null");
+            .hasMessageContaining(mapFunctionName + " for map cannot be null");
 
         assertThatThrownBy(() -> applicative.map(validMapper, null))
             .isInstanceOf(NullPointerException.class)
@@ -353,8 +353,7 @@ public final class FlexibleValidationConfig {
       if (flatMapHasClassContext && flatMapContextClass != null) {
         assertThatThrownBy(() -> monad.flatMap(null, validKind))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining(
-                "Function " + flatMapFunctionName + " for flatMap cannot be null");
+            .hasMessageContaining(flatMapFunctionName + " for flatMap cannot be null");
 
         assertThatThrownBy(() -> monad.flatMap(validFlatMapper, null))
             .isInstanceOf(NullPointerException.class)
@@ -362,8 +361,7 @@ public final class FlexibleValidationConfig {
       } else {
         assertThatThrownBy(() -> monad.flatMap(null, validKind))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining(
-                "Function " + flatMapFunctionName + " for flatMap cannot be null");
+            .hasMessageContaining(flatMapFunctionName + " for flatMap cannot be null");
 
         assertThatThrownBy(() -> monad.flatMap(validFlatMapper, null))
             .isInstanceOf(NullPointerException.class)

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryFunctorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryFunctorTest.java
@@ -176,7 +176,7 @@ class TryFunctorTest extends TryTestBase {
     void map_shouldThrowNPEIfMapperIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> functor.map(null, validKind))
-          .withMessageContaining("Function f for map cannot be null");
+          .withMessageContaining("f for map cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryKindHelperTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryKindHelperTest.java
@@ -268,7 +268,7 @@ class TryKindHelperTest extends TryTestBase {
     void tryOf_shouldThrowNPEForNullSupplier() {
       assertThatNullPointerException()
           .isThrownBy(() -> TRY.tryOf(null))
-          .withMessageContaining("Function supplier for of cannot be null");
+          .withMessageContaining("supplier for of cannot be null");
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryMonadTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryMonadTest.java
@@ -335,7 +335,7 @@ class TryMonadTest extends TryTestBase {
       Function<String, Kind<TryKind.Witness, Integer>> testValidFlatMapper =
           s -> TRY.widen(Try.success(s.length()));
       return Stream.of(
-          Arguments.of("Function f", testValidKind, null),
+          Arguments.of("f for", testValidKind, null),
           Arguments.of("Kind", null, testValidFlatMapper));
     }
 
@@ -358,7 +358,7 @@ class TryMonadTest extends TryTestBase {
           t -> TRY.widen(Try.success("recovered"));
       return Stream.of(
           Arguments.of("Kind", null, validHandler),
-          Arguments.of("Function handler", testValidKind, null));
+          Arguments.of("handler for", testValidKind, null));
     }
 
     @ParameterizedTest(name = "handleErrorWith validates {0} parameter is non-null")

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/trymonad/TryTest.java
@@ -178,7 +178,7 @@ class TryTest extends TryTestBase {
     void of_shouldThrowNPEForNullSupplier() {
       assertThatNullPointerException()
           .isThrownBy(() -> Try.of(null))
-          .withMessageContaining("Function supplier for of cannot be null");
+          .withMessageContaining("supplier for of cannot be null");
     }
 
     @Test
@@ -235,7 +235,7 @@ class TryTest extends TryTestBase {
     void attempt_shouldThrowNPEForNullSupplier() {
       assertThatNullPointerException()
           .isThrownBy(() -> Try.attempt(null))
-          .withMessageContaining("Function supplier for attempt cannot be null");
+          .withMessageContaining("supplier for attempt cannot be null");
     }
 
     @Test
@@ -382,11 +382,11 @@ class TryTest extends TryTestBase {
     void orElseGet_shouldThrowIfSupplierIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.orElseGet(null))
-          .withMessageContaining("Function supplier for orElseGet cannot be null");
+          .withMessageContaining("supplier for orElseGet cannot be null");
 
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.orElseGet(null))
-          .withMessageContaining("Function supplier for orElseGet cannot be null");
+          .withMessageContaining("supplier for orElseGet cannot be null");
     }
   }
 
@@ -436,7 +436,7 @@ class TryTest extends TryTestBase {
     void fold_shouldThrowIfSuccessMapperIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.fold(null, failureMapper))
-          .withMessageContaining("Function successMapper for fold cannot be null");
+          .withMessageContaining("successMapper for fold cannot be null");
     }
 
     @Test
@@ -444,7 +444,7 @@ class TryTest extends TryTestBase {
     void fold_shouldThrowIfFailureMapperIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.fold(successMapper, null))
-          .withMessageContaining("Function failureMapper for fold cannot be null");
+          .withMessageContaining("failureMapper for fold cannot be null");
     }
 
     @Test
@@ -516,11 +516,11 @@ class TryTest extends TryTestBase {
     void toEither_shouldThrowNPEIfMapperIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.toEither(null))
-          .withMessageContaining("Function failureToLeftMapper for toEither cannot be null");
+          .withMessageContaining("failureToLeftMapper for toEither cannot be null");
 
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.toEither(null))
-          .withMessageContaining("Function failureToLeftMapper for toEither cannot be null");
+          .withMessageContaining("failureToLeftMapper for toEither cannot be null");
     }
 
     @Test
@@ -605,11 +605,11 @@ class TryTest extends TryTestBase {
     void map_shouldThrowIfMapperIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.map(null))
-          .withMessageContaining("Function mapper for map cannot be null");
+          .withMessageContaining("mapper for map cannot be null");
 
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.map(null))
-          .withMessageContaining("Function mapper for map cannot be null");
+          .withMessageContaining("mapper for map cannot be null");
     }
   }
 
@@ -678,11 +678,11 @@ class TryTest extends TryTestBase {
     void flatMap_shouldThrowIfMapperIsNull() {
       assertThatException()
           .isThrownBy(() -> successInstance.flatMap(null))
-          .withMessageContaining("Function mapper for flatMap cannot be null");
+          .withMessageContaining("mapper for flatMap cannot be null");
 
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.flatMap(null))
-          .withMessageContaining("Function mapper for flatMap cannot be null");
+          .withMessageContaining("mapper for flatMap cannot be null");
     }
 
     @Test
@@ -763,11 +763,11 @@ class TryTest extends TryTestBase {
     void recover_shouldThrowIfRecoveryFuncIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.recover(null))
-          .withMessageContaining("Function recoveryFunction for recover cannot be null");
+          .withMessageContaining("recoveryFunction for recover cannot be null");
 
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.recover(null))
-          .withMessageContaining("Function recoveryFunction for recoverFunction cannot be null");
+          .withMessageContaining("recoveryFunction for recoverFunction cannot be null");
     }
   }
 
@@ -848,11 +848,11 @@ class TryTest extends TryTestBase {
     void recoverWith_shouldThrowIfRecoveryFuncIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.recoverWith(null))
-          .withMessageContaining("Function recoveryFunction for recoverWith cannot be null");
+          .withMessageContaining("recoveryFunction for recoverWith cannot be null");
 
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.recoverWith(null))
-          .withMessageContaining("Function recoveryFunction for recoverWith cannot be null");
+          .withMessageContaining("recoveryFunction for recoverWith cannot be null");
     }
   }
 
@@ -917,7 +917,7 @@ class TryTest extends TryTestBase {
     void match_shouldThrowIfSuccessActionIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> successInstance.match(null, failureAction))
-          .withMessageContaining("Function successAction for match cannot be null");
+          .withMessageContaining("successAction for match cannot be null");
     }
 
     @Test
@@ -925,7 +925,7 @@ class TryTest extends TryTestBase {
     void match_shouldThrowIfFailureActionIsNull() {
       assertThatNullPointerException()
           .isThrownBy(() -> failureInstance.match(successAction, null))
-          .withMessageContaining("Function failureAction for match cannot be null");
+          .withMessageContaining("failureAction for match cannot be null");
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/BulkValidatorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/BulkValidatorTest.java
@@ -1,0 +1,354 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.util.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
+import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
+import static org.higherkindedj.hkt.util.validation.Operation.MAP;
+
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Functor;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monoid;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either.EitherKind;
+import org.higherkindedj.hkt.either.EitherMonad;
+import org.higherkindedj.hkt.exception.KindUnwrapException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Bulk validators and recent additions")
+class BulkValidatorTest {
+
+  private static final Function<String, Integer> F = String::length;
+  private static final Function<String, Kind<EitherKind.Witness<String>, Integer>> KF =
+      s -> EITHER.widen(Either.<String, Integer>right(s.length()));
+  private static final Kind<EitherKind.Witness<String>, String> KA =
+      EITHER.widen(Either.<String, String>right("hi"));
+  private static final Kind<EitherKind.Witness<String>, Function<String, Integer>> KFF =
+      EITHER.widen(Either.<String, Function<String, Integer>>right(F));
+
+  // ==================== FunctionValidator bulk helpers ====================
+
+  @Nested
+  @DisplayName("FunctionValidator.validateMap")
+  class ValidateMap {
+    @Test
+    void happyPath() {
+      Validation.function().validateMap(F, KA);
+    }
+
+    @Test
+    void rejectsNullFunction() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateMap(null, KA))
+          .withMessage("f for map cannot be null");
+    }
+
+    @Test
+    void rejectsNullKind() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateMap(F, null))
+          .withMessage("Kind for map cannot be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("FunctionValidator.validateFlatMap")
+  class ValidateFlatMap {
+    @Test
+    void happyPath() {
+      Validation.function().validateFlatMap(KF, KA);
+    }
+
+    @Test
+    void rejectsNullFunction() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateFlatMap(null, KA))
+          .withMessage("f for flatMap cannot be null");
+    }
+
+    @Test
+    void rejectsNullKind() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateFlatMap(KF, null))
+          .withMessage("Kind for flatMap cannot be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("FunctionValidator.validateTraverse")
+  class ValidateTraverse {
+    private final Applicative<EitherKind.Witness<String>> applicative = EitherMonad.instance();
+
+    @Test
+    void happyPath() {
+      Validation.function().validateTraverse(applicative, KF, KA);
+    }
+
+    @Test
+    void rejectsNullApplicative() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateTraverse(null, KF, KA))
+          .withMessage("applicative for traverse cannot be null");
+    }
+
+    @Test
+    void rejectsNullFunction() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateTraverse(applicative, null, KA))
+          .withMessage("f for traverse cannot be null");
+    }
+
+    @Test
+    void rejectsNullKind() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateTraverse(applicative, KF, null))
+          .withMessage("Kind for traverse cannot be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("FunctionValidator.validateFoldMap")
+  class ValidateFoldMap {
+    private final Monoid<Integer> monoid =
+        new Monoid<>() {
+          @Override
+          public Integer empty() {
+            return 0;
+          }
+
+          @Override
+          public Integer combine(Integer a, Integer b) {
+            return a + b;
+          }
+        };
+
+    @Test
+    void happyPath() {
+      Validation.function().validateFoldMap(monoid, F, KA);
+    }
+
+    @Test
+    void rejectsNullMonoid() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateFoldMap(null, F, KA))
+          .withMessage("monoid for foldMap cannot be null");
+    }
+
+    @Test
+    void rejectsNullFunction() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateFoldMap(monoid, null, KA))
+          .withMessage("f for foldMap cannot be null");
+    }
+
+    @Test
+    void rejectsNullKind() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateFoldMap(monoid, F, null))
+          .withMessage("Kind for foldMap cannot be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("FunctionValidator.validateHandleErrorWith")
+  class ValidateHandleErrorWith {
+    private final Function<String, Kind<EitherKind.Witness<String>, String>> handler =
+        e -> EITHER.widen(Either.right("recovered"));
+
+    @Test
+    void happyPath() {
+      Validation.function().validateHandleErrorWith(KA, handler);
+    }
+
+    @Test
+    void rejectsNullSource() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateHandleErrorWith(null, handler))
+          .withMessage("Kind for handleErrorWith (source) cannot be null");
+    }
+
+    @Test
+    void rejectsNullHandler() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.function().validateHandleErrorWith(KA, null))
+          .withMessage("handler for handleErrorWith cannot be null");
+    }
+  }
+
+  // ==================== KindValidator additions ====================
+
+  @Nested
+  @DisplayName("KindValidator.validateAp")
+  class ValidateAp {
+    @Test
+    void happyPath() {
+      Validation.kind().validateAp(KFF, KA);
+    }
+
+    @Test
+    void rejectsNullFunctionKind() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.kind().validateAp(null, KA))
+          .withMessage("Kind for ap (function) cannot be null");
+    }
+
+    @Test
+    void rejectsNullArgumentKind() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.kind().validateAp(KFF, null))
+          .withMessage("Kind for ap (argument) cannot be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("KindValidator.narrowHolder")
+  class NarrowHolder {
+    @Test
+    void unwrapsViaAccessor() {
+      var either = Either.<String, Integer>right(42);
+      var kind = EITHER.widen(either);
+
+      // Use real EITHER.narrow exercising narrowHolder under the hood
+      Either<String, Integer> result = EITHER.narrow(kind);
+
+      assertThat(result).isEqualTo(either);
+    }
+
+    @Test
+    void throwsForNullKind() {
+      assertThatExceptionOfType(KindUnwrapException.class)
+          .isThrownBy(() -> EITHER.narrow(null))
+          .withMessageContaining("narrow")
+          .withMessageContaining("null");
+    }
+  }
+
+  // Fixture types for exercising the deprecated narrowWithPattern method directly,
+  // since the 12 KindHelpers have all migrated to narrowHolder.
+  interface FixtureWitness extends WitnessArity<TypeArity.Unary> {}
+
+  record FixtureHolder<A>(A value) implements Kind<FixtureWitness, A> {}
+
+  record OtherHolder<A>(A value) implements Kind<FixtureWitness, A> {}
+
+  @Nested
+  @DisplayName("KindValidator.narrowWithPattern (deprecated)")
+  @SuppressWarnings({"removal", "unchecked", "rawtypes"})
+  class NarrowWithPattern {
+
+    private final Class<FixtureHolder> holderClass = FixtureHolder.class;
+
+    @Test
+    void unwrapsViaExtractor() {
+      Kind<FixtureWitness, String> kind = new FixtureHolder<>("hello");
+
+      Object result =
+          Validation.KIND.narrowWithPattern(kind, Object.class, holderClass, FixtureHolder::value);
+
+      assertThat(result).isEqualTo("hello");
+    }
+
+    @Test
+    void throwsForNullKind() {
+      assertThatExceptionOfType(KindUnwrapException.class)
+          .isThrownBy(
+              () ->
+                  Validation.KIND.narrowWithPattern(
+                      null, Object.class, holderClass, FixtureHolder::value))
+          .withMessageContaining("narrow")
+          .withMessageContaining("null");
+    }
+
+    @Test
+    void throwsForWrongHolderType() {
+      Kind<FixtureWitness, String> wrongKind = new OtherHolder<>("hello");
+
+      assertThatExceptionOfType(KindUnwrapException.class)
+          .isThrownBy(
+              () ->
+                  Validation.KIND.narrowWithPattern(
+                      wrongKind, Object.class, holderClass, FixtureHolder::value))
+          .withMessageContaining("OtherHolder");
+    }
+  }
+
+  // ==================== TransformerValidator additions ====================
+
+  private static final class FakeT {}
+
+  @Nested
+  @DisplayName("TransformerValidator.requireOuterApplicative")
+  class RequireOuterApplicative {
+    private final Applicative<EitherKind.Witness<String>> applicative = EitherMonad.instance();
+
+    @Test
+    void returnsApplicative() {
+      var result =
+          Validation.transformer().requireOuterApplicative(applicative, FakeT.class, CONSTRUCTION);
+      assertThat(result).isSameAs(applicative);
+    }
+
+    @Test
+    void rejectsNull() {
+      assertThatNullPointerException()
+          .isThrownBy(
+              () ->
+                  Validation.transformer().requireOuterApplicative(null, FakeT.class, CONSTRUCTION))
+          .withMessage("Outer Applicative cannot be null for FakeT construction");
+    }
+  }
+
+  @Nested
+  @DisplayName("TransformerValidator.requireOuterFunctor")
+  class RequireOuterFunctor {
+    private final Functor<EitherKind.Witness<String>> functor = EitherMonad.instance();
+
+    @Test
+    void returnsFunctor() {
+      var result = Validation.transformer().requireOuterFunctor(functor, FakeT.class, MAP);
+      assertThat(result).isSameAs(functor);
+    }
+
+    @Test
+    void rejectsNull() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> Validation.transformer().requireOuterFunctor(null, FakeT.class, MAP))
+          .withMessage("Outer Functor cannot be null for FakeT map");
+    }
+  }
+
+  // ==================== Validation static field aliases ====================
+
+  @Nested
+  @DisplayName("Validation static field aliases match accessor methods")
+  class StaticFieldAliases {
+    @Test
+    void kind() {
+      assertThat(Validation.KIND).isSameAs(Validation.kind());
+    }
+
+    @Test
+    void function() {
+      assertThat(Validation.FUNCTION).isSameAs(Validation.function());
+    }
+
+    @Test
+    void transformer() {
+      assertThat(Validation.TRANSFORMER).isSameAs(Validation.transformer());
+    }
+
+    @Test
+    void core() {
+      assertThat(Validation.CORE).isSameAs(Validation.coreType());
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/OperationTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/OperationTest.java
@@ -96,7 +96,9 @@ class OperationTest {
         Arguments.of(MAP_FOURTH, "mapFourth"),
         Arguments.of(MAP_FIFTH, "mapFifth"),
         Arguments.of(MAP_ERROR, "mapError"),
-        Arguments.of(MAP_WRITTEN, "mapWritten"));
+        Arguments.of(MAP_WRITTEN, "mapWritten"),
+        Arguments.of(WIDEN, "widen"),
+        Arguments.of(NARROW, "narrow"));
   }
 
   @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/TransformerValidatorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/TransformerValidatorTest.java
@@ -70,12 +70,12 @@ class TransformerValidatorTest {
     }
 
     @Test
-    @DisplayName("should throw NullPointerException when method name is null")
-    void shouldThrowWhenMethodNameIsNull() {
+    @DisplayName("should throw NullPointerException when operation is null")
+    void shouldThrowWhenOperationIsNull() {
       assertThatNullPointerException()
           .isThrownBy(
               () -> Validation.transformer().requireOuterMonad(TEST_MONAD, StateT.class, null))
-          .withMessage("methodName cannot be null");
+          .withMessage("operation cannot be null");
     }
   }
 
@@ -155,15 +155,15 @@ class TransformerValidatorTest {
     }
 
     @Test
-    @DisplayName("should throw NullPointerException when method name is null")
-    void shouldThrowWhenMethodNameIsNull() {
+    @DisplayName("should throw NullPointerException when operation is null")
+    void shouldThrowWhenOperationIsNull() {
       assertThatNullPointerException()
           .isThrownBy(
               () ->
                   Validation.transformer()
                       .requireTransformerComponent(
                           "component", "inner Optional", OptionalT.class, null))
-          .withMessage("methodName cannot be null");
+          .withMessage("operation cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/validated/InvalidTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/validated/InvalidTest.java
@@ -341,7 +341,7 @@ class InvalidTest {
     void foldValidatesInvalidMapperIsNonNull() {
       assertThatThrownBy(() -> invalidInstance.fold(null, v -> "valid"))
           .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("Function invalidMapper for fold cannot be null");
+          .hasMessageContaining("invalidMapper for fold cannot be null");
     }
 
     @Test
@@ -349,7 +349,7 @@ class InvalidTest {
     void foldValidatesValidMapperIsNonNull() {
       assertThatThrownBy(() -> invalidInstance.fold(e -> "invalid", null))
           .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("Function validMapper for fold cannot be null");
+          .hasMessageContaining("validMapper for fold cannot be null");
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/validated/ValidTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/validated/ValidTest.java
@@ -261,7 +261,7 @@ class ValidTest extends ValidatedTestBase {
     void mapValidatesMapperIsNonNull() {
       assertThatThrownBy(() -> validInstance.map(null))
           .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("Function fn for map cannot be null");
+          .hasMessageContaining("fn for map cannot be null");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/vtask/ResourceTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/vtask/ResourceTest.java
@@ -35,7 +35,7 @@ class ResourceTest {
     void makeValidatesNonNullAcquire() {
       assertThatNullPointerException()
           .isThrownBy(() -> Resource.make(null, s -> {}))
-          .withMessageContaining("acquire must not be null");
+          .withMessageContaining("acquire for");
     }
 
     @Test
@@ -43,7 +43,7 @@ class ResourceTest {
     void makeValidatesNonNullRelease() {
       assertThatNullPointerException()
           .isThrownBy(() -> Resource.make(() -> "test", null))
-          .withMessageContaining("release must not be null");
+          .withMessageContaining("release for");
     }
 
     @Test
@@ -66,7 +66,7 @@ class ResourceTest {
     void fromAutoCloseableValidatesNonNullAcquire() {
       assertThatNullPointerException()
           .isThrownBy(() -> Resource.fromAutoCloseable(null))
-          .withMessageContaining("acquire must not be null");
+          .withMessageContaining("acquire for");
     }
 
     @Test
@@ -156,7 +156,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.use(null))
-          .withMessageContaining("f must not be null");
+          .withMessageContaining("f for");
     }
 
     @Test
@@ -167,9 +167,7 @@ class ResourceTest {
 
       VTask<String> task = resource.use(r -> null);
 
-      assertThatNullPointerException()
-          .isThrownBy(task::run)
-          .withMessageContaining("must not return null");
+      assertThatNullPointerException().isThrownBy(task::run).withMessageContaining("returned null");
       assertThat(released).isTrue(); // Resource should still be released
     }
 
@@ -180,7 +178,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.useSync(null))
-          .withMessageContaining("f must not be null");
+          .withMessageContaining("f for");
     }
 
     @Test
@@ -240,7 +238,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.map(null))
-          .withMessageContaining("f must not be null");
+          .withMessageContaining("f for");
     }
 
     @Test
@@ -349,7 +347,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.flatMap(null))
-          .withMessageContaining("f must not be null");
+          .withMessageContaining("f for");
     }
 
     @Test
@@ -412,7 +410,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> chained.useSync(s -> s).run())
-          .withMessageContaining("must not return null");
+          .withMessageContaining("returned null");
       assertThat(released).isTrue();
     }
 
@@ -526,7 +524,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.and(null))
-          .withMessageContaining("other must not be null");
+          .withMessageContaining("other for");
     }
 
     @Test
@@ -714,7 +712,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> first.and(null, third))
-          .withMessageContaining("second must not be null");
+          .withMessageContaining("second for");
     }
 
     @Test
@@ -725,7 +723,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> first.and(second, null))
-          .withMessageContaining("third must not be null");
+          .withMessageContaining("third for");
     }
 
     @Test
@@ -997,7 +995,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.withFinalizer(null))
-          .withMessageContaining("finalizer must not be null");
+          .withMessageContaining("finalizer for");
     }
 
     @Test
@@ -1007,7 +1005,7 @@ class ResourceTest {
 
       assertThatNullPointerException()
           .isThrownBy(() -> resource.onFailure(null))
-          .withMessageContaining("onFailure must not be null");
+          .withMessageContaining("onFailure for");
     }
 
     @Test


### PR DESCRIPTION
Pulls the validation package onto a single, consistent surface:

- Operation gains WIDEN and NARROW; KindValidator now routes every context through the enum instead of bare strings.
- Validation exposes KIND/FUNCTION/TRANSFORMER/CORE static fields alongside the existing accessor methods, and documents the NPE vs KindUnwrapException contract.
- TransformerValidator's mistyped `methodName` parameter is renamed to `operation` to match its declared Operation type, and gains requireOuterApplicative / requireOuterFunctor as siblings of requireOuterMonad.
- FunctionValidator gains validateMap; 44 Functor/Monad sites move off the repeated require(f) + requireNonNull(fa) pair, and the misleading "Function ..." noun is dropped from the null message (it was wrong every time the validator was used for a monoid, error, optic, value, applicative or functor).
- KindValidator gains narrowHolder; the 12 KindHelpers move to method-reference accessors (OptionalHolder::optional, etc.) and narrowWithPattern is @Deprecated(since="0.4.4", forRemoval=true) for 0.5.0 removal.
- Resource and FreeAp migrate from raw Objects.requireNonNull to the validators so their messages carry the same operation context as the rest of the codebase.
- BulkValidatorTest backfills coverage for the bulk validators, narrowHolder, the new transformer overloads, and the static-field aliases. 38 pre-existing test assertions on the legacy "Function X for Y..." format are updated to the new format.
