### PR TITLE
Add "Where to Start" navigation guide and improve tooling docs

### DIFF
--- a/hkj-book/src/SUMMARY.md
+++ b/hkj-book/src/SUMMARY.md
@@ -3,6 +3,7 @@
 
 - [Quickstart](quickstart.md)
 - [Cheat Sheet](cheatsheet.md)
+- [Where to Start](where_to_start.md)
 - [Effect Path API](effect/ch_intro.md)
   - [Quickstart](effect/quickstart.md)
   - [Core Paths](effect/effect_path_overview.md)
@@ -245,8 +246,8 @@
   - [Troubleshooting](tutorials/troubleshooting.md)
 
 - [Tooling](tooling/ch_intro.md)
-  - [Manual Gradle and Maven Setup](tooling/manual_setup.md)
   - [Build Plugins](tooling/gradle_plugin.md)
+  - [Manual Gradle and Maven Setup](tooling/manual_setup.md)
   - [Compile-Time Checks](tooling/compile_checks.md)
   - [Diagnostics](tooling/diagnostics.md)
   - [Traversal Generator Plugins](tooling/generator_plugins.md)

--- a/hkj-book/src/spring/spring_boot_integration.md
+++ b/hkj-book/src/spring/spring_boot_integration.md
@@ -30,7 +30,7 @@ The **hkj-spring-boot-starter** solves these problems by bringing functional pro
 
 ---
 
-## Quick Start {#quick-start}
+## Quickstart {#quickstart}
 
 ### Step 1: Add the Dependency
 
