### PR TITLE
build(deps): update Spring Boot to 4.1.0 (Jackson 3.1.4)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,14 +18,14 @@ truth = "1.4.5"
 jmh = "1.37"
 jol = "0.17"
 
-# Spring Boot 4.0.6 (requires Java 17+, Jakarta EE 11, Servlet 6.1)
+# Spring Boot 4.1.0 (requires Java 17+, Jakarta EE 11, Servlet 6.1; Spring Framework 7.0.8)
 # Note: hkj-spring 0.2.7 supports Spring Boot 3.5.7, 0.2.8+ requires Spring Boot 4.0.1+
-spring-boot = "4.0.6"
+spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
 
 # Jackson 3.x (group ID changed from com.fasterxml.jackson to tools.jackson in Spring Boot 4)
-# 3.1.2 matches the tools.jackson:jackson-bom managed by Spring Boot 4.0.6
-jackson = "3.1.2"
+# 3.1.4 matches the tools.jackson:jackson-bom managed by Spring Boot 4.1.0
+jackson = "3.1.4"
 
 # JOOQ - Database access library (for spec interface examples)
 jooq = "3.21.5"

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -14,6 +14,12 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ### v0.4.7-SNAPSHOT (in development)
 
+**Spring Boot 4.1.0 / Framework 7.0.8 upgrade**
+
+The `hkj-spring` integration modules move from Spring Boot 4.0.6 to 4.1.0 (Spring Framework 7.0.8), with the managed Jackson 3.x line advancing from 3.1.2 to 3.1.4 to match the `tools.jackson:jackson-bom` shipped by Boot 4.1.0 ([#575](https://github.com/higher-kinded-j/higher-kinded-j/pull/575)).
+
+- Dependency-only change, centralised in the version catalog (`spring-boot` and `jackson` entries); Spring Framework 7.0.8 and the rest of the stack flow through transitively via the BOM. The `autoconfigure`, `example` and `effect-example` modules compile and pass their test suites against 4.1.0 with no source changes, and the upgrade introduces no new deprecations. No public API change.
+
 **`Writer.of(log, value)` factory**
 
 `Writer<W, A>` exposed `Writer.value(Monoid<W>, A)` (empty log) and `Writer.tell(W)` (`Unit` value) but had no factory for the common custom-log-plus-value case, leaving the raw `new Writer<>(log, value)` constructor as the only option. Because a `Writer` legitimately holds a null value, that constructor's diamond infers a `@Nullable A` type argument, which trips nullness analysis at the call site ("returning a class with nullable type arguments where not-null expected"); a static factory whose return type is the plain `Writer<W, A>` launders the nullness contract once, in production code.


### PR DESCRIPTION
## Summary

Bumps the Spring Boot version-catalog entry from **4.0.6 → 4.1.0** and the managed Jackson line from **3.1.2 → 3.1.4** (the `tools.jackson:jackson-bom` version managed by Spring Boot 4.1.0). Spring Framework 7.0.8 and the rest of the Spring stack (Security 7.1.0, etc.) flow through transitively via the BOM, so only the `spring-boot` and `jackson` catalog entries needed touching.

All Spring versioning is centralised in `gradle/libs.versions.toml`, so the change is 4 lines (two versions + their explanatory comments).

## Changes required to hkj-spring: none

- **autoconfigure**, **example**, and **effect-example** all compile and pass their full test suites against 4.1.0.
- The 4.1 deprecation/removal surface (layertools jar mode, Derby, Devtools LiveReload, Spring Data JPA bootstrap modes) is not used by hkj-spring.
- The pre-existing "uses a deprecated API" compiler note in the test sources appears with an identical count on 4.0.6 — the upgrade introduces **no new deprecations**.

## Test plan

- [x] `gradle :hkj-spring:autoconfigure:test :hkj-spring:example:test :hkj-spring:effect-example:test --rerun-tasks` → BUILD SUCCESSFUL

Refs: [Spring Boot 4.1 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.1-Release-Notes)