### PR TITLE
refactor(hkt): audited covary helpers + typed IdBox identity carrier (#562)

### DIFF
--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IdBox.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IdBox.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.indexed;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.higherkindedj.hkt.Applicative;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.TypeArity;
+import org.higherkindedj.hkt.WitnessArity;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A minimal, package-private identity functor used internally by {@link
+ * IndexedTraversal#asIndexedFold()} to run an {@code imodifyF} traversal whose only purpose is to
+ * collect index/value pairs.
+ *
+ * <p>It exists because hkj-api cannot depend on hkj-core's {@code Id}. Unlike the earlier raw
+ * {@code Kind} wrapper, this models the witness explicitly, so the value field is typed and only
+ * the single, fundamental {@link #narrow} cast remains.
+ *
+ * @param <A> the wrapped value type
+ */
+@NullMarked
+record IdBox<A>(A value) implements Kind<IdBox.Witness, A> {
+
+  /** Witness type for the identity functor. */
+  static final class Witness implements WitnessArity<TypeArity.Unary> {
+    private Witness() {}
+  }
+
+  @SuppressWarnings("unchecked") // every Kind<Witness, A> is an IdBox<A> by construction
+  static <A> IdBox<A> narrow(Kind<Witness, A> kind) {
+    return (IdBox<A>) Objects.requireNonNull(kind);
+  }
+
+  /**
+   * Creates the identity {@link Applicative}: {@code of} wraps the value, {@code map} applies the
+   * function, and {@code ap} applies the wrapped function to the wrapped value.
+   *
+   * @return an Applicative instance for {@code IdBox.Witness}.
+   */
+  static Applicative<Witness> applicative() {
+    return new Applicative<>() {
+      @Override
+      public <A> Kind<Witness, A> of(A value) {
+        return new IdBox<>(value);
+      }
+
+      @Override
+      public <A, B> Kind<Witness, B> map(Function<? super A, ? extends B> f, Kind<Witness, A> fa) {
+        return new IdBox<>(f.apply(narrow(fa).value()));
+      }
+
+      @Override
+      public <A, B> Kind<Witness, B> ap(
+          Kind<Witness, ? extends Function<A, B>> ff, Kind<Witness, A> fa) {
+        return new IdBox<>(narrow(ff).value().apply(narrow(fa).value()));
+      }
+    };
+  }
+}

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IdBox.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IdBox.java
@@ -35,28 +35,38 @@ record IdBox<A>(A value) implements Kind<IdBox.Witness, A> {
   }
 
   /**
-   * Creates the identity {@link Applicative}: {@code of} wraps the value, {@code map} applies the
-   * function, and {@code ap} applies the wrapped function to the wrapped value.
+   * The identity {@link Applicative}: {@code of} wraps the value, {@code map} applies the function,
+   * and {@code ap} applies the wrapped function to the wrapped value.
+   *
+   * <p>Stateless and thread-safe, so it is cached as a single shared instance rather than allocated
+   * per {@link #applicative()} call (unlike the monoid-parameterised {@code ConstForFold}).
+   */
+  private static final Applicative<Witness> INSTANCE =
+      new Applicative<>() {
+        @Override
+        public <A> Kind<Witness, A> of(A value) {
+          return new IdBox<>(value);
+        }
+
+        @Override
+        public <A, B> Kind<Witness, B> map(
+            Function<? super A, ? extends B> f, Kind<Witness, A> fa) {
+          return new IdBox<>(f.apply(narrow(fa).value()));
+        }
+
+        @Override
+        public <A, B> Kind<Witness, B> ap(
+            Kind<Witness, ? extends Function<A, B>> ff, Kind<Witness, A> fa) {
+          return new IdBox<>(narrow(ff).value().apply(narrow(fa).value()));
+        }
+      };
+
+  /**
+   * Returns the shared identity {@link Applicative} for {@code IdBox.Witness}.
    *
    * @return an Applicative instance for {@code IdBox.Witness}.
    */
   static Applicative<Witness> applicative() {
-    return new Applicative<>() {
-      @Override
-      public <A> Kind<Witness, A> of(A value) {
-        return new IdBox<>(value);
-      }
-
-      @Override
-      public <A, B> Kind<Witness, B> map(Function<? super A, ? extends B> f, Kind<Witness, A> fa) {
-        return new IdBox<>(f.apply(narrow(fa).value()));
-      }
-
-      @Override
-      public <A, B> Kind<Witness, B> ap(
-          Kind<Witness, ? extends Function<A, B>> ff, Kind<Witness, A> fa) {
-        return new IdBox<>(narrow(ff).value().apply(narrow(fa).value()));
-      }
-    };
+    return INSTANCE;
   }
 }

--- a/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedTraversal.java
+++ b/hkj-api/src/main/java/org/higherkindedj/optics/indexed/IndexedTraversal.java
@@ -233,62 +233,19 @@ public interface IndexedTraversal<I, S, A> extends IndexedOptic<I, S, A> {
       @Override
       public <M> M ifoldMap(
           Monoid<M> monoid, BiFunction<? super I, ? super A, ? extends M> f, S source) {
-        // We need to traverse all elements and fold them using the monoid.
-        // Since we can't reference Id/IdMonad from hkj-core, we define a minimal
-        // identity-like applicative inline.
+        // Run the traversal purely to collect every index/value pair, using a minimal identity
+        // applicative (we cannot depend on hkj-core's Id from hkj-api).
         final List<Pair<I, A>> collected = new ArrayList<>();
 
-        // Define a simple identity wrapper that implements Kind and WitnessArity
-        // This is a local class to avoid circular dependencies
-        @SuppressWarnings("rawtypes")
-        final class IdWrapper implements Kind, WitnessArity<TypeArity.Unary> {
-          final Object value;
-
-          IdWrapper(Object value) {
-            this.value = value;
-          }
-        }
-
-        // Create a minimal Applicative for IdWrapper
-        Applicative<IdWrapper> idApp =
-            new Applicative<>() {
-              @Override
-              @SuppressWarnings("unchecked")
-              public <A1> Kind<IdWrapper, A1> of(A1 a) {
-                return (Kind<IdWrapper, A1>) new IdWrapper(a);
-              }
-
-              @Override
-              @SuppressWarnings("unchecked")
-              public <A1, B1> Kind<IdWrapper, B1> map(
-                  Function<? super A1, ? extends B1> fn, Kind<IdWrapper, A1> fa) {
-                IdWrapper wrapper = (IdWrapper) fa;
-                return (Kind<IdWrapper, B1>) new IdWrapper(fn.apply((A1) wrapper.value));
-              }
-
-              @Override
-              @SuppressWarnings("unchecked")
-              public <A1, B1> Kind<IdWrapper, B1> ap(
-                  Kind<IdWrapper, ? extends Function<A1, B1>> ff, Kind<IdWrapper, A1> fa) {
-                IdWrapper wrapperF = (IdWrapper) ff;
-                IdWrapper wrapperA = (IdWrapper) fa;
-                Function<A1, B1> fn = (Function<A1, B1>) wrapperF.value;
-                return (Kind<IdWrapper, B1>) new IdWrapper(fn.apply((A1) wrapperA.value));
-              }
-            };
-
-        // Use the traversal to collect all index-value pairs
         self.imodifyF(
             (i, a) -> {
               collected.add(new Pair<>(i, a));
-              @SuppressWarnings("unchecked")
-              Kind<IdWrapper, A> result = (Kind<IdWrapper, A>) new IdWrapper(a);
-              return result;
+              return new IdBox<>(a);
             },
             source,
-            idApp);
+            IdBox.applicative());
 
-        // Fold over the collected pairs using the provided monoid
+        // Fold over the collected pairs using the provided monoid.
         M result = monoid.empty();
         for (Pair<I, A> pair : collected) {
           result = monoid.combine(result, f.apply(pair.first(), pair.second()));

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -55,6 +55,13 @@ Following the same pattern, every HKJ-owned type that still wrapped `widen` in a
 - `Lazy` deliberately keeps its holder: it is a mutable memoising thunk, and the immutable holder keeps the `Kind` carrier immutable (an architecture invariant enforced by `ImmutabilityRules`). JDK-wrapped types (`Optional`, `List`, `Stream`, `CompletableFuture`) keep theirs by necessity. After this change those, plus the generated `Tuple2`, are the only holders left.
 - Behaviour-preserving for normal use: a widened `Kind` is now the value itself rather than a wrapper (`narrow(widen(x))` still round-trips). `Free.widen` additionally rejects null now, and `ErrorOp`/`EitherF`/`FreeAp`'s `narrow(null)` now raise `KindUnwrapException` rather than `NullPointerException`, matching the rest of the family. Tests that asserted the holder type or the old exceptions were updated. Purely internal; no public API change.
 
+**Audited `covary` helpers and a typed identity carrier**
+
+Two small internal-soundness cleanups ([#562](https://github.com/higher-kinded-j/higher-kinded-j/issues/562)):
+
+- The covariant reinterpretations in `flatMap`/`recoverWith` (e.g. casting a `Try<? extends U>` produced by the mapper to `Try<U>`) are now funnelled through a private `covary` helper on each immutable sealed type — `Try`, `Maybe`, `Either`, `Validated`, `Id` — that carries the safety proof in one place rather than repeating an inline `@SuppressWarnings` cast at each call site. (The audit found six such sites, not the dozens first estimated; the unrelated phantom-type recasts in `mapError`/`mapLeft` keep their existing inline form.) No public API change.
+- `IndexedTraversal.asIndexedFold()` in **hkj-api** replaced its raw `@SuppressWarnings("rawtypes")` identity wrapper with a typed `IdBox` record (witness modelled explicitly, mirroring the sibling `ConstForFold`), so the wrapped value is typed and only the single fundamental `narrow` cast remains. This removes the one raw-`Kind` construction from the public API module.
+
 ---
 
 ### v0.4.6 (7 June 2026)

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/either/Either.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/either/Either.java
@@ -395,6 +395,24 @@ public sealed interface Either<L, R> extends EitherKind<L, R>, EitherKind2<L, R>
   }
 
   /**
+   * Reinterprets an {@code Either<L, ? extends R>} as an {@code Either<L, R>}.
+   *
+   * <p>Safe: {@code Either} is sealed and immutable, so a value produced as {@code Either<L, ?
+   * extends R>} can be observed as {@code Either<L, R>} without risk — there is no operation
+   * through which the narrowed right type could be written back. Centralises the covariant
+   * reinterpretation that {@code flatMap} would otherwise cast inline.
+   *
+   * @param e the value to reinterpret; never null in practice (callers validate first)
+   * @param <L> the left type
+   * @param <R> the target right type
+   * @return {@code e} viewed as {@code Either<L, R>}
+   */
+  @SuppressWarnings("unchecked") // sealed + immutable: covariant reinterpretation is unobservable
+  private static <L, R> Either<L, R> covary(Either<L, ? extends R> e) {
+    return (Either<L, R>) e;
+  }
+
+  /**
    * Represents the {@link Left} case of an {@link Either}. By convention, this holds an error or
    * alternative value. This is a {@link Record} for conciseness and immutability.
    *
@@ -496,15 +514,13 @@ public sealed interface Either<L, R> extends EitherKind<L, R>, EitherKind2<L, R>
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <R2> Either<L, R2> flatMap(
         Function<? super R, ? extends Either<L, ? extends R2>> mapper) {
       Validation.function().require(mapper, "mapper", FLAT_MAP);
       // Apply the mapper, which itself returns an Either.
       Either<L, ? extends R2> result = mapper.apply(value);
       Validation.function().requireNonNullResult(result, "mapper", FLAT_MAP);
-      // Cast is safe because ? extends R2 is compatible with R2
-      return (Either<L, R2>) result;
+      return covary(result);
     }
 
     @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/id/Id.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/id/Id.java
@@ -63,9 +63,22 @@ public record Id<A>(@Nullable A value) implements IdKind<A> {
     Id<? extends B> result = fn.apply(value());
     Validation.function().requireNonNullResult(result, "fn", FLAT_MAP);
 
-    // The cast is safe because fn returns Id<? extends B> which is covariant
-    @SuppressWarnings("unchecked")
-    Id<B> typedResult = (Id<B>) result;
-    return typedResult;
+    return covary(result);
+  }
+
+  /**
+   * Reinterprets an {@code Id<? extends B>} as an {@code Id<B>}.
+   *
+   * <p>Safe: {@code Id} is an immutable record, so a value produced as {@code Id<? extends B>} can
+   * be observed as {@code Id<B>} without risk — there is no operation through which the narrowed
+   * element type could be written back.
+   *
+   * @param id the value to reinterpret; never null in practice (callers validate first)
+   * @param <B> the target element type
+   * @return {@code id} viewed as {@code Id<B>}
+   */
+  @SuppressWarnings("unchecked") // immutable record: covariant reinterpretation is unobservable
+  private static <B> Id<B> covary(Id<? extends B> id) {
+    return (Id<B>) id;
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/maybe/Just.java
@@ -59,10 +59,19 @@ record Just<T>(T value) implements Maybe<T> {
     Maybe<? extends U> result = mapper.apply(value);
     Validation.function().requireNonNullResult(result, "mapper", FLAT_MAP);
 
-    // Cast needed because of <? extends U> - unavoidable Java type system limitation
-    @SuppressWarnings("unchecked")
-    Maybe<U> typedResult = (Maybe<U>) result;
-    return typedResult;
+    return covary(result);
+  }
+
+  /**
+   * Reinterprets a {@code Maybe<? extends U>} as a {@code Maybe<U>}.
+   *
+   * <p>Safe: {@code Maybe} is sealed and immutable, so a value produced as {@code Maybe<? extends
+   * U>} can be observed as {@code Maybe<U>} without risk — there is no operation through which the
+   * narrowed element type could be written back.
+   */
+  @SuppressWarnings("unchecked") // sealed + immutable: covariant reinterpretation is unobservable
+  private static <U> Maybe<U> covary(Maybe<? extends U> m) {
+    return (Maybe<U>) m;
   }
 
   @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/Try.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/trymonad/Try.java
@@ -169,6 +169,23 @@ public sealed interface Try<T> extends TryKind<T> permits Try.Success, Try.Failu
   }
 
   /**
+   * Reinterprets a {@code Try<? extends U>} as a {@code Try<U>}.
+   *
+   * <p>Safe: {@code Try} is sealed and immutable, so a value produced as {@code Try<? extends U>}
+   * can be observed as {@code Try<U>} without risk — there is no operation through which the
+   * narrowed element type could be written back. Centralises the covariant reinterpretation that
+   * {@code flatMap}/{@code recoverWith} would otherwise each cast inline.
+   *
+   * @param t the value to reinterpret; never null in practice (callers validate first)
+   * @param <U> the target element type
+   * @return {@code t} viewed as {@code Try<U>}
+   */
+  @SuppressWarnings("unchecked") // sealed + immutable: covariant reinterpretation is unobservable
+  private static <U> Try<U> covary(Try<? extends U> t) {
+    return (Try<U>) t;
+  }
+
+  /**
    * Checks if this {@code Try} instance represents a successful computation (i.e., is a {@link
    * Success}).
    *
@@ -443,9 +460,7 @@ public sealed interface Try<T> extends TryKind<T> permits Try.Success, Try.Failu
       }
 
       Validation.function().requireNonNullResult(result, "mapper", FLAT_MAP);
-      @SuppressWarnings("unchecked")
-      Try<U> typedResult = (Try<U>) result;
-      return typedResult;
+      return covary(result);
     }
 
     @Override
@@ -545,9 +560,7 @@ public sealed interface Try<T> extends TryKind<T> permits Try.Success, Try.Failu
         return new Failure<>(e);
       }
       Validation.function().requireNonNullResult(result, "recoveryFunction", RECOVER_WITH);
-      @SuppressWarnings("unchecked")
-      Try<T> typedResult = (Try<T>) result;
-      return typedResult;
+      return covary(result);
     }
 
     @Override

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Valid.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/validated/Valid.java
@@ -105,9 +105,19 @@ public record Valid<E, A>(A value) implements Validated<E, A> {
     Validated<E, ? extends B> result = fn.apply(value);
     Validation.function().requireNonNullResult(result, "fn", FLAT_MAP);
 
-    @SuppressWarnings("unchecked")
-    Validated<E, B> typedResult = (Validated<E, B>) result;
-    return typedResult;
+    return covary(result);
+  }
+
+  /**
+   * Reinterprets a {@code Validated<E, ? extends B>} as a {@code Validated<E, B>}.
+   *
+   * <p>Safe: {@code Validated} is sealed and immutable, so a value produced as {@code Validated<E,
+   * ? extends B>} can be observed as {@code Validated<E, B>} without risk — there is no operation
+   * through which the narrowed value type could be written back.
+   */
+  @SuppressWarnings("unchecked") // sealed + immutable: covariant reinterpretation is unobservable
+  private static <E, B> Validated<E, B> covary(Validated<E, ? extends B> v) {
+    return (Validated<E, B>) v;
   }
 
   @Override


### PR DESCRIPTION
Closes #562.

## What

Two small internal-soundness cleanups.

### 1. Audited `covary` helpers

The covariant reinterpretations in `flatMap`/`recoverWith` — casting a value the mapper produced as `X<? extends U>` to `X<U>` — are now funnelled through a private `covary` helper per immutable sealed type, carrying the safety proof in one documented place instead of an inline `@SuppressWarnings` cast at each call site.

- `Try` (2 sites), `Either` (right param), `Id` — private static on the type (leaves are nestmates).
- `Maybe`, `Validated` — on the `Just` / `Valid` leaf, because their leaves are separate top-level classes and a sealed interface cannot host a package-private static. The single call site lives there.

**Scope note:** the issue estimated "~30 sites", but the audit found **6** genuine `? extends` covariance casts. The other casts in these types are *phantom-type recasts* (`Left<L,R>` reused as `Either<L,R2>`, etc.) — a different pattern a `covary(X<? extends U>): X<U>` helper cannot serve — so they keep their existing inline `// cast is safe` form. Per discussion, `covary` is kept **private** (no public API change); promotable later if users want it.

### 2. Typed `IdBox` identity carrier

`IndexedTraversal.asIndexedFold()` in **hkj-api** replaced its raw `@SuppressWarnings("rawtypes") class IdWrapper implements Kind` (with an untyped `Object value` and six unchecked casts) with a typed `IdBox` record whose witness is modelled explicitly — mirroring the sibling `ConstForFold`. The wrapped value is now typed and only the single fundamental `narrow` cast remains. This removes the one raw-`Kind` construction from the public API module (the anti-pattern hkj-checker's spikes call "the sole silent path" to a wrong-witness narrow).

## Compatibility & verification

- No public API change; `covary` is private and `IdBox` is a package-private record. Behaviour-preserving (`covary` is an identity cast; `IdBox` is behaviourally identical to the old wrapper).

