### PR TITLE
Deprecate StateT monadF accessor and single-arg runners ahead of 0.5.…

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -50,6 +50,14 @@ The arity ladder above `Lens.paired`: a record with three or more cross-field in
 - `hkj-processor` adds `CoupledLensGenerator`, wired into the existing `@GenerateForComprehensions` trigger alongside the Tuple/For-step generators. Generation caps at arity 9 (cross-field invariants past that point are vanishing in practice); raising the cap is a one-line change to the generator.
 - Tutorial 23 (exercise + teaching solution) demonstrating `coupled3` on a 3-field monotonic invariant and `coupled5` on the same shape at higher arity, including the canonical "chained set throws" failure mode that coupled lenses sidestep.
 
+**API Deprecations Ahead of 0.5.0**
+
+This release prepares users for a record-shape change to `StateT` that lands in 0.5.0. The single-argument runner methods and the explicit `monadF()` accessor are deprecated now so call sites can migrate ahead of time; the record component itself stays in place until 0.5.0.
+
+- `StateT` runner methods accept an explicit `Monad<F>`: new overloads `StateT.evalStateT(state, monad)` and `StateT.execStateT(state, monad)` use the supplied monad rather than the one stored on the record. The matching helpers `StateTKindHelper.evalStateT(kind, state, monad)` and `execStateT(kind, state, monad)` are added on the same shape. New code should prefer these overloads; the single-argument forms are deprecated for removal in 0.5.0 ([#445](https://github.com/higher-kinded-j/higher-kinded-j/issues/445))
+- `StateT.monadF()` deprecation: the explicit accessor is now `@Deprecated(forRemoval = true)`. In 0.5.0 the `monadF` record component itself is removed so that two `StateT` values with the same state function are considered equal regardless of which `Monad` instance they were constructed with. `equals`, `hashCode`, and `toString` therefore change in 0.5.0; until then the record-generated implementations still discriminate on the stored monad, which is the underlying defect the deprecation is staging
+- Internal call sites in `MutableContext.evalWith` and `execWith` are migrated to the new two-argument overloads; library builds emit no deprecation warnings of their own
+
 ---
 
 ### v0.4.5 (22 May 2026)

--- a/hkj-book/src/transformers/statet_transformer.md
+++ b/hkj-book/src/transformers/statet_transformer.md
@@ -182,13 +182,17 @@ var result    = StateTKindHelper.runStateT(computation, 10);
 // → Optional.of(StateTuple(11, "Value: 10"))
 
 // Eval: returns F<A> (discards state)
-var valueOnly = StateTKindHelper.evalStateT(computation, 10);
+var valueOnly = StateTKindHelper.evalStateT(computation, 10, optionalMonad);
 // → Optional.of("Value: 10")
 
 // Exec: returns F<S> (discards value)
-var stateOnly = StateTKindHelper.execStateT(computation, 10);
+var stateOnly = StateTKindHelper.execStateT(computation, 10, optionalMonad);
 // → Optional.of(11)
 ```
+
+~~~admonish note title="0.4.6 API Note"
+`evalStateT` and `execStateT` now take the `Monad<F>` as an explicit argument. The single-argument forms (`evalStateT(computation, 10)`, `execStateT(computation, 10)`) and the matching instance methods on `StateT` are deprecated for removal in 0.5.0, when the stored `monadF` record component is dropped so that two `StateT` values with the same state function compare equal regardless of the `Monad` instance they were built with. See the v0.4.6 entry in the [release history](../release-history.md) and [issue #445](https://github.com/higher-kinded-j/higher-kinded-j/issues/445).
+~~~
 
 ---
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/context/MutableContext.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/context/MutableContext.java
@@ -255,7 +255,7 @@ public final class MutableContext<F extends WitnessArity<TypeArity.Unary>, S, A>
    */
   @SuppressWarnings("unchecked")
   public IOPath<A> evalWith(S initialState) {
-    Kind<F, A> result = transformer.evalStateT(initialState);
+    Kind<F, A> result = transformer.evalStateT(initialState, outerMonad);
     IO<A> io = IO_OP.narrow((Kind<IOKind.Witness, A>) result);
     return Path.ioPath(io);
   }
@@ -269,7 +269,7 @@ public final class MutableContext<F extends WitnessArity<TypeArity.Unary>, S, A>
    */
   @SuppressWarnings("unchecked")
   public IOPath<S> execWith(S initialState) {
-    Kind<F, S> result = transformer.execStateT(initialState);
+    Kind<F, S> result = transformer.execStateT(initialState, outerMonad);
     IO<S> io = IO_OP.narrow((Kind<IOKind.Witness, S>) result);
     return Path.ioPath(io);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateT.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateT.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.hkt.state_t;
 
 import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
+import static org.higherkindedj.hkt.util.validation.Operation.EVAL_STATE_T;
+import static org.higherkindedj.hkt.util.validation.Operation.EXEC_STATE_T;
 import static org.higherkindedj.hkt.util.validation.Operation.MAP_T;
 
 import java.util.function.Function;
@@ -48,6 +50,25 @@ public record StateT<S, F extends WitnessArity<TypeArity.Unary>, A>(
   }
 
   /**
+   * Accessor for the stored {@link Monad} instance.
+   *
+   * <p>This explicit accessor overrides the record's auto-generated accessor solely to carry the
+   * {@link Deprecated} annotation; the runtime behaviour is identical to the implicit accessor.
+   *
+   * @return The {@link Monad} instance for the underlying monad {@code F}.
+   * @deprecated since 0.4.6, scheduled for removal in 0.5.0. The {@code monadF} record component
+   *     itself will be removed in 0.5.0 so that two {@code StateT} values with the same state
+   *     function are considered equal regardless of which {@link Monad} instance they were
+   *     constructed with. Pass the {@link Monad} explicitly to {@link #evalStateT(Object, Monad)}
+   *     and {@link #execStateT(Object, Monad)} instead. See <a
+   *     href="https://github.com/higher-kinded-j/higher-kinded-j/issues/445">issue #445</a>.
+   */
+  @Deprecated(since = "0.4.6", forRemoval = true)
+  public Monad<F> monadF() {
+    return monadF;
+  }
+
+  /**
    * Factory method to create a StateT instance. This delegates to the record's canonical
    * constructor.
    *
@@ -80,9 +101,31 @@ public record StateT<S, F extends WitnessArity<TypeArity.Unary>, A>(
    *
    * @param initialState The initial state.
    * @return The final value within the underlying monad F.
+   * @deprecated since 0.4.6, scheduled for removal in 0.5.0. The {@code monadF} record component is
+   *     being removed; pass the {@link Monad} explicitly via {@link #evalStateT(Object, Monad)}.
+   *     See <a href="https://github.com/higher-kinded-j/higher-kinded-j/issues/445">issue #445</a>.
    */
+  @Deprecated(since = "0.4.6", forRemoval = true)
   public Kind<F, A> evalStateT(S initialState) {
     return this.monadF.map(StateTuple::value, runStateT(initialState));
+  }
+
+  /**
+   * Runs the stateful computation and extracts only the final value, discarding the state.
+   *
+   * <p>This overload accepts the {@link Monad} instance explicitly rather than relying on the
+   * record's stored {@code monadF} component. New code should prefer this form; the no-monad
+   * overload is deprecated for removal in 0.5.0 when {@code monadF} is dropped from the record
+   * components.
+   *
+   * @param initialState The initial state.
+   * @param monad The {@link Monad} instance for the underlying monad {@code F}. Must not be null.
+   * @return The final value within the underlying monad F.
+   * @throws NullPointerException if {@code monad} is null.
+   */
+  public Kind<F, A> evalStateT(S initialState, Monad<F> monad) {
+    Validation.transformer().requireOuterMonad(monad, STATE_T_CLASS, EVAL_STATE_T);
+    return monad.map(StateTuple::value, runStateT(initialState));
   }
 
   /**
@@ -127,8 +170,30 @@ public record StateT<S, F extends WitnessArity<TypeArity.Unary>, A>(
    *
    * @param initialState The initial state.
    * @return The final state within the underlying monad F.
+   * @deprecated since 0.4.6, scheduled for removal in 0.5.0. The {@code monadF} record component is
+   *     being removed; pass the {@link Monad} explicitly via {@link #execStateT(Object, Monad)}.
+   *     See <a href="https://github.com/higher-kinded-j/higher-kinded-j/issues/445">issue #445</a>.
    */
+  @Deprecated(since = "0.4.6", forRemoval = true)
   public Kind<F, S> execStateT(S initialState) {
     return this.monadF.map(StateTuple::state, runStateT(initialState));
+  }
+
+  /**
+   * Runs the stateful computation and extracts only the final state, discarding the value.
+   *
+   * <p>This overload accepts the {@link Monad} instance explicitly rather than relying on the
+   * record's stored {@code monadF} component. New code should prefer this form; the no-monad
+   * overload is deprecated for removal in 0.5.0 when {@code monadF} is dropped from the record
+   * components.
+   *
+   * @param initialState The initial state.
+   * @param monad The {@link Monad} instance for the underlying monad {@code F}. Must not be null.
+   * @return The final state within the underlying monad F.
+   * @throws NullPointerException if {@code monad} is null.
+   */
+  public Kind<F, S> execStateT(S initialState, Monad<F> monad) {
+    Validation.transformer().requireOuterMonad(monad, STATE_T_CLASS, EXEC_STATE_T);
+    return monad.map(StateTuple::state, runStateT(initialState));
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKindHelper.java
@@ -136,11 +136,40 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code kind} is not a valid
    *     {@code StateT} representation.
    * @throws NullPointerException if {@code kind} is null.
+   * @deprecated since 0.4.6, scheduled for removal in 0.5.0. Pass the {@link Monad} explicitly via
+   *     {@link #evalStateT(Kind, Object, Monad)}. See <a
+   *     href="https://github.com/higher-kinded-j/higher-kinded-j/issues/445">issue #445</a>.
    */
+  @Deprecated(since = "0.4.6", forRemoval = true)
+  @SuppressWarnings("removal")
   public <S, F extends WitnessArity<TypeArity.Unary>, A> Kind<F, A> evalStateT(
       Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
     Validation.kind().requireNonNull(kind, EVAL_STATE_T);
     return this.narrow(kind).evalStateT(initialState);
+  }
+
+  /**
+   * Runs the {@link StateT} computation and extracts the final value.
+   *
+   * <p>This overload accepts the {@link Monad} instance explicitly rather than relying on the
+   * {@code StateT}'s stored {@code monadF} record component, which is deprecated for removal in
+   * 0.5.0.
+   *
+   * @param kind The non-null {@code StateT} computation, as a {@code Kind}.
+   * @param initialState The initial state.
+   * @param monad The non-null {@link Monad} instance for the underlying monad {@code F}.
+   * @param <S> The state type.
+   * @param <F> The higher-kinded type witness for the underlying monad.
+   * @param <A> The value type.
+   * @return A {@code Kind<F, A>} representing the final value.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code kind} is not a valid
+   *     {@code StateT} representation.
+   * @throws NullPointerException if {@code kind} or {@code monad} is null.
+   */
+  public <S, F extends WitnessArity<TypeArity.Unary>, A> Kind<F, A> evalStateT(
+      Kind<StateTKind.Witness<S, F>, A> kind, S initialState, Monad<F> monad) {
+    Validation.kind().requireNonNull(kind, EVAL_STATE_T);
+    return this.narrow(kind).evalStateT(initialState, monad);
   }
 
   /**
@@ -155,10 +184,39 @@ public enum StateTKindHelper implements StateTConverterOps {
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code kind} is not a valid
    *     {@code StateT} representation.
    * @throws NullPointerException if {@code kind} is null.
+   * @deprecated since 0.4.6, scheduled for removal in 0.5.0. Pass the {@link Monad} explicitly via
+   *     {@link #execStateT(Kind, Object, Monad)}. See <a
+   *     href="https://github.com/higher-kinded-j/higher-kinded-j/issues/445">issue #445</a>.
    */
+  @Deprecated(since = "0.4.6", forRemoval = true)
+  @SuppressWarnings("removal")
   public <S, F extends WitnessArity<TypeArity.Unary>, A> Kind<F, S> execStateT(
       Kind<StateTKind.Witness<S, F>, A> kind, S initialState) {
     Validation.kind().requireNonNull(kind, EXEC_STATE_T);
     return this.narrow(kind).execStateT(initialState);
+  }
+
+  /**
+   * Runs the {@link StateT} computation and extracts the final state.
+   *
+   * <p>This overload accepts the {@link Monad} instance explicitly rather than relying on the
+   * {@code StateT}'s stored {@code monadF} record component, which is deprecated for removal in
+   * 0.5.0.
+   *
+   * @param kind The non-null {@code StateT} computation, as a {@code Kind}.
+   * @param initialState The initial state.
+   * @param monad The non-null {@link Monad} instance for the underlying monad {@code F}.
+   * @param <S> The state type.
+   * @param <F> The higher-kinded type witness for the underlying monad.
+   * @param <A> The value type.
+   * @return A {@code Kind<F, S>} representing the final state.
+   * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code kind} is not a valid
+   *     {@code StateT} representation.
+   * @throws NullPointerException if {@code kind} or {@code monad} is null.
+   */
+  public <S, F extends WitnessArity<TypeArity.Unary>, A> Kind<F, S> execStateT(
+      Kind<StateTKind.Witness<S, F>, A> kind, S initialState, Monad<F> monad) {
+    Validation.kind().requireNonNull(kind, EXEC_STATE_T);
+    return this.narrow(kind).execStateT(initialState, monad);
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTKindHelperTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTKindHelperTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("StateTKindHelper Tests ")
 // (F=OptionalKind.Witness)
+@SuppressWarnings({"deprecation", "removal"})
 class StateTKindHelperTest {
 
   private static final String TYPE_NAME = "StateT";
@@ -316,6 +317,64 @@ class StateTKindHelperTest {
       assertThatThrownBy(() -> STATE_T.execStateT(null, "initial"))
           .isInstanceOf(NullPointerException.class)
           .hasMessageContaining("Kind")
+          .hasMessageContaining("execStateT");
+    }
+
+    @Test
+    @DisplayName("evalStateT(kind, state, monad) should extract value via helper")
+    void evalStateTWithExplicitMonad_shouldExtractValue() {
+      Kind<StateTKind.Witness<String, OptionalKind.Witness>, Integer> kind = STATE_T.widen(stateT);
+
+      Kind<OptionalKind.Witness, Integer> result = STATE_T.evalStateT(kind, "initial", outerMonad);
+
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("execStateT(kind, state, monad) should extract state via helper")
+    void execStateTWithExplicitMonad_shouldExtractState() {
+      Kind<StateTKind.Witness<String, OptionalKind.Witness>, Integer> kind = STATE_T.widen(stateT);
+
+      Kind<OptionalKind.Witness, String> result = STATE_T.execStateT(kind, "initial", outerMonad);
+
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("evalStateT(kind, state, monad) should throw when Kind is null")
+    void evalStateTWithExplicitMonad_nullKind_shouldThrow() {
+      assertThatThrownBy(() -> STATE_T.evalStateT(null, "initial", outerMonad))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("Kind")
+          .hasMessageContaining("evalStateT");
+    }
+
+    @Test
+    @DisplayName("execStateT(kind, state, monad) should throw when Kind is null")
+    void execStateTWithExplicitMonad_nullKind_shouldThrow() {
+      assertThatThrownBy(() -> STATE_T.execStateT(null, "initial", outerMonad))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("Kind")
+          .hasMessageContaining("execStateT");
+    }
+
+    @Test
+    @DisplayName("evalStateT(kind, state, monad) should throw when monad is null")
+    void evalStateTWithExplicitMonad_nullMonad_shouldThrow() {
+      Kind<StateTKind.Witness<String, OptionalKind.Witness>, Integer> kind = STATE_T.widen(stateT);
+      assertThatThrownBy(() -> STATE_T.evalStateT(kind, "initial", null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("StateT")
+          .hasMessageContaining("evalStateT");
+    }
+
+    @Test
+    @DisplayName("execStateT(kind, state, monad) should throw when monad is null")
+    void execStateTWithExplicitMonad_nullMonad_shouldThrow() {
+      Kind<StateTKind.Witness<String, OptionalKind.Witness>, Integer> kind = STATE_T.widen(stateT);
+      assertThatThrownBy(() -> STATE_T.execStateT(kind, "initial", null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("StateT")
           .hasMessageContaining("execStateT");
     }
   }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/state_t/StateTTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("StateT Core Type Tests ")
 // (Outer: OptionalKind.Witness)
+@SuppressWarnings({"deprecation", "removal"})
 class StateTTest {
 
   private Monad<OptionalKind.Witness> outerMonad;
@@ -165,6 +166,67 @@ class StateTTest {
       StateT<String, OptionalKind.Witness, Integer> nullStateT = StateT.create(runFn, outerMonad);
 
       Kind<OptionalKind.Witness, String> result = nullStateT.execStateT(null);
+
+      Optional<String> unwrapped = OPTIONAL.narrow(result);
+      assertThat(unwrapped).isPresent().contains(updatedState);
+    }
+
+    @Test
+    @DisplayName("evalStateT(state, monad) should extract value using the passed monad")
+    void evalStateTWithExplicitMonad_extractsValue() {
+      Kind<OptionalKind.Witness, Integer> result = stateT.evalStateT(initialState, outerMonad);
+
+      Optional<Integer> unwrapped = OPTIONAL.narrow(result);
+      assertThat(unwrapped).isPresent().contains(initialValue);
+    }
+
+    @Test
+    @DisplayName("execStateT(state, monad) should extract state using the passed monad")
+    void execStateTWithExplicitMonad_extractsState() {
+      Kind<OptionalKind.Witness, String> result = stateT.execStateT(initialState, outerMonad);
+
+      Optional<String> unwrapped = OPTIONAL.narrow(result);
+      assertThat(unwrapped).isPresent().contains(updatedState);
+    }
+
+    @Test
+    @DisplayName("evalStateT(state, monad) should reject null monad")
+    void evalStateTWithExplicitMonad_rejectsNullMonad() {
+      assertThatThrownBy(() -> stateT.evalStateT(initialState, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("StateT")
+          .hasMessageContaining("evalStateT");
+    }
+
+    @Test
+    @DisplayName("execStateT(state, monad) should reject null monad")
+    void execStateTWithExplicitMonad_rejectsNullMonad() {
+      assertThatThrownBy(() -> stateT.execStateT(initialState, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("StateT")
+          .hasMessageContaining("execStateT");
+    }
+
+    @Test
+    @DisplayName(
+        "evalStateT(state, monad) should ignore the stored monadF and use the passed monad")
+    void evalStateTWithExplicitMonad_usesPassedMonad() {
+      // Pass a different (but compatible) Monad instance to prove the passed one is what drives
+      // the map. The result must still be correct because the runStateTFn already produces a
+      // Kind<F, StateTuple<S, A>> in the OptionalKind.Witness context.
+      Monad<OptionalKind.Witness> alternateMonad = Instances.monad(optional());
+      Kind<OptionalKind.Witness, Integer> result = stateT.evalStateT(initialState, alternateMonad);
+
+      Optional<Integer> unwrapped = OPTIONAL.narrow(result);
+      assertThat(unwrapped).isPresent().contains(initialValue);
+    }
+
+    @Test
+    @DisplayName(
+        "execStateT(state, monad) should ignore the stored monadF and use the passed monad")
+    void execStateTWithExplicitMonad_usesPassedMonad() {
+      Monad<OptionalKind.Witness> alternateMonad = Instances.monad(optional());
+      Kind<OptionalKind.Witness, String> result = stateT.execStateT(initialState, alternateMonad);
 
       Optional<String> unwrapped = OPTIONAL.narrow(result);
       assertThat(unwrapped).isPresent().contains(updatedState);

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/test/api/coretype/state_t/StateTTestExecutor.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/test/api/coretype/state_t/StateTTestExecutor.java
@@ -92,10 +92,13 @@ final class StateTTestExecutor<S, F extends WitnessArity<TypeArity.Unary>, A, B>
     if (includeEdgeCases) testEdgeCases();
   }
 
+  @SuppressWarnings({"deprecation", "removal"})
   private void testFactoryMethods() {
     // Test create() factory method
     assertThat(firstInstance).isNotNull();
     assertThat(firstInstance.runStateTFn()).isNotNull();
+    // monadF() is deprecated for removal in 0.5.0 (issue #445) but still asserts non-null while
+    // the record component exists in 0.4.6.
     assertThat(firstInstance.monadF()).isNotNull();
 
     // Test that created instance is valid
@@ -113,12 +116,12 @@ final class StateTTestExecutor<S, F extends WitnessArity<TypeArity.Unary>, A, B>
     Kind<F, StateTuple<S, A>> result = firstInstance.runStateT(testState);
     assertThat(result).as("runStateT should return non-null result").isNotNull();
 
-    // Test evalStateT() - returns Kind<F, A> (extracts value)
-    Kind<F, A> valueResult = firstInstance.evalStateT(testState);
+    // Test evalStateT(state, monad) - returns Kind<F, A> (extracts value)
+    Kind<F, A> valueResult = firstInstance.evalStateT(testState, outerMonad);
     assertThat(valueResult).as("evalStateT should return non-null result").isNotNull();
 
-    // Test execStateT() - returns Kind<F, S> (extracts state)
-    Kind<F, S> stateResult = firstInstance.execStateT(testState);
+    // Test execStateT(state, monad) - returns Kind<F, S> (extracts state)
+    Kind<F, S> stateResult = firstInstance.execStateT(testState, outerMonad);
     assertThat(stateResult).as("execStateT should return non-null result").isNotNull();
   }
 
@@ -151,10 +154,10 @@ final class StateTTestExecutor<S, F extends WitnessArity<TypeArity.Unary>, A, B>
     Kind<F, StateTuple<S, A>> nullStateResult = firstInstance.runStateT(nullState);
     assertThat(nullStateResult).isNotNull();
 
-    Kind<F, A> nullStateValue = firstInstance.evalStateT(nullState);
+    Kind<F, A> nullStateValue = firstInstance.evalStateT(nullState, outerMonad);
     assertThat(nullStateValue).isNotNull();
 
-    Kind<F, S> nullStateExtracted = firstInstance.execStateT(nullState);
+    Kind<F, S> nullStateExtracted = firstInstance.execStateT(nullState, outerMonad);
     assertThat(nullStateExtracted).isNotNull();
 
     // Test toString


### PR DESCRIPTION


Adds StateT.evalStateT(state, monad) and execStateT(state, monad) overloads (and matching StateTKindHelper variants) that take the underlying monad explicitly rather than relying on the record's stored monadF component. The single-arg forms and the explicit monadF() accessor are deprecated for removal in 0.5.0, when the monadF record component itself is dropped so that two StateT values with the same state function compare equal regardless of the Monad instance they were built with. equals, hashCode, and toString therefore change in 0.5.0; until then the record-generated implementations still discriminate on monadF, which is the underlying defect the deprecation is staging.

Internal call sites in MutableContext and the StateT core-type test executor are migrated to the new two-arg overloads so the library build emits no deprecation warnings of its own. The transformer page runner-example block now uses the new signatures, with a note pointing at the release-history entry and the issue. JaCoCo holds at 100% line and branch coverage on StateT, StateTKindHelper, StateTMonad, StateTMonadState, and MutableContext.

Relates to #445 