@@ -52,6 +52,64 @@ Or with Maven:
     <version>LATEST_VERSION</version>
 </dependency>
 ```
+
+#### Recommended: align versions with the BOM
+
+A Spring project usually pulls in more than the starter alone -- typically
+`hkj-core` for the Path types your services return, and `hkj-test` for the
+AssertJ helpers in your slice tests. Importing the `hkj-bom` platform pins
+all HKJ modules to one consistent version, so you declare the version once
+and leave it off every individual dependency.
+
+```gradle
+// build.gradle.kts
+dependencies {
+    implementation(platform("io.github.higher-kinded-j:hkj-bom:LATEST_VERSION"))
+
+    implementation("io.github.higher-kinded-j:hkj-spring-boot-starter")
+    implementation("io.github.higher-kinded-j:hkj-core")
+    testImplementation("io.github.higher-kinded-j:hkj-test")
+}
+```
+
+Or with Maven:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.higher-kinded-j</groupId>
+            <artifactId>hkj-bom</artifactId>
+            <version>LATEST_VERSION</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>io.github.higher-kinded-j</groupId>
+        <artifactId>hkj-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.github.higher-kinded-j</groupId>
+        <artifactId>hkj-core</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.github.higher-kinded-j</groupId>
+        <artifactId>hkj-test</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+~~~admonish tip title="Already using the HKJ build plugin?"
+The [HKJ Gradle and Maven plugins](../tooling/gradle_plugin.md) import the
+BOM for you and add the starter when Spring integration is enabled, so you
+do not need the version management above. This BOM snippet is for Spring
+projects that wire HKJ in by hand.
+~~~
 
 ### Step 2: Return Functional Types from Controllers
 

--- a/hkj-book/src/tooling/ch_intro.md
+++ b/hkj-book/src/tooling/ch_intro.md
@@ -10,9 +10,9 @@ The HKJ tooling catches these mistakes before your code ever runs. Both Gradle a
 ---
 
 ~~~admonish info title="In This Chapter"
-- **[Manual Gradle and Maven Setup](manual_setup.md)** -- Full `build.gradle.kts` and `pom.xml` configuration for projects that cannot use the HKJ build plugin. Covers dependencies, annotation processors, Java preview flags, and snapshot repositories.
+- **[Build Plugins](gradle_plugin.md)** -- One-line setup for Gradle or Maven that configures dependencies, preview features, and compile-time checks automatically. This is the recommended way to add Higher-Kinded-J to a project; reach for it first.
 
-- **[Build Plugins](gradle_plugin.md)** -- One-line setup for Gradle or Maven that configures dependencies, preview features, and compile-time checks automatically. Replaces multi-block boilerplate configuration with a single plugin application.
+- **[Manual Gradle and Maven Setup](manual_setup.md)** -- Full `build.gradle.kts` and `pom.xml` configuration for the projects that cannot use the build plugin (constrained environments, in-house build frameworks, or a conflicting plugin). The fallback, not the starting point.
 
 - **[Compile-Time Checks](compile_checks.md)** -- A javac plugin that detects Path type mismatches at compile time, preventing runtime `IllegalArgumentException` errors. Follows a strict no-false-positives policy.
 
@@ -31,8 +31,8 @@ The HKJ tooling catches these mistakes before your code ever runs. Both Gradle a
 
 ## Chapter Contents
 
-1. [Manual Gradle and Maven Setup](manual_setup.md) - Full manual build configuration
-2. [Build Plugins](gradle_plugin.md) - One-line project setup for Gradle and Maven
+1. [Build Plugins](gradle_plugin.md) - One-line project setup for Gradle and Maven (recommended)
+2. [Manual Gradle and Maven Setup](manual_setup.md) - Full manual build configuration (fallback)
 3. [Compile-Time Checks](compile_checks.md) - Path type mismatch detection
 4. [Diagnostics](diagnostics.md) - Configuration reporting and troubleshooting
 5. [Traversal Generator Plugins](generator_plugins.md) - Supported types and custom generators
@@ -43,4 +43,4 @@ The HKJ tooling catches these mistakes before your code ever runs. Both Gradle a
 
 ---
 
-**Next:** [Manual Gradle and Maven Setup](manual_setup.md)
+**Next:** [Build Plugins](gradle_plugin.md)

--- a/hkj-book/src/tooling/compile_checks.md
+++ b/hkj-book/src/tooling/compile_checks.md
@@ -208,5 +208,5 @@ In these cases, the checker silently skips the check. Runtime type checking in t
 
 ---
 
-**Previous:** [Build Plugins](gradle_plugin.md)
+**Previous:** [Manual Gradle and Maven Setup](manual_setup.md)
 **Next:** [Diagnostics](diagnostics.md)

--- a/hkj-book/src/tooling/gradle_plugin.md
+++ b/hkj-book/src/tooling/gradle_plugin.md
@@ -246,5 +246,5 @@ Projects that cannot apply the Maven plugin should see [Manual Gradle and Maven 
 
 ---
 
-**Previous:** [Manual Gradle and Maven Setup](manual_setup.md)
-**Next:** [Compile-Time Checks](compile_checks.md)
+**Previous:** [Tooling](ch_intro.md)
+**Next:** [Manual Gradle and Maven Setup](manual_setup.md)

--- a/hkj-book/src/tooling/manual_setup.md
+++ b/hkj-book/src/tooling/manual_setup.md
@@ -6,7 +6,7 @@
 - Snapshot repository configuration for both build tools
 ~~~
 
-Most projects should use the [HKJ build plugin](gradle_plugin.md) covered in the next chapter -- a single line replaces all the boilerplate below. This page documents the full manual configuration for projects that cannot use the plugin (constrained environments, in-house build frameworks, or plugins that conflict with the HKJ plugin).
+Most projects should use the [HKJ build plugin](gradle_plugin.md) -- a single line replaces all the boilerplate below. This page documents the full manual configuration for the projects that cannot use the plugin (constrained environments, in-house build frameworks, or plugins that conflict with the HKJ plugin). If the plugin is an option for you, start there instead.
 
 ---
 
@@ -138,5 +138,5 @@ The [HKJ build plugin](gradle_plugin.md) handles all of the above -- dependencie
 
 ---
 
-**Previous:** [Tooling](ch_intro.md)
-**Next:** [Build Plugins](gradle_plugin.md)
+**Previous:** [Build Plugins](gradle_plugin.md)
+**Next:** [Compile-Time Checks](compile_checks.md)

--- a/hkj-book/src/tutorials/learning_paths.md
+++ b/hkj-book/src/tutorials/learning_paths.md
@@ -46,7 +46,7 @@ Each journey is designed to be completed in a single sitting (25–40 minutes). 
 
 ---
 
-### Path B: Quick Start
+### Path B: Quickstart
 *Get productive with Higher-Kinded-J quickly.*
 
 | Session | Journey | Duration |

--- a/hkj-book/src/tutorials/tutorials_intro.md
+++ b/hkj-book/src/tutorials/tutorials_intro.md
@@ -181,7 +181,7 @@ Tutorial tests are **excluded** from `./gradlew test` because they are incomplet
 
 See the full [Learning Paths](learning_paths.md) guide for detailed sequences. A quick overview:
 
-### Quick Start (2 sessions)
+### Quickstart (2 sessions)
 [Core: Foundations](coretypes/foundations_journey.md) → [Effect API](effect/effect_journey.md)
 
 ### Practical FP (4 sessions)

--- a/hkj-book/src/where_to_start.md
+++ b/hkj-book/src/where_to_start.md
@@ -1,0 +1,264 @@
+# Where to Start
+
+> *"Would you tell me, please, which way I ought to go from here?"*
+>
+> *"That depends a good deal on where you want to get to," said the Cat.*
+>
+> -- Lewis Carroll, *Alice's Adventures in Wonderland*
+
+Alice's reply was that she did not much care where, at which point the Cat
+told her any road would do. This page is built on the opposite assumption:
+that you do care, that you already have a problem in front of you, and that
+what you need is the shortest route to the chapter that solves it.
+
+~~~admonish info title="What You'll Learn"
+- Which tool fits the problem you have, before you know the library's vocabulary
+- How the four tool families combine when one is not enough
+- Where to go next once you have picked your direction
+~~~
+
+---
+
+## The one question
+
+> *What are you actually trying to do?*
+
+Pick the branch that matches. If two match, read both and combine them;
+the [Combining tools](#combining-tools) section below covers the common
+overlaps.
+
+1. [I'm working with values that might fail or be absent](#1-values-that-might-fail-or-be-absent)
+2. [I'm reading or updating data inside immutable records](#2-reading-or-updating-nested-data)
+3. [I'm doing concurrent, async, or deferred I/O](#3-concurrent-async-or-deferred-io)
+4. [I'm sequencing several effects together](#4-sequencing-several-effects)
+5. [I'm writing library or polymorphic code that others will compose with](#5-library-or-polymorphic-code)
+
+---
+
+## 1. Values that might fail or be absent
+
+You have a function that may return nothing, throw, or report a domain error.
+You want chaining, short-circuiting, and a clear extraction point.
+
+| Your situation | Reach for |
+|---|---|
+| Value may be missing; the reason does not matter | [`MaybePath`](effect/path_maybe.md) |
+| Bridging to Java's `Optional` | [`OptionalPath`](effect/path_optional.md) |
+| Failure carries a typed domain error you control | [`EitherPath`](effect/path_either.md) |
+| Failure comes from code that throws exceptions | [`TryPath`](effect/path_try.md) |
+| You want **all** validation errors, not just the first | [`ValidationPath`](effect/path_validation.md) |
+
+If you are not sure between `EitherPath` and `TryPath`, ask: *would I want to
+unit-test the error branch?* If yes, `EitherPath`. If the error is genuinely
+exceptional (file system blew up), `TryPath` is honest about it.
+
+Go to: [Effect Path Quickstart](effect/quickstart.md) ·
+[Core Paths](effect/effect_path_overview.md) ·
+[full Path decision tree](effect/path_types.md)
+
+---
+
+## 2. Reading or updating nested data
+
+You have records (often deeply nested), sealed hierarchies, or collections,
+and you want to read or update one field without rebuilding the surrounding
+structure by hand.
+
+| Your situation | Reach for |
+|---|---|
+| Required field on a record, get/set | [`Lens`](optics/lenses.md), via [Focus DSL](optics/focus_dsl.md) |
+| Optional field, or a field that may be absent | [`Affine`](optics/affine.md) / [`AffinePath`](optics/affine.md) |
+| One variant of a sealed type | [`Prism`](optics/prisms.md) |
+| Every element of a collection | [`Traversal`](optics/traversals.md) |
+| Two equivalent representations | [`Iso`](optics/iso.md) |
+| The type isn't yours to annotate | [`@ImportOptics`](optics/importing_optics.md) or an [`OpticsSpec`](optics/optics_spec_interfaces.md) |
+
+In practice almost everyone starts with the [Focus DSL](optics/focus_dsl.md)
+and annotations like `@GenerateLenses`, `@GenerateFocus`, `@GeneratePrisms`;
+hand-written optic composition is rarely needed.
+
+Go to: [Optics Quickstart](optics/quickstart.md) ·
+[full Optics decision trees](optics/decision_trees.md)
+
+---
+
+## 3. Concurrent, async, or deferred I/O
+
+You are calling APIs, talking to a database, reading files, fanning out work
+across threads, and you want a sane composition story.
+
+| Your situation | Reach for |
+|---|---|
+| Defer a side effect; do not run it until you ask | [`IOPath`](effect/path_io.md) |
+| Concurrent work, virtual threads, structured concurrency | [`VTaskPath`](effect/path_vtask.md) |
+| Lazy pull-based streaming, possibly infinite | [`VStreamPath`](effect/path_vstream.md) |
+| Existing `CompletableFuture<T>` returns you must integrate with | [`CompletableFuturePath`](monads/cf_monad.md) |
+| Memoise a deferred computation | [`LazyPath`](monads/lazy_monad.md) |
+| Deeply recursive algorithm that would blow the stack | [`TrampolinePath`](effect/path_trampoline.md) |
+
+If you are starting a new service from scratch on Java 21+, default to
+[`VTaskPath`](effect/path_vtask.md); it gives you virtual-thread
+concurrency without forcing the rest of your code reactive.
+
+Go to: [VTask Monad](monads/vtask_monad.md) ·
+[Structured Concurrency](monads/vtask_scope.md)
+
+---
+
+## 4. Sequencing several effects
+
+You have more than one of the above to do, in order. Two answers, depending
+on how regular the pipeline is.
+
+| Your situation | Reach for |
+|---|---|
+| A linear pipeline: do A, then B with A's result, then C | The Path's own `.flatMap` / `.map` chain |
+| A pipeline that pulls from several independent sources | [`ForPath` comprehension](effect/forpath_comprehension.md) |
+| Independent steps you want to run in parallel | [`ForPath` parallel](effect/forpath_par.md) |
+| The same operation across a collection | [`ForPath` traverse](effect/forpath_traverse.md) |
+| A DSL you want to interpret in multiple ways (prod, audit, dry-run) | [`FreePath`](effect/path_free.md) and [Effect Handlers](effect/effect_handlers_intro.md) |
+
+`ForPath` is the answer most of the time once a pipeline has more than two
+steps and one of them needs a name. It reads top-to-bottom and removes the
+nesting that `flatMap` chains accumulate.
+
+Go to: [For Comprehension](functional/for_comprehension.md) ·
+[Composition Patterns](effect/composition.md)
+
+---
+
+## 5. Library or polymorphic code
+
+You are not writing application code; you are writing a function that
+**other teams will compose into their effect stack**. The Path API fixes the
+outer effect at the call site, which is wrong for this case.
+
+| Your situation | Reach for |
+|---|---|
+| You need to read configuration without fixing the caller's effect | [`MonadReader`](transformers/mtl_reader.md) |
+| You need to read **and modify** state polymorphically | [`MonadState`](transformers/mtl_state.md) |
+| You need to record an audit log polymorphically | [`MonadWriter`](transformers/mtl_writer.md) |
+| You need to combine several of the above | [MTL Combining Capabilities](transformers/mtl_combining.md) |
+| Bridging to a third-party type like `Mono<Either<E, A>>` | [`EitherT`](transformers/eithert_transformer.md) directly |
+
+If you are not in one of these cases, you do not need the transformer
+chapter. The full reasoning lives in
+[Path or Transformer?](transformers/when_to_drop_to_transformers.md).
+
+Go to: [MTL Capabilities](transformers/mtl_capabilities.md) ·
+[Transformers Quickstart](transformers/quickstart.md)
+
+---
+
+## Combining tools
+
+The four families overlap. Here are the five combinations that come up most
+often in real code, each with the right entry point.
+
+### Validation **and** nested update
+
+You need to update a field inside a record, but the update can fail.
+
+- **Tools:** Focus DSL (to navigate) + `EitherPath` or `ValidationPath` (to
+  carry the error).
+- **API:** Call `.focus(lens)` on the Path, or `lens.toEitherPath()` from
+  Focus.
+- **Read:** [Optics Integration](effect/focus_integration.md) ·
+  [Capstone: Effects Meet Optics](effect/capstone_focus_effect.md) ·
+  [Tutorial14_FocusEffectBridge](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial14_FocusEffectBridge.java)
+
+### Async **and** typed errors
+
+You need to call an async API that can return a domain error before the
+result is materialised.
+
+- **Tools:** `VTaskPath` for the async, `EitherPath` for the error, composed
+  through `ForPath`. For polymorphic code or third-party `Mono<Either<...>>`
+  shapes, drop to `EitherT<VTaskKind.Witness, E, A>`
+  ([EitherT](transformers/eithert_transformer.md)).
+- **Read:** [Composition Patterns](effect/composition.md) ·
+  [Path or Transformer?](transformers/when_to_drop_to_transformers.md#signal-1-you-need-an-outer-monad-path-does-not-wrap)
+
+### Async **and** resilience (retry, circuit breaker, bulkhead, saga)
+
+You have async or deferred work and you need to make it survive partial
+failure.
+
+- **Tools:** [`VTaskPath`](effect/path_vtask.md) or [`IOPath`](effect/path_io.md) underneath the resilience combinators.
+- **Read:** [Resilience Patterns](resilience/ch_intro.md) ·
+  [Retry](resilience/retry.md) ·
+  [Saga](resilience/saga.md)
+
+### Pure logic **and** I/O at the edges
+
+You want a functional core (pure, testable, no effects) and an imperative
+shell that runs the effects.
+
+- **Tools:** Plain data types in the core, [`IOPath`](effect/path_io.md) / [`VTaskPath`](effect/path_vtask.md) at the
+  boundary, `.unsafeRun()` only at the entry point (`main`, controller,
+  test).
+- **Read:** [the hkj-arch skill](tooling/claude_code_skills.md), [Effect Boundary Integration](spring/effect_boundary_integration.md).
+
+### A DSL **and** multiple interpreters
+
+You want to describe a workflow once and run it differently in production,
+tests, audits, or dry-runs.
+
+- **Tools:** [`FreePath`](effect/path_free.md) for the description, [`@EffectAlgebra`](effect/effect_handlers_intro.md) for the
+  vocabulary, interpreters for each run mode.
+- **Read:** [Effect Handlers](effect/effect_handlers_intro.md) ·
+  [Free Monad](monads/free_monad.md) · [the hkj-effects skill](tooling/claude_code_skills.md).
+
+---
+
+## Escape hatches
+
+If none of the above fits, you are in one of these situations:
+
+- **A custom monad with no Path.** Use [`GenericPath<F, A>`](effect/path_generic.md)
+  given a `Monad<F>` instance.
+- **You are extending the library itself with a new HKT.** Read
+  [Extending](hkts/extending-simulation.md) and the
+  [0.3.0 migration guide](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/MIGRATION-0.3.0.md)
+  for the witness arity contract.
+- **You are stuck on a compiler error and the type doesn't make sense.**
+  See [Common Compiler Errors](effect/compiler_errors.md) for effects,
+  [Optics Compiler Errors](optics/compiler_errors.md) for optics, or
+  [Transformer Errors](transformers/common_errors.md) for transformers.
+
+---
+
+## Quick reference
+
+| If you're doing this... | Start here |
+|---|---|
+| Absent values | [`MaybePath`](effect/path_maybe.md) |
+| Typed domain errors | [`EitherPath`](effect/path_either.md) |
+| Wrapping throwing code | [`TryPath`](effect/path_try.md) |
+| Accumulating validation errors | [`ValidationPath`](effect/path_validation.md) |
+| Deferred side effect | [`IOPath`](effect/path_io.md) |
+| Async on virtual threads | [`VTaskPath`](effect/path_vtask.md) |
+| Lazy streaming | [`VStreamPath`](effect/path_vstream.md) |
+| Reading or updating one nested field | [Focus DSL](optics/focus_dsl.md) |
+| Sealed-type variant | [Prism](optics/prisms.md) |
+| Every element of a collection | [Traversal](optics/traversals.md) |
+| Linear pipeline | [`.flatMap`](effect/composition.md) on the Path |
+| Pipeline pulling from several sources | [`ForPath`](effect/forpath_comprehension.md) |
+| Validation + nested update | [Optics Integration](effect/focus_integration.md) |
+| Async + typed errors | [Composition Patterns](effect/composition.md) |
+| Resilience around async work | [Resilience Patterns](resilience/ch_intro.md) |
+| Polymorphic library function | [MTL Capabilities](transformers/mtl_capabilities.md) |
+| Third-party outer effect | [`EitherT`](transformers/eithert_transformer.md) |
+| DSL with multiple interpreters | [`FreePath`](effect/path_free.md) + [Effect Handlers](effect/effect_handlers_intro.md) |
+
+~~~admonish tip title="Still not sure?"
+Start with the [Quickstart](quickstart.md). Most production workflows use
+one or two Paths and a Focus DSL, and that combination is enough to ship.
+Reach for transformers, MTL, or Free monads only when one of the signals
+on this page actually fires.
+~~~
+
+---
+
+**Previous:** [Cheat Sheet](cheatsheet.md)
+**Next:** [Effect Path API](effect/ch_intro.md)

--- a/hkj-book/theme/chapter-title.js
+++ b/hkj-book/theme/chapter-title.js
@@ -9,6 +9,7 @@
   const CHAPTER_INTRO_PATHS = [
     '/quickstart.html',
     '/cheatsheet.html',
+    '/where_to_start.html',
     '/effect/ch_intro.html',
     '/optics/ch_intro.html',
     '/transformers/ch_intro.html',


### PR DESCRIPTION
## Description

This PR adds a comprehensive "Where to Start" guide to help users navigate the Higher-Kinded-J library based on their specific use case, rather than requiring them to read documentation linearly. The guide provides decision trees for five common problem categories (values that might fail, nested data updates, async/concurrent I/O, effect sequencing, and polymorphic code) with quick reference tables and combination patterns for overlapping scenarios.

Additionally, this PR improves the tooling documentation by reordering chapters to prioritize the build plugin (the recommended approach) over manual setup, and makes minor terminology consistency updates throughout the documentation.

Relates to improving user onboarding and documentation discoverability.

## Type of change

- [x] New feature (adds functionality)
- [x] Documentation update
- [x] Refactoring/Code cleanup

## Changes Made

### New Content
- **`hkj-book/src/where_to_start.md`** (263 lines): Comprehensive navigation guide with:
  - Five decision trees for common use cases (values, nested data, async I/O, effect sequencing, polymorphic code)
  - Quick reference table mapping problems to solutions
  - Five combination patterns for overlapping scenarios (validation + nested update, async + typed errors, etc.)
  - Escape hatches for edge cases
  - Links to relevant documentation sections

### Documentation Improvements
- **`hkj-book/src/SUMMARY.md`**: Added "Where to Start" to the main navigation, positioned after "Cheat Sheet"
- **`hkj-book/src/tooling/ch_intro.md`**: Reordered chapter descriptions to recommend the build plugin first, with manual setup as the fallback
- **`hkj-book/src/tooling/gradle_plugin.md`**: Updated navigation links to reflect new chapter ordering
- **`hkj-book/src/tooling/manual_setup.md`**: Updated introductory text to clarify it's for constrained environments
- **`hkj-book/src/tooling/compile_checks.md`**: Updated previous chapter link
- **`hkj-book/src/spring/spring_boot_integration.md`**: 
  - Standardized "Quick Start" → "Quickstart" heading
  - Added BOM (Bill of Materials) setup section with Gradle and Maven examples
  - Added tip about HKJ build plugin handling BOM imports automatically
- **`hkj-book/src/tutorials/learning_paths.md`**: Standardized "Quick Start" → "Quickstart"
- **`hkj-book/src/tutorials/tutorials_intro.md`**: Standardized heading terminology
- **`hkj-book/theme/chapter-title.js`**: Added `/where_to_start.html` to chapter intro paths for proper styling

## How Has This Been Tested?

- [x] Documentation builds without errors (mdbook validation)
- [x] All internal links in the new guide are valid
- [x] Navigation structure is consistent with existing chapters

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The GitHub Actions CI build should pass with these changes (documentation-only)

## Additional Comments

The "Where to Start" guide is designed to be the first page users encounter after the quickstart and cheat sheet, providing a pragmatic entry point based on their immediate problem rather than library structure. The guide emphasizes that most users will need only one or two Paths and the Focus DSL, with transformers and advanced features as opt-in when specific signals fire.

The BOM section in Spring Boot integration documentation addresses a common pain point of version management across multiple HKJ modules in Spring projects.
