### PR TITLE
Add request-batching substrate for optic traversals

### DIFF
--- a/hkj-core/build.gradle.kts
+++ b/hkj-core/build.gradle.kts
@@ -50,6 +50,8 @@ tasks.javadoc {
 tasks.test {
   useJUnitPlatform()
   finalizedBy(tasks.jacocoTestReport)
+  // Headroom for large-N stack-safety stress tests (e.g. 200,000-element traversals).
+  maxHeapSize = "1g"
  // jvmArgs = listOf("--add-opens", "org.higherkindedj.hkj/org.higherkindedj.internal=ALL-UNNAMED")
 
   // Note: Parallel execution disabled due to:

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/BatchLoader.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/BatchLoader.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A keyed batch-loading function: resolve a whole set of keys in one call. This is the only
+ * contract {@link Fetch#runAsync} needs from a backend, and it is transport- and datastore-neutral.
+ *
+ * <p>Its shape ({@code Set<K> -> CompletableFuture<Map<K, V>>}) matches several existing contracts,
+ * so adapting them needs little or no glue: a GraphQL {@code MappedBatchLoader}, a repository batch
+ * lookup such as {@code findAllById}, or a single {@code IN}/{@code $in} query. See {@link
+ * BatchLoaders} for the adapters.
+ *
+ * <p>The {@code Fetch} runner guarantees this is invoked once per round with the deduplicated,
+ * not-yet-cached key set.
+ *
+ * @param <K> request key type
+ * @param <V> resolved value type
+ */
+@FunctionalInterface
+public interface BatchLoader<K, V> {
+
+  /** Resolve a whole set of keys in one call. */
+  CompletableFuture<Map<K, V>> loadAll(Set<K> keys);
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/BatchLoaders.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/BatchLoaders.java
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+/**
+ * Adapters that turn an ordinary keyed lookup into a {@link BatchLoader} for {@link
+ * Fetch#runAsync}.
+ *
+ * <p>These are transport- and datastore-neutral. A {@code BatchLoader} is simply {@code Set<K> ->
+ * CompletableFuture<Map<K, V>>}; anything that resolves a set of keys in one call can be a backend:
+ *
+ * <ul>
+ *   <li>a repository batch lookup ({@code findAllById}, a single {@code IN}/{@code $in} query);
+ *   <li>a GraphQL {@code MappedBatchLoader} (the shapes are identical; see {@link BatchLoader});
+ *   <li>an in-memory map, a remote service, a cache tier; anything keyed.
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ *
+ * <pre>{@code
+ * // Navigate with optics + the batching applicative; the whole traversal becomes one Fetch:
+ * var program = teamTraversal.modifyF(
+ *     id -> FETCH.widen(Fetch.fetch(id)),
+ *     team,
+ *     FetchApplicative.<String, User>instance());
+ *
+ * // Drive it through any keyed backend:
+ * CompletableFuture<Fetch.RunResult<String, ...>> result =
+ *     Fetch.runAsync(FETCH.narrow(program),
+ *                    BatchLoaders.fromMappedResolver(userRepo::findAllByIdAsMap),
+ *                    new ConcurrentHashMap<>());
+ * }</pre>
+ *
+ * <p>The boundary it plugs into (a GraphQL resolver, a REST controller, a batch job) is the
+ * caller's choice and lives outside this class.
+ */
+public final class BatchLoaders {
+
+  /**
+   * Default executor for the blocking {@link #fromMappedResolver(Function)} adapter: one virtual
+   * thread per task. Virtual threads suit blocking I/O and avoid starving a shared platform-thread
+   * pool such as {@code ForkJoinPool.commonPool()}.
+   */
+  private static final Executor BLOCKING_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
+
+  private BatchLoaders() {}
+
+  /**
+   * Adapts a synchronous keyed lookup (for example a blocking repository's {@code findAllById})
+   * into an async {@link BatchLoader}, running it on a virtual-thread-per-task executor. Use {@link
+   * #fromMappedResolver(Function, Executor)} to run on a specific executor instead.
+   */
+  public static <K, V> BatchLoader<K, V> fromMappedResolver(Function<Set<K>, Map<K, V>> resolver) {
+    return fromMappedResolver(resolver, BLOCKING_EXECUTOR);
+  }
+
+  /**
+   * Adapts a synchronous keyed lookup into an async {@link BatchLoader}, running it on the supplied
+   * {@code executor}. Prefer this overload when the blocking work should run on an executor sized
+   * and isolated for it rather than on a shared pool.
+   */
+  public static <K, V> BatchLoader<K, V> fromMappedResolver(
+      Function<Set<K>, Map<K, V>> resolver, Executor executor) {
+    return keys -> CompletableFuture.supplyAsync(() -> resolver.apply(keys), executor);
+  }
+
+  /**
+   * Adapts an already-asynchronous keyed lookup into a {@link BatchLoader}. This is an
+   * identity-level bridge; it exists to document that a function of the right shape (such as a
+   * GraphQL {@code MappedBatchLoader}) needs no real adaptation.
+   */
+  public static <K, V> BatchLoader<K, V> fromAsyncResolver(
+      Function<Set<K>, CompletableFuture<Map<K, V>>> asyncResolver) {
+    return asyncResolver::apply;
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/Fetch.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/Fetch.java
@@ -1,0 +1,275 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.higherkindedj.hkt.trampoline.Trampoline;
+
+/**
+ * A free-applicative-style reification of deferred, batchable data requests.
+ *
+ * <p>A {@code Fetch<K, V, A>} describes a computation producing an {@code A} that may require
+ * resolving requests of key type {@code K} into values of type {@code V}. Building a {@code Fetch}
+ * performs no I/O; only {@link #runCached(Fetch, Function)} and {@link #runAsync(Fetch,
+ * BatchLoader, Map)} execute, in <em>rounds</em>, handing every key discovered in a round to a
+ * single batch resolver.
+ *
+ * <p>The applicative combinator {@link #ap(Fetch, Fetch)} unions the pending requests of its two
+ * independent arguments, so a traversal over N elements collapses to one backend call.
+ *
+ * <p><b>Stack safety.</b> Resolving a round is driven by the HKJ {@link Trampoline}: each {@link
+ * Blocked#resume} step returns a {@code Trampoline<Fetch>} that only <em>builds</em> deferred
+ * nodes, and {@link Trampoline#run()} collapses an arbitrarily deep structure in constant stack
+ * space. Pending keys are held as a {@link PendingKeys} deferred-union tree so that {@code ap} is
+ * O(1).
+ *
+ * @param <K> request key type
+ * @param <V> resolved value type
+ * @param <A> result type
+ */
+public sealed interface Fetch<K, V, A> permits Fetch.Done, Fetch.Blocked {
+
+  /** A completed computation with no outstanding requests. */
+  record Done<K, V, A>(A value) implements Fetch<K, V, A> {}
+
+  /**
+   * A computation blocked on a tree of pending requests, with a continuation that resumes (stack-
+   * safely, via a {@link Trampoline}) once those requests have been resolved.
+   */
+  record Blocked<K, V, A>(
+      PendingKeys<K> pending, Function<Map<K, V>, Trampoline<Fetch<K, V, A>>> resume)
+      implements Fetch<K, V, A> {}
+
+  /** Lifts a pure value (no requests). */
+  static <K, V, A> Fetch<K, V, A> done(A value) {
+    return new Done<>(value);
+  }
+
+  /** A single request for {@code key}; resolves to the value the resolver returns for it. */
+  static <K, V> Fetch<K, V, V> fetch(K key) {
+    requireNonNull(key, "key");
+    return new Blocked<>(
+        PendingKeys.one(key), resolved -> Trampoline.done(done(resolved.get(key))));
+  }
+
+  /** Functorial map: structure (and pending requests) preserved, result transformed. */
+  default <B> Fetch<K, V, B> map(Function<? super A, ? extends B> f) {
+    requireNonNull(f, "f");
+    return switch (this) {
+      case Done<K, V, A> d -> done(f.apply(d.value()));
+      case Blocked<K, V, A> b ->
+          new Blocked<>(
+              b.pending(),
+              m -> Trampoline.defer(() -> b.resume().apply(m)).map(inner -> inner.map(f)));
+    };
+  }
+
+  /**
+   * Applicative apply. The two arguments are independent, so their pending request trees are merged
+   * (O(1)) into one round; this is what turns N per-element fetches into one batch.
+   */
+  @SuppressWarnings("unchecked")
+  static <K, V, A, B> Fetch<K, V, B> ap(
+      Fetch<K, V, ? extends Function<A, B>> ff, Fetch<K, V, A> fa) {
+    requireNonNull(ff, "ff");
+    requireNonNull(fa, "fa");
+    Fetch<K, V, Function<A, B>> fnf = (Fetch<K, V, Function<A, B>>) ff;
+
+    if (fnf instanceof Done<K, V, Function<A, B>> df && fa instanceof Done<K, V, A> da) {
+      return done(df.value().apply(da.value()));
+    }
+    if (fnf instanceof Done<K, V, Function<A, B>> df) {
+      Blocked<K, V, A> ba = (Blocked<K, V, A>) fa;
+      return new Blocked<>(
+          ba.pending(), m -> Trampoline.defer(() -> ba.resume().apply(m)).map(faR -> ap(df, faR)));
+    }
+    if (fa instanceof Done<K, V, A> da) {
+      Blocked<K, V, Function<A, B>> bf = (Blocked<K, V, Function<A, B>>) fnf;
+      return new Blocked<>(
+          bf.pending(), m -> Trampoline.defer(() -> bf.resume().apply(m)).map(ffR -> ap(ffR, da)));
+    }
+    Blocked<K, V, Function<A, B>> bf = (Blocked<K, V, Function<A, B>>) fnf;
+    Blocked<K, V, A> ba = (Blocked<K, V, A>) fa;
+    return new Blocked<>(
+        PendingKeys.merge(bf.pending(), ba.pending()),
+        m ->
+            Trampoline.defer(() -> bf.resume().apply(m))
+                .flatMap(
+                    ffR -> Trampoline.defer(() -> ba.resume().apply(m)).map(faR -> ap(ffR, faR))));
+  }
+
+  /**
+   * Monadic bind. The continuation's requests are unknowable until {@code this} is resolved, so a
+   * dependency chain of N binds costs N rounds: the Applicative/Monad batching boundary.
+   */
+  default <B> Fetch<K, V, B> flatMap(Function<? super A, ? extends Fetch<K, V, B>> f) {
+    requireNonNull(f, "f");
+    return switch (this) {
+      case Done<K, V, A> d -> f.apply(d.value());
+      case Blocked<K, V, A> b ->
+          new Blocked<>(
+              b.pending(),
+              m -> Trampoline.defer(() -> b.resume().apply(m)).map(inner -> inner.flatMap(f)));
+    };
+  }
+
+  /**
+   * The outcome of a run. {@code rounds} counts {@link Blocked} nodes resolved; {@code
+   * backendCalls} counts how many of those rounds actually hit the resolver (a round whose keys are
+   * all already cached costs zero backend calls); {@code fetchedBatches} records the key set sent
+   * to the resolver on each backend call; {@code cacheHits} counts individual keys served from the
+   * per-run cache instead of being fetched.
+   */
+  record RunResult<K, A>(
+      A value, int rounds, int backendCalls, List<Set<K>> fetchedBatches, int cacheHits) {}
+
+  /**
+   * Runs the computation with a per-run request cache. Each round flattens the current pending-key
+   * tree, hands the uncached subset to {@code batchResolver} once, and resumes stack-safely.
+   * Deduplication spans <em>rounds</em>: a key requested again in a later round (e.g. across a
+   * {@link #flatMap} dependency) is served from cache and never re-fetched. Pure applicative
+   * programs terminate in a single round; monadic dependency chains take one round per dependency.
+   *
+   * @param batchResolver resolves a whole set of keys in one call (e.g. {@code findAllById}, a
+   *     single {@code $in} query, or a GraphQL batch-loader dispatch); it must return a value for
+   *     every requested key (see {@link MissingKeyException})
+   */
+  static <K, V, A> RunResult<K, A> runCached(
+      Fetch<K, V, A> fetch, Function<Set<K>, Map<K, V>> batchResolver) {
+    requireNonNull(fetch, "fetch");
+    requireNonNull(batchResolver, "batchResolver");
+    Map<K, V> cache = new HashMap<>();
+    int rounds = 0;
+    int backendCalls = 0;
+    int cacheHits = 0;
+    ArrayList<Set<K>> fetchedBatches = new ArrayList<>();
+    Fetch<K, V, A> current = fetch;
+    while (current instanceof Blocked<K, V, A> blocked) {
+      rounds++;
+      Set<K> pending = blocked.pending().flatten();
+      Set<K> uncached = LinkedHashSet.newLinkedHashSet(pending.size());
+      for (K k : pending) {
+        if (cache.containsKey(k)) {
+          cacheHits++;
+        } else {
+          uncached.add(k);
+        }
+      }
+      if (!uncached.isEmpty()) {
+        backendCalls++;
+        Set<K> roundKeys = Collections.unmodifiableSet(uncached);
+        fetchedBatches.add(roundKeys);
+        Map<K, V> returned = batchResolver.apply(roundKeys);
+        requireNonNull(returned, "batchResolver returned null");
+        requireAllResolved(roundKeys, returned);
+        cache.putAll(returned);
+      }
+      Map<K, V> view = Collections.unmodifiableMap(cache);
+      current = blocked.resume().apply(view).run();
+    }
+    // The loop exits only when `current` is no longer Blocked; Fetch is sealed, so it is Done.
+    @SuppressWarnings("unchecked")
+    Done<K, V, A> done = (Done<K, V, A>) current;
+    return new RunResult<>(
+        done.value(), rounds, backendCalls, List.copyOf(fetchedBatches), cacheHits);
+  }
+
+  /**
+   * Asynchronous cached run against a {@link BatchLoader} ({@code Set<K> ->
+   * CompletableFuture<Map<K, V>>}). Each {@link Blocked} round becomes one loader dispatch; the
+   * supplied {@code cache} carries across rounds. See {@link BatchLoaders} for adapters from
+   * repository lookups, GraphQL mapped batch loaders, or any other keyed source.
+   *
+   * <p>The {@code cache} is owned by this single invocation; rounds run sequentially, so it is
+   * accessed single-threaded, and must not be shared across concurrent {@code runAsync} calls.
+   */
+  static <K, V, A> CompletableFuture<RunResult<K, A>> runAsync(
+      Fetch<K, V, A> fetch, BatchLoader<K, V> loader, Map<K, V> cache) {
+    requireNonNull(fetch, "fetch");
+    requireNonNull(loader, "loader");
+    requireNonNull(cache, "cache");
+    return runAsyncLoop(fetch, loader, cache, 0, 0, 0, new ArrayList<>());
+  }
+
+  private static <K, V, A> CompletableFuture<RunResult<K, A>> runAsyncLoop(
+      Fetch<K, V, A> current,
+      BatchLoader<K, V> loader,
+      Map<K, V> cache,
+      int rounds,
+      int backendCalls,
+      int cacheHits,
+      List<Set<K>> fetchedBatches) {
+    if (current instanceof Blocked<K, V, A> blocked) {
+      Set<K> pending = blocked.pending().flatten();
+      Set<K> uncached = LinkedHashSet.newLinkedHashSet(pending.size());
+      int hits = cacheHits;
+      for (K k : pending) {
+        if (cache.containsKey(k)) {
+          hits++;
+        } else {
+          uncached.add(k);
+        }
+      }
+      Set<K> roundKeys = Collections.unmodifiableSet(uncached);
+      int nextRounds = rounds + 1;
+      int finalHits = hits;
+      CompletableFuture<Map<K, V>> dispatch =
+          roundKeys.isEmpty()
+              ? CompletableFuture.completedFuture(Map.of())
+              : loader.loadAll(roundKeys);
+      requireNonNull(dispatch, "loader returned a null future");
+      if (!roundKeys.isEmpty()) {
+        fetchedBatches.add(roundKeys);
+      }
+      int nextBackendCalls = roundKeys.isEmpty() ? backendCalls : backendCalls + 1;
+      return dispatch.thenCompose(
+          loaded -> {
+            requireNonNull(loaded, "loader resolved to null");
+            requireAllResolved(roundKeys, loaded);
+            cache.putAll(loaded);
+            Map<K, V> view = Collections.unmodifiableMap(cache);
+            return runAsyncLoop(
+                blocked.resume().apply(view).run(),
+                loader,
+                cache,
+                nextRounds,
+                nextBackendCalls,
+                finalHits,
+                fetchedBatches);
+          });
+    }
+    // Fetch is sealed: not Blocked means Done.
+    @SuppressWarnings("unchecked")
+    Done<K, V, A> done = (Done<K, V, A>) current;
+    return CompletableFuture.completedFuture(
+        new RunResult<>(
+            done.value(), rounds, backendCalls, List.copyOf(fetchedBatches), cacheHits));
+  }
+
+  /**
+   * Verifies that a resolver returned an entry for every requested key. A round requires a value
+   * for each key it asked for; a missing entry would otherwise become a silent {@code null} in the
+   * result, so it is reported as a {@link MissingKeyException} instead.
+   */
+  private static <K, V> void requireAllResolved(Set<K> requested, Map<K, V> returned) {
+    LinkedHashSet<K> missing = new LinkedHashSet<>();
+    for (K k : requested) {
+      if (!returned.containsKey(k)) {
+        missing.add(k);
+      }
+    }
+    if (!missing.isEmpty()) {
+      throw new MissingKeyException(missing);
+    }
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/FetchApplicative.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/FetchApplicative.java
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The batching {@link Applicative} for {@link Fetch}.
+ *
+ * <p>Hand this to {@code Optic.modifyF(f, source, applicative)} where {@code f} maps each focused
+ * element to a {@link Fetch} request. Because {@link #ap} merges the pending request sets of
+ * independent arguments, an optic {@code Traversal} over N elements produces a single {@link
+ * Fetch.Blocked} node carrying all N (deduplicated) keys: one batched backend call instead of N.
+ * The optic core is untouched; only the supplied applicative changes.
+ *
+ * @param <K> request key type
+ * @param <V> resolved value type
+ */
+public final class FetchApplicative<K, V> implements Applicative<FetchKind.Witness<K, V>> {
+
+  private static final FetchApplicative<?, ?> INSTANCE = new FetchApplicative<>();
+
+  private FetchApplicative() {}
+
+  @SuppressWarnings("unchecked")
+  public static <K, V> FetchApplicative<K, V> instance() {
+    return (FetchApplicative<K, V>) INSTANCE;
+  }
+
+  @Override
+  public <A> Kind<FetchKind.Witness<K, V>, A> of(@Nullable A value) {
+    return FETCH.widen(Fetch.done(value));
+  }
+
+  @Override
+  public <A, B> Kind<FetchKind.Witness<K, V>, B> map(
+      Function<? super A, ? extends B> f, Kind<FetchKind.Witness<K, V>, A> fa) {
+    Objects.requireNonNull(f, "f");
+    Objects.requireNonNull(fa, "fa");
+    return FETCH.widen(FETCH.narrow(fa).map(f));
+  }
+
+  @Override
+  public <A, B> Kind<FetchKind.Witness<K, V>, B> ap(
+      Kind<FetchKind.Witness<K, V>, ? extends Function<A, B>> ff,
+      Kind<FetchKind.Witness<K, V>, A> fa) {
+    Objects.requireNonNull(ff, "ff");
+    Objects.requireNonNull(fa, "fa");
+    Fetch<K, V, ? extends Function<A, B>> fnf = FETCH.narrow(ff);
+    Fetch<K, V, A> fva = FETCH.narrow(fa);
+    return FETCH.widen(Fetch.ap(fnf, fva));
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/FetchKind.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/FetchKind.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+
+/**
+ * Kind marker for the partially-applied {@code Fetch<K, V, ?>} type constructor.
+ *
+ * <p>{@code K} and {@code V} (the request domain) are fixed; the free parameter is the result type
+ * {@code A}, giving a unary witness usable with {@link org.higherkindedj.hkt.Applicative}.
+ *
+ * @param <K> request key type (fixed)
+ * @param <V> resolved value type (fixed)
+ * @param <A> the free result type
+ */
+public interface FetchKind<K, V, A> extends Kind<FetchKind.Witness<K, V>, A> {
+
+  /** Phantom witness for {@code Fetch<K, V, ?>}. */
+  final class Witness<K, V> implements WitnessArity<TypeArity.Unary> {
+    private Witness() {}
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/FetchKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/FetchKindHelper.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.exception.KindUnwrapException;
+import org.jspecify.annotations.Nullable;
+
+/** {@code widen}/{@code narrow} between {@link Fetch} and its {@link FetchKind} representation. */
+public enum FetchKindHelper {
+  FETCH;
+
+  record FetchHolder<K, V, A>(Fetch<K, V, A> fetch) implements FetchKind<K, V, A> {
+    FetchHolder {
+      if (fetch == null) {
+        throw new KindUnwrapException("Cannot widen a null Fetch");
+      }
+    }
+  }
+
+  /** Widens a concrete {@link Fetch} into its {@link Kind} representation. */
+  public <K, V, A> Kind<FetchKind.Witness<K, V>, A> widen(Fetch<K, V, A> fetch) {
+    return new FetchHolder<>(fetch);
+  }
+
+  /** Narrows a {@link Kind} back to its concrete {@link Fetch}. */
+  @SuppressWarnings("unchecked")
+  public <K, V, A> Fetch<K, V, A> narrow(@Nullable Kind<FetchKind.Witness<K, V>, A> kind) {
+    if (kind == null) {
+      throw new KindUnwrapException("Cannot narrow null Kind for Fetch");
+    }
+    if (!(kind instanceof FetchHolder<?, ?, ?>)) {
+      throw new KindUnwrapException(
+          "Kind instance cannot be narrowed to Fetch (received: "
+              + kind.getClass().getSimpleName()
+              + ")");
+    }
+    return ((FetchHolder<K, V, A>) kind).fetch();
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/MissingKeyException.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/MissingKeyException.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import java.util.Set;
+
+/**
+ * Thrown when a batch resolver (or {@link BatchLoader}) returns no entry for one or more requested
+ * keys.
+ *
+ * <p>A {@code Fetch} round hands the resolver a precise set of keys and requires a value for every
+ * one of them. Silently substituting {@code null} for an omitted key would corrupt the result, so
+ * the omission is reported as this exception instead. (A future railway error channel will let this
+ * be surfaced as an {@code Either}/{@code Validated} value rather than thrown.)
+ */
+public final class MissingKeyException extends RuntimeException {
+
+  /**
+   * @param missingKeys the requested keys for which the resolver returned no entry
+   */
+  public MissingKeyException(Set<?> missingKeys) {
+    super("Batch resolver returned no value for requested key(s): " + missingKeys);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/PendingKeys.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/PendingKeys.java
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+
+/**
+ * A deferred-union tree of pending request keys.
+ *
+ * <p>The batching applicative combines the pending keys of two independent fetches on every {@code
+ * ap}. Eagerly merging them into a {@code Set} each time is O(n²) across a wide traversal, because
+ * each merge copies the growing accumulator. This structure instead records a union as a single
+ * {@link Union} node (an O(1) operation regardless of operand size) and is flattened to an
+ * insertion-ordered, de-duplicated set exactly once, when a round is run.
+ *
+ * <p>It is the binary generalisation of a cons-list (cf. {@code org.higherkindedj.hkt.util.FList}):
+ * a cons-list gives O(1) prepend of one element; this gives O(1) merge of two trees.
+ *
+ * @param <K> the request key type
+ */
+sealed interface PendingKeys<K> permits PendingKeys.One, PendingKeys.Union {
+
+  /** A single pending key. */
+  record One<K>(K key) implements PendingKeys<K> {}
+
+  /** The union of two pending-key trees. Construction is O(1). */
+  record Union<K>(PendingKeys<K> left, PendingKeys<K> right) implements PendingKeys<K> {}
+
+  /** A tree holding exactly one key. */
+  static <K> PendingKeys<K> one(K key) {
+    return new One<>(key);
+  }
+
+  /** Merges two trees in O(1); the keys are flattened lazily by {@link #flatten()}. */
+  static <K> PendingKeys<K> merge(PendingKeys<K> left, PendingKeys<K> right) {
+    return new Union<>(left, right);
+  }
+
+  /**
+   * Flattens this tree into an insertion-ordered, de-duplicated set. Uses an explicit work stack,
+   * so it is stack-safe regardless of tree depth.
+   */
+  default LinkedHashSet<K> flatten() {
+    LinkedHashSet<K> out = new LinkedHashSet<>();
+    Deque<PendingKeys<K>> stack = new ArrayDeque<>();
+    stack.push(this);
+    while (!stack.isEmpty()) {
+      switch (stack.pop()) {
+        case One<K> one -> out.add(one.key());
+        case Union<K> union -> {
+          stack.push(union.right());
+          stack.push(union.left());
+        }
+      }
+    }
+    return out;
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/fetch/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/fetch/package-info.java
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+/**
+ * Prototype: a request-batching {@link org.higherkindedj.hkt.Applicative} for optic traversals.
+ *
+ * <p>This package demonstrates that the van Laarhoven encoding of HKJ optics ({@code
+ * Optic.modifyF(f, s, applicative)}) is a sufficient seam to add Haxl-style request batching
+ * <em>without modifying the optic core</em>. The {@link org.higherkindedj.optics.fetch.Fetch} type
+ * is a free-applicative-style reification of deferred data requests; {@link
+ * org.higherkindedj.optics.fetch.FetchApplicative} merges the pending request sets of independent
+ * branches so that a deep traversal collapses to a single batched backend call (eliminating the N+1
+ * access pattern), with deduplication. The package is transport- and datastore-neutral: the backend
+ * is any keyed lookup (a repository batch query, a GraphQL mapped batch loader, an in-memory map),
+ * supplied via {@link org.higherkindedj.optics.fetch.BatchLoader}.
+ *
+ * <p>It also makes the fundamental Applicative-vs-Monad batching boundary explicit: {@link
+ * org.higherkindedj.optics.fetch.Fetch#flatMap} cannot coalesce across a data dependency and is
+ * resolved in multiple rounds, whereas applicative composition is resolved in one.
+ *
+ * <h2>Concurrency model</h2>
+ *
+ * <p>{@code Fetch} values are immutable and {@code FetchApplicative} is a stateless shared
+ * singleton; both are safe to share across threads. {@code Fetch.runCached} creates a fresh cache
+ * per invocation and holds no shared mutable state, so independent calls run safely in parallel.
+ * {@code Fetch.runAsync} resolves rounds sequentially (via {@code thenCompose}), so the {@code Map}
+ * cache it is given is accessed single-threaded by that one invocation; that cache must not be
+ * shared across concurrent {@code runAsync} calls. A {@link
+ * org.higherkindedj.optics.fetch.BatchLoader} shared between concurrent programs must itself be
+ * thread-safe.
+ *
+ * <h2>API surface</h2>
+ *
+ * <p>This is a prototype, and the package is intentionally <em>not exported</em> by the module: its
+ * types (including the {@code Fetch.Done}/{@code Fetch.Blocked} ADT and {@code PendingKeys}) are
+ * not public API. The intended surface is {@code Fetch.fetch}, {@code Fetch.runCached}/{@code
+ * runAsync}, {@code FetchApplicative}, and {@code BatchLoader}/{@code BatchLoaders}. If the
+ * prototype graduates, the ADT constructors move to package-private and the surface is exported
+ * deliberately.
+ */
+@NullMarked
+package org.higherkindedj.optics.fetch;
+
+import org.jspecify.annotations.NullMarked;

--- a/hkj-core/src/test/java/org/higherkindedj/optics/fetch/FetchApplicativeLawsTestFactory.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/fetch/FetchApplicativeLawsTestFactory.java
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.higherkindedj.hkt.Kind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ * Dynamic test factory for the applicative laws of {@link FetchApplicative}.
+ *
+ * <p>Follows the project's {@code @TestFactory}/{@link DynamicTest} law-testing idiom (cf. {@code
+ * FunctorLawsTestFactory}, {@code MonadLawsTestFactory}). Each law is checked across several data
+ * cases; because {@code Fetch} structures hold continuations and are not value-comparable, the two
+ * sides of each law are compared by running them and comparing the resulting values.
+ */
+@DisplayName("FetchApplicative Laws - Dynamic Test Factory")
+class FetchApplicativeLawsTestFactory {
+
+  private static final FetchApplicative<String, String> APP = FetchApplicative.instance();
+
+  /** Echoes every requested key as {@code "val:" + key}. */
+  private static final Function<Set<String>, Map<String, String>> ECHO =
+      keys -> {
+        Map<String, String> out = new HashMap<>();
+        keys.forEach(k -> out.put(k, "val:" + k));
+        return out;
+      };
+
+  /** Runs a Fetch program to its value under the echo resolver. */
+  private static <A> A run(Kind<FetchKind.Witness<String, String>, A> k) {
+    return Fetch.runCached(FETCH.narrow(k), ECHO).value();
+  }
+
+  /** A function-valued Fetch: resolves {@code key}, then prefixes its argument with the result. */
+  private static Kind<FetchKind.Witness<String, String>, Function<String, String>> prefixFn(
+      String key) {
+    return APP.map(
+        s -> (Function<String, String>) arg -> s + ">" + arg, FETCH.widen(Fetch.fetch(key)));
+  }
+
+  @TestFactory
+  @DisplayName("Identity: ap(of(id), v) = v")
+  Stream<DynamicTest> identityLaw() {
+    return Stream.of("a", "b", "c")
+        .map(
+            key ->
+                DynamicTest.dynamicTest(
+                    "v = fetch(" + key + ")",
+                    () -> {
+                      Kind<FetchKind.Witness<String, String>, String> v =
+                          FETCH.widen(Fetch.fetch(key));
+                      Kind<FetchKind.Witness<String, String>, String> lhs =
+                          APP.ap(APP.of(Function.<String>identity()), v);
+                      assertThat(run(lhs)).isEqualTo(run(v));
+                    }));
+  }
+
+  @TestFactory
+  @DisplayName("Homomorphism: ap(of(f), of(x)) = of(f(x))")
+  Stream<DynamicTest> homomorphismLaw() {
+    record Case(String name, Function<String, String> f, String x) {}
+    return Stream.of(
+            new Case("toUpperCase / hello", String::toUpperCase, "hello"),
+            new Case("append-bang / hi", s -> s + "!", "hi"))
+        .map(
+            c ->
+                DynamicTest.dynamicTest(
+                    c.name(),
+                    () -> {
+                      Kind<FetchKind.Witness<String, String>, String> lhs =
+                          APP.ap(APP.of(c.f()), APP.of(c.x()));
+                      Kind<FetchKind.Witness<String, String>, String> rhs =
+                          APP.of(c.f().apply(c.x()));
+                      assertThat(run(lhs)).isEqualTo(run(rhs));
+                    }));
+  }
+
+  @TestFactory
+  @DisplayName("Interchange: ap(u, of(y)) = ap(of(g -> g(y)), u)")
+  Stream<DynamicTest> interchangeLaw() {
+    return Stream.of("Y", "Z")
+        .map(
+            y ->
+                DynamicTest.dynamicTest(
+                    "y = " + y,
+                    () -> {
+                      Kind<FetchKind.Witness<String, String>, Function<String, String>> u =
+                          prefixFn("u");
+                      Kind<FetchKind.Witness<String, String>, String> lhs = APP.ap(u, APP.of(y));
+                      Function<Function<String, String>, String> applyY = g -> g.apply(y);
+                      Kind<FetchKind.Witness<String, String>, String> rhs =
+                          APP.ap(APP.of(applyY), u);
+                      assertThat(run(lhs)).isEqualTo(run(rhs));
+                    }));
+  }
+
+  @TestFactory
+  @DisplayName("Composition: ap(ap(map(compose, u), v), w) = ap(u, ap(v, w))")
+  Stream<DynamicTest> compositionLaw() {
+    return Stream.of("w1", "w2")
+        .map(
+            wKey ->
+                DynamicTest.dynamicTest(
+                    "w = fetch(" + wKey + ")",
+                    () -> {
+                      Kind<FetchKind.Witness<String, String>, Function<String, String>> u =
+                          prefixFn("u");
+                      Kind<FetchKind.Witness<String, String>, Function<String, String>> v =
+                          prefixFn("v");
+                      Kind<FetchKind.Witness<String, String>, String> w =
+                          FETCH.widen(Fetch.fetch(wKey));
+                      Function<
+                              Function<String, String>,
+                              Function<Function<String, String>, Function<String, String>>>
+                          compose = g -> h -> x -> g.apply(h.apply(x));
+
+                      Kind<FetchKind.Witness<String, String>, String> lhs =
+                          APP.ap(APP.ap(APP.map(compose, u), v), w);
+                      Kind<FetchKind.Witness<String, String>, String> rhs = APP.ap(u, APP.ap(v, w));
+                      assertThat(run(lhs)).isEqualTo(run(rhs));
+                    }));
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/fetch/FetchApplicativeTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/fetch/FetchApplicativeTest.java
@@ -1,0 +1,439 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.focus.FocusPaths;
+import org.higherkindedj.optics.indexed.Pair;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates that {@link FetchApplicative} added at the {@code Optic.modifyF} seam batches per-leaf
+ * data requests across an optic traversal (eliminating the N+1 access pattern) without any change
+ * to the optic core.
+ */
+@DisplayName("FetchApplicative batches optic-traversal requests at the modifyF seam")
+class FetchApplicativeTest {
+
+  /** A backend that can only be queried in batches; counts how many round-trips it serves. */
+  static final class BatchingBackend {
+    final AtomicInteger calls = new AtomicInteger();
+    final java.util.ArrayList<Set<String>> seenBatches = new java.util.ArrayList<>();
+
+    Map<String, String> resolve(Set<String> ids) {
+      calls.incrementAndGet();
+      seenBatches.add(Set.copyOf(ids));
+      Map<String, String> out = new HashMap<>();
+      for (String id : ids) {
+        out.put(id, "User#" + id);
+      }
+      return out;
+    }
+  }
+
+  private static Function<String, Kind<FetchKind.Witness<String, String>, String>> fetchName() {
+    return id -> FETCH.widen(Fetch.fetch(id));
+  }
+
+  @Nested
+  @DisplayName("flat list traversal")
+  class FlatList {
+
+    @Test
+    @DisplayName("N elements collapse to ONE batched backend call")
+    void nPlusOneEliminated() {
+      var backend = new BatchingBackend();
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      List<String> input = List.of("1", "2", "3", "4", "5");
+
+      Kind<FetchKind.Witness<String, String>, List<String>> program =
+          ids.modifyF(fetchName(), input, FetchApplicative.instance());
+
+      Fetch.RunResult<String, List<String>> result =
+          Fetch.runCached(FETCH.narrow(program), backend::resolve);
+
+      assertThat(result.value()).containsExactly("User#1", "User#2", "User#3", "User#4", "User#5");
+      assertThat(backend.calls.get()).isEqualTo(1);
+      assertThat(result.rounds()).isEqualTo(1);
+      assertThat(result.fetchedBatches()).hasSize(1);
+      assertThat(result.fetchedBatches().get(0)).containsExactly("1", "2", "3", "4", "5");
+    }
+
+    @Test
+    @DisplayName("duplicate keys are deduplicated within the single batch")
+    void deduplicatesWithinBatch() {
+      var backend = new BatchingBackend();
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      List<String> input = List.of("7", "7", "9", "7", "9");
+
+      var program = ids.modifyF(fetchName(), input, FetchApplicative.instance());
+      Fetch.RunResult<String, List<String>> result =
+          Fetch.runCached(FETCH.narrow(program), backend::resolve);
+
+      // Positional output is still correct for every (including repeated) element...
+      assertThat(result.value()).containsExactly("User#7", "User#7", "User#9", "User#7", "User#9");
+      // ...but the backend only ever saw the distinct keys, once.
+      assertThat(backend.calls.get()).isEqualTo(1);
+      assertThat(backend.seenBatches.get(0)).containsExactlyInAnyOrder("7", "9");
+    }
+  }
+
+  @Nested
+  @DisplayName("nested structure (composed traversal)")
+  class Nested2D {
+
+    @Test
+    @DisplayName("a deep List<List<>> traversal still batches into ONE call")
+    void deepTraversalSingleBatch() {
+      var backend = new BatchingBackend();
+      Traversal<List<List<String>>, String> deep =
+          FocusPaths.<List<String>>listElements().andThen(FocusPaths.<String>listElements());
+      List<List<String>> input = List.of(List.of("a", "b"), List.of("c"), List.of("d", "e", "f"));
+
+      var program = deep.modifyF(fetchName(), input, FetchApplicative.instance());
+      Fetch.RunResult<String, List<List<String>>> result =
+          Fetch.runCached(FETCH.narrow(program), backend::resolve);
+
+      assertThat(result.value())
+          .containsExactly(
+              List.of("User#a", "User#b"),
+              List.of("User#c"),
+              List.of("User#d", "User#e", "User#f"));
+      // The entire nested selection set resolved in a single backend round-trip.
+      assertThat(backend.calls.get()).isEqualTo(1);
+      assertThat(result.rounds()).isEqualTo(1);
+      assertThat(result.fetchedBatches().get(0)).containsExactly("a", "b", "c", "d", "e", "f");
+    }
+  }
+
+  @Nested
+  @DisplayName("the Applicative/Monad batching boundary")
+  class MonadicBoundary {
+
+    @Test
+    @DisplayName("applicative composition of two fetches = ONE round")
+    void applicativeStaysOneRound() {
+      var backend = new BatchingBackend();
+      Fetch<String, String, String> a = Fetch.fetch("x");
+      Fetch<String, String, String> b = Fetch.fetch("y");
+
+      Fetch<String, String, String> combined =
+          Fetch.ap(a.map(av -> (Function<String, String>) bv -> av + "+" + bv), b);
+
+      var result = Fetch.runCached(combined, backend::resolve);
+
+      assertThat(result.value()).isEqualTo("User#x+User#y");
+      assertThat(result.rounds()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("monadic dependency between fetches forces a second round (documented limit)")
+    void flatMapBreaksBatching() {
+      var backend = new BatchingBackend();
+
+      // Stage 2's key depends on stage 1's resolved value -> cannot be known up front.
+      Fetch<String, String, String> dependent =
+          Fetch.<String, String>fetch("root")
+              .flatMap(rootName -> Fetch.fetch("child-of:" + rootName));
+
+      var result = Fetch.runCached(dependent, backend::resolve);
+
+      assertThat(result.value()).isEqualTo("User#child-of:User#root");
+      assertThat(result.rounds()).isEqualTo(2);
+      assertThat(backend.calls.get()).isEqualTo(2);
+      assertThat(result.fetchedBatches().get(0)).containsExactly("root");
+      assertThat(result.fetchedBatches().get(1)).containsExactly("child-of:User#root");
+    }
+  }
+
+  @Nested
+  @DisplayName("coupled-field optic (Lens.paired) over the batching seam")
+  class CoupledFields {
+
+    /** Two coupled bounds with a cross-field invariant enforced in the canonical constructor. */
+    record Range(int lo, int hi) {
+      Range {
+        if (lo > hi) {
+          throw new IllegalArgumentException(
+              "invariant violated: lo > hi (" + lo + " > " + hi + ")");
+        }
+      }
+    }
+
+    private static final Lens<Range, Integer> LO =
+        Lens.of(Range::lo, (r, lo) -> new Range(lo, r.hi()));
+    private static final Lens<Range, Integer> HI =
+        Lens.of(Range::hi, (r, hi) -> new Range(r.lo(), hi));
+
+    // The coupled-field optic: lo and hi are ONE focus, rebuilt atomically.
+    private static final Lens<Range, Pair<Integer, Integer>> BOUNDS =
+        Lens.paired(LO, HI, Range::new);
+
+    /** Resolves "lo"/"hi" from a backend that can only be queried in batches. */
+    static final class BoundsBackend {
+      final AtomicInteger calls = new AtomicInteger();
+      Set<String> lastBatch = Set.of();
+      private final int loVal;
+      private final int hiVal;
+
+      BoundsBackend(int loVal, int hiVal) {
+        this.loVal = loVal;
+        this.hiVal = hiVal;
+      }
+
+      Map<String, Integer> resolve(Set<String> keys) {
+        calls.incrementAndGet();
+        lastBatch = Set.copyOf(keys);
+        Map<String, Integer> out = new HashMap<>();
+        for (String k : keys) {
+          out.put(k, k.equals("lo") ? loVal : hiVal);
+        }
+        return out;
+      }
+    }
+
+    /** Builds a Fetch that loads BOTH bounds as siblings (one applicative combination). */
+    private static Kind<FetchKind.Witness<String, Integer>, Pair<Integer, Integer>> loadBounds(
+        Pair<Integer, Integer> ignoredCurrent) {
+      Fetch<String, Integer, Pair<Integer, Integer>> both =
+          Fetch.ap(
+              Fetch.<String, Integer>fetch("lo")
+                  .map(lo -> (Function<Integer, Pair<Integer, Integer>>) hi -> Pair.of(lo, hi)),
+              Fetch.<String, Integer>fetch("hi"));
+      return FETCH.widen(both);
+    }
+
+    @Test
+    @DisplayName("both coupled fields resolve in ONE batch round and rebuild atomically")
+    void coupledFieldsBatchAtomically() {
+      var backend = new BoundsBackend(11, 12);
+      Range start = new Range(1, 2);
+
+      // Sequential lens updates here would pass through Range(11, 2) and THROW.
+      // The paired optic hands both final values to ONE reconstruction.
+      var program =
+          BOUNDS.modifyF(
+              CoupledFields::loadBounds, start, FetchApplicative.<String, Integer>instance());
+
+      Fetch.RunResult<String, Range> result =
+          Fetch.runCached(FETCH.narrow(program), backend::resolve);
+
+      assertThat(result.value()).isEqualTo(new Range(11, 12));
+      assertThat(backend.calls.get()).isEqualTo(1); // one round-trip for both fields
+      assertThat(result.rounds()).isEqualTo(1);
+      assertThat(backend.lastBatch).containsExactlyInAnyOrder("lo", "hi");
+    }
+
+    @Test
+    @DisplayName("invariant is enforced at the single atomic reconstruction, not field-by-field")
+    void invariantEnforcedAtomically() {
+      // Backend resolves to lo=20, hi=5 -> the COUPLED reconstruction must reject it.
+      var backend = new BoundsBackend(20, 5);
+      Range start = new Range(1, 2);
+
+      var program =
+          BOUNDS.modifyF(
+              CoupledFields::loadBounds, start, FetchApplicative.<String, Integer>instance());
+
+      // The failure surfaces exactly once, at the atomic rebuild after the single batch;
+      // no illegal intermediate Range was ever constructed along the way.
+      assertThatThrownBy(() -> Fetch.runCached(FETCH.narrow(program), backend::resolve))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("invariant violated");
+      assertThat(backend.calls.get()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("cross-round cache + async BatchLoader bridge")
+  class CachingAndBridge {
+
+    @Test
+    @DisplayName("a key reused across a flatMap round is served from cache, not re-fetched")
+    void crossRoundCacheEliminatesRefetch() {
+      var backend = new BatchingBackend();
+
+      // Stage 1 fetches "u1"; stage 2 (data-dependent) needs "u1" AGAIN plus "u2".
+      Fetch<String, String, String> program =
+          Fetch.<String, String>fetch("u1")
+              .flatMap(
+                  first ->
+                      Fetch.ap(
+                          Fetch.<String, String>fetch("u1")
+                              .map(a -> (Function<String, String>) b -> first + "|" + a + "|" + b),
+                          Fetch.<String, String>fetch("u2")));
+
+      Fetch.RunResult<String, String> r = Fetch.runCached(program, backend::resolve);
+
+      assertThat(r.value()).isEqualTo("User#u1|User#u1|User#u2");
+      assertThat(r.rounds()).isEqualTo(2); // monadic dependency => two rounds
+      assertThat(r.backendCalls()).isEqualTo(2);
+      // Round 1 fetched {u1}; round 2 only fetched {u2} ("u1" came from cache).
+      assertThat(r.fetchedBatches().get(0)).containsExactly("u1");
+      assertThat(r.fetchedBatches().get(1)).containsExactly("u2");
+      assertThat(r.cacheHits()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("an optic traversal drives ONE async batch dispatch")
+    void opticTraversalThroughAsyncBatchLoader() throws Exception {
+      var dispatches = new AtomicInteger();
+      BatchLoader<String, String> loader =
+          keys ->
+              CompletableFuture.supplyAsync(
+                  () -> {
+                    dispatches.incrementAndGet();
+                    Map<String, String> out = new HashMap<>();
+                    for (String k : keys) {
+                      out.put(k, "User#" + k);
+                    }
+                    return out;
+                  });
+
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      List<String> input = List.of("a", "b", "a", "c"); // note the duplicate
+
+      var program = ids.modifyF(fetchName(), input, FetchApplicative.instance());
+
+      Fetch.RunResult<String, List<String>> r =
+          Fetch.runAsync(FETCH.narrow(program), loader, new ConcurrentHashMap<>()).get();
+
+      assertThat(r.value()).containsExactly("User#a", "User#b", "User#a", "User#c");
+      assertThat(dispatches.get()).isEqualTo(1); // whole traversal => one dispatch
+      assertThat(r.backendCalls()).isEqualTo(1);
+      assertThat(r.fetchedBatches().get(0)).containsExactly("a", "b", "c"); // deduped
+    }
+
+    @Test
+    @DisplayName("BatchLoaders bridges a blocking mapped resolver unchanged")
+    void bridgeAdaptsBlockingResolver() throws Exception {
+      var calls = new AtomicInteger();
+      BatchLoader<String, String> loader =
+          BatchLoaders.fromMappedResolver(
+              keys -> {
+                calls.incrementAndGet();
+                Map<String, String> out = new HashMap<>();
+                keys.forEach(k -> out.put(k, "User#" + k));
+                return out;
+              });
+
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      var program = ids.modifyF(fetchName(), List.of("1", "2", "3"), FetchApplicative.instance());
+
+      var r = Fetch.runAsync(FETCH.narrow(program), loader, new ConcurrentHashMap<>()).get();
+
+      assertThat(r.value()).containsExactly("User#1", "User#2", "User#3");
+      assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("BatchLoaders adapts an already-async resolver unchanged")
+    void bridgeAdaptsAsyncResolver() throws Exception {
+      var calls = new AtomicInteger();
+      BatchLoader<String, String> loader =
+          BatchLoaders.fromAsyncResolver(
+              keys ->
+                  CompletableFuture.supplyAsync(
+                      () -> {
+                        calls.incrementAndGet();
+                        Map<String, String> out = new HashMap<>();
+                        keys.forEach(k -> out.put(k, "User#" + k));
+                        return out;
+                      }));
+
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      var program = ids.modifyF(fetchName(), List.of("7", "8"), FetchApplicative.instance());
+
+      var r = Fetch.runAsync(FETCH.narrow(program), loader, new ConcurrentHashMap<>()).get();
+
+      assertThat(r.value()).containsExactly("User#7", "User#8");
+      assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a round whose keys are all cached makes no backend call (runCached)")
+    void allCachedRoundMakesNoBackendCall() {
+      var backend = new BatchingBackend();
+      // Stage 2 re-requests the SAME key stage 1 already fetched.
+      Fetch<String, String, String> program =
+          Fetch.<String, String>fetch("k").flatMap(v -> Fetch.<String, String>fetch("k"));
+
+      Fetch.RunResult<String, String> r = Fetch.runCached(program, backend::resolve);
+
+      assertThat(r.value()).isEqualTo("User#k");
+      assertThat(r.rounds()).isEqualTo(2);
+      assertThat(r.backendCalls()).isEqualTo(1); // round 2 was fully cached
+      assertThat(r.cacheHits()).isEqualTo(1);
+      assertThat(backend.calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a round whose keys are all cached dispatches no loader call (runAsync)")
+    void allCachedRoundMakesNoDispatch() throws Exception {
+      var dispatches = new AtomicInteger();
+      BatchLoader<String, String> loader =
+          keys ->
+              CompletableFuture.supplyAsync(
+                  () -> {
+                    dispatches.incrementAndGet();
+                    Map<String, String> out = new HashMap<>();
+                    keys.forEach(k -> out.put(k, "User#" + k));
+                    return out;
+                  });
+      Fetch<String, String, String> program =
+          Fetch.<String, String>fetch("k").flatMap(v -> Fetch.<String, String>fetch("k"));
+
+      Fetch.RunResult<String, String> r =
+          Fetch.runAsync(program, loader, new ConcurrentHashMap<>()).get();
+
+      assertThat(r.value()).isEqualTo("User#k");
+      assertThat(r.rounds()).isEqualTo(2);
+      assertThat(r.backendCalls()).isEqualTo(1);
+      assertThat(dispatches.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("BatchLoaders runs a blocking resolver on the supplied executor")
+    void bridgeRunsOnSuppliedExecutor() throws Exception {
+      var executorUses = new AtomicInteger();
+      Executor counting =
+          runnable -> {
+            executorUses.incrementAndGet();
+            runnable.run();
+          };
+      BatchLoader<String, String> loader =
+          BatchLoaders.fromMappedResolver(
+              keys -> {
+                Map<String, String> out = new HashMap<>();
+                keys.forEach(k -> out.put(k, "User#" + k));
+                return out;
+              },
+              counting);
+
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      var program = ids.modifyF(fetchName(), List.of("1", "2"), FetchApplicative.instance());
+
+      var r = Fetch.runAsync(FETCH.narrow(program), loader, new ConcurrentHashMap<>()).get();
+
+      assertThat(r.value()).containsExactly("User#1", "User#2");
+      assertThat(executorUses.get()).isEqualTo(1); // the supplied executor ran the blocking work
+    }
+  }
+}

--- a/hkj-core/src/test/java/org/higherkindedj/optics/fetch/FetchHardeningTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/fetch/FetchHardeningTest.java
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.fetch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.exception.KindUnwrapException;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.focus.FocusPaths;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase 0 substrate-hardening specification, written test-first.
+ *
+ * <p>These tests encode the definition of done for Phase 0 of the effectful-optic batching delivery
+ * plan: stack safety (B1), the missing-key policy (B2), and the contract checks and Kind-narrowing
+ * robustness. The applicative laws (M4) are exercised separately by {@code
+ * FetchApplicativeLawsTestFactory}.
+ */
+@DisplayName("Phase 0 substrate hardening: TDD spec")
+class FetchHardeningTest {
+
+  /** A resolver that echoes every requested key as {@code "val:" + key}. */
+  private static final Function<Set<String>, Map<String, String>> ECHO =
+      keys -> {
+        Map<String, String> out = new HashMap<>();
+        keys.forEach(k -> out.put(k, "val:" + k));
+        return out;
+      };
+
+  private static Function<String, Kind<FetchKind.Witness<String, String>, String>> fetchEach() {
+    return id -> FETCH.widen(Fetch.<String, String>fetch(id));
+  }
+
+  @Nested
+  @DisplayName("B1: stack safety")
+  class StackSafety {
+
+    /**
+     * Stack usage of the trampolined resolution is constant in N, so passing well above the
+     * empirically-confirmed failure point (StackOverflow at N=25,000 before the fix) is conclusive
+     * proof of stack safety. Million-element throughput/memory is a benchmark concern, not a unit
+     * test.
+     */
+    @Test
+    @DisplayName("a 200,000-element optic traversal resolves without StackOverflowError")
+    void wideTraversalIsStackSafe() {
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      List<String> input = IntStream.range(0, 200_000).mapToObj(Integer::toString).toList();
+
+      var program = ids.modifyF(fetchEach(), input, FetchApplicative.<String, String>instance());
+
+      Fetch.RunResult<String, List<String>> result = Fetch.runCached(FETCH.narrow(program), ECHO);
+
+      assertThat(result.value()).hasSize(200_000);
+      assertThat(result.backendCalls()).isEqualTo(1);
+      assertThat(result.rounds()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("B2: missing-key policy")
+  class MissingKeyPolicy {
+
+    private static final List<String> ABC = List.of("a", "b", "c");
+
+    @Test
+    @DisplayName("runCached fails clearly when a resolver omits a key, never a silent null")
+    void missingKeyFailsClearly() {
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      var program = ids.modifyF(fetchEach(), ABC, FetchApplicative.<String, String>instance());
+
+      Function<Set<String>, Map<String, String>> omitsB =
+          keys -> {
+            Map<String, String> out = new HashMap<>();
+            keys.forEach(
+                k -> {
+                  if (!k.equals("b")) {
+                    out.put(k, "val:" + k);
+                  }
+                });
+            return out;
+          };
+
+      assertThatThrownBy(() -> Fetch.runCached(FETCH.narrow(program), omitsB))
+          .isInstanceOf(MissingKeyException.class)
+          .hasMessageContaining("b");
+    }
+
+    @Test
+    @DisplayName("runAsync fails the future when a loader omits a key")
+    void missingKeyFailsTheAsyncFuture() {
+      Traversal<List<String>, String> ids = FocusPaths.listElements();
+      var program = ids.modifyF(fetchEach(), ABC, FetchApplicative.<String, String>instance());
+
+      BatchLoader<String, String> omitsB =
+          keys -> {
+            Map<String, String> out = new HashMap<>();
+            keys.forEach(
+                k -> {
+                  if (!k.equals("b")) {
+                    out.put(k, "val:" + k);
+                  }
+                });
+            return CompletableFuture.completedFuture(out);
+          };
+
+      assertThatThrownBy(
+              () -> Fetch.runAsync(FETCH.narrow(program), omitsB, new ConcurrentHashMap<>()).get())
+          .hasCauseInstanceOf(MissingKeyException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("m1: contract checks")
+  class ContractChecks {
+
+    @Test
+    @DisplayName("public entry points reject null arguments")
+    void nullArgumentsRejected() {
+      Fetch<String, String, String> someFetch = Fetch.fetch("k");
+      FetchApplicative<String, String> app = FetchApplicative.instance();
+      Kind<FetchKind.Witness<String, String>, String> someKind = FETCH.widen(someFetch);
+      BatchLoader<String, String> loader = keys -> CompletableFuture.completedFuture(Map.of());
+
+      assertThatThrownBy(() -> Fetch.fetch(null)).isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> Fetch.runCached(null, ECHO))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> Fetch.runCached(someFetch, null))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(
+              () -> Fetch.runAsync(null, loader, new ConcurrentHashMap<String, String>()))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> someFetch.map(null)).isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> someFetch.flatMap(null)).isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> app.ap(null, someKind)).isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> app.map(null, someKind)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("null results from a resolver or loader are rejected with a clear message")
+    void nullResultsFromUserCallbacksRejected() {
+      Fetch<String, String, String> program = Fetch.fetch("k");
+
+      // A resolver that returns a null map.
+      assertThatThrownBy(() -> Fetch.runCached(program, keys -> null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("batchResolver");
+
+      // A loader that returns a null future.
+      assertThatThrownBy(() -> Fetch.runAsync(program, keys -> null, new ConcurrentHashMap<>()))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("loader");
+
+      // A loader whose future resolves to null.
+      assertThatThrownBy(
+              () ->
+                  Fetch.runAsync(
+                          program,
+                          keys -> CompletableFuture.completedFuture(null),
+                          new ConcurrentHashMap<>())
+                      .get())
+          .hasCauseInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("Kind narrowing")
+  class KindNarrowing {
+
+    @Test
+    @DisplayName("narrow rejects a null Kind")
+    void narrowRejectsNull() {
+      assertThatThrownBy(() -> FETCH.narrow(null)).isInstanceOf(KindUnwrapException.class);
+    }
+
+    @Test
+    @DisplayName("narrow rejects a Kind that is not a Fetch")
+    void narrowRejectsForeignKind() {
+      Kind<FetchKind.Witness<String, String>, String> foreign = new Kind<>() {};
+      assertThatThrownBy(() -> FETCH.narrow(foreign)).isInstanceOf(KindUnwrapException.class);
+    }
+  }
+}


### PR DESCRIPTION
Introduces org.higherkindedj.optics.fetch: a request-batching Applicative that plugs into the optic modifyF seam, so a traversal whose focused values are loaded from a backend coalesces those loads into one batched call instead of N (the classic N+1).

- Fetch<K,V,A>: a free-applicative-style reification of deferred, batchable requests (Done | Blocked). Stack-safe resolution via the HKJ Trampoline; O(1) ap merge via the PendingKeys deferred-union tree.
- FetchApplicative: the batching Applicative instance; no optic changes.
- BatchLoader / BatchLoaders: a transport- and datastore-neutral keyed batch contract (Set<K> to CompletableFuture<Map<K,V>>) with adapters.
- runCached / runAsync: round-based runners with a per-run request cache (cross-round de-duplication); a missing key fails fast with a typed MissingKeyException.

The package is intentionally module-internal (not exported): it is the foundation for later data-access capabilities and has no public API yet.

100% line/branch coverage; applicative laws verified via FetchApplicativeLawsTestFactory.

Closes #535 