### PR TITLE
Eliminate unchecked casts and add -Xlint ratchet (#560)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,11 @@ subprojects {
     }
 
     tasks.withType<JavaCompile>().configureEach {
-        options.compilerArgs.addAll(listOf("-Xmaxerrs", "10000", "--enable-preview"))
+        options.compilerArgs.addAll(
+            // -Werror ratchet: a new unchecked/raw-type use must carry an explicit,
+            // justified @SuppressWarnings or the build fails (see issue #560).
+            listOf("-Xmaxerrs", "10000", "--enable-preview", "-Xlint:unchecked,rawtypes", "-Werror")
+        )
     }
 
     tasks.withType<Test>().configureEach {

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -29,6 +29,15 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 - `recover(ma, value)` rejects a null source but keeps `@Nullable value` (routed through `of`), so `recover(failure, null)` remains a valid `Success(null)` / `Nothing` / empty per type. `ValidatedMonad` intentionally keeps only `recoverWith`: its `of` rejects null, so a `recover` override could not honour the `@Nullable value` contract.
 - Purely additive and behaviour-preserving except on null input. The constant-fallback `recover` / `recoverWith` shortcuts are now documented on the MonadError and per-type monad pages.
 
+**Unchecked-cast hygiene: zero-cost eliminations and a lint ratchet**
+
+The build previously surfaced no unchecked warnings at all, so a new unguarded cast could land silently, and a handful of `@SuppressWarnings("unchecked")` sites suppressed casts the type system can already express. This release removes the avoidable casts and turns on `-Xlint:unchecked,rawtypes` across all modules so every future unchecked operation must carry an explicit, justified suppression ([#560](https://github.com/higher-kinded-j/higher-kinded-j/issues/560)).
+
+- Zero-cost eliminations: `VStreamPar.parEvalMap` / `parEvalMapUnordered` now accept `Function<? super A, VTask<B>>`, removing the double casts in `DefaultVStreamPath` (binary-compatible widening); `CompletableFuturePath.zipWith3` and `ValidationPath.zipWith3Accum` pair intermediate values with `Tuple2` instead of `Object[]`; `Resource.flatMap` and `VStreamPar.pullBatch` hold state in `AtomicReference` instead of raw one-element arrays; `VStream`'s finalizer wrapping types its `Step.Done` arm explicitly instead of casting the whole switch.
+- Lint ratchet: all modules compile with `-Xlint:unchecked,rawtypes -Werror`, so a new unchecked or raw-type use fails the build unless it carries an explicit suppression. Pre-existing, deliberate unchecked operations (the `KindHelper` narrow methods, whose raw `Class` tokens are runtime-checked via `Class.isInstance`) now carry uniform single-line suppressions stating why they are safe.
+- Generated code: `@ComposeEffects` Support classes now carry `@SuppressWarnings({"unchecked", "rawtypes"})`, so downstream projects compiling generated sources with lint enabled stay warning-free.
+- Purely internal; no behaviour or public API change.
+
 ---
 
 ### v0.4.6 (7 June 2026)

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/context/ContextKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/context/ContextKindHelper.java
@@ -79,7 +79,7 @@ public enum ContextKindHelper implements ContextConverterOps {
    *     valid ContextHolder.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <R, A> Context<R, A> narrow(@Nullable Kind<ContextKind.Witness<R>, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, CONTEXT_CLASS, ContextHolder.class, ContextHolder::context);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/CompletableFuturePath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/CompletableFuturePath.java
@@ -17,6 +17,7 @@ import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.hkt.resilience.Retry;
 import org.higherkindedj.hkt.resilience.RetryPolicy;
 import org.higherkindedj.hkt.trymonad.Try;
+import org.higherkindedj.hkt.tuple.Tuple2;
 
 /**
  * A fluent path wrapper for {@link CompletableFuture} async computations.
@@ -277,16 +278,8 @@ public final class CompletableFuturePath<A> implements Recoverable<Exception, A>
 
     CompletableFuture<D> combined =
         future
-            .thenCombine(second.future, (a, b) -> new Object[] {a, b})
-            .thenCombine(
-                third.future,
-                (arr, c) -> {
-                  @SuppressWarnings("unchecked")
-                  A a = (A) arr[0];
-                  @SuppressWarnings("unchecked")
-                  B b = (B) arr[1];
-                  return combiner.apply(a, b, c);
-                });
+            .thenCombine(second.future, Tuple2<A, B>::new)
+            .thenCombine(third.future, (pair, c) -> combiner.apply(pair._1(), pair._2(), c));
 
     return new CompletableFuturePath<>(combined);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/DefaultVStreamPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/DefaultVStreamPath.java
@@ -244,17 +244,13 @@ public record DefaultVStreamPath<A>(VStream<A> stream) implements VStreamPath<A>
   @Override
   public <B> VStreamPath<B> parEvalMap(int concurrency, Function<? super A, VTask<B>> f) {
     Objects.requireNonNull(f, "f must not be null");
-    @SuppressWarnings("unchecked")
-    Function<A, VTask<B>> typedF = (Function<A, VTask<B>>) (Function<?, ?>) f;
-    return new DefaultVStreamPath<>(VStreamPar.parEvalMap(stream, concurrency, typedF));
+    return new DefaultVStreamPath<>(VStreamPar.parEvalMap(stream, concurrency, f));
   }
 
   @Override
   public <B> VStreamPath<B> parEvalMapUnordered(int concurrency, Function<? super A, VTask<B>> f) {
     Objects.requireNonNull(f, "f must not be null");
-    @SuppressWarnings("unchecked")
-    Function<A, VTask<B>> typedF = (Function<A, VTask<B>>) (Function<?, ?>) f;
-    return new DefaultVStreamPath<>(VStreamPar.parEvalMapUnordered(stream, concurrency, typedF));
+    return new DefaultVStreamPath<>(VStreamPar.parEvalMapUnordered(stream, concurrency, f));
   }
 
   // ===== Chunking operations =====
@@ -305,11 +301,9 @@ public record DefaultVStreamPath<A>(VStream<A> stream) implements VStreamPath<A>
   // ===== Effectful mapping =====
 
   @Override
-  @SuppressWarnings("unchecked")
   public <B> VStreamPath<B> mapTask(Function<? super A, ? extends VTask<B>> f) {
     Objects.requireNonNull(f, "f must not be null");
-    Function<A, VTask<B>> typedF = (Function<A, VTask<B>>) (Function<?, ?>) f;
-    return new DefaultVStreamPath<>(stream.mapTask(typedF));
+    return new DefaultVStreamPath<>(stream.mapTask(f));
   }
 
   // ===== Rate limiting =====

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/PathOps.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/PathOps.java
@@ -848,7 +848,7 @@ public final class PathOps {
         paths.stream().map(CompletableFuturePath::toCompletableFuture).collect(Collectors.toList());
 
     CompletableFuture<List<A>> combined =
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
             .thenApply(_ -> futures.stream().map(CompletableFuture::join).toList());
 
     return CompletableFuturePath.fromFuture(combined);
@@ -880,7 +880,7 @@ public final class PathOps {
         items.stream().map(item -> f.apply(item).toCompletableFuture()).toList();
 
     CompletableFuture<List<B>> combined =
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
             .thenApply(_ -> futures.stream().map(CompletableFuture::join).toList());
 
     return CompletableFuturePath.fromFuture(combined);
@@ -963,7 +963,7 @@ public final class PathOps {
                       .toList();
 
               try {
-                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).get();
                 return futures.stream().map(CompletableFuture::join).toList();
               } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/effect/ValidationPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/effect/ValidationPath.java
@@ -18,6 +18,7 @@ import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.hkt.function.Function3;
 import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.hkt.trymonad.Try;
+import org.higherkindedj.hkt.tuple.Tuple2;
 import org.higherkindedj.hkt.validated.Invalid;
 import org.higherkindedj.hkt.validated.Valid;
 import org.higherkindedj.hkt.validated.Validated;
@@ -341,16 +342,8 @@ public final class ValidationPath<E, A>
     Objects.requireNonNull(combiner, "combiner must not be null");
 
     // Implement via two zipWithAccum calls to properly accumulate all errors
-    return this.zipWithAccum(second, (a, b) -> new Object[] {a, b})
-        .zipWithAccum(
-            third,
-            (pair, c) -> {
-              @SuppressWarnings("unchecked")
-              A a = (A) pair[0];
-              @SuppressWarnings("unchecked")
-              B b = (B) pair[1];
-              return combiner.apply(a, b, c);
-            });
+    return this.zipWithAccum(second, Tuple2<A, B>::new)
+        .zipWithAccum(third, (pair, c) -> combiner.apply(pair._1(), pair._2(), c));
   }
 
   @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherKindHelper.java
@@ -56,6 +56,7 @@ public enum EitherKindHelper implements EitherConverterOps {
    *     null} or not an instance of {@code Either}.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <L, R> Either<L, R> narrow(@Nullable Kind<EitherKind.Witness<L>, R> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, EITHER_CLASS);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free/Free.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free/Free.java
@@ -420,7 +420,7 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A>
         // the recursive interpretation through the Trampoline for stack safety.
         // For lazy monads (IO, State), the monad's own laziness provides stack safety.
         @SuppressWarnings("unchecked")
-        Free<F, A>[] innerFreeRef = (Free<F, A>[]) new Free[1];
+        Free<F, A>[] innerFreeRef = (Free<F, A>[]) new Free<?, ?>[1];
         boolean[] eager = {false};
         monad.map(
             innerFree -> {
@@ -495,7 +495,7 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A>
 
         // Try to extract the inner Free eagerly (works for strict monads).
         @SuppressWarnings("unchecked")
-        Free<F, A>[] innerFreeRef = (Free<F, A>[]) new Free[1];
+        Free<F, A>[] innerFreeRef = (Free<F, A>[]) new Free<?, ?>[1];
         boolean[] eager = {false};
         monad.map(
             innerFree -> {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free/FreeKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free/FreeKindHelper.java
@@ -60,7 +60,7 @@ public enum FreeKindHelper {
    * @return The concrete Free instance
    * @throws ClassCastException if the Kind is not a FreeHolder
    */
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <F extends WitnessArity<TypeArity.Unary>, A> Free<F, A> narrow(
       @Nullable Kind<FreeKind.Witness<F>, A> kind) {
     return Validation.kind().narrowHolder(kind, Free.class, FreeHolder.class, FreeHolder::free);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/future/CompletableFutureKindHelper.java
@@ -66,7 +66,7 @@ public enum CompletableFutureKindHelper implements CompletableFutureConverterOps
    *     contains a {@code null} future.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> CompletableFuture<A> narrow(@Nullable Kind<CompletableFutureKind.Witness, A> kind) {
     return Validation.kind()
         .narrowHolder(

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/IdKindHelper.java
@@ -46,6 +46,7 @@ public enum IdKindHelper implements IdConverterOps {
    *     instance.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <A> Id<A> narrow(@Nullable Kind<IdKind.Witness, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, ID_CLASS);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/io/IOKindHelper.java
@@ -52,6 +52,7 @@ public enum IOKindHelper implements IOConverterOps {
    *     null}, or not an instance of {@code IO}.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <A> IO<A> narrow(@Nullable Kind<IOKind.Witness, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, IO_CLASS);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/lazy/LazyKindHelper.java
@@ -60,7 +60,7 @@ public enum LazyKindHelper implements LazyConverterOps {
    *     null}, or not an instance of the expected underlying holder type for Lazy.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> Lazy<A> narrow(@Nullable Kind<LazyKind.Witness, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, LAZY_CLASS, LazyHolder.class, LazyHolder::lazyInstance);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/list/ListKindHelper.java
@@ -62,7 +62,7 @@ public enum ListKindHelper implements ListConverterOps {
    *     ListKind representation.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> List<A> narrow(@Nullable Kind<ListKind.Witness, A> kind) {
     return Validation.kind().narrowHolder(kind, LIST_CLASS, ListHolder.class, ListHolder::list);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeKindHelper.java
@@ -52,6 +52,7 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    *     if {@code kind} is not an instance of {@code Maybe}.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <A> Maybe<A> narrow(@Nullable Kind<MaybeKind.Witness, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, MAYBE_CLASS);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe_t/MaybeTKindHelper.java
@@ -53,6 +53,7 @@ public enum MaybeTKindHelper implements MaybeTConverterOps {
    *     valid {@link MaybeT} instance.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <F extends WitnessArity<TypeArity.Unary>, A> MaybeT<F, A> narrow(
       @Nullable Kind<MaybeTKind.Witness<F>, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, MAYBE_T_CLASS);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional/OptionalKindHelper.java
@@ -68,7 +68,7 @@ public enum OptionalKindHelper implements OptionalConverterOps {
    *     null} or not an instance of {@code OptionalHolder}.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> Optional<A> narrow(@Nullable Kind<OptionalKind.Witness, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, OPTIONAL_CLASS, OptionalHolder.class, OptionalHolder::optional);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/optional_t/OptionalTKindHelper.java
@@ -53,6 +53,7 @@ public enum OptionalTKindHelper implements OptionalTConverterOps {
    *     valid {@link OptionalT} instance.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <F extends WitnessArity<TypeArity.Unary>, A> OptionalT<F, A> narrow(
       @Nullable Kind<OptionalTKind.Witness<F>, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, OPTIONAL_T_CLASS);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader/ReaderKindHelper.java
@@ -76,7 +76,7 @@ public enum ReaderKindHelper implements ReaderConverterOps {
    *     internal {@code reader} is non-null.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <R, A> Reader<R, A> narrow(@Nullable Kind<ReaderKind.Witness<R>, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, READER_CLASS, ReaderHolder.class, ReaderHolder::reader);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/reader_t/ReaderTKindHelper.java
@@ -54,6 +54,7 @@ public enum ReaderTKindHelper implements ReaderTConverterOps {
    *     valid {@link ReaderT} instance.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <F extends WitnessArity<TypeArity.Unary>, R_ENV, A> ReaderT<F, R_ENV, A> narrow(
       @Nullable Kind<ReaderTKind.Witness<F, R_ENV>, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, READER_T_CLASS);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state/StateKindHelper.java
@@ -75,7 +75,7 @@ public enum StateKindHelper implements StateConverterOps {
    *     internal {@code stateInstance} is non-null.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <S, A> State<S, A> narrow(@Nullable Kind<StateKind.Witness<S>, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, STATE_CLASS, StateHolder.class, StateHolder::stateInstance);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKind.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKind.java
@@ -90,6 +90,7 @@ public interface StateTKind<S, F, A> extends Kind<StateTKind.Witness<S, F>, A> {
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code kind} is {@code null} or
    *     not actually an instance of {@link StateT} (or a compatible subtype).
    */
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   static <S, F extends WitnessArity<TypeArity.Unary>, A> StateT<S, F, A> narrow(
       @Nullable Kind<StateTKind.Witness<S, F>, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, StateT.class);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/state_t/StateTKindHelper.java
@@ -59,6 +59,7 @@ public enum StateTKindHelper implements StateTConverterOps {
    *     not a valid {@link StateT} instance.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <S, F extends WitnessArity<TypeArity.Unary>, A> StateT<S, F, A> narrow(
       @Nullable Kind<StateTKind.Witness<S, F>, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, STATE_T_CLASS);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/stream/StreamKindHelper.java
@@ -81,7 +81,7 @@ public enum StreamKindHelper implements StreamConverterOps {
    *     StreamKind representation.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> Stream<A> narrow(@Nullable Kind<StreamKind.Witness, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, STREAM_CLASS, StreamHolder.class, StreamHolder::stream);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trampoline/TrampolineKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trampoline/TrampolineKindHelper.java
@@ -64,7 +64,7 @@ public enum TrampolineKindHelper implements TrampolineConverterOps {
    *     TrampolineHolder} internally contains a {@code null} {@link Trampoline} instance.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> Trampoline<A> narrow(@Nullable Kind<TrampolineKind.Witness, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, TRAMPOLINE_CLASS, TrampolineHolder.class, TrampolineHolder::trampoline);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/TryKindHelper.java
@@ -61,7 +61,7 @@ public enum TryKindHelper implements TryConverterOps {
    *     wrong type or invalid internal state).
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <A> Try<A> narrow(@Nullable Kind<TryKind.Witness, A> kind) {
     return Validation.kind().narrowHolder(kind, TRY_CLASS, TryHolder.class, TryHolder::tryInstance);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStream.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStream.java
@@ -1338,22 +1338,21 @@ public interface VStream<A> extends VStreamKind<A> {
       public VTask<Step<A>> pull() {
         VTask<Step<A>> pullTask = source.pull();
         return pullTask
-            .map(
+            .<Step<A>>map(
                 step ->
-                    (Step<A>)
-                        switch (step) {
-                          case Step.Emit<A> e ->
-                              new Step.Emit<>(
-                                  e.value(), wrapWithFinalizer(e.tail(), finalizer, released));
-                          case Step.Skip<A> s ->
-                              new Step.Skip<>(wrapWithFinalizer(s.tail(), finalizer, released));
-                          case Step.Done<A> _ -> {
-                            if (released.compareAndSet(false, true)) {
-                              finalizer.run();
-                            }
-                            yield new Step.Done<>();
-                          }
-                        })
+                    switch (step) {
+                      case Step.Emit<A> e ->
+                          new Step.Emit<>(
+                              e.value(), wrapWithFinalizer(e.tail(), finalizer, released));
+                      case Step.Skip<A> s ->
+                          new Step.Skip<>(wrapWithFinalizer(s.tail(), finalizer, released));
+                      case Step.Done<A> _ -> {
+                        if (released.compareAndSet(false, true)) {
+                          finalizer.run();
+                        }
+                        yield new Step.Done<A>();
+                      }
+                    })
             .recoverWith(
                 error -> {
                   if (released.compareAndSet(false, true)) {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamKindHelper.java
@@ -56,6 +56,7 @@ public enum VStreamKindHelper implements VStreamConverterOps {
    *     null}, or not an instance of {@code VStream}.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <A> VStream<A> narrow(@Nullable Kind<VStreamKind.Witness, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, VSTREAM_CLASS);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamPar.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vstream/VStreamPar.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.StructuredTaskScope;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.vtask.VTask;
@@ -114,7 +115,7 @@ public final class VStreamPar {
    */
   @SuppressWarnings("preview")
   public static <A, B> VStream<B> parEvalMap(
-      VStream<A> stream, int concurrency, Function<A, VTask<B>> f) {
+      VStream<A> stream, int concurrency, Function<? super A, VTask<B>> f) {
     Objects.requireNonNull(stream, "stream must not be null");
     Objects.requireNonNull(f, "f must not be null");
     if (concurrency <= 0) {
@@ -125,7 +126,7 @@ public final class VStreamPar {
         () -> {
           // Pull up to concurrency elements from source
           List<A> batch = new ArrayList<>(concurrency);
-          VStream<A>[] tailHolder = new VStream[] {stream};
+          AtomicReference<VStream<A>> tailHolder = new AtomicReference<>(stream);
           boolean done = pullBatch(tailHolder, batch, concurrency);
 
           if (batch.isEmpty()) {
@@ -143,7 +144,7 @@ public final class VStreamPar {
           }
 
           // Recursively process remaining elements
-          return batchStream.concat(parEvalMap(tailHolder[0], concurrency, f));
+          return batchStream.concat(parEvalMap(tailHolder.get(), concurrency, f));
         });
   }
 
@@ -169,7 +170,7 @@ public final class VStreamPar {
    */
   @SuppressWarnings("preview")
   public static <A, B> VStream<B> parEvalMapUnordered(
-      VStream<A> stream, int concurrency, Function<A, VTask<B>> f) {
+      VStream<A> stream, int concurrency, Function<? super A, VTask<B>> f) {
     Objects.requireNonNull(stream, "stream must not be null");
     Objects.requireNonNull(f, "f must not be null");
     if (concurrency <= 0) {
@@ -180,7 +181,7 @@ public final class VStreamPar {
         () -> {
           // Pull up to concurrency elements from source
           List<A> batch = new ArrayList<>(concurrency);
-          VStream<A>[] tailHolder = new VStream[] {stream};
+          AtomicReference<VStream<A>> tailHolder = new AtomicReference<>(stream);
           boolean done = pullBatch(tailHolder, batch, concurrency);
 
           if (batch.isEmpty()) {
@@ -197,7 +198,7 @@ public final class VStreamPar {
             return batchStream;
           }
 
-          return batchStream.concat(parEvalMapUnordered(tailHolder[0], concurrency, f));
+          return batchStream.concat(parEvalMapUnordered(tailHolder.get(), concurrency, f));
         });
   }
 
@@ -499,9 +500,9 @@ public final class VStreamPar {
    *
    * @return true if the stream is exhausted (Done), false if more elements remain.
    */
-  @SuppressWarnings("unchecked")
-  private static <A> boolean pullBatch(VStream<A>[] tailHolder, List<A> batch, int count) {
-    VStream<A> current = tailHolder[0];
+  private static <A> boolean pullBatch(
+      AtomicReference<VStream<A>> tailHolder, List<A> batch, int count) {
+    VStream<A> current = tailHolder.get();
     for (int i = 0; i < count; i++) {
       VStream.Step<A> step = current.pull().run();
       switch (step) {
@@ -514,18 +515,19 @@ public final class VStreamPar {
           i--; // Don't count skips
         }
         case VStream.Step.Done<A> _ -> {
-          tailHolder[0] = current;
+          tailHolder.set(current);
           return true;
         }
       }
     }
-    tailHolder[0] = current;
+    tailHolder.set(current);
     return false;
   }
 
   /** Processes a batch of elements in parallel using StructuredTaskScope, preserving order. */
   @SuppressWarnings("preview")
-  private static <A, B> VTask<List<B>> processBatchOrdered(List<A> batch, Function<A, VTask<B>> f) {
+  private static <A, B> VTask<List<B>> processBatchOrdered(
+      List<A> batch, Function<? super A, VTask<B>> f) {
     return VTask.of(
         () -> {
           try (var scope = StructuredTaskScope.open()) {
@@ -559,7 +561,7 @@ public final class VStreamPar {
    */
   @SuppressWarnings("preview")
   private static <A, B> VTask<List<B>> processBatchUnordered(
-      List<A> batch, Function<A, VTask<B>> f) {
+      List<A> batch, Function<? super A, VTask<B>> f) {
     return VTask.of(
         () -> {
           try (var scope = StructuredTaskScope.open()) {

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/Resource.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/Resource.java
@@ -9,6 +9,7 @@ import static org.higherkindedj.hkt.util.validation.Operation.MAP;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.higherkindedj.hkt.util.validation.Validation;
@@ -241,20 +242,18 @@ public final class Resource<A> {
     Validation.function().require(f, "f", FLAT_MAP);
 
     // Holders to capture the outer resource and inner release for proper cleanup
-    @SuppressWarnings("unchecked")
-    Object[] outerHolder = new Object[1];
-    @SuppressWarnings("unchecked")
-    Consumer<B>[] innerReleaseHolder = new Consumer[1];
+    AtomicReference<A> outerHolder = new AtomicReference<>();
+    AtomicReference<Consumer<B>> innerReleaseHolder = new AtomicReference<>();
 
     return new Resource<>(
         () -> {
           A a = acquire.call();
-          outerHolder[0] = a;
+          outerHolder.set(a);
           try {
             Resource<B> resourceB = f.apply(a);
             Objects.requireNonNull(
                 resourceB, "f returned null in Resource.flatMap, which is not allowed");
-            innerReleaseHolder[0] = resourceB.release;
+            innerReleaseHolder.set(resourceB.release);
             return resourceB.acquire.call();
           } catch (Throwable t) {
             // If acquiring B fails, release A
@@ -270,17 +269,16 @@ public final class Resource<A> {
           Throwable firstException = null;
 
           // Release inner resource (B) first
-          // innerReleaseHolder[0] is always set before acquire returns successfully,
+          // innerReleaseHolder is always set before acquire returns successfully,
           // so it is guaranteed non-null when this release lambda is called.
           try {
-            innerReleaseHolder[0].accept(b);
+            innerReleaseHolder.get().accept(b);
           } catch (Throwable t) {
             firstException = t;
           }
 
           // Release outer resource (A) second
-          @SuppressWarnings("unchecked")
-          A a = (A) outerHolder[0];
+          A a = outerHolder.get();
           if (a != null) {
             try {
               release.accept(a);

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/VTaskKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/vtask/VTaskKindHelper.java
@@ -60,6 +60,7 @@ public enum VTaskKindHelper implements VTaskConverterOps {
    *     null}, or not an instance of {@code VTask}.
    */
   @Override
+  @SuppressWarnings("unchecked") // raw Class token; runtime-checked via Class.isInstance
   public <A> VTask<A> narrow(@Nullable Kind<VTaskKind.Witness, A> kind) {
     return Validation.kind().narrowWithTypeCheck(kind, VTASK_CLASS);
   }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/writer/WriterKindHelper.java
@@ -86,7 +86,7 @@ public enum WriterKindHelper implements WriterConverterOps {
    *     internal {@code writer} is non-null.
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"}) // raw holder Class token; runtime-checked
   public <W, A> Writer<W, A> narrow(@Nullable Kind<WriterKind.Witness<W>, A> kind) {
     return Validation.kind()
         .narrowHolder(kind, WRITER_CLASS, WriterHolder.class, WriterHolder::writer);

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/reader/ReaderTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/reader/ReaderTest.java
@@ -754,18 +754,17 @@ class ReaderTest extends ReaderTestBase {
 
     @Test
     @DisplayName("Reader instances are lightweight")
-    @SuppressWarnings("unchecked") // generic array of Readers
     void readerInstancesAreLightweight() {
       // Creating many readers should not cause issues
-      Reader<TestConfig, String>[] readers = new Reader[1000];
-      for (int i = 0; i < readers.length; i++) {
+      List<Reader<TestConfig, String>> readers = new ArrayList<>();
+      for (int i = 0; i < 1000; i++) {
         final int index = i;
-        readers[i] = Reader.of(cfg -> cfg.url() + ":" + index);
+        readers.add(Reader.of(cfg -> cfg.url() + ":" + index));
       }
 
       // All should work correctly
-      for (int i = 0; i < readers.length; i++) {
-        assertThatReader(readers[i]).whenRunWith(TEST_CONFIG).produces(DEFAULT_URL + ":" + i);
+      for (int i = 0; i < readers.size(); i++) {
+        assertThatReader(readers.get(i)).whenRunWith(TEST_CONFIG).produces(DEFAULT_URL + ":" + i);
       }
     }
 

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/MonoidLawsTestFactory.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/MonoidLawsTestFactory.java
@@ -107,19 +107,18 @@ class MonoidLawsTestFactory {
         .map(
             data ->
                 DynamicTest.dynamicTest(
-                    data.name() + " satisfies left identity",
-                    () -> {
-                      Monoid<Object> monoid = (Monoid<Object>) data.monoid();
-                      Object testValue = data.testValue1();
+                    data.name() + " satisfies left identity", () -> assertLeftIdentity(data)));
+  }
 
-                      Object result = monoid.combine(monoid.empty(), testValue);
+  private static <T> void assertLeftIdentity(MonoidTestData<T> data) {
+    Monoid<T> monoid = data.monoid();
+    T testValue = data.testValue1();
 
-                      assertThat(result)
-                          .as(
-                              "Left identity law failed for %s: combine(empty, %s)",
-                              data.name(), testValue)
-                          .isEqualTo(testValue);
-                    }));
+    T result = monoid.combine(monoid.empty(), testValue);
+
+    assertThat(result)
+        .as("Left identity law failed for %s: combine(empty, %s)", data.name(), testValue)
+        .isEqualTo(testValue);
   }
 
   /**
@@ -135,19 +134,18 @@ class MonoidLawsTestFactory {
         .map(
             data ->
                 DynamicTest.dynamicTest(
-                    data.name() + " satisfies right identity",
-                    () -> {
-                      Monoid<Object> monoid = (Monoid<Object>) data.monoid();
-                      Object testValue = data.testValue1();
+                    data.name() + " satisfies right identity", () -> assertRightIdentity(data)));
+  }
 
-                      Object result = monoid.combine(testValue, monoid.empty());
+  private static <T> void assertRightIdentity(MonoidTestData<T> data) {
+    Monoid<T> monoid = data.monoid();
+    T testValue = data.testValue1();
 
-                      assertThat(result)
-                          .as(
-                              "Right identity law failed for %s: combine(%s, empty)",
-                              data.name(), testValue)
-                          .isEqualTo(testValue);
-                    }));
+    T result = monoid.combine(testValue, monoid.empty());
+
+    assertThat(result)
+        .as("Right identity law failed for %s: combine(%s, empty)", data.name(), testValue)
+        .isEqualTo(testValue);
   }
 
   /**
@@ -170,24 +168,25 @@ class MonoidLawsTestFactory {
 
               return Stream.of(
                   DynamicTest.dynamicTest(
-                      data.name() + " satisfies associativity",
-                      () -> {
-                        Monoid<Object> monoid = (Monoid<Object>) data.monoid();
-                        Object a = data.testValue1();
-                        Object b = data.testValue2();
-                        Object c = data.testValue3();
-
-                        Object leftAssoc = monoid.combine(monoid.combine(a, b), c);
-                        Object rightAssoc = monoid.combine(a, monoid.combine(b, c));
-
-                        assertThat(leftAssoc)
-                            .as(
-                                "Associativity law failed for %s: left=%s, right=%s",
-                                data.name(), leftAssoc, rightAssoc)
-                            .isEqualTo(rightAssoc)
-                            .isEqualTo(data.expectedAssociativeResult());
-                      }));
+                      data.name() + " satisfies associativity", () -> assertAssociativity(data)));
             });
+  }
+
+  private static <T> void assertAssociativity(MonoidTestData<T> data) {
+    Monoid<T> monoid = data.monoid();
+    T a = data.testValue1();
+    T b = data.testValue2();
+    T c = data.testValue3();
+
+    T leftAssoc = monoid.combine(monoid.combine(a, b), c);
+    T rightAssoc = monoid.combine(a, monoid.combine(b, c));
+
+    assertThat(leftAssoc)
+        .as(
+            "Associativity law failed for %s: left=%s, right=%s",
+            data.name(), leftAssoc, rightAssoc)
+        .isEqualTo(rightAssoc)
+        .isEqualTo(data.expectedAssociativeResult());
   }
 
   /**
@@ -199,30 +198,29 @@ class MonoidLawsTestFactory {
   @TestFactory
   @DisplayName("Empty element is a true identity for multiple values")
   Stream<DynamicTest> emptyIsIdentityWithMultipleValues() {
-    return allMonoids()
-        .flatMap(
-            data -> {
-              Monoid<Object> monoid = (Monoid<Object>) data.monoid();
-              List<Object> testValues =
-                  List.of(data.testValue1(), data.testValue2(), data.testValue3());
+    return allMonoids().flatMap(data -> emptyIdentityTests(data));
+  }
 
-              return testValues.stream()
-                  .map(
-                      value ->
-                          DynamicTest.dynamicTest(
-                              String.format("%s: empty is identity for %s", data.name(), value),
-                              () -> {
-                                Object leftResult = monoid.combine(monoid.empty(), value);
-                                Object rightResult = monoid.combine(value, monoid.empty());
+  private static <T> Stream<DynamicTest> emptyIdentityTests(MonoidTestData<T> data) {
+    Monoid<T> monoid = data.monoid();
+    List<T> testValues = List.of(data.testValue1(), data.testValue2(), data.testValue3());
 
-                                assertThat(leftResult)
-                                    .as("Left identity failed for value: %s", value)
-                                    .isEqualTo(value);
-                                assertThat(rightResult)
-                                    .as("Right identity failed for value: %s", value)
-                                    .isEqualTo(value);
-                              }));
-            });
+    return testValues.stream()
+        .map(
+            value ->
+                DynamicTest.dynamicTest(
+                    String.format("%s: empty is identity for %s", data.name(), value),
+                    () -> {
+                      T leftResult = monoid.combine(monoid.empty(), value);
+                      T rightResult = monoid.combine(value, monoid.empty());
+
+                      assertThat(leftResult)
+                          .as("Left identity failed for value: %s", value)
+                          .isEqualTo(value);
+                      assertThat(rightResult)
+                          .as("Right identity failed for value: %s", value)
+                          .isEqualTo(value);
+                    }));
   }
 
   /**
@@ -246,15 +244,15 @@ class MonoidLawsTestFactory {
             data ->
                 DynamicTest.dynamicTest(
                     data.name() + " is idempotent: combine(x, x) = x",
-                    () -> {
-                      Monoid<Object> monoid = (Monoid<Object>) data.monoid();
-                      Object testValue = data.testValue1();
+                    () -> assertIdempotence(data)));
+  }
 
-                      Object result = monoid.combine(testValue, testValue);
+  private static <T> void assertIdempotence(MonoidTestData<T> data) {
+    Monoid<T> monoid = data.monoid();
+    T testValue = data.testValue1();
 
-                      assertThat(result)
-                          .as("Idempotence failed for %s", data.name())
-                          .isEqualTo(testValue);
-                    }));
+    T result = monoid.combine(testValue, testValue);
+
+    assertThat(result).as("Idempotence failed for %s", data.name()).isEqualTo(testValue);
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/KindValidatorTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/util/validation/KindValidatorTest.java
@@ -120,6 +120,7 @@ class KindValidatorTest {
 
     @Test
     @DisplayName("should preserve narrowing for different types")
+    @SuppressWarnings("unchecked") // typed class literal for narrow
     void shouldPreserveNarrowingForDifferentTypes() {
       var maybeInt = Maybe.just(42);
       var kindInt = MAYBE.widen(maybeInt);
@@ -829,6 +830,7 @@ class KindValidatorTest {
 
     @Test
     @DisplayName("should validate complete narrow-widen cycle")
+    @SuppressWarnings("unchecked") // raw Either.class keeps the validation chain unchecked
     void shouldValidateCompleteNarrowWidenCycle() {
       // Create original
       var original = Either.<String, Integer>right(42);
@@ -845,7 +847,6 @@ class KindValidatorTest {
       assertThat(validatedKind).isEqualTo(widened);
 
       // Narrow
-      @SuppressWarnings("unchecked")
       var narrowed =
           Validation.kind()
               .<EitherKind.Witness<String>, Integer, Either<String, Integer>>narrow(
@@ -859,6 +860,7 @@ class KindValidatorTest {
 
     @Test
     @DisplayName("should handle validation chain with multiple operations")
+    @SuppressWarnings("unchecked") // raw Either.class keeps the validation chain unchecked
     void shouldHandleValidationChainWithMultipleOperations() {
       var either = Either.<String, String>right("test");
 
@@ -901,6 +903,7 @@ class KindValidatorTest {
 
     @Test
     @DisplayName("should handle concurrent validation requests")
+    @SuppressWarnings("unchecked") // raw Either.class keeps the validation chain unchecked
     void shouldHandleConcurrentValidationRequests() throws InterruptedException {
       int threadCount = 10;
       CountDownLatch startLatch = new CountDownLatch(1);
@@ -948,15 +951,14 @@ class KindValidatorTest {
                   i ->
                       CompletableFuture.supplyAsync(
                           () -> new KindValidator.KindContext(Either.class, "narrow")))
-              .toArray(CompletableFuture[]::new);
+              .toArray(CompletableFuture<?>[]::new);
 
       CompletableFuture.allOf(futures).join();
 
       // All contexts should be equal
-      var first = ((CompletableFuture<KindValidator.KindContext>) futures[0]).join();
+      var first = futures[0].join();
       for (var future : futures) {
-        @SuppressWarnings("unchecked")
-        var context = ((CompletableFuture<KindValidator.KindContext>) future).join();
+        var context = future.join();
         assertThat(context).isEqualTo(first);
       }
     }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/basic/alternative/AlternativeConfigExample.java
@@ -68,6 +68,7 @@ public class AlternativeConfigExample {
   }
 
   /** Demonstrates orElseAll() for chaining multiple sources. */
+  @SuppressWarnings("unchecked") // orElseAll varargs; @SafeVarargs not allowed on default methods
   private static void demonstrateOrElseChain() {
     System.out.println("2. orElseAll() - Multiple Fallback Sources");
     System.out.println("------------------------------------------");
@@ -213,6 +214,7 @@ public class AlternativeConfigExample {
   }
 
   /** Tries to parse input as boolean, then as integer, then returns original string. */
+  @SuppressWarnings("unchecked") // orElseAll varargs; @SafeVarargs not allowed on default methods
   private static Maybe<String> parseValue(String input) {
     Kind<MaybeKind.Witness, String> result =
         alt.orElseAll(

--- a/hkj-examples/src/main/java/org/higherkindedj/example/free/ConsoleProgram.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/free/ConsoleProgram.java
@@ -108,6 +108,7 @@ public class ConsoleProgram {
     private static final ConsoleOpKindHelper CONSOLE = ConsoleOpKindHelper.CONSOLE;
 
     @Override
+    @SuppressWarnings("unchecked") // simplified example DSL: map returns the operation unchanged
     public <A, B> Kind<ConsoleOpKind.Witness, B> map(
         Function<? super A, ? extends B> f, Kind<ConsoleOpKind.Witness, A> fa) {
       ConsoleOp<A> op = CONSOLE.narrow(fa);
@@ -127,8 +128,7 @@ public class ConsoleProgram {
       // and must return Kind<IO.Witness, Free<ConsoleOp.Witness, X>>
       Function<Kind<ConsoleOpKind.Witness, ?>, Kind<IOKind.Witness, ?>> transform =
           kind -> {
-            ConsoleOp<?> op =
-                ConsoleOpKindHelper.CONSOLE.narrow((Kind<ConsoleOpKind.Witness, Object>) kind);
+            ConsoleOp<?> op = ConsoleOpKindHelper.CONSOLE.narrow(kind);
             // Execute the instruction IMMEDIATELY and wrap the result in Free.pure
             // NOTE: Side effects happen here during interpretation, not deferred.
             // This is why we use a simple IO wrapper instead of the lazy core IO type.
@@ -168,8 +168,7 @@ public class ConsoleProgram {
       // and must return Kind<TestResult.Witness, Free<ConsoleOp.Witness, X>>
       Function<Kind<ConsoleOpKind.Witness, ?>, Kind<TestResultKind.Witness, ?>> transform =
           kind -> {
-            ConsoleOp<?> op =
-                ConsoleOpKindHelper.CONSOLE.narrow((Kind<ConsoleOpKind.Witness, Object>) kind);
+            ConsoleOp<?> op = ConsoleOpKindHelper.CONSOLE.narrow(kind);
             // Execute the instruction and wrap the result in Free.pure
             Free<ConsoleOpKind.Witness, ?> freeResult =
                 switch (op) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessor.java
@@ -168,6 +168,10 @@ public class ComposeEffectsProcessor extends AbstractProcessor {
         TypeSpec.classBuilder(supportName)
             .addAnnotation(NULL_MARKED)
             .addAnnotation(GENERATED)
+            .addAnnotation(
+                AnnotationSpec.builder(SuppressWarnings.class)
+                    .addMember("value", "{$S, $S}", "unchecked", "rawtypes")
+                    .build()) // generated dispatch code performs witness-erased casts
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedOpticLawsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedOpticLawsTest.java
@@ -460,7 +460,7 @@ class GeneratedOpticLawsTest {
           () -> {
             Object prism = compiled.invokeStatic(TEST_PACKAGE + ".OrderStatusPrisms", prismMethod);
             Class<?> enumClass = compiled.loadClass("org.higherkindedj.test.OrderStatus");
-            Object value = Enum.valueOf(enumClass.asSubclass(Enum.class), enumConstant);
+            Object value = enumValueOf(enumClass, enumConstant);
 
             Object built = compiled.invokePrismBuild(prism, value);
             Optional<Object> extracted = compiled.invokePrismGetOptional(prism, built);
@@ -479,7 +479,7 @@ class GeneratedOpticLawsTest {
           () -> {
             Object prism = compiled.invokeStatic(TEST_PACKAGE + ".OrderStatusPrisms", prismMethod);
             Class<?> enumClass = compiled.loadClass("org.higherkindedj.test.OrderStatus");
-            Object source = Enum.valueOf(enumClass.asSubclass(Enum.class), enumConstant);
+            Object source = enumValueOf(enumClass, enumConstant);
 
             Optional<Object> extracted = compiled.invokePrismGetOptional(prism, source);
             Object result = extracted.map(v -> invokePrismBuildSafe(prism, v)).orElse(source);
@@ -496,6 +496,16 @@ class GeneratedOpticLawsTest {
       } catch (ReflectiveOperationException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    /** Looks up an enum constant by name on a reflectively loaded enum class. */
+    private static Object enumValueOf(Class<?> enumClass, String name) {
+      for (Object constant : enumClass.getEnumConstants()) {
+        if (((Enum<?>) constant).name().equals(name)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("No enum constant " + enumClass.getName() + "." + name);
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/actuator/HkjMetricsEndpointTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/actuator/HkjMetricsEndpointTest.java
@@ -29,6 +29,12 @@ class HkjMetricsEndpointTest {
     endpoint = new HkjMetricsEndpoint(properties, metricsService);
   }
 
+  /** Narrows a section of the endpoint payload, which is built as nested string-keyed maps. */
+  @SuppressWarnings("unchecked") // endpoint payload is nested Map<String, Object> by construction
+  private static Map<String, Object> section(Map<String, Object> parent, String key) {
+    return (Map<String, Object>) parent.get(key);
+  }
+
   @Nested
   @DisplayName("Configuration Section Tests")
   class ConfigurationSectionTests {
@@ -39,10 +45,10 @@ class HkjMetricsEndpointTest {
       Map<String, Object> result = endpoint.hkjMetrics();
 
       assertThat(result).containsKey("configuration");
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
       assertThat(config).containsKey("web");
 
-      Map<String, Object> web = (Map<String, Object>) config.get("web");
+      Map<String, Object> web = section(config, "web");
       assertThat(web.get("eitherPathEnabled")).isEqualTo(true);
       assertThat(web.get("maybePathEnabled")).isEqualTo(true);
       assertThat(web.get("tryPathEnabled")).isEqualTo(true);
@@ -64,8 +70,8 @@ class HkjMetricsEndpointTest {
       properties.getWeb().setDefaultErrorStatus(500);
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
-      Map<String, Object> web = (Map<String, Object>) config.get("web");
+      Map<String, Object> config = section(result, "configuration");
+      Map<String, Object> web = section(config, "web");
 
       assertThat(web.get("eitherPathEnabled")).isEqualTo(false);
       assertThat(web.get("maybePathEnabled")).isEqualTo(false);
@@ -81,10 +87,10 @@ class HkjMetricsEndpointTest {
     void shouldIncludeJacksonConfigurationWithDefaults() {
       Map<String, Object> result = endpoint.hkjMetrics();
 
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
       assertThat(config).containsKey("jackson");
 
-      Map<String, Object> jackson = (Map<String, Object>) config.get("jackson");
+      Map<String, Object> jackson = section(config, "jackson");
       assertThat(jackson.get("customSerializersEnabled")).isEqualTo(true);
       assertThat(jackson.get("eitherFormat")).isEqualTo("TAGGED");
       assertThat(jackson.get("validatedFormat")).isEqualTo("TAGGED");
@@ -100,8 +106,8 @@ class HkjMetricsEndpointTest {
       properties.getJson().setMaybeFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
-      Map<String, Object> jackson = (Map<String, Object>) config.get("jackson");
+      Map<String, Object> config = section(result, "configuration");
+      Map<String, Object> jackson = section(config, "jackson");
 
       assertThat(jackson.get("customSerializersEnabled")).isEqualTo(false);
       assertThat(jackson.get("eitherFormat")).isEqualTo("SIMPLE");
@@ -115,7 +121,7 @@ class HkjMetricsEndpointTest {
       Map<String, Object> result = endpoint.hkjMetrics();
 
       assertThat(result).containsKeys("configuration");
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
       assertThat(config).containsKeys("web", "jackson");
     }
   }
@@ -129,8 +135,8 @@ class HkjMetricsEndpointTest {
     void shouldReportEitherMetricsWithZeroCounts() {
       Map<String, Object> result = endpoint.hkjMetrics();
 
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       assertThat(either.get("successCount")).isEqualTo(0L);
       assertThat(either.get("errorCount")).isEqualTo(0L);
@@ -146,8 +152,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherSuccess();
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       assertThat(either.get("successCount")).isEqualTo(3L);
       assertThat(either.get("errorCount")).isEqualTo(0L);
@@ -162,8 +168,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherError("Error2");
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       assertThat(either.get("successCount")).isEqualTo(0L);
       assertThat(either.get("errorCount")).isEqualTo(2L);
@@ -183,8 +189,8 @@ class HkjMetricsEndpointTest {
       }
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       assertThat(either.get("successCount")).isEqualTo(7L);
       assertThat(either.get("errorCount")).isEqualTo(3L);
@@ -203,8 +209,8 @@ class HkjMetricsEndpointTest {
       }
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       assertThat(either.get("successCount")).isEqualTo(1000L);
       assertThat(either.get("errorCount")).isEqualTo(500L);
@@ -222,8 +228,8 @@ class HkjMetricsEndpointTest {
     void shouldReportValidatedMetricsWithZeroCounts() {
       Map<String, Object> result = endpoint.hkjMetrics();
 
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> validated = section(metrics, "validated");
 
       assertThat(validated.get("validCount")).isEqualTo(0L);
       assertThat(validated.get("invalidCount")).isEqualTo(0L);
@@ -240,8 +246,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordValidatedValid();
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> validated = section(metrics, "validated");
 
       assertThat(validated.get("validCount")).isEqualTo(4L);
       assertThat(validated.get("invalidCount")).isEqualTo(0L);
@@ -256,8 +262,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordValidatedInvalid(3);
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> validated = section(metrics, "validated");
 
       assertThat(validated.get("validCount")).isEqualTo(0L);
       assertThat(validated.get("invalidCount")).isEqualTo(2L);
@@ -277,8 +283,8 @@ class HkjMetricsEndpointTest {
       }
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> validated = section(metrics, "validated");
 
       assertThat(validated.get("validCount")).isEqualTo(8L);
       assertThat(validated.get("invalidCount")).isEqualTo(2L);
@@ -297,8 +303,8 @@ class HkjMetricsEndpointTest {
       }
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> validated = section(metrics, "validated");
 
       assertThat(validated.get("validCount")).isEqualTo(750L);
       assertThat(validated.get("invalidCount")).isEqualTo(250L);
@@ -316,8 +322,8 @@ class HkjMetricsEndpointTest {
     void shouldReportEitherTMetricsWithZeroCounts() {
       Map<String, Object> result = endpoint.hkjMetrics();
 
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
 
       assertThat(eitherT.get("successCount")).isEqualTo(0L);
       assertThat(eitherT.get("errorCount")).isEqualTo(0L);
@@ -332,8 +338,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherTSuccess();
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
 
       assertThat(eitherT.get("successCount")).isEqualTo(2L);
       assertThat(eitherT.get("errorCount")).isEqualTo(0L);
@@ -349,8 +355,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherTError("AsyncError3");
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
 
       assertThat(eitherT.get("successCount")).isEqualTo(0L);
       assertThat(eitherT.get("errorCount")).isEqualTo(3L);
@@ -368,8 +374,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherTError("Error");
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
 
       assertThat(eitherT.get("successCount")).isEqualTo(9L);
       assertThat(eitherT.get("errorCount")).isEqualTo(1L);
@@ -388,8 +394,8 @@ class HkjMetricsEndpointTest {
       }
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
 
       assertThat(eitherT.get("successCount")).isEqualTo(850L);
       assertThat(eitherT.get("errorCount")).isEqualTo(150L);
@@ -410,7 +416,7 @@ class HkjMetricsEndpointTest {
       Map<String, Object> result = endpoint.hkjMetrics();
 
       assertThat(result).containsKey("metrics");
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
       assertThat(metrics).containsEntry("enabled", false);
       assertThat(metrics).doesNotContainKeys("either", "validated", "eitherT");
     }
@@ -423,7 +429,7 @@ class HkjMetricsEndpointTest {
       Map<String, Object> result = endpoint.hkjMetrics();
 
       assertThat(result).containsKey("configuration");
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
       assertThat(config).containsKeys("web", "jackson");
     }
   }
@@ -454,27 +460,27 @@ class HkjMetricsEndpointTest {
       assertThat(result).containsKeys("configuration", "metrics");
 
       // Verify configuration
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
       assertThat(config).containsKeys("web", "jackson");
 
       // Verify metrics
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
       assertThat(metrics).containsKeys("either", "validated", "eitherT");
 
       // Verify Either metrics
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> either = section(metrics, "either");
       assertThat(either.get("successCount")).isEqualTo(2L);
       assertThat(either.get("errorCount")).isEqualTo(1L);
       assertThat(either.get("totalCount")).isEqualTo(3L);
 
       // Verify Validated metrics
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> validated = section(metrics, "validated");
       assertThat(validated.get("validCount")).isEqualTo(3L);
       assertThat(validated.get("invalidCount")).isEqualTo(1L);
       assertThat(validated.get("totalCount")).isEqualTo(4L);
 
       // Verify EitherT metrics
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
       assertThat(eitherT.get("successCount")).isEqualTo(1L);
       assertThat(eitherT.get("errorCount")).isEqualTo(1L);
       assertThat(eitherT.get("totalCount")).isEqualTo(2L);
@@ -485,17 +491,17 @@ class HkjMetricsEndpointTest {
     void shouldHandleAllMetricsAtZero() {
       Map<String, Object> result = endpoint.hkjMetrics();
 
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
 
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> either = section(metrics, "either");
       assertThat(either.get("totalCount")).isEqualTo(0L);
       assertThat(either.get("successRate")).isEqualTo(0.0);
 
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> validated = section(metrics, "validated");
       assertThat(validated.get("totalCount")).isEqualTo(0L);
       assertThat(validated.get("validRate")).isEqualTo(0.0);
 
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
       assertThat(eitherT.get("totalCount")).isEqualTo(0L);
       assertThat(eitherT.get("successRate")).isEqualTo(0.0);
     }
@@ -508,18 +514,18 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherSuccess();
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
 
       // Either should have counts
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> either = section(metrics, "either");
       assertThat(either.get("totalCount")).isEqualTo(2L);
 
       // Validated should be zero
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> validated = section(metrics, "validated");
       assertThat(validated.get("totalCount")).isEqualTo(0L);
 
       // EitherT should be zero
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
       assertThat(eitherT.get("totalCount")).isEqualTo(0L);
     }
 
@@ -531,12 +537,12 @@ class HkjMetricsEndpointTest {
       properties.getJson().setEitherFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
 
-      Map<String, Object> web = (Map<String, Object>) config.get("web");
+      Map<String, Object> web = section(config, "web");
       assertThat(web.get("defaultErrorStatus")).isEqualTo(422);
 
-      Map<String, Object> jackson = (Map<String, Object>) config.get("jackson");
+      Map<String, Object> jackson = section(config, "jackson");
       assertThat(jackson.get("eitherFormat")).isEqualTo("SIMPLE");
     }
 
@@ -560,15 +566,15 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherTError("Error");
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
 
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> either = section(metrics, "either");
       assertThat((double) either.get("successRate")).isCloseTo(0.5, within(0.001));
 
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> validated = section(metrics, "validated");
       assertThat((double) validated.get("validRate")).isCloseTo(0.25, within(0.001));
 
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
       assertThat((double) eitherT.get("successRate")).isCloseTo(0.75, within(0.001));
     }
   }
@@ -581,16 +587,16 @@ class HkjMetricsEndpointTest {
     @DisplayName("Should handle division by zero for success rates")
     void shouldHandleDivisionByZeroForSuccessRates() {
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
 
       // All rates should be 0.0, not NaN or Infinity
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> either = section(metrics, "either");
       assertThat(either.get("successRate")).isEqualTo(0.0);
 
-      Map<String, Object> validated = (Map<String, Object>) metrics.get("validated");
+      Map<String, Object> validated = section(metrics, "validated");
       assertThat(validated.get("validRate")).isEqualTo(0.0);
 
-      Map<String, Object> eitherT = (Map<String, Object>) metrics.get("eitherT");
+      Map<String, Object> eitherT = section(metrics, "eitherT");
       assertThat(eitherT.get("successRate")).isEqualTo(0.0);
     }
 
@@ -600,8 +606,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherSuccess();
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       assertThat(either.get("successCount")).isInstanceOf(Long.class);
       assertThat(either.get("errorCount")).isInstanceOf(Long.class);
@@ -617,14 +623,14 @@ class HkjMetricsEndpointTest {
       // Top level should have configuration before metrics
       assertThat(result.keySet()).containsExactly("configuration", "metrics");
 
-      Map<String, Object> config = (Map<String, Object>) result.get("configuration");
+      Map<String, Object> config = section(result, "configuration");
       assertThat(config.keySet()).containsExactly("web", "jackson");
 
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
+      Map<String, Object> metrics = section(result, "metrics");
       assertThat(metrics.keySet())
           .containsExactly("either", "validated", "eitherT", "vtask", "vstream");
 
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> either = section(metrics, "either");
       assertThat(either.keySet())
           .containsExactly("successCount", "errorCount", "totalCount", "successRate");
     }
@@ -638,8 +644,8 @@ class HkjMetricsEndpointTest {
       metricsService.recordEitherError("Error2");
 
       Map<String, Object> result = endpoint.hkjMetrics();
-      Map<String, Object> metrics = (Map<String, Object>) result.get("metrics");
-      Map<String, Object> either = (Map<String, Object>) metrics.get("either");
+      Map<String, Object> metrics = section(result, "metrics");
+      Map<String, Object> either = section(metrics, "either");
 
       double successRate = (double) either.get("successRate");
       assertThat(successRate).isCloseTo(0.3333, within(0.001));

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandlerTest.java
@@ -4,7 +4,7 @@ package org.higherkindedj.spring.web.returnvalue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.time.Duration;
 import java.util.Map;
@@ -73,7 +73,7 @@ class CompletableFuturePathReturnValueHandlerTest {
     @Test
     @DisplayName("Should support CompletableFuturePath return type")
     void shouldSupportCompletableFuturePathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) CompletableFuturePath.class);
+      doReturn(CompletableFuturePath.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 
@@ -83,7 +83,7 @@ class CompletableFuturePathReturnValueHandlerTest {
     @Test
     @DisplayName("Should not support non-CompletableFuturePath return type")
     void shouldNotSupportNonCompletableFuturePathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) String.class);
+      doReturn(String.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandlerTest.java
@@ -69,7 +69,7 @@ class EitherPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should support EitherPath return type")
     void shouldSupportEitherPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) EitherPath.class);
+      doReturn(EitherPath.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 
@@ -79,7 +79,7 @@ class EitherPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should not support non-EitherPath return type")
     void shouldNotSupportNonEitherPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) String.class);
+      doReturn(String.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandlerTest.java
@@ -67,7 +67,7 @@ class IOPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should support IOPath return type")
     void shouldSupportIOPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) IOPath.class);
+      doReturn(IOPath.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 
@@ -77,7 +77,7 @@ class IOPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should not support non-IOPath return type")
     void shouldNotSupportNonIOPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) String.class);
+      doReturn(String.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandlerTest.java
@@ -67,7 +67,7 @@ class MaybePathReturnValueHandlerTest {
     @Test
     @DisplayName("Should support MaybePath return type")
     void shouldSupportMaybePathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) MaybePath.class);
+      doReturn(MaybePath.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 
@@ -77,7 +77,7 @@ class MaybePathReturnValueHandlerTest {
     @Test
     @DisplayName("Should not support non-MaybePath return type")
     void shouldNotSupportNonMaybePathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) String.class);
+      doReturn(String.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandlerTest.java
@@ -67,7 +67,7 @@ class TryPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should support TryPath return type")
     void shouldSupportTryPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) TryPath.class);
+      doReturn(TryPath.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 
@@ -77,7 +77,7 @@ class TryPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should not support non-TryPath return type")
     void shouldNotSupportNonTryPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) String.class);
+      doReturn(String.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandlerTest.java
@@ -68,7 +68,7 @@ class ValidationPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should support ValidationPath return type")
     void shouldSupportValidationPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) ValidationPath.class);
+      doReturn(ValidationPath.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 
@@ -78,7 +78,7 @@ class ValidationPathReturnValueHandlerTest {
     @Test
     @DisplayName("Should not support non-ValidationPath return type")
     void shouldNotSupportNonValidationPathReturnType() {
-      when(returnType.getParameterType()).thenReturn((Class) String.class);
+      doReturn(String.class).when(returnType).getParameterType();
 
       boolean result = handler.supportsReturnType(returnType);
 


### PR DESCRIPTION
Closes #560.

## What

Two parts, as scoped in the issue:

**1. Harvest the zero-cost cast eliminations** — casts the type system can already express, removed with no suppression:
- `VStreamPar.parEvalMap` / `parEvalMapUnordered` now accept `Function<? super A, VTask<B>>`, deleting the double casts in `DefaultVStreamPath` (binary-compatible widening; the public `VStreamPath` interface already declared `? super A`).
- `CompletableFuturePath.zipWith3` and `ValidationPath.zipWith3Accum` pair intermediate values with `Tuple2` instead of `Object[]`, so the element casts vanish.
- `Resource.flatMap` and `VStreamPar.pullBatch` hold state in `AtomicReference` instead of raw one-element arrays.
- `VStream`'s finalizer wrapping types its `map` call explicitly (`.<Step<A>>map(...)`) instead of casting the whole switch.

**2. Turn on the ratchet** — `-Xlint:unchecked,rawtypes -Werror` across all modules, so any new unchecked or raw-type use fails the build unless it carries an explicit, justified `@SuppressWarnings`.

Enabling the flag surfaced previously-invisible warnings. These were resolved by **fixing properly where trivial** (e.g. binding the wildcard in a generic helper in `MonoidLawsTestFactory`, mockito `doReturn` style in the spring handler tests, a warning-free `enumValueOf` in `GeneratedOpticLawsTest`) and **suppressing where the operation is deliberate and runtime-checked** — notably the `KindHelper` narrow methods, whose raw `Class` tokens are validated via `Class.isInstance` before the cast. All suppressions use the repo's single-line trailing style with a justification.

**Generated code:** `@ComposeEffects` Support classes now emit `@SuppressWarnings({"unchecked", "rawtypes"})`, so downstream projects compiling generated sources with lint enabled stay warning-free.

## Scope of change

Purely internal — no behaviour change, no public API change. The one signature touched (`VStreamPar`, package-internal substrate) is a binary-compatible widening.

## Verification

- Full `gradle build` — **BUILD SUCCESSFUL**, all module tests green (hkj-spring autoconfigure: 102/102).
- hkj-core **JaCoCo byte-identical to `main`** (verified against a clean `main` worktree; the lone uncovered `MonadError.recoverWith` default is a pre-existing gap on `main`, unrelated to this change).
- `spotlessCheck` clean.

## Note

`@SafeVarargs` on `Alternative.orElseAll` (mentioned in the issue) is **not legal** — it is a `default` interface method, and `@SafeVarargs` is permitted only on `static`/`final`/`private` methods. The two example call sites carry a justified call-site suppression instead.


