### PR TITLE
feat(checker): raw-kind rule — flag raw Kind/Kind2 usage (#565)

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -77,6 +77,13 @@ Two small internal-soundness cleanups ([#562](https://github.com/higher-kinded-j
 - `Each.eachWithIndex()` is **deprecated for removal in 0.5.0**. It still works as a bridge (so existing code compiles), but new code should narrow to `EachIndexed` and call `indexedTraversal()`. `Each.supportsIndexed()` reports `true` for any `EachIndexed`, falling back to the deprecated `eachWithIndex()` so a legacy `Each` that overrode it keeps working until the method is removed.
 - API change: additive (`EachIndexed`, sharper factory return types) plus one deprecation; no behaviour change for existing callers. The [Each type class](optics/each_typeclass.md) and [Indexed Optics](optics/indexed_optics.md) chapters show the typed form.
 
+**`raw-kind` checker rule**
+
+The HKJ compiler plugin gains a `raw-kind` rule ([#565](https://github.com/higher-kinded-j/higher-kinded-j/issues/565)). A raw `Kind`/`Kind2` used as a type drops its witness type argument, which is the one route that lets a value tagged with one witness be narrowed through another — it compiles silently and throws `KindUnwrapException` at runtime. javac accepts the raw use, so the checker is the sole compile-time signal.
+
+- Flags raw `Kind`/`Kind2` in a variable, parameter or field declaration, or a cast, at **warn** severity by default (honouring `disable=raw-kind` and `severity:raw-kind=error`). A properly parameterised `Kind<W, A>` (wildcards included) is never flagged, and an unresolved type is skipped — the no-false-positives policy holds.
+- The diagnostic names the fix (`Kind<XKind.Witness, A>`). Documented in [Compile-Time Checks](tooling/compile_checks.md).
+
 ---
 
 ### v0.4.6 (7 June 2026)

--- a/hkj-book/src/tooling/compile_checks.md
+++ b/hkj-book/src/tooling/compile_checks.md
@@ -59,6 +59,7 @@ soak.
 | `via-non-path` | `via`/`flatMap`/`then` given a function that returns a plain value instead of a Path (use `map`) | error | Companion |
 | `map-nests-effect` | `map` given a function that returns the **same** Path type — silently nests the effect; you meant `via` | **warn** | No — sole signal |
 | `migration-nudge` | `Free.liftF`/`Free.suspend` (→ FreePath/`*Ops`) and `InjectInstances.injectLeft/injectRight/injectRightThen` (→ `@ComposeEffects`) — valid code, an ergonomics nudge | **warn** | No — advisory |
+| `raw-kind` | A raw `Kind`/`Kind2` used as a type (variable, parameter, field or cast) — drops the witness type argument, the one compile-silent route to a wrong-witness `narrow()` and a runtime `KindUnwrapException` | **warn** | No — sole signal |
 
 "Companion" checks add an actionable HKJ message beside `javac`'s own
 cryptic error. "Sole signal" / "advisory" checks are the only
@@ -81,7 +82,8 @@ splits `-Xplugin` on whitespace into the plugin name and its arguments:
 - `severity=error|warn` — the global default for the error-default
   checks (default `error`). It does **not** silently promote the
   warn-default checks (`error-type-mismatch`, `map-nests-effect`,
-  `migration-nudge`) — those stay `warn` unless promoted explicitly.
+  `migration-nudge`, `raw-kind`) — those stay `warn` unless promoted
+  explicitly.
 - `severity:<id>=error|warn` — override one check. Wins over the global
   default and over a check's built-in default, so a team can promote a
   warn-default check, e.g. `severity:error-type-mismatch=error`, or

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/CheckVisitor.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/CheckVisitor.java
@@ -4,6 +4,7 @@ package org.higherkindedj.checker;
 
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.SwitchExpressionTree;
@@ -88,4 +89,13 @@ interface CheckVisitor {
    * @param path the tree path to {@code node}
    */
   default void onTypeCast(TypeCastTree node, TreePath path) {}
+
+  /**
+   * Invoked for each method declaration node visited during the scan (e.g. to inspect a return
+   * type).
+   *
+   * @param node the method node
+   * @param path the tree path to {@code node}
+   */
+  default void onMethod(MethodTree node, TreePath path) {}
 }

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/CheckVisitor.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/CheckVisitor.java
@@ -8,6 +8,8 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.SwitchExpressionTree;
 import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.TypeCastTree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 
 /**
@@ -70,4 +72,20 @@ interface CheckVisitor {
    * @param path the tree path to {@code node}
    */
   default void onParameterizedType(ParameterizedTypeTree node, TreePath path) {}
+
+  /**
+   * Invoked for each variable node (local, field or parameter) visited during the scan.
+   *
+   * @param node the variable node
+   * @param path the tree path to {@code node}
+   */
+  default void onVariable(VariableTree node, TreePath path) {}
+
+  /**
+   * Invoked for each cast expression node visited during the scan.
+   *
+   * @param node the cast node
+   * @param path the tree path to {@code node}
+   */
+  default void onTypeCast(TypeCastTree node, TreePath path) {}
 }

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/CheckerConfig.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/CheckerConfig.java
@@ -73,12 +73,15 @@ public final class CheckerConfig {
   /** Check id for {@link MigrationNudgeChecker} (advisory; warn-default). */
   public static final String MIGRATION_NUDGE = "migration-nudge";
 
+  /** Check id for {@link RawKindChecker} (advisory; warn-default). */
+  public static final String RAW_KIND = "raw-kind";
+
   /**
    * Checks whose built-in default is {@code WARNING}: they are the sole compile-time signal over
    * code javac accepts, so they only nudge until a per-check override promotes them.
    */
   private static final Set<String> WARN_DEFAULT_CHECKS =
-      Set.of(ERROR_TYPE_MISMATCH, MAP_NESTS_EFFECT, MIGRATION_NUDGE);
+      Set.of(ERROR_TYPE_MISMATCH, MAP_NESTS_EFFECT, MIGRATION_NUDGE, RAW_KIND);
 
   private final Set<String> disabled;
   private final Diagnostic.Kind severity;

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/DiagnosticMessages.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/DiagnosticMessages.java
@@ -211,6 +211,23 @@ public final class DiagnosticMessages {
   }
 
   /**
+   * Formats the advisory diagnostic for a raw {@code Kind}/{@code Kind2} used as a type.
+   *
+   * <p>A raw {@code Kind} drops its witness type argument, which is the one compile-silent route to
+   * a wrong-witness {@code narrow()} and a runtime {@code KindUnwrapException}. javac accepts the
+   * raw use, so this is the sole signal.
+   *
+   * @param kindName the raw type's simple name ({@code Kind} or {@code Kind2})
+   * @return a formatted advisory message
+   */
+  public static String rawKind(String kindName) {
+    return ("Raw %s drops its witness type argument — the one way to reach a wrong-witness narrow() "
+            + "that compiles but throws KindUnwrapException at runtime. Parameterise it: "
+            + "%s<XKind.Witness, A> (use %s<XKind.Witness, E, A> for Kind2).")
+        .formatted(kindName, kindName, kindName);
+  }
+
+  /**
    * Formats the companion diagnostic for {@code via}/{@code flatMap}/{@code then} given a function
    * that returns a plain value instead of a {@code Chainable} ({@code effect/compiler_errors.md}
    * section 3).

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/HKJCheckerPlugin.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/HKJCheckerPlugin.java
@@ -118,6 +118,9 @@ public class HKJCheckerPlugin implements Plugin {
           new WitnessArityChecker(
               trees, types, elements, config.severityFor(CheckerConfig.WITNESS_ARITY)));
     }
+    if (config.isEnabled(CheckerConfig.RAW_KIND)) {
+      checks.add(new RawKindChecker(trees, config.severityFor(CheckerConfig.RAW_KIND)));
+    }
     if (config.isEnabled(CheckerConfig.VIA_NON_PATH)) {
       checks.add(
           new ViaNonPathChecker(

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/HkjCheckScanner.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/HkjCheckScanner.java
@@ -4,6 +4,7 @@ package org.higherkindedj.checker;
 
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.SwitchExpressionTree;
@@ -92,5 +93,13 @@ final class HkjCheckScanner extends TreePathScanner<Void, Void> {
       c.onTypeCast(node, getCurrentPath());
     }
     return super.visitTypeCast(node, unused);
+  }
+
+  @Override
+  public Void visitMethod(MethodTree node, Void unused) {
+    for (CheckVisitor c : checks) {
+      c.onMethod(node, getCurrentPath());
+    }
+    return super.visitMethod(node, unused);
   }
 }

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/HkjCheckScanner.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/HkjCheckScanner.java
@@ -8,6 +8,8 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.SwitchExpressionTree;
 import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.TypeCastTree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePathScanner;
 import java.util.List;
 
@@ -74,5 +76,21 @@ final class HkjCheckScanner extends TreePathScanner<Void, Void> {
       c.onParameterizedType(node, getCurrentPath());
     }
     return super.visitParameterizedType(node, unused);
+  }
+
+  @Override
+  public Void visitVariable(VariableTree node, Void unused) {
+    for (CheckVisitor c : checks) {
+      c.onVariable(node, getCurrentPath());
+    }
+    return super.visitVariable(node, unused);
+  }
+
+  @Override
+  public Void visitTypeCast(TypeCastTree node, Void unused) {
+    for (CheckVisitor c : checks) {
+      c.onTypeCast(node, getCurrentPath());
+    }
+    return super.visitTypeCast(node, unused);
   }
 }

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/RawKindChecker.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/RawKindChecker.java
@@ -2,11 +2,15 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.checker;
 
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import java.util.Set;
 import javax.lang.model.element.TypeElement;
@@ -16,8 +20,9 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 
 /**
- * Detects a raw {@code Kind} or {@code Kind2} used as a type — a variable, field or parameter
- * declared as bare {@code Kind}, or a cast to bare {@code Kind}.
+ * Detects a raw {@code Kind} or {@code Kind2} used as a type — in a variable, field or parameter
+ * declaration, a cast, or a method return type, whether bare ({@code Kind}) or nested ({@code
+ * List<Kind>}).
  *
  * <p>Raw {@code Kind} is the one compile-silent route to a wrong-witness {@code narrow()}: {@code
  * Kind raw = OPTIONAL.widen(opt); EITHER.narrow(raw);} compiles cleanly and throws {@code
@@ -28,11 +33,13 @@ import javax.tools.Diagnostic;
  *
  * <h2>Rule</h2>
  *
- * <p>At a variable/parameter declaration or a cast, resolve the written type. Diagnose iff it
- * resolves to {@code org.higherkindedj.hkt.Kind} or {@code Kind2} as a <em>raw</em> type — the
- * element declares type parameters but the use supplied none. A properly parameterised {@code
- * Kind<W, A>} (including wildcards like {@code Kind<F, ?>}) is never flagged, and an unresolved
- * type is skipped, so the no-false-positives policy holds.
+ * <p>At a variable, parameter or field declaration, a cast, or a method return type, the written
+ * type tree is walked and every reference to {@code org.higherkindedj.hkt.Kind} or {@code Kind2}
+ * that resolves to a <em>raw</em> type — the element declares type parameters but the use supplied
+ * none — is flagged. This catches both a bare {@code Kind} and a nested one such as {@code
+ * List<Kind>}, {@code Kind[]} or {@code ? extends Kind}. A properly parameterised {@code Kind<W,
+ * A>} (wildcards like {@code Kind<F, ?>} included) is never flagged, and an unresolved type is
+ * skipped, so the no-false-positives policy holds.
  */
 public final class RawKindChecker implements CheckVisitor {
 
@@ -63,10 +70,47 @@ public final class RawKindChecker implements CheckVisitor {
     inspect(node.getType(), path);
   }
 
+  @Override
+  public void onMethod(MethodTree node, TreePath path) {
+    inspect(node.getReturnType(), path);
+  }
+
+  /**
+   * Walks a written type tree and flags every raw {@code Kind}/{@code Kind2} within it — the type
+   * itself or one nested inside a parameterised type, array or wildcard.
+   */
   private void inspect(Tree typeTree, TreePath path) {
-    if (typeTree == null || typeTree instanceof ParameterizedTypeTree) {
-      return; // no type tree, or already parameterised (Kind<…> is fine)
+    if (typeTree == null) {
+      return;
     }
+    new TreePathScanner<Void, Void>() {
+      @Override
+      public Void visitParameterizedType(ParameterizedTypeTree node, Void unused) {
+        // The head (e.g. Kind in Kind<W, A>) is parameterised and so never raw; only the type
+        // arguments can hide a nested raw Kind, so recurse into those alone.
+        for (Tree arg : node.getTypeArguments()) {
+          scan(arg, unused);
+        }
+        return null;
+      }
+
+      @Override
+      public Void visitIdentifier(IdentifierTree node, Void unused) {
+        flagIfRawKind(node, getCurrentPath());
+        return null;
+      }
+
+      @Override
+      public Void visitMemberSelect(MemberSelectTree node, Void unused) {
+        // A qualified type reference (e.g. fully-qualified Kind); its qualifier is a package or
+        // outer type, never a raw Kind we care about, so do not recurse into it.
+        flagIfRawKind(node, getCurrentPath());
+        return null;
+      }
+    }.scan(new TreePath(path, typeTree), null);
+  }
+
+  private void flagIfRawKind(Tree typeTree, TreePath path) {
     TypeMirror tm = typeOf(path, typeTree);
     if (tm == null || tm.getKind() != TypeKind.DECLARED) {
       return; // unresolved or not a declared type: skip (no false positives)

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/RawKindChecker.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/RawKindChecker.java
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
+import java.util.Set;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
+
+/**
+ * Detects a raw {@code Kind} or {@code Kind2} used as a type — a variable, field or parameter
+ * declared as bare {@code Kind}, or a cast to bare {@code Kind}.
+ *
+ * <p>Raw {@code Kind} is the one compile-silent route to a wrong-witness {@code narrow()}: {@code
+ * Kind raw = OPTIONAL.widen(opt); EITHER.narrow(raw);} compiles cleanly and throws {@code
+ * KindUnwrapException} (or {@code ClassCastException}) at runtime, because the lost witness type
+ * argument lets a value tagged with one witness be narrowed through another. The HKJ {@code narrow}
+ * helpers are typed precisely enough that the only way to feed them a mismatched witness is to drop
+ * to a raw {@code Kind} first. This checker restores a compile-time signal there.
+ *
+ * <h2>Rule</h2>
+ *
+ * <p>At a variable/parameter declaration or a cast, resolve the written type. Diagnose iff it
+ * resolves to {@code org.higherkindedj.hkt.Kind} or {@code Kind2} as a <em>raw</em> type — the
+ * element declares type parameters but the use supplied none. A properly parameterised {@code
+ * Kind<W, A>} (including wildcards like {@code Kind<F, ?>}) is never flagged, and an unresolved
+ * type is skipped, so the no-false-positives policy holds.
+ */
+public final class RawKindChecker implements CheckVisitor {
+
+  private static final Set<String> RAW_KIND_TYPES =
+      Set.of("org.higherkindedj.hkt.Kind", "org.higherkindedj.hkt.Kind2");
+
+  private final Trees trees;
+  private final Diagnostic.Kind severity;
+
+  /**
+   * Creates a checker reporting at the given severity.
+   *
+   * @param trees the {@link Trees} utility for AST and type resolution
+   * @param severity the severity at which the diagnostic is reported
+   */
+  public RawKindChecker(Trees trees, Diagnostic.Kind severity) {
+    this.trees = trees;
+    this.severity = severity;
+  }
+
+  @Override
+  public void onVariable(VariableTree node, TreePath path) {
+    inspect(node.getType(), path);
+  }
+
+  @Override
+  public void onTypeCast(TypeCastTree node, TreePath path) {
+    inspect(node.getType(), path);
+  }
+
+  private void inspect(Tree typeTree, TreePath path) {
+    if (typeTree == null || typeTree instanceof ParameterizedTypeTree) {
+      return; // no type tree, or already parameterised (Kind<…> is fine)
+    }
+    TypeMirror tm = typeOf(path, typeTree);
+    if (tm == null || tm.getKind() != TypeKind.DECLARED) {
+      return; // unresolved or not a declared type: skip (no false positives)
+    }
+    DeclaredType dt = (DeclaredType) tm;
+    if (!(dt.asElement() instanceof TypeElement te)) {
+      return;
+    }
+    if (!RAW_KIND_TYPES.contains(te.getQualifiedName().toString())) {
+      return;
+    }
+    // Raw iff the element declares type parameters but this use supplied none.
+    if (dt.getTypeArguments().isEmpty() && !te.getTypeParameters().isEmpty()) {
+      trees.printMessage(
+          severity,
+          DiagnosticMessages.rawKind(te.getSimpleName().toString()),
+          typeTree,
+          path.getCompilationUnit());
+    }
+  }
+
+  private TypeMirror typeOf(TreePath path, Tree t) {
+    try {
+      return trees.getTypeMirror(new TreePath(path, t));
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+}

--- a/hkj-checker/src/main/java/org/higherkindedj/checker/RawKindChecker.java
+++ b/hkj-checker/src/main/java/org/higherkindedj/checker/RawKindChecker.java
@@ -111,7 +111,8 @@ public final class RawKindChecker implements CheckVisitor {
   }
 
   private void flagIfRawKind(Tree typeTree, TreePath path) {
-    TypeMirror tm = typeOf(path, typeTree);
+    // path already points at typeTree (it is the scanner's current path).
+    TypeMirror tm = typeOf(path);
     if (tm == null || tm.getKind() != TypeKind.DECLARED) {
       return; // unresolved or not a declared type: skip (no false positives)
     }
@@ -132,9 +133,9 @@ public final class RawKindChecker implements CheckVisitor {
     }
   }
 
-  private TypeMirror typeOf(TreePath path, Tree t) {
+  private TypeMirror typeOf(TreePath path) {
     try {
-      return trees.getTypeMirror(new TreePath(path, t));
+      return trees.getTypeMirror(path);
     } catch (RuntimeException e) {
       return null;
     }

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/CheckerConfigSeverityTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/CheckerConfigSeverityTest.java
@@ -35,6 +35,7 @@ class CheckerConfigSeverityTest {
       assertThat(c.severityFor(CheckerConfig.ERROR_TYPE_MISMATCH))
           .isEqualTo(Diagnostic.Kind.WARNING);
       assertThat(c.severityFor(CheckerConfig.MAP_NESTS_EFFECT)).isEqualTo(Diagnostic.Kind.WARNING);
+      assertThat(c.severityFor(CheckerConfig.RAW_KIND)).isEqualTo(Diagnostic.Kind.WARNING);
     }
   }
 

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/RawKindCheckerTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/RawKindCheckerTest.java
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.checker;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("RawKindChecker")
+class RawKindCheckerTest {
+
+  private Compilation compile(String pluginArgs, JavaFileObject source) {
+    return com.google.testing.compile.Compiler.javac()
+        .withOptions(
+            "-Xplugin:HKJChecker" + (pluginArgs.isEmpty() ? "" : " " + pluginArgs),
+            "--enable-preview",
+            "--release",
+            "25")
+        .compile(source);
+  }
+
+  private Compilation compile(JavaFileObject source) {
+    return compile("", source);
+  }
+
+  private static JavaFileObject src(String name, String body) {
+    return JavaFileObjects.forSourceString(name, body);
+  }
+
+  private static long rawKindDiagnostics(Compilation c, Diagnostic.Kind kind) {
+    return c.diagnostics().stream()
+        .filter(d -> d.getKind() == kind)
+        .filter(d -> String.valueOf(d.getMessage(null)).contains("drops its witness type argument"))
+        .count();
+  }
+
+  private static boolean mentionsRawKind(Compilation c) {
+    return c.diagnostics().stream()
+        .anyMatch(
+            d -> String.valueOf(d.getMessage(null)).contains("drops its witness type argument"));
+  }
+
+  @Nested
+  @DisplayName("flags raw Kind / Kind2")
+  class TruePositives {
+
+    @Test
+    @DisplayName("raw Kind local variable")
+    void rawLocalVariable() {
+      JavaFileObject source =
+          src(
+              "test.RawVar",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              public class RawVar {
+                void use() {
+                  Kind raw = null;
+                }
+              }
+              """);
+      Assertions.assertThat(rawKindDiagnostics(compile(source), Diagnostic.Kind.WARNING))
+          .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("raw Kind method parameter")
+    void rawParameter() {
+      JavaFileObject source =
+          src(
+              "test.RawParam",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              public class RawParam {
+                void use(Kind raw) {}
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
+
+    @Test
+    @DisplayName("cast to raw Kind")
+    void rawCast() {
+      JavaFileObject source =
+          src(
+              "test.RawCast",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              public class RawCast {
+                Object use(Object x) {
+                  return (Kind) x;
+                }
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
+
+    @Test
+    @DisplayName("raw Kind2 field")
+    void rawKind2Field() {
+      JavaFileObject source =
+          src(
+              "test.RawKind2",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind2;
+              public class RawKind2 {
+                Kind2 field;
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("does not flag parameterised Kind")
+  class TrueNegatives {
+
+    @Test
+    @DisplayName("Kind<Witness, A> is fine")
+    void parameterisedKind() {
+      JavaFileObject source =
+          src(
+              "test.GoodKind",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              import org.higherkindedj.hkt.maybe.MaybeKind;
+              public class GoodKind {
+                void use(Kind<MaybeKind.Witness, String> k) {}
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Kind<Witness, ?> wildcard is fine")
+    void wildcardKind() {
+      JavaFileObject source =
+          src(
+              "test.WildcardKind",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              import org.higherkindedj.hkt.maybe.MaybeKind;
+              public class WildcardKind {
+                void use(Kind<MaybeKind.Witness, ?> k) {}
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isFalse();
+    }
+
+    @Test
+    @DisplayName("an unrelated raw type is not flagged")
+    void unrelatedRawType() {
+      JavaFileObject source =
+          src(
+              "test.RawList",
+              """
+              package test;
+              import java.util.List;
+              public class RawList {
+                List raw;
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("honours configuration")
+  class Configuration {
+
+    private static final JavaFileObject RAW_VAR =
+        src(
+            "test.RawVar2",
+            """
+            package test;
+            import org.higherkindedj.hkt.Kind;
+            public class RawVar2 {
+              void use() {
+                Kind raw = null;
+              }
+            }
+            """);
+
+    @Test
+    @DisplayName("disable=raw-kind suppresses the diagnostic")
+    void disabled() {
+      Assertions.assertThat(mentionsRawKind(compile("disable=raw-kind", RAW_VAR))).isFalse();
+    }
+
+    @Test
+    @DisplayName("severity:raw-kind=error promotes it to an error")
+    void promotedToError() {
+      Compilation c = compile("severity:raw-kind=error", RAW_VAR);
+      Assertions.assertThat(rawKindDiagnostics(c, Diagnostic.Kind.ERROR)).isEqualTo(1);
+    }
+  }
+}

--- a/hkj-checker/src/test/java/org/higherkindedj/checker/RawKindCheckerTest.java
+++ b/hkj-checker/src/test/java/org/higherkindedj/checker/RawKindCheckerTest.java
@@ -117,6 +117,74 @@ class RawKindCheckerTest {
               """);
       Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
     }
+
+    @Test
+    @DisplayName("raw Kind in a method return type")
+    void rawMethodReturnType() {
+      JavaFileObject source =
+          src(
+              "test.RawReturn",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              public class RawReturn {
+                Kind use() {
+                  return null;
+                }
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
+
+    @Test
+    @DisplayName("raw Kind nested inside a parameterised type")
+    void rawNestedInParameterised() {
+      JavaFileObject source =
+          src(
+              "test.RawNested",
+              """
+              package test;
+              import java.util.List;
+              import org.higherkindedj.hkt.Kind;
+              public class RawNested {
+                List<Kind> rawList;
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
+
+    @Test
+    @DisplayName("raw Kind array")
+    void rawArray() {
+      JavaFileObject source =
+          src(
+              "test.RawArray",
+              """
+              package test;
+              import org.higherkindedj.hkt.Kind;
+              public class RawArray {
+                Kind[] arr;
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
+
+    @Test
+    @DisplayName("raw Kind in a wildcard bound")
+    void rawWildcardBound() {
+      JavaFileObject source =
+          src(
+              "test.RawWildcard",
+              """
+              package test;
+              import java.util.List;
+              import org.higherkindedj.hkt.Kind;
+              public class RawWildcard {
+                List<? extends Kind> xs;
+              }
+              """);
+      Assertions.assertThat(mentionsRawKind(compile(source))).isTrue();
+    }
   }
 
   @Nested


### PR DESCRIPTION
Closes #565.

## Problem

A raw `Kind`/`Kind2` used as a type drops its witness type argument — and that is the **one compile-silent route to a wrong-witness `narrow()`**:

```java
Kind raw = OPTIONAL.widen(opt);   // raw: witness lost
Either<E, A> e = EITHER.narrow(raw);   // compiles; throws KindUnwrapException at runtime
```

The HKJ `narrow` helpers are typed precisely enough that the only way to feed them a mismatched witness is to drop to a raw `Kind` first. javac accepts the raw use, so there is no signal — the checker's own spike tests already flagged this as the lone silent path.

## Solution

New **`RawKindChecker`** (id `raw-kind`, **warn**-default) flags a raw `Kind`/`Kind2` in a variable, parameter or field declaration, or a cast.

- It resolves the written type and diagnoses **only** a `Kind`/`Kind2` declared type with no type arguments whose element declares them. A parameterised `Kind<W, A>` — wildcards like `Kind<F, ?>` included — is never flagged, and an unresolved type is skipped, so the no-false-positives policy holds.
- The diagnostic names the fix: `Kind<XKind.Witness, A>` (`Kind2<XKind.Witness, E, A>` for `Kind2`).
- Honours the existing config: `disable=raw-kind` and `severity:raw-kind=error`.

## Changes

- New `RawKindChecker` + two new `CheckVisitor` hooks (`onVariable`, `onTypeCast`) wired through `HkjCheckScanner` (raw `Kind` has no `ParameterizedTypeTree`, so the existing hooks couldn't see it).
- Registered: `CheckerConfig.RAW_KIND` (added to the warn-default set) and `HKJCheckerPlugin`; `DiagnosticMessages.rawKind`.
- Compile-testing tests covering raw var/param/field/cast (flagged), parameterised + wildcard + unrelated-raw-type (not flagged), and `disable` / `severity:raw-kind=error`.
- Documented in the [Compile-Time Checks](https://higher-kinded-j.github.io/tooling/compile_checks.html) chapter; release-history entry.

## Notes

- Self-contained: only the `hkj-checker` module (plus docs). No hkj-core/api change.
- The optional "dogfood the plugin on hkj-examples" follow-on from the issue is left out as a separate decision.

## Verification

- Full `gradle build` — **BUILD SUCCESSFUL** under `-Werror`; the full `hkj-checker` suite passes (existing checkers unaffected by the new hooks).
- hkj-core JaCoCo unchanged (no hkj-core code touched); a transient `CircuitBreaker.protect` coverage dip in the first run was the known timing-flaky spot and recovered to baseline on re-run.
- `spotlessCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
