### PR TITLE
refactor(hkt): root data types extend their Kind interfaces — cast-free widen (#561)

### DIFF
--- a/hkj-book/src/hkts/lifting_the_hood.md
+++ b/hkj-book/src/hkts/lifting_the_hood.md
@@ -68,7 +68,9 @@ What actually happens at the bytecode level:
 
 There is no allocation. The same `Right(10)` object that we created on the first line is the object that lives inside the `Kind`. If we sat at a debugger and inspected `kind.getClass()`, it would say `Either$Right`.
 
-This is the path for *library types*. For JDK types like `Optional`, `widen` allocates a small `Holder` record instead. We will see that variant lower down.
+This is the path for *library types*. `Either` (along with `Maybe`, `Validated`, `Id`, `IO`, `VTask` and `VStream`) declares its sealed interface as extending its own `Kind` interface — e.g. `Either<L, R> extends EitherKind<L, R>` — so every value *is* a `Kind` already and `widen` is a cast-free upcast. The relationship is compiler-checked: a new implementation that forgot it would not compile, rather than failing at runtime. For JDK types like `Optional`, `widen` allocates a small `Holder` record instead, because we cannot make `java.util.Optional` implement our interfaces. We will see that variant lower down.
+
+`widen`/`narrow` remain the idiomatic boundary for *every* type — they read uniformly and validate their input, and they are the only option for the holder-backed types. The structural relationship above is an internal guarantee, not an invitation to drop `widen` for a favoured few.
 
 ---
 

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -38,6 +38,15 @@ The build previously surfaced no unchecked warnings at all, so a new unguarded c
 - Generated code: `@ComposeEffects` Support classes now carry `@SuppressWarnings({"unchecked", "rawtypes"})`, so downstream projects compiling generated sources with lint enabled stay warning-free.
 - Purely internal; no behaviour or public API change.
 
+**Cast-free `widen`: root data types extend their `Kind` interfaces**
+
+`Maybe`, `Either` and `Validated` had concrete leaves (`Just`/`Nothing`, `Left`/`Right`, `Valid`/`Invalid`) that each implemented the corresponding `Kind` interface, but the sealed root interface itself did not — so `widen` needed an `@SuppressWarnings("unchecked")` cast whose only safety argument was "every leaf happens to implement the `Kind`". This release declares the relationship on the root type, making it structural and compiler-checked ([#561](https://github.com/higher-kinded-j/higher-kinded-j/issues/561)).
+
+- `Maybe<T> extends MaybeKind<T>`; `Either<L, R> extends EitherKind<L, R>, EitherKind2<L, R>`; `Validated<E, A> extends ValidatedKind<E, A>, ValidatedKind2<E, A>`. The leaves drop their now-redundant `Kind` clauses.
+- The five `widen` / `widen2` methods become cast-free upcasts (`return value;`), removing five `@SuppressWarnings("unchecked")` annotations. A future leaf that forgot to be a `Kind` is now a compile error rather than a latent `KindUnwrapException`.
+- `Id`, `IO`, `VTask` and `VStream` already extended their `Kind` interfaces and were unchanged. Holder-backed types (`Try`, `Lazy`, `State`, `Reader`, `Writer`, `Optional`, `List`, `Stream`, …) keep their holder indirection — for the JDK-wrapped ones it is fundamental, and converting the HKJ-owned ones would change widened-`Kind` identity, so it is left as a separate consideration.
+- `widen` / `narrow` remain the idiomatic, uniform boundary for every type; the structural relationship is an internal guarantee, documented in [Lifting the Hood](hkts/lifting_the_hood.md), not a reason to drop `widen` for these types. Purely internal; behaviour-preserving; the added superinterfaces are binary- and source-compatible.
+
 ---
 
 ### v0.4.6 (7 June 2026)

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/Either.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/Either.java
@@ -24,6 +24,12 @@ import org.jspecify.annotations.Nullable;
  * Right}, which are provided as nested records. This allows for exhaustive pattern matching using
  * `switch` expressions.
  *
+ * <p>As part of the HKT simulation, {@code Either} extends both {@link EitherKind} and {@link
+ * EitherKind2}, so every {@code Either} is already a {@code Kind<EitherKind.Witness<L>, R>} (for
+ * functors/monads over the right value) and a {@code Kind2<EitherKind2.Witness, L, R>} (for
+ * bifunctors). Widening via {@link EitherKindHelper} is therefore a cast-free upcast, and any
+ * future implementation that forgot the relationship would be a compile error.
+ *
  * <p>Example of use:
  *
  * <pre>{@code
@@ -47,7 +53,8 @@ import org.jspecify.annotations.Nullable;
  * @param <L> The type of the value if this is a {@link Left}. Conventionally the error type.
  * @param <R> The type of the value if this is a {@link Right}. Conventionally the success type.
  */
-public sealed interface Either<L, R> permits Either.Left, Either.Right {
+public sealed interface Either<L, R> extends EitherKind<L, R>, EitherKind2<L, R>
+    permits Either.Left, Either.Right {
 
   /**
    * Checks if this {@code Either} instance is a {@link Left}.
@@ -391,8 +398,8 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
    * Represents the {@link Left} case of an {@link Either}. By convention, this holds an error or
    * alternative value. This is a {@link Record} for conciseness and immutability.
    *
-   * <p>As part of the HKT pattern, this class implements both {@link EitherKind} and {@link
-   * EitherKind2}, allowing it to be used with typeclasses expecting {@code
+   * <p>As part of the HKT pattern, {@link Either} extends both {@link EitherKind} and {@link
+   * EitherKind2}, so this record is already usable with typeclasses expecting {@code
    * Kind<EitherKind.Witness<L>, R>} (for functors/monads) or {@code Kind2<EitherKind2.Witness, L,
    * R>} (for bifunctors).
    *
@@ -400,8 +407,7 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
    * @param <R> The type of the {@link Right} value (phantom type for {@code Left}).
    * @param value The value of type {@code L}. Can be {@code null}.
    */
-  record Left<L, R>(@Nullable L value)
-      implements Either<L, R>, EitherKind<L, R>, EitherKind2<L, R> {
+  record Left<L, R>(@Nullable L value) implements Either<L, R> {
 
     @Override
     public boolean isLeft() {
@@ -459,8 +465,8 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
    * Represents the {@link Right} case of an {@link Either}. By convention, this holds the
    * successful or primary value. This is a {@link Record} for conciseness and immutability.
    *
-   * <p>As part of the HKT pattern, this class implements both {@link EitherKind} and {@link
-   * EitherKind2}, allowing it to be used with typeclasses expecting {@code
+   * <p>As part of the HKT pattern, {@link Either} extends both {@link EitherKind} and {@link
+   * EitherKind2}, so this record is already usable with typeclasses expecting {@code
    * Kind<EitherKind.Witness<L>, R>} (for functors/monads) or {@code Kind2<EitherKind2.Witness, L,
    * R>} (for bifunctors).
    *
@@ -468,8 +474,7 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
    * @param <R> The type of the value held.
    * @param value The value of type {@code R}. Can be {@code null}.
    */
-  record Right<L, R>(@Nullable R value)
-      implements Either<L, R>, EitherKind<L, R>, EitherKind2<L, R> {
+  record Right<L, R>(@Nullable R value) implements Either<L, R> {
     @Override
     public boolean isLeft() {
       return false;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/EitherKindHelper.java
@@ -25,8 +25,8 @@ public enum EitherKindHelper implements EitherConverterOps {
    * Widens a concrete {@code Either<L, R>} instance into its higher-kinded representation, {@code
    * Kind<EitherKind.Witness<L>, R>}. Implements {@link EitherConverterOps#widen}.
    *
-   * <p>Since {@code Left} and {@code Right} directly implement {@code EitherKind}, this method
-   * performs a simple type-safe cast without requiring a wrapper object.
+   * <p>Since {@code Either} extends {@code EitherKind}, this is a cast-free upcast: the validated
+   * {@code either} is already a {@code Kind<EitherKind.Witness<L>, R>}.
    *
    * @param <L> The type of the "Left" value of the {@code Either}.
    * @param <R> The type of the "Right" value of the {@code Either}.
@@ -35,10 +35,9 @@ public enum EitherKindHelper implements EitherConverterOps {
    * @throws NullPointerException if {@code either} is {@code null}.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <L, R> Kind<EitherKind.Witness<L>, R> widen(Either<L, R> either) {
     Validation.kind().requireForWiden(either, EITHER_CLASS);
-    return (Kind<EitherKind.Witness<L>, R>) either;
+    return either;
   }
 
   /**
@@ -65,8 +64,8 @@ public enum EitherKindHelper implements EitherConverterOps {
    * Widens a concrete {@code Either<L, R>} instance into its Kind2 representation, {@code
    * Kind2<EitherKind2.Witness, L, R>}. Implements {@link EitherConverterOps#widen2}.
    *
-   * <p>Since {@code Left} and {@code Right} directly implement {@code EitherKind2}, this method
-   * performs a simple type-safe cast without requiring a wrapper object.
+   * <p>Since {@code Either} extends {@code EitherKind2}, this is a cast-free upcast: the validated
+   * {@code either} is already a {@code Kind2<EitherKind2.Witness, L, R>}.
    *
    * @param <L> The type of the "Left" value of the {@code Either}.
    * @param <R> The type of the "Right" value of the {@code Either}.
@@ -75,10 +74,9 @@ public enum EitherKindHelper implements EitherConverterOps {
    * @throws NullPointerException if {@code either} is {@code null}.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <L, R> Kind2<EitherKind2.Witness, L, R> widen2(Either<L, R> either) {
     Validation.kind().requireForWiden(either, EITHER_CLASS);
-    return (Kind2<EitherKind2.Witness, L, R>) either;
+    return either;
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
@@ -13,11 +13,11 @@ import org.jspecify.annotations.Nullable;
 /**
  * Concrete implementation of Maybe representing the presence of a value.
  *
- * <p>As part of the HKT pattern, this class implements {@link MaybeKind}, allowing it to be used
- * with typeclasses expecting {@code Kind<MaybeKind.Witness, T>}.
+ * <p>As part of the HKT pattern, {@link Maybe} extends {@link MaybeKind}, so this type is already a
+ * {@code Kind<MaybeKind.Witness, T>} and can be used with typeclasses expecting it.
  */
 // Value must be NonNull because Maybe.just requires it
-record Just<T>(T value) implements Maybe<T>, MaybeKind<T> {
+record Just<T>(T value) implements Maybe<T> {
   // Constructor implicitly checks value is non-null via Maybe.just factory
 
   @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Maybe.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Maybe.java
@@ -25,16 +25,19 @@ import org.jspecify.annotations.Nullable;
  * within a {@link Just} instance; the {@code Nothing} state should be used to represent the absence
  * of a value.
  *
- * <p>As part of the Higher-Kinded-J HKT simulation, both {@link Just} and {@link Nothing} directly
- * implement {@link MaybeKind}, allowing them to participate in the HKT framework without requiring
- * wrapper types. This means that widen/narrow operations via {@link MaybeKindHelper} have zero
- * runtime overhead (simple type-safe casts rather than object allocation).
+ * <p>As part of the Higher-Kinded-J HKT simulation, {@code Maybe} itself extends {@link MaybeKind},
+ * so every {@code Maybe} is already a {@code Kind<MaybeKind.Witness, T>} and can participate in the
+ * HKT framework without requiring wrapper types. This means that widen/narrow operations via {@link
+ * MaybeKindHelper} have zero runtime overhead (the widen is a cast-free upcast rather than object
+ * allocation). Because the relationship is declared on the sealed interface, any future
+ * implementation that forgot to be a {@code MaybeKind} would be a compile error rather than a
+ * latent failure.
  *
  * @param <T> the type of the value held by this {@code Maybe} instance. This type parameter itself
  *     can be nullable if {@code T} represents a type that can be null, but a {@link Just} instance
  *     will always wrap a non-null value.
  */
-public sealed interface Maybe<T> permits Just, Nothing {
+public sealed interface Maybe<T> extends MaybeKind<T> permits Just, Nothing {
 
   Class<Maybe> MAYBE_CLASS = Maybe.class;
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/MaybeKindHelper.java
@@ -23,8 +23,8 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    * Widens a concrete {@link Maybe}&lt;A&gt; instance into its HKT representation, {@link
    * Kind}&lt;{@link MaybeKind.Witness}, A&gt;. Implements {@link MaybeConverterOps#widen}.
    *
-   * <p>Since {@code Just} and {@code Nothing} directly implement {@code MaybeKind}, this method
-   * performs a simple type-safe cast without requiring a wrapper object.
+   * <p>Since {@code Maybe} extends {@code MaybeKind}, this is a cast-free upcast: the validated
+   * {@code maybe} is already a {@code Kind<MaybeKind.Witness, A>}.
    *
    * @param <A> The element type of the {@code Maybe}.
    * @param maybe The concrete {@link Maybe}&lt;A&gt; instance to widen. Must be non-null.
@@ -32,10 +32,9 @@ public enum MaybeKindHelper implements MaybeConverterOps {
    * @throws NullPointerException if {@code maybe} is {@code null}.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <A> Kind<MaybeKind.Witness, A> widen(Maybe<A> maybe) {
     Validation.kind().requireForWiden(maybe, MAYBE_CLASS);
-    return (Kind<MaybeKind.Witness, A>) maybe;
+    return maybe;
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Nothing.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Nothing.java
@@ -13,10 +13,10 @@ import org.jspecify.annotations.Nullable;
 /**
  * Concrete implementation of Maybe representing the absence of a value (singleton).
  *
- * <p>As part of the HKT pattern, this class implements {@link MaybeKind}, allowing it to be used
- * with typeclasses expecting {@code Kind<MaybeKind.Witness, T>}.
+ * <p>As part of the HKT pattern, {@link Maybe} extends {@link MaybeKind}, so this type is already a
+ * {@code Kind<MaybeKind.Witness, T>} and can be used with typeclasses expecting it.
  */
-final class Nothing<T> implements Maybe<T>, MaybeKind<T> {
+final class Nothing<T> implements Maybe<T> {
   // Singleton instance
   private static final Nothing<?> INSTANCE = new Nothing<>();
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Invalid.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Invalid.java
@@ -16,8 +16,8 @@ import org.higherkindedj.hkt.util.validation.Validation;
  * Represents the erroneous (Invalid) case of a {@link Validated}. It holds a non-null error value
  * of type {@code E}. This class is an immutable record.
  *
- * <p>As part of the HKT pattern, this class implements both {@link ValidatedKind} and {@link
- * ValidatedKind2}, allowing it to be used with typeclasses expecting {@code
+ * <p>As part of the HKT pattern, {@link Validated} extends both {@link ValidatedKind} and {@link
+ * ValidatedKind2}, so this record is already usable with typeclasses expecting {@code
  * Kind<ValidatedKind.Witness<E>, A>} (for functors/applicatives) or {@code
  * Kind2<ValidatedKind2.Witness, E, A>} (for bifunctors).
  *
@@ -26,8 +26,7 @@ import org.higherkindedj.hkt.util.validation.Validation;
  *     {@link Validated} contract).
  * @param error The non-null error value held by this {@code Invalid} instance.
  */
-public record Invalid<E, A>(E error)
-    implements Validated<E, A>, ValidatedKind<E, A>, ValidatedKind2<E, A> {
+public record Invalid<E, A>(E error) implements Validated<E, A> {
 
   /**
    * Compact constructor for {@code Invalid}. Ensures the encapsulated error is non-null.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Valid.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Valid.java
@@ -16,8 +16,8 @@ import org.higherkindedj.hkt.util.validation.Validation;
  * Represents the correct (Valid) case of a {@link Validated}. It holds a non-null value of type
  * {@code A}. This class is an immutable record.
  *
- * <p>As part of the HKT pattern, this class implements both {@link ValidatedKind} and {@link
- * ValidatedKind2}, allowing it to be used with typeclasses expecting {@code
+ * <p>As part of the HKT pattern, {@link Validated} extends both {@link ValidatedKind} and {@link
+ * ValidatedKind2}, so this record is already usable with typeclasses expecting {@code
  * Kind<ValidatedKind.Witness<E>, A>} (for functors/applicatives) or {@code
  * Kind2<ValidatedKind2.Witness, E, A>} (for bifunctors).
  *
@@ -26,8 +26,7 @@ import org.higherkindedj.hkt.util.validation.Validation;
  * @param <A> The type of the encapsulated value.
  * @param value The non-null value held by this {@code Valid} instance.
  */
-public record Valid<E, A>(A value)
-    implements Validated<E, A>, ValidatedKind<E, A>, ValidatedKind2<E, A> {
+public record Valid<E, A>(A value) implements Validated<E, A> {
 
   private static final Class<Valid> VALID_CLASS = Valid.class;
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Validated.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Validated.java
@@ -23,10 +23,17 @@ import org.higherkindedj.hkt.util.validation.Validation;
  * #flatMap(Function)} are right-biased, operating on the {@link Valid} value and passing {@link
  * Invalid} values through unchanged.
  *
+ * <p>As part of the HKT simulation, {@code Validated} extends both {@link ValidatedKind} and {@link
+ * ValidatedKind2}, so every {@code Validated} is already a {@code Kind<ValidatedKind.Witness<E>,
+ * A>} and a {@code Kind2<ValidatedKind2.Witness, E, A>}. Widening via {@link ValidatedKindHelper}
+ * is a cast-free upcast, and any future implementation that forgot the relationship would be a
+ * compile error.
+ *
  * @param <E> The type of the error in case of an Invalid value.
  * @param <A> The type of the value in case of a Valid value.
  */
-public sealed interface Validated<E, A> permits Valid, Invalid {
+public sealed interface Validated<E, A> extends ValidatedKind<E, A>, ValidatedKind2<E, A>
+    permits Valid, Invalid {
 
   Class<Validated> VALIDATED_CLASS = Validated.class;
 

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedKindHelper.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/ValidatedKindHelper.java
@@ -25,19 +25,14 @@ public enum ValidatedKindHelper implements ValidatedConverterOps {
    * Widens a {@link Validated} to its {@link Kind} representation. Implements {@link
    * ValidatedConverterOps#widen}.
    *
-   * <p>The {@code @SuppressWarnings("unchecked")} is necessary because Java's type system doesn't
-   * fully capture that {@code Validated<E, A>} is inherently a {@code
-   * Kind<ValidatedKind.Witness<E>, A>} in this HKT emulation. This cast is fundamental to the HKT
-   * pattern for {@code Validated} in this library.
-   *
-   * <p>Note: Unlike other KindHelpers, Validated doesn't use a holder because Valid and Invalid
-   * already implement ValidatedKind directly.
+   * <p>Since {@code Validated} extends {@code ValidatedKind}, this is a cast-free upcast: the
+   * validated {@code validated} is already a {@code Kind<ValidatedKind.Witness<E>, A>}. Unlike the
+   * holder-based KindHelpers, {@code Validated} needs no wrapper object.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <E, A> Kind<ValidatedKind.Witness<E>, A> widen(Validated<E, A> validated) {
     Validation.kind().requireForWiden(validated, VALIDATED_CLASS);
-    return (Kind<ValidatedKind.Witness<E>, A>) validated;
+    return validated;
   }
 
   /**
@@ -86,19 +81,14 @@ public enum ValidatedKindHelper implements ValidatedConverterOps {
    * Widens a {@link Validated} to its {@link Kind2} representation. Implements {@link
    * ValidatedConverterOps#widen2}.
    *
-   * <p>The {@code @SuppressWarnings("unchecked")} is necessary because Java's type system doesn't
-   * fully capture that {@code Validated<E, A>} is inherently a {@code Kind2<ValidatedKind2.Witness,
-   * E, A>} in this HKT emulation. This cast is fundamental to the HKT pattern for {@code Validated}
-   * in this library.
-   *
-   * <p>Note: Like the Kind version, Validated doesn't use a holder because Valid and Invalid
-   * already implement ValidatedKind2 directly.
+   * <p>Since {@code Validated} extends {@code ValidatedKind2}, this is a cast-free upcast: the
+   * validated {@code validated} is already a {@code Kind2<ValidatedKind2.Witness, E, A>}, with no
+   * wrapper object required.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public <E, A> Kind2<ValidatedKind2.Witness, E, A> widen2(Validated<E, A> validated) {
     Validation.kind().requireForWiden(validated, VALIDATED_CLASS);
-    return (Kind2<ValidatedKind2.Witness, E, A>) validated;
+    return validated;
   }
 
   /**


### PR DESCRIPTION
Closes #561.

## What

`Maybe`, `Either` and `Validated` had concrete leaves (`Just`/`Nothing`, `Left`/`Right`, `Valid`/`Invalid`) that each implemented the corresponding `Kind` interface, but the **sealed root interface itself did not**. So `widen` needed an `@SuppressWarnings("unchecked")` cast whose only safety argument was "every leaf happens to implement the `Kind`". This declares the relationship on the root type, making it structural and compiler-checked:

- `Maybe<T> extends MaybeKind<T>`
- `Either<L, R> extends EitherKind<L, R>, EitherKind2<L, R>`
- `Validated<E, A> extends ValidatedKind<E, A>, ValidatedKind2<E, A>`

The leaves drop their now-redundant `Kind` clauses. The five `widen`/`widen2` methods become cast-free upcasts (`return value;`), removing **5** `@SuppressWarnings("unchecked")` annotations. A future leaf that forgot to be a `Kind` is now a **compile error** rather than a latent `KindUnwrapException`.

## POC

Validated on `Maybe` first ([recorded on the issue](https://github.com/higher-kinded-j/higher-kinded-j/issues/561#issuecomment-4698345672)): compiles under `-Werror` across all modules; no `foo(Maybe)`/`foo(Kind)` overload pairs exist (and the more-specific rule protects any future one), so no silent overload-selection change is possible; runtime suites pass.

## Scope (the issue's ~20–25 estimate was high)

- **Done** (leaves already direct-implementers, root link missing): Maybe, Either, Validated → 5 suppressions removed.
- **Already cast-free, unchanged:** `Id`, `IO`, `VTask`, `VStream`.
- **Out of scope — holder-backed:** `Try`, `Lazy`, `State`, `Reader`, `Writer`, `Trampoline`, `Context`, `Free`, and JDK-wrapped `Optional`/`List`/`Stream`/`CompletableFuture`. JDK holders are fundamental; converting the HKJ-owned holder types means removing the holder, which changes the identity of a widened `Kind` and deletes a type — a behavioural change deserving its own POC, not bundled here.

## Docs

`widen`/`narrow` are taught as a **uniform** boundary across all containers. Promoting "skip `widen` for these three" would teach an inconsistent pattern (it works for direct-implementers, not holder-backed types) — a footgun. So this is documented as an *internal guarantee* on **Lifting the Hood**, and the `widen`-based examples (book + hkj-examples) are deliberately left unchanged.

