### PR TITLE
refactor(hkt): consolidate Free's two interpreters behind the Natural path (#563)

### DIFF
--- a/hkj-book/src/monads/free_monad.md
+++ b/hkj-book/src/monads/free_monad.md
@@ -99,6 +99,15 @@ Free program (tree):                  foldMap walks it:
 `foldMap` converts each instruction from your DSL (`F`) into a target monad (`M`) using a natural transformation, then sequences the results. It uses Higher-Kinded-J's own `Trampoline` internally for stack safety.
 ~~~
 
+~~~admonish tip title="Prefer a type-safe `Natural` transformation"
+`foldMap` is overloaded: it takes either a type-safe `Natural<F, M>` or a raw
+`Function<Kind<F, ?>, Kind<M, ?>>`. **Prefer `Natural`** — it makes the per-instruction
+correspondence (`Kind<F, B>` maps to `Kind<M, B>` for every `B`) explicit, so a witness mismatch
+is caught at compile time instead of riding on an unchecked cast. The `Function` form (used in
+some examples below for brevity) stays for convenience and interop; internally both overloads run
+through the same `Natural`-based interpreter.
+~~~
+
 ## Building a DSL: Step by Step
 
 ### Step 1: Define Your Instruction Set

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -62,6 +62,13 @@ Two small internal-soundness cleanups ([#562](https://github.com/higher-kinded-j
 - The covariant reinterpretations in `flatMap`/`recoverWith` (e.g. casting a `Try<? extends U>` produced by the mapper to `Try<U>`) are now funnelled through a private `covary` helper on each immutable sealed type — `Try`, `Maybe`, `Either`, `Validated`, `Id` — that carries the safety proof in one place rather than repeating an inline `@SuppressWarnings` cast at each call site. (The audit found six such sites, not the dozens first estimated; the unrelated phantom-type recasts in `mapError`/`mapLeft` keep their existing inline form.) No public API change.
 - `IndexedTraversal.asIndexedFold()` in **hkj-api** replaced its raw `@SuppressWarnings("rawtypes")` identity wrapper with a typed `IdBox` record (witness modelled explicitly, mirroring the sibling `ConstForFold`), so the wrapped value is typed and only the single fundamental `narrow` cast remains. This removes the one raw-`Kind` construction from the public API module.
 
+**`Free` interpreter consolidation**
+
+`Free.foldMap` is overloaded to accept either a type-safe `Natural<F, M>` or a raw `Function<Kind<F, ?>, Kind<M, ?>>`, and each overload had its own ~100-line stack-safe interpreter — two near-identical copies of the same Trampoline traversal and strict-vs-lazy eagerness probe, differing only in one unchecked cast. They are now a single interpreter ([#563](https://github.com/higher-kinded-j/higher-kinded-j/issues/563)).
+
+- The `Function`-based `foldMap` now adapts its argument to a `Natural` through a small `asNatural` helper (the one place the function's erased per-element correspondence is reasserted) and runs through the single `Natural`-based interpreter. `interpretFree` and `interpretApFunction` are deleted — `Free.java` loses ~64 lines and three `@SuppressWarnings`, with one trust boundary instead of two.
+- Behaviour is preserved exactly (the strict/lazy probe is unchanged and now documented as the deliberate internal trick it is); the full Free / FreePath suites pass. The `Natural` form is the recommended one, now noted in the [Free Monad](monads/free_monad.md) chapter. Purely internal; no public API change.
+
 ---
 
 ### v0.4.6 (7 June 2026)

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free/Free.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free/Free.java
@@ -390,85 +390,32 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A> extends
    */
   default <M extends WitnessArity<TypeArity.Unary>> Kind<M, A> foldMap(
       Function<Kind<F, ?>, Kind<M, ?>> transform, Monad<M> monad) {
-    return interpretFree(this, transform, monad).run();
+    // Adapt the raw function to a Natural and interpret through the single Natural-based path.
+    return foldMap(asNatural(transform), monad);
   }
 
   /**
-   * Internal helper that interprets a Free monad using Trampoline for stack-safe traversal.
+   * Adapts a raw {@code Function<Kind<F, ?>, Kind<M, ?>>} into a {@link Natural} so the
+   * function-based {@link #foldMap(Function, Monad)} can reuse the single type-safe interpreter.
    *
-   * @param free The Free monad to interpret
-   * @param transform The natural transformation from F to M
-   * @param monad The monad instance for M
-   * @param <F> The functor type
-   * @param <M> The target monad type
-   * @param <A> The result type
-   * @return A Trampoline that produces the interpreted result in monad M
+   * <p>This is the one place where the function overload's erased per-element correspondence is
+   * reasserted: the function promises (by contract) to map {@code Kind<F, B>} to {@code Kind<M, B>}
+   * for every {@code B}, which the {@code Natural} signature makes explicit. The unchecked cast is
+   * confined here rather than scattered across a duplicate interpreter.
+   *
+   * @param transform the raw function transformation
+   * @param <F> the source functor witness
+   * @param <M> the target monad witness
+   * @return a {@code Natural<F, M>} backed by {@code transform}
    */
-  private static <
-          F extends WitnessArity<TypeArity.Unary>, M extends WitnessArity<TypeArity.Unary>, A>
-      Trampoline<Kind<M, A>> interpretFree(
-          Free<F, A> free, Function<Kind<F, ?>, Kind<M, ?>> transform, Monad<M> monad) {
-
-    return switch (free) {
-      case Pure<F, A> pure ->
-          // Terminal case: lift the pure value into the target monad
-          Trampoline.done(monad.of(pure.value()));
-
-      case Suspend<F, A> suspend -> {
-        // Transform the suspended computation and recursively interpret
-        @SuppressWarnings("unchecked")
-        Kind<M, Free<F, A>> transformed =
-            (Kind<M, Free<F, A>>) transform.apply(suspend.computation());
-
-        // Try to extract the inner Free eagerly (works for strict monads like Identity).
-        // For strict monads, monad.map evaluates immediately, allowing us to defer
-        // the recursive interpretation through the Trampoline for stack safety.
-        // For lazy monads (IO, State), the monad's own laziness provides stack safety.
-        @SuppressWarnings("unchecked")
-        Free<F, A>[] innerFreeRef = (Free<F, A>[]) new Free<?, ?>[1];
-        boolean[] eager = {false};
-        monad.map(
-            innerFree -> {
-              innerFreeRef[0] = innerFree;
-              eager[0] = true;
-              return innerFree;
-            },
-            transformed);
-
-        if (eager[0]) {
-          // Strict monad: defer interpretation through Trampoline for stack safety
-          Free<F, A> innerFree = innerFreeRef[0];
-          yield Trampoline.defer(() -> interpretFree(innerFree, transform, monad));
-        } else {
-          // Lazy monad: use monad.flatMap (the monad's laziness provides stack safety)
-          yield Trampoline.done(
-              monad.flatMap(
-                  innerFree -> interpretFree(innerFree, transform, monad).run(), transformed));
-        }
+  private static <F extends WitnessArity<TypeArity.Unary>, M extends WitnessArity<TypeArity.Unary>>
+      Natural<F, M> asNatural(Function<Kind<F, ?>, Kind<M, ?>> transform) {
+    return new Natural<>() {
+      @Override
+      @SuppressWarnings("unchecked") // function contract: Kind<F, B> maps to Kind<M, B> for every B
+      public <B> Kind<M, B> apply(Kind<F, B> fa) {
+        return (Kind<M, B>) transform.apply(fa);
       }
-
-      case FlatMapped<F, ?, A> flatMapped -> {
-        // Handle FlatMapped by deferring the interpretation
-        @SuppressWarnings("unchecked")
-        FlatMapped<F, Object, A> fm = (FlatMapped<F, Object, A>) flatMapped;
-
-        yield Trampoline.defer(
-            () ->
-                interpretFree(fm.sub(), transform, monad)
-                    .map(
-                        kindOfX ->
-                            monad.flatMap(
-                                x -> {
-                                  Free<F, A> next = fm.continuation().apply(x);
-                                  return interpretFree(next, transform, monad).run();
-                                },
-                                kindOfX)));
-      }
-
-      case HandleError<F, ?, A> he ->
-          interpretHandleError(he, f -> interpretFree(f, transform, monad), monad);
-
-      case Ap<F, A> ap -> interpretApFunction(ap, transform, monad);
     };
   }
 
@@ -498,7 +445,12 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A> extends
         // Transform the suspended computation using the type-safe Natural transformation
         Kind<M, Free<F, A>> transformed = transform.apply(suspend.computation());
 
-        // Try to extract the inner Free eagerly (works for strict monads).
+        // Probe whether the target monad is strict by running a side-effecting map over the
+        // transformed value: a strict monad (e.g. Id-based transformers) invokes the mapper
+        // synchronously, setting eager[0] and capturing the inner Free; a lazy monad (IO, State)
+        // defers the mapper, leaving eager[0] false. This deliberately exploits map's evaluation
+        // timing to branch — it is an internal interpreter trick, not a pattern to emulate, and
+        // relies on map being called at most once per element.
         @SuppressWarnings("unchecked")
         Free<F, A>[] innerFreeRef = (Free<F, A>[]) new Free<?, ?>[1];
         boolean[] eager = {false};
@@ -511,9 +463,11 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A> extends
             transformed);
 
         if (eager[0]) {
+          // Strict monad: defer interpretation through the Trampoline for stack safety.
           Free<F, A> innerFree = innerFreeRef[0];
           yield Trampoline.defer(() -> interpretFreeNatural(innerFree, transform, monad));
         } else {
+          // Lazy monad: the monad's own laziness provides stack safety via flatMap.
           yield Trampoline.done(
               monad.flatMap(
                   innerFree -> interpretFreeNatural(innerFree, transform, monad).run(),
@@ -595,26 +549,6 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A> extends
       Trampoline<Kind<M, A>> interpretApNatural(
           Ap<F, A> ap, Natural<F, M> transform, Monad<M> monad) {
     Kind<M, A> result = ap.applicative().foldMap(transform, monad);
-    return Trampoline.done(result);
-  }
-
-  /**
-   * Interprets an Ap node using the function-based transformation. Adapts the function into a
-   * Natural for use with FreeAp.foldMap.
-   */
-  @SuppressWarnings("unchecked")
-  private static <
-          F extends WitnessArity<TypeArity.Unary>, M extends WitnessArity<TypeArity.Unary>, A>
-      Trampoline<Kind<M, A>> interpretApFunction(
-          Ap<F, A> ap, Function<Kind<F, ?>, Kind<M, ?>> transform, Monad<M> monad) {
-    Natural<F, M> adapted =
-        new Natural<>() {
-          @Override
-          public <B> Kind<M, B> apply(Kind<F, B> fa) {
-            return (Kind<M, B>) transform.apply(fa);
-          }
-        };
-    Kind<M, A> result = ap.applicative().foldMap(adapted, monad);
     return Trampoline.done(result);
   }
 }

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/free/Free.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/free/Free.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.hkt.free;
 
 import static org.higherkindedj.hkt.util.validation.Operation.CONSTRUCTION;
+import static org.higherkindedj.hkt.util.validation.Operation.FOLD_MAP;
 import static org.higherkindedj.hkt.util.validation.Operation.FROM_KIND;
 
 import java.util.function.Function;
@@ -357,10 +358,13 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A> extends
    * @param monad The monad instance for M. Must not be null.
    * @param <M> The target monad type
    * @return The interpreted result in monad M
+   * @throws NullPointerException if {@code transform} or {@code monad} is null
    * @see Natural
    */
   default <M extends WitnessArity<TypeArity.Unary>> Kind<M, A> foldMap(
       Natural<F, M> transform, Monad<M> monad) {
+    Validation.function().require(transform, "transform", FOLD_MAP);
+    Validation.function().require(monad, "monad", FOLD_MAP);
     return interpretFreeNatural(this, transform, monad).run();
   }
 
@@ -386,12 +390,15 @@ public sealed interface Free<F extends WitnessArity<TypeArity.Unary>, A> extends
    * @param monad The monad instance for M
    * @param <M> The target monad type
    * @return The interpreted result in monad M
+   * @throws NullPointerException if {@code transform} or {@code monad} is null
    * @see #foldMap(Natural, Monad)
    */
   default <M extends WitnessArity<TypeArity.Unary>> Kind<M, A> foldMap(
       Function<Kind<F, ?>, Kind<M, ?>> transform, Monad<M> monad) {
+    Validation.function().require(transform, "transform", FOLD_MAP);
+    Validation.function().require(monad, "monad", FOLD_MAP);
     // Adapt the raw function to a Natural and interpret through the single Natural-based path.
-    return foldMap(asNatural(transform), monad);
+    return interpretFreeNatural(this, asNatural(transform), monad).run();
   }
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/free/FreeFunctionFoldMapTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/free/FreeFunctionFoldMapTest.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.hkt.free;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.higherkindedj.hkt.free.test.IdentityKindHelper.IDENTITY;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.trymonad.TryKindHelper.TRY;
@@ -23,9 +24,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for the function-based foldMap path (interpretFree) with HandleError and Ap. The Natural
- * path (interpretFreeNatural) is tested in FreeHandleErrorTest and FreeApTest. This file covers the
- * alternative code path through foldMap(Function, Monad).
+ * Tests for the function-based {@code foldMap(Function, Monad)} overload with HandleError and Ap.
+ * Since the function overload now adapts to a {@code Natural} and runs through the single
+ * interpreter, these exercise that adapter path; the direct Natural path is covered in
+ * FreeHandleErrorTest and FreeApTest.
  */
 @DisplayName("Free function-based foldMap: HandleError and Ap coverage")
 class FreeFunctionFoldMapTest {
@@ -138,6 +140,47 @@ class FreeFunctionFoldMapTest {
       Try<String> tryResult = TRY.narrow(result);
       assertThat(tryResult.isSuccess()).isTrue();
       assertThat(tryResult.orElse(null)).isEqualTo("recovered: translated boom");
+    }
+  }
+
+  @Nested
+  @DisplayName("foldMap argument validation")
+  class ArgumentValidation {
+
+    private final Free<IdentityKind.Witness, Integer> program = Free.pure(42);
+
+    @Test
+    @DisplayName("foldMap(Function) rejects a null transform")
+    @SuppressWarnings("DataFlowIssue") // null is passed deliberately to verify rejection
+    void functionFoldMapRejectsNullTransform() {
+      Function<Kind<IdentityKind.Witness, ?>, Kind<IdentityKind.Witness, ?>> nullTransform = null;
+      assertThatThrownBy(() -> program.foldMap(nullTransform, identityMonad))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("foldMap(Function) rejects a null monad")
+    @SuppressWarnings("DataFlowIssue") // null is passed deliberately to verify rejection
+    void functionFoldMapRejectsNullMonad() {
+      assertThatThrownBy(() -> program.foldMap(identityTransform, null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("foldMap(Natural) rejects a null transform")
+    @SuppressWarnings("DataFlowIssue") // null is passed deliberately to verify rejection
+    void naturalFoldMapRejectsNullTransform() {
+      Natural<IdentityKind.Witness, IdentityKind.Witness> nullTransform = null;
+      assertThatThrownBy(() -> program.foldMap(nullTransform, identityMonad))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("foldMap(Natural) rejects a null monad")
+    @SuppressWarnings("DataFlowIssue") // null is passed deliberately to verify rejection
+    void naturalFoldMapRejectsNullMonad() {
+      Natural<IdentityKind.Witness, IdentityKind.Witness> nat = Natural.identity();
+      assertThatThrownBy(() -> program.foldMap(nat, null)).isInstanceOf(NullPointerException.class);
     }
   }
 }


### PR DESCRIPTION
Closes #563.

## What

`Free.foldMap` is overloaded to accept either a type-safe `Natural<F, M>` or a raw `Function<Kind<F, ?>, Kind<M, ?>>`. Each overload had its **own** ~100-line stack-safe interpreter (`interpretFreeNatural` / `interpretFree`) — two near-identical copies of the same Trampoline traversal and strict-vs-lazy eagerness probe, differing only in **one unchecked cast** at the `Suspend` site.

This collapses them to a single interpreter:

- The `Function`-based `foldMap` adapts its argument to a `Natural` via a small `asNatural` helper — the one place the function's erased per-element correspondence (`Kind<F, B>` → `Kind<M, B>`) is reasserted — and runs through the single `Natural`-based interpreter.
- `interpretFree` and `interpretApFunction` are deleted. `Free.java` loses **~64 lines and three `@SuppressWarnings`** (8 remain, down from 11), leaving **one trust boundary instead of two**.

## Behaviour & verification

- **Behaviour preserved exactly.** The only difference between the two interpreters was where the cast lived; `asNatural` performs the identical cast in one spot. The strict/lazy eagerness probe is unchanged — and now carries a comment explaining it is a deliberate internal trick (branching on `map`'s evaluation timing), not a pattern to emulate.
- Both `foldMap` overloads remain in the public API; only the internal interpreter changed.
- Full `gradle build` — **BUILD SUCCESSFUL** under `-Werror`; the Free / FreePath suites (491 tests, incl. the function-based `interpretFree` lazy/eager-branch tests) pass.
- hkj-core **JaCoCo at baseline** — `missed=8` instructions, BRANCH/CLASS 100%; the function-path tests now exercise `asNatural` + the shared interpreter, so deleting `interpretFree` leaves no gap. Only the pre-existing `MonadError.recoverWith` default is uncovered.
- `spotlessCheck` clean.

## Docs

The [Free Monad](https://higher-kinded-j.github.io/monads/free_monad.html) chapter now notes that `foldMap` accepts both forms and recommends the type-safe `Natural` (a witness mismatch is then a compile error rather than an unchecked cast); the existing `Function`-form examples are kept for brevity.

