### PR TITLE
feat(writer): add Writer.of(log, value) factory (#554)

### DIFF
--- a/hkj-book/src/functional/bifunctor.md
+++ b/hkj-book/src/functional/bifunctor.md
@@ -268,7 +268,7 @@ import org.higherkindedj.hkt.writer.WriterBifunctor;
 Bifunctor<WriterKind2.Witness> bifunctor = WriterBifunctor.INSTANCE;
 
 // A Writer with a log and a result
-Writer<String, Integer> computation = new Writer<>("Calculated: ", 42);
+Writer<String, Integer> computation = Writer.of("Calculated: ", 42);
 
 // Transform the log channel
 Kind2<WriterKind2.Witness, String, Integer> uppercaseLog =

--- a/hkj-book/src/hkts/hkt_basic_examples.md
+++ b/hkj-book/src/hkts/hkt_basic_examples.md
@@ -331,7 +331,7 @@ Function<Integer, Kind<WriterKind.Witness<String>, Integer>> addAndLog =
     x -> {
       int result = x + 10;
       String logMsg = "Added 10 to " + x + " -> " + result + "; ";
-      return WRITER.widen(new Writer<>(logMsg, result));
+      return WRITER.widen(Writer.of(logMsg, result));
     };
 
 // The monad combines the logs from each step automatically

--- a/hkj-book/src/monads/writer_monad.md
+++ b/hkj-book/src/monads/writer_monad.md
@@ -125,19 +125,19 @@ Each step returns a Writer: the result *and* a log entry. No log parameter neede
 // Each function: takes a price, returns Writer(log, newPrice)
 Function<Double, Kind<WriterKind.Witness<String>, Double>> addTax = price -> {
     var taxed = price * 1.08;
-    return WRITER.widen(new Writer<>(
+    return WRITER.widen(Writer.of(
         "Tax 8%%: $%.2f -> $%.2f; ".formatted(price, taxed), taxed));
 };
 
 Function<Double, Kind<WriterKind.Witness<String>, Double>> applyDiscount = price -> {
     var discounted = price * 0.90;
-    return WRITER.widen(new Writer<>(
+    return WRITER.widen(Writer.of(
         "Discount 10%%: $%.2f -> $%.2f; ".formatted(price, discounted), discounted));
 };
 
 Function<Double, Kind<WriterKind.Witness<String>, Double>> addShipping = price -> {
     var shipped = price + 5.00;
-    return WRITER.widen(new Writer<>(
+    return WRITER.widen(Writer.of(
         "Shipping: +$5.00 -> $%.2f; ".formatted(shipped), shipped));
 };
 ```

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -12,6 +12,17 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ## Recent Releases
 
+### v0.4.7-SNAPSHOT (in development)
+
+**`Writer.of(log, value)` factory**
+
+`Writer<W, A>` exposed `Writer.value(Monoid<W>, A)` (empty log) and `Writer.tell(W)` (`Unit` value) but had no factory for the common custom-log-plus-value case, leaving the raw `new Writer<>(log, value)` constructor as the only option. Because a `Writer` legitimately holds a null value, that constructor's diamond infers a `@Nullable A` type argument, which trips nullness analysis at the call site ("returning a class with nullable type arguments where not-null expected"); a static factory whose return type is the plain `Writer<W, A>` launders the nullness contract once, in production code.
+
+- `Writer.of(W log, @Nullable A value)`: New static factory returning `Writer<W, A>` with the given log and value. The argument order `(log, value)` mirrors the record components, the `log()` / `value()` accessors, and the `Writer<W, A>` type parameters, so it is a direct drop-in for the constructor. The effect-layer `WriterPath.writer(value, log, monoid)` deliberately keeps its existing value-first order — the one place in the Path API that pairs a separate log and value — and the divergence is documented on `Writer.of` itself ([#554](https://github.com/higher-kinded-j/higher-kinded-j/issues/554)).
+- Purely additive and non-breaking. The internal `WriterTestBase.writerOf` helper now delegates to `Writer.of`, which allows removing its `@SuppressWarnings("NullableProblems")` annotation.
+
+---
+
 ### v0.4.6 (7 June 2026)
 
 **Optic-Driven Request Batching**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/Writer.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/Writer.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.Nullable;
  * <ul>
  *   <li>{@link #value(Monoid, Object)}: Creates a {@code Writer} with a pure value and an empty
  *       log.
+ *   <li>{@link #of(Object, Object)}: Creates a {@code Writer} with a custom log and value.
  *   <li>{@link #tell(Object)}: Creates a {@code Writer} that only produces a log entry, with {@link
  *       Unit#INSTANCE} as its value.
  *   <li>{@link #map(Function)}: Transforms the computed value without affecting the log.
@@ -81,6 +82,28 @@ public record Writer<W, A>(W log, @Nullable A value) {
   public static <W, A> Writer<W, A> value(Monoid<W> monoidW, @Nullable A value) {
     Validation.function().require(monoidW, "monoidW", VALUE);
     return new Writer<>(monoidW.empty(), value);
+  }
+
+  /**
+   * Creates a {@code Writer} with the given log and value.
+   *
+   * <p>The argument order {@code (log, value)} mirrors the record components and the {@code
+   * Writer<W, A>} type parameters, making this a direct, null-laundering replacement for the {@code
+   * new Writer<>(log, value)} constructor. Note that the effect-layer factory {@code
+   * WriterPath.writer} takes {@code (value, log, monoid)} — value first — instead.
+   *
+   * @param <W> The type of the log.
+   * @param <A> The type of the value.
+   * @param log The accumulated log. Must not be {@code null}.
+   * @param value The computed value. Can be {@code null} if {@code A} is a nullable type. If {@code
+   *     A} is {@link Unit}, pass {@link Unit#INSTANCE}.
+   * @return A new {@code Writer<W, A>} with the given log and value.
+   * @throws NullPointerException if {@code log} is {@code null}.
+   * @see #value(Monoid, Object)
+   * @see #tell(Object)
+   */
+  public static <W, A> Writer<W, A> of(W log, @Nullable A value) {
+    return new Writer<>(log, value);
   }
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/writer/WriterTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/writer/WriterTest.java
@@ -62,15 +62,19 @@ class WriterTest extends WriterTestBase {
     }
 
     @Test
-    @DisplayName("Constructor creates correct instances")
-    void constructorCreatesCorrectInstances() {
-      // Standard case
-      Writer<String, Integer> w1 = writerOf("Log", 10);
+    @DisplayName("of() creates correct instances with a custom log")
+    void ofCreatesCorrectInstances() {
+      // Non-null value with a custom log
+      Writer<String, Integer> w1 = Writer.of("Log", 10);
       assertThatWriter(w1).hasLog("Log").hasValue(10);
 
-      // Null value
-      Writer<String, Integer> w2 = writerOf("Log", null);
+      // Null value with a custom log
+      Writer<String, Integer> w2 = Writer.of("Log", null);
       assertThatWriter(w2).hasLog("Log").hasNullValue();
+
+      // Complex value type
+      Writer<String, String> w3 = Writer.of("Init;", "test");
+      assertThatWriter(w3).hasLog("Init;").hasValue("test");
     }
   }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/writer/WriterTestBase.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/writer/WriterTestBase.java
@@ -82,9 +82,8 @@ abstract class WriterTestBase
    * @param value The value to include
    * @return A new Writer instance
    */
-  @SuppressWarnings("NullableProblems") // Writer value is @Nullable, so the diamond infers nullable
   protected <A> Writer<String, A> writerOf(String log, @Nullable A value) {
-    return new Writer<>(log, value);
+    return Writer.of(log, value);
   }
 
   /**

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/bifunctor/BifunctorExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/bifunctor/BifunctorExample.java
@@ -206,7 +206,7 @@ public class BifunctorExample {
     Bifunctor<WriterKind2.Witness> bifunctor = WriterBifunctor.INSTANCE;
 
     // A Writer with a log and a computation result
-    Writer<String, Integer> computation = new Writer<>("Calculated: ", 42);
+    Writer<String, Integer> computation = Writer.of("Calculated: ", 42);
     Kind2<WriterKind2.Witness, String, Integer> wrappedWriter = WRITER.widen2(computation);
 
     // Transform only the log channel

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer/WriterExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/writer/WriterExample.java
@@ -30,15 +30,14 @@ public class WriterExample {
       x -> {
         int result = x + 10;
         String logMsg = "Added 10 to " + x + " -> " + result + "; ";
-        // Assuming direct creation with log and value if Writer.create was meant for that
-        return WRITER.widen(new Writer<>(logMsg, result));
+        return WRITER.widen(Writer.of(logMsg, result));
       };
 
   Function<Integer, Kind<WriterKind.Witness<String>, String>> multiplyAndLogToString =
       x -> {
         int result = x * 2;
         String logMsg = "Multiplied " + x + " by 2 -> " + result + "; ";
-        return WRITER.widen(new Writer<>(logMsg, "Final:" + result));
+        return WRITER.widen(Writer.of(logMsg, "Final:" + result));
       };
 
   public static void main(String[] args) {


### PR DESCRIPTION
Closes #554.

## Summary

Adds a static `Writer.of(W log, @Nullable A value)` factory for the common custom-log-plus-value case, mirroring `Writer.value`'s signature. Previously the only way to build one was the raw `new Writer<>(log, value)` constructor, whose diamond infers a `@Nullable A` type argument (a `Writer` legitimately holds a null value) and trips nullness analysis at the call site. The factory's plain `Writer<W, A>` return type launders the nullness contract once, in production code.

```java
public static <W, A> Writer<W, A> of(W log, @Nullable A value) {
  return new Writer<>(log, value);
}
```

## Design notes

- **Argument order is log-first `(log, value)`** to match the record components, the `log()` / `value()` accessors, and the `Writer<W, A>` type parameters — so it is a direct drop-in for the constructor. The effect-layer `WriterPath.writer(value, log, monoid)` keeps its existing value-first order (the one factory in the Path API that pairs a separate log and value); the divergence is documented on `Writer.of` itself rather than reconciled, since reordering shipped API would be breaking.
- Named `of` (the dominant factory name across the codebase). `Writer` has no existing `of`/`pure` to collide with — its applicative point is `value(Monoid, A)` — so there is no overload ambiguity.

## Changes

- `Writer.of(...)` added with Javadoc, listed in the class-level "Common operations".
- `WriterTestBase.writerOf` now delegates to `Writer.of`, dropping its `@SuppressWarnings("NullableProblems")`.
- The old indirect "Constructor" test in `WriterTest` (which used `writerOf`) is replaced with a **direct** `of()` unit test covering non-null value, null value, and a complex type — all with a custom log.
- Documented under `0.4.7-SNAPSHOT` in `release-history.md`.

Purely additive and **non-breaking** — safe within the current SNAPSHOT.

## Verification

`gradle :hkj-core:spotlessCheck :hkj-core:test :hkj-core:jacocoTestCoverageVerification` — **BUILD SUCCESSFUL**; `hkj-core` JaCoCo stays at 100%.