### PR TITLE
Deprecate StateTKind.narrowK for removal in 0.5.0 (#455)

### DIFF
--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKind.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKind.java
@@ -119,7 +119,12 @@ public interface StateTKind<S, F, A> extends Kind<StateTKind.Witness<S, F>, A> {
    *     a valid, non-null {@code StateT} representation.
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code kind} is {@code null} or
    *     not actually an instance of {@link StateT}.
+   * @deprecated since 0.4.5, scheduled for removal in 0.5.0. The wildcard {@code Kind<?, A>}
+   *     parameter bypasses the HKT witness type safety enforced everywhere else in the library, and
+   *     this method has no callers. Use {@link #narrow(Kind)} instead, which enforces the witness
+   *     type at compile time.
    */
+  @Deprecated(since = "0.4.5", forRemoval = true)
   @SuppressWarnings("unchecked")
   static <S, F extends WitnessArity<TypeArity.Unary>, A> StateT<S, F, A> narrowK(
       @Nullable Kind<?, A> kind) {

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/expression/ForTraverseTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/expression/ForTraverseTest.java
@@ -284,14 +284,14 @@ class ForTraverseTest {
   }
 
   @Nested
-  @DisplayName("FilterableSteps1 traverse with Maybe Monad")
-  class FilterableSteps1TraverseTest {
+  @DisplayName("MonadicSteps1 traverse/sequence/flatTraverse with Maybe Monad")
+  class MonadicSteps1TraverseSequenceFlatTraverseMaybeTest {
     private final MonadError<MaybeKind.Witness, Unit> maybeMonad = Instances.monadError(maybe());
     private final ListTraverse listTraverse = ListTraverse.INSTANCE;
 
     @Test
-    @DisplayName("traverse: should work on filterable comprehension")
-    void traverseOnFilterable() {
+    @DisplayName("traverse: should work on a MonadicSteps1 comprehension")
+    void traverseOnMonadicSteps1() {
       Kind<MaybeKind.Witness, List<Integer>> result =
           For.from(maybeMonad, MAYBE.just(Arrays.asList(1, 2, 3)))
               .traverse(listTraverse, list -> LIST.widen(list), (Integer i) -> MAYBE.just(i * 2))
@@ -302,8 +302,8 @@ class ForTraverseTest {
     }
 
     @Test
-    @DisplayName("sequence: should work on filterable comprehension")
-    void sequenceOnFilterable() {
+    @DisplayName("sequence: should work on a MonadicSteps1 comprehension")
+    void sequenceOnMonadicSteps1() {
       List<Kind<MaybeKind.Witness, Integer>> listOfMaybes =
           Arrays.asList(MAYBE.just(1), MAYBE.just(2), MAYBE.just(3));
       Kind<ListKind.Witness, Kind<MaybeKind.Witness, Integer>> kindList = LIST.widen(listOfMaybes);
@@ -318,8 +318,8 @@ class ForTraverseTest {
     }
 
     @Test
-    @DisplayName("flatTraverse: should work on filterable comprehension")
-    void flatTraverseOnFilterable() {
+    @DisplayName("flatTraverse: should work on a MonadicSteps1 comprehension")
+    void flatTraverseOnMonadicSteps1() {
       Kind<MaybeKind.Witness, List<Integer>> result =
           For.from(maybeMonad, MAYBE.just(Arrays.asList(1, 2)))
               .flatTraverse(
@@ -355,6 +355,144 @@ class ForTraverseTest {
                     return a + ":" + tList;
                   });
       assertThat(IdKindHelper.ID.unwrap(result)).isEqualTo("10:[20, 22, 24]");
+    }
+  }
+
+  @Nested
+  @DisplayName("FilterableSteps1 traverse / sequence / flatTraverse via MonadZero")
+  class FilterableSteps1TraverseMonadZeroTest {
+    private final MonadZero<MaybeKind.Witness> maybeMonad = Instances.monadZero(maybe());
+    private final MonadZero<ListKind.Witness> listMonad = Instances.monadZero(list());
+    private final ListTraverse listTraverse = ListTraverse.INSTANCE;
+
+    @Test
+    @DisplayName("traverse: should traverse a list applying a Maybe effect to each element")
+    void filterableTraverse() {
+      Kind<MaybeKind.Witness, List<Integer>> result =
+          For.from(maybeMonad, MAYBE.just(Arrays.asList(1, 2, 3)))
+              .traverse(listTraverse, list -> LIST.widen(list), (Integer i) -> MAYBE.just(i * 2))
+              .yield((original, traversed) -> LIST.narrow(traversed));
+      Maybe<List<Integer>> maybe = MAYBE.narrow(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).containsExactly(2, 4, 6);
+    }
+
+    @Test
+    @DisplayName("traverse: should short-circuit when an element returns Nothing")
+    void filterableTraverseNothing() {
+      Kind<MaybeKind.Witness, List<Integer>> result =
+          For.from(maybeMonad, MAYBE.just(Arrays.asList(1, 2, 3)))
+              .traverse(
+                  listTraverse,
+                  list -> LIST.widen(list),
+                  (Integer i) -> i == 2 ? MAYBE.<Integer>nothing() : MAYBE.just(i * 2))
+              .yield((original, traversed) -> LIST.narrow(traversed));
+      assertThat(MAYBE.narrow(result).isJust()).isFalse();
+    }
+
+    @Test
+    @DisplayName("traverse: should reject null arguments")
+    void filterableTraverseNullArgs() {
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .traverse(null, list -> LIST.widen(list), (Integer i) -> MAYBE.just(i)))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("traversable");
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .traverse(listTraverse, null, (Integer i) -> MAYBE.just(i)))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("extractor");
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .traverse(listTraverse, list -> LIST.widen(list), null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("function");
+    }
+
+    @Test
+    @DisplayName("sequence: should turn List<Maybe<Int>> into Maybe<List<Int>>")
+    void filterableSequence() {
+      List<Kind<MaybeKind.Witness, Integer>> listOfMaybes =
+          Arrays.asList(MAYBE.just(1), MAYBE.just(2), MAYBE.just(3));
+      Kind<ListKind.Witness, Kind<MaybeKind.Witness, Integer>> kindList = LIST.widen(listOfMaybes);
+
+      Kind<MaybeKind.Witness, List<Integer>> result =
+          For.from(maybeMonad, MAYBE.just(kindList))
+              .sequence(listTraverse, Function.identity())
+              .yield((original, sequenced) -> LIST.narrow(sequenced));
+
+      Maybe<List<Integer>> maybe = MAYBE.narrow(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("sequence: should reject null arguments")
+    void filterableSequenceNullArgs() {
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(LIST.widen(List.of(MAYBE.just(1)))))
+                      .sequence(null, Function.identity()))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("traversable");
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(LIST.widen(List.of(MAYBE.just(1)))))
+                      .sequence(listTraverse, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("extractor");
+    }
+
+    @Test
+    @DisplayName("flatTraverse: should traverse and flatten inner lists")
+    void filterableFlatTraverse() {
+      Kind<MaybeKind.Witness, List<Integer>> result =
+          For.from(maybeMonad, MAYBE.just(Arrays.asList(1, 2, 3)))
+              .flatTraverse(
+                  listTraverse,
+                  listMonad,
+                  list -> LIST.widen(list),
+                  (Integer i) -> MAYBE.just(LIST.widen(Arrays.asList(i, i * 10))))
+              .yield((original, traversed) -> LIST.narrow(traversed));
+      Maybe<List<Integer>> maybe = MAYBE.narrow(result);
+      assertThat(maybe.isJust()).isTrue();
+      assertThat(maybe.get()).containsExactly(1, 10, 2, 20, 3, 30);
+    }
+
+    @Test
+    @DisplayName("flatTraverse: should reject null arguments")
+    void filterableFlatTraverseNullArgs() {
+      Function<List<Integer>, Kind<ListKind.Witness, Integer>> extractor = list -> LIST.widen(list);
+      Function<Integer, Kind<MaybeKind.Witness, Kind<ListKind.Witness, Integer>>> f =
+          i -> MAYBE.just(LIST.widen(List.of(i)));
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .flatTraverse(null, listMonad, extractor, f))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("traversable");
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .flatTraverse(listTraverse, null, extractor, f))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("innerMonad");
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .flatTraverse(listTraverse, listMonad, null, f))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("extractor");
+      assertThatThrownBy(
+              () ->
+                  For.from(maybeMonad, MAYBE.just(List.of(1)))
+                      .flatTraverse(listTraverse, listMonad, extractor, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("function");
     }
   }
 }


### PR DESCRIPTION
narrowK accepts Kind<?, A> with a wildcard witness, bypassing the HKT witness type safety enforced everywhere else in the library. It has no callers, and the type-safe narrow(Kind) already covers the use case. Mark it @Deprecated(forRemoval = true) now; remove in 0.5.0.

While verifying coverage, found that For.FilterableSteps1's traverse, sequence, and flatTraverse were never exercised: the existing FilterableSteps1TraverseTest passed a MonadError, which resolves to the MonadicSteps1 For.from overload. Add a nested test that builds the comprehension via a MonadZero source to select the FilterableSteps1 overload (happy paths plus all null-argument guards), and rename the misnamed existing class to MonadicSteps1TraverseSequenceFlatTraverseMaybeTest to reflect what it actually tests. Restores hkj-core to 100% instruction/branch/line/method coverage.
Fixes #455 