### PR TITLE
Harden the order & market examples; adopt hkj-test across hkj-examples

### DIFF
--- a/hkj-book/src/examples/examples_market_data.md
+++ b/hkj-book/src/examples/examples_market_data.md
@@ -231,7 +231,7 @@ Every HKJ feature used in the pipeline, mapped to the stage where it appears:
 | **Merge** | `VStreamPar.merge` | Concurrent multi-source merging | [Building](market_building.md#step-2) |
 | **Enrich** | `Par.map2` | Run two VTasks in parallel, combine | [Building](market_building.md#step-3) |
 | **Enrich** | `VStreamPar.parEvalMap` | Bounded parallel map, order preserved | [Building](market_building.md#step-3) |
-| **Risk** | `parEvalMapUnordered` | Bounded parallel map, completion order | [Building](market_building.md#step-4) |
+| **Risk** | `parEvalMap` | Bounded parallel map, order preserved | [Building](market_building.md#step-4) |
 | **Window** | `VStream.chunk` | Group elements into fixed-size batches | [Building](market_building.md#step-5) |
 | **Aggregate** | `VStream.map` | Transform each chunk into a summary | [Building](market_building.md#step-5) |
 | **Detect** | `VStream.flatMap` | Each element produces zero or more results | [Alerts](market_alerts.md#step-6) |

--- a/hkj-book/src/examples/examples_order.md
+++ b/hkj-book/src/examples/examples_order.md
@@ -67,12 +67,12 @@ public EitherPath<OrderError, OrderResult> process(OrderRequest request) {
                 ProcessingState.initial(address, customer, order))
 
             // Phase 2 (Enrich): named field access via ForState + lenses
-            .fromThen(s -> lift(reserveInventory(s.order())),        reservationLens)
-            .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), discountLens)
-            .fromThen(s -> lift(processPayment(s.order(), s.discount())), paymentLens)
-            .fromThen(s -> lift(createShipment(s.order(), s.address())), shipmentLens)
+            .fromThen(s -> lift(reserveInventory(s.order())),        ProcessingStateLenses.reservation())
+            .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), ProcessingStateLenses.discount())
+            .fromThen(s -> lift(processPayment(s.order(), s.discount())), ProcessingStateLenses.payment())
+            .fromThen(s -> lift(createShipment(s.order(), s.address())), ProcessingStateLenses.shipment())
             .fromThen(s -> lift(sendNotifications(s.order(), s.customer(), s.discount())),
-                notificationLens)
+                ProcessingStateLenses.notification())
             .yield(OrderWorkflow::toOrderResult);
 
     return Path.either(EITHER.narrow(result));

--- a/hkj-book/src/examples/market_alerts.md
+++ b/hkj-book/src/examples/market_alerts.md
@@ -305,7 +305,7 @@ public class MarketDataPipeline {
   <div class="pipeline-row pipeline-row-center">
     <span class="pipeline-node pn-orange">enrich — Par.map2 ×8</span>
     <span class="pipeline-arrow">→</span>
-    <span class="pipeline-node pn-orange">risk — parEvalMapUnordered ×4</span>
+    <span class="pipeline-node pn-orange">risk — parEvalMap ×4</span>
   </div>
   <div class="pipeline-arrow-down">▼</div>
   <div class="pipeline-row pipeline-row-center">

--- a/hkj-book/src/examples/market_building.md
+++ b/hkj-book/src/examples/market_building.md
@@ -192,23 +192,34 @@ stream, we want bounded concurrency (don't open 10,000 connections at once).
 
 ```java
 public class TickEnricher {
-    // Per-tick: fetch instrument + FX rate in parallel
-    public VTask<EnrichedTick> enrichOne(PriceTick tick) {
+    // Per-tick: fetch instrument + FX rate in parallel; a failed lookup becomes a typed error.
+    public VTask<Either<MarketError, EnrichedTick>> enrichOne(PriceTick tick) {
         VTask<Instrument> instrumentTask = refData.lookup(tick.symbol());
         VTask<BigDecimal> fxTask = fxService.rateToUsd(tick.exchange().currency());
 
         return Par.map2(instrumentTask, fxTask,
-            (instrument, fxRate) -> new EnrichedTick(tick, instrument, fxRate));
+                (instrument, fxRate) ->
+                    Either.<MarketError, EnrichedTick>right(
+                        new EnrichedTick(tick, instrument, fxRate)))
+            // An unknown instrument/currency is recovered into a typed EnrichmentFailed (carrying
+            // the tick's symbol) instead of propagating as an exception.
+            .recover(error ->
+                Either.left(new MarketError.EnrichmentFailed(tick.symbol(), error.getMessage())));
     }
 
-    // Across the stream: bounded concurrent enrichment
+    // Across the stream: bounded concurrent enrichment. Failed ticks are reported through the
+    // typed-error channel and dropped, so one bad symbol can't abort the feed.
     public VStream<EnrichedTick> enrich(VStream<PriceTick> ticks) {
-        return VStreamPar.parEvalMap(ticks, concurrency, this::enrichOne);
+        return VStreamPar.parEvalMap(ticks, concurrency, this::enrichOne)
+            .peek(result -> result.ifLeft(onEnrichmentError))
+            .flatMap(result -> result.fold(_ -> VStream.empty(), VStream::of));
     }
 }
 ```
 
-This creates two levels of concurrency that compose naturally:
+`enrichOne` returns `VTask<Either<MarketError, EnrichedTick>>`: the `MarketError` channel makes a
+lookup miss a *value*, not a thrown exception, so the pipeline filters failures instead of crashing.
+The enrichment also creates two levels of concurrency that compose naturally:
 
 ```
    ┌──────────────── parEvalMap (across stream, 8 concurrent) ──────────────┐
@@ -274,19 +285,19 @@ The same pattern is available within for-comprehensions via `ForPath.par()`. For
 
 ---
 
-## Step 4: Parallel Risk Assessment with `parEvalMapUnordered` {#step-4}
+## Step 4: Parallel Risk Assessment with `parEvalMap` {#step-4}
 
-**Problem:** Each enriched tick needs a risk score. Risk calculations are independent:
-the order doesn't matter for downstream aggregation, so we can maximise throughput by
-emitting results in completion order.
+**Problem:** Each enriched tick needs a risk score. The calculations are independent of one
+another, but the results feed straight into a count-based windower (`chunk`), so emission
+order must match arrival order — otherwise ticks would land in the wrong window.
 
-**HKJ feature:** `VStreamPar.parEvalMapUnordered(stream, concurrency, f)`: same as
-`parEvalMap`, but emits results as they complete rather than preserving input order.
+**HKJ feature:** `VStreamPar.parEvalMap(stream, concurrency, f)`: applies an effectful
+function to each element with bounded concurrency while **preserving input order**.
 
 ```java
 public class RiskPipeline {
     public VStream<RiskAssessment> assess(VStream<EnrichedTick> enrichedTicks) {
-        return VStreamPar.parEvalMapUnordered(
+        return VStreamPar.parEvalMap(
             enrichedTicks, concurrency, calculator::assess);
     }
 }
@@ -308,12 +319,15 @@ Both variants:
 - Fork each element's VTask via `StructuredTaskScope`
 - Fail fast if any element throws (remaining tasks are cancelled)
 
-~~~admonish note title="Design Decision: Why unordered for risk?"
-Risk assessment feeds into `chunk()`, which groups consecutive elements into windows. The
-**identity** of the ticks in a window matters (we need valid prices), but their **order**
-within the window doesn't affect the VWAP calculation or anomaly detection. By using the
-unordered variant, a fast risk assessment for tick₅ doesn't have to wait behind a slow
-assessment for tick₃.
+~~~admonish note title="Design Decision: Why ordered for risk?"
+Risk assessment feeds into `chunk()`, which groups **consecutive** elements into fixed-size
+windows. Because the window boundaries are positional — every `windowSize` ticks in stream
+order — emission order decides *which* ticks share a window. The unordered variant emits in
+completion order, so a fast assessment for tick₅ could overtake a slow one for tick₃ and land
+in an earlier window, scrambling window membership and making per-window VWAP meaningless.
+`parEvalMap` keeps the assessments in arrival order, so each window holds the temporally
+adjacent ticks it should — paying the per-batch "wait for the slowest" cost in exchange for
+correct windows.
 ~~~
 
 ---

--- a/hkj-book/src/examples/market_reference.md
+++ b/hkj-book/src/examples/market_reference.md
@@ -16,7 +16,7 @@ file without scrolling through three chapters.
 | **Merge** | `VStreamPar.merge` | Concurrent multi-source merging with virtual threads |
 | **Enrich** | `Par.map2` | Run two VTasks in parallel, combine results |
 | **Enrich** | `VStreamPar.parEvalMap` | Bounded parallel map preserving order |
-| **Risk** | `VStreamPar.parEvalMapUnordered` | Bounded parallel map in completion order |
+| **Risk** | `VStreamPar.parEvalMap` | Bounded parallel map preserving order (windowing needs it) |
 | **Window** | `VStream.chunk` | Group elements into fixed-size batches |
 | **Aggregate** | `VStream.map` | Transform each chunk into a summary |
 | **Detect** | `VStream.flatMap` | Each element produces zero or more results |
@@ -40,10 +40,11 @@ cancels the other. This is what the enrichment stage does with its reference-dat
 FX-rate lookups.
 
 **I need to apply an effectful function to every element in a stream.**
-If downstream order matters (e.g. enrichment feeds into risk assessment), use
-`parEvalMap`. It processes elements concurrently but emits them in the original order.
-If order does not matter and you want maximum throughput (e.g. independent risk
-calculations), use `parEvalMapUnordered`. It emits results as they complete.
+If downstream order matters, use `parEvalMap`. It processes elements concurrently but emits
+them in the original order — the pipeline uses it for both enrichment *and* risk assessment,
+because the risk results feed a count-based windower (`chunk`) that groups ticks by position.
+If order genuinely does not matter and you want maximum throughput, use
+`parEvalMapUnordered`. It emits results as they complete.
 
 **I need to fan out to multiple channels and all must succeed.**
 Use `Scope.allSucceed` with `fork` for each channel and `join` to wait. If any channel
@@ -69,7 +70,7 @@ starting the second.
 | Feed combination | `merge` over `concat` | Live feeds must interleave by arrival time |
 | Lookup parallelism | `Par.map2` over `flatMap` | Two independent lookups: 50ms vs 100ms |
 | Stream parallelism | `parEvalMap` for enrichment | Order matters for downstream processing |
-| Risk parallelism | `parEvalMapUnordered` | Order irrelevant, maximise throughput |
+| Risk parallelism | `parEvalMap` | Windowing groups ticks by position, so order matters |
 | Windowing | `chunk` (fixed-size) | Deterministic, simple; time-based is a config change |
 | Detection | `flatMap` over `map` + `filter` | Natural 0-to-many mapping per view |
 | Alert dispatch | `Scope.allSucceed` | All-or-nothing: every channel must confirm |

--- a/hkj-book/src/hkts/order-composition.md
+++ b/hkj-book/src/hkts/order-composition.md
@@ -114,22 +114,28 @@ public EitherPath<OrderError, OrderResult> process(OrderRequest request) {
             .toState((address, customer, order) ->
                 ProcessingState.initial(address, customer, order))
 
-            // Phase 2 (Enrich): named field access via ForState + lenses
+            // Phase 2 (Enrich): named field access via ForState + generated lenses
             .fromThen(s -> lift(reserveInventory(s.order().orderId(), s.order().lines())),
-                reservationLens)
+                ProcessingStateLenses.reservation())
             .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())),
-                discountLens)
+                ProcessingStateLenses.discount())
             .fromThen(s -> lift(processPayment(s.order(), s.discount())),
-                paymentLens)
+                ProcessingStateLenses.payment())
             .fromThen(s -> lift(createShipment(s.order(), s.address())),
-                shipmentLens)
+                ProcessingStateLenses.shipment())
             .fromThen(s -> lift(sendNotifications(s.order(), s.customer(), s.discount())),
-                notificationLens)
+                ProcessingStateLenses.notification())
             .yield(OrderWorkflow::toOrderResult);
 
     return Path.either(EITHER.narrow(result));
 }
 ```
+
+In the current example, `process` first runs **accumulating** field validation: `validateRequest`
+collects every malformed field at once via `ValidationPath.zipWithAccum`, converts to `EitherPath`,
+and only then delegates to the `For` → `ForState` pipeline above (factored out as `processValidated`).
+The composition pattern is unchanged — the validation front door just reports all input errors
+together rather than one per round-trip.
 
 ### Two-Phase Design
 
@@ -157,7 +163,8 @@ With `EitherPath`, the benefit is documentation of intent; execution remains seq
 The `ProcessingState` record gives every intermediate value a name:
 
 ```java
-record ProcessingState(
+@GenerateLenses
+public record ProcessingState(
     ValidatedShippingAddress address,
     Customer customer,
     ValidatedOrder order,
@@ -178,20 +185,24 @@ After `toState()`, the `fromThen()` steps access earlier results by name — `s.
 
 ### Lenses Connect ForState to the State Record
 
-Each `fromThen(function, lens)` call runs a monadic operation and stores the result via a lens:
+Each `fromThen(function, lens)` call runs a monadic operation and stores the result via a lens.
+Because `ProcessingState` is annotated `@GenerateLenses`, the processor generates one lens per field
+— `ProcessingStateLenses.reservation()`, `ProcessingStateLenses.discount()`, … — so the workflow
+above never hand-writes a lens. Each generated lens is just a getter/setter pair;
+`ProcessingStateLenses.discount()` is equivalent to:
 
 ```java
-// In production: @GenerateLenses on ProcessingState generates these automatically
-static final Lens<ProcessingState, DiscountResult> discountLens =
-    Lens.of(
-        ProcessingState::discount,
-        (s, v) -> new ProcessingState(
-            s.address(), s.customer(), s.order(), s.reservation(),
-            v, s.payment(), s.shipment(), s.notification()));
+Lens.of(
+    ProcessingState::discount,
+    (s, v) -> new ProcessingState(
+        s.address(), s.customer(), s.order(), s.reservation(),
+        v, s.payment(), s.shipment(), s.notification()));
 ```
 
-~~~admonish tip title="Use @GenerateLenses in production"
-Annotate your state record with `@GenerateLenses` and the annotation processor generates all lenses automatically. The manual definitions shown here are for clarity.
+~~~admonish tip title="@GenerateLenses removes the boilerplate"
+Annotating the state record with `@GenerateLenses` generates all five enrich-phase lenses
+automatically — the `Lens.of(...)` form above is shown only to illustrate what each generated lens
+does. The example workflow calls `ProcessingStateLenses.discount()` and friends directly.
 ~~~
 
 ### Kind Lifting
@@ -271,7 +282,7 @@ private Either<OrderError, NotificationResult> sendNotifications(
 }
 ```
 
-The `fold()` method handles both cases: on error, it recovers with a "no notification" result; on success, it passes through. The `ForState` step that calls this method via `fromThen()` will store the result via `notificationLens` either way.
+The `fold()` method handles both cases: on error, it recovers with a "no notification" result; on success, it passes through. The `ForState` step that calls this method via `fromThen()` will store the result via `ProcessingStateLenses.notification()` either way.
 
 ### Recovery Options
 

--- a/hkj-book/src/hkts/order-production.md
+++ b/hkj-book/src/hkts/order-production.md
@@ -19,20 +19,30 @@ This page covers production-grade patterns for the order workflow: resilience wi
 
 ## Resilience: Retry and Timeout
 
-The `ConfigurableOrderWorkflow` demonstrates production-grade resilience:
+The `ConfigurableOrderWorkflow` applies resilience **per step**, not around the whole flow:
 
 ```java
 public EitherPath<OrderError, OrderResult> process(OrderRequest request) {
     var retryPolicy = createRetryPolicy();
-    var totalTimeout = calculateTotalTimeout();
 
-    return Resilience.resilient(
+    // Phase 1 — RETRY only the idempotent pre-flight (customer eligibility + address validation);
+    // re-running these reads is always safe.
+    EitherPath<OrderError, Unit> preflight = Resilience.resilient(
+        Path.io(() -> runPreflight(request)),
+        retryPolicy, preflightTimeout, "ConfigurableOrderWorkflow.preflight");
+
+    // Phase 2 — run the committing workflow (reserve -> payment -> ship) EXACTLY ONCE under a
+    // timeout, never retried.
+    return preflight.via(_ -> Resilience.withTimeout(
         Path.io(() -> executeWorkflow(request)),
-        retryPolicy,
-        totalTimeout,
-        "ConfigurableOrderWorkflow.process");
+        commitTimeout, "ConfigurableOrderWorkflow.commit"));
 }
 ```
+
+Granularity matters: payment is **not** idempotent, so wrapping the *entire* workflow in retry
+could re-run a charge that already succeeded and double-bill the customer. Retry is confined to the
+safe pre-flight reads; the commit runs once. (Per-step refund-on-failure compensation across
+reserve → pay → ship would use a `Saga` — see the future-work draft issues.)
 
 ### Retry Policy
 

--- a/hkj-book/src/hkts/order-walkthrough.md
+++ b/hkj-book/src/hkts/order-walkthrough.md
@@ -120,12 +120,12 @@ public EitherPath<OrderError, OrderResult> process(OrderRequest request) {
                 ProcessingState.initial(address, customer, order))
 
             // Enrich phase: named field access via ForState + lenses
-            .fromThen(s -> lift(reserveInventory(s.order())),        reservationLens)
-            .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), discountLens)
-            .fromThen(s -> lift(processPayment(s.order(), s.discount())), paymentLens)
-            .fromThen(s -> lift(createShipment(s.order(), s.address())), shipmentLens)
+            .fromThen(s -> lift(reserveInventory(s.order())),        ProcessingStateLenses.reservation())
+            .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), ProcessingStateLenses.discount())
+            .fromThen(s -> lift(processPayment(s.order(), s.discount())), ProcessingStateLenses.payment())
+            .fromThen(s -> lift(createShipment(s.order(), s.address())), ProcessingStateLenses.shipment())
             .fromThen(s -> lift(sendNotifications(s.order(), s.customer(), s.discount())),
-                notificationLens)
+                ProcessingStateLenses.notification())
             .yield(OrderWorkflow::toOrderResult);
 
     return Path.either(EITHER.narrow(result));
@@ -162,12 +162,12 @@ For.from(monad, lift(validateShippingAddress(request.shippingAddress())))
     .from(t -> lift(buildValidatedOrder(orderId, request, t._2(), t._1())))
     .toState((address, customer, order) ->
         ProcessingState.initial(address, customer, order))
-    .fromThen(s -> lift(reserveInventory(s.order())),        reservationLens)
-    .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), discountLens)
-    .fromThen(s -> lift(processPayment(s.order(), s.discount())), paymentLens)
-    .fromThen(s -> lift(createShipment(s.order(), s.address())), shipmentLens)
+    .fromThen(s -> lift(reserveInventory(s.order())),        ProcessingStateLenses.reservation())
+    .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), ProcessingStateLenses.discount())
+    .fromThen(s -> lift(processPayment(s.order(), s.discount())), ProcessingStateLenses.payment())
+    .fromThen(s -> lift(createShipment(s.order(), s.address())), ProcessingStateLenses.shipment())
     .fromThen(s -> lift(sendNotifications(s.order(), s.customer(), s.discount())),
-        notificationLens)
+        ProcessingStateLenses.notification())
     .yield(OrderWorkflow::toOrderResult);
 ```
 

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -25,7 +25,7 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 **`EitherOrBoth`: an inclusive-or for "success that also carries warnings"**
 
-`Either` and `Validated` are both *exclusive*: a result is a failure or a success, never both. Neither models a successful value that also carries accumulated, non-fatal problems: config that parses but reports deprecations, an import that yields records *and* a skipped-rows list. New `EitherOrBoth<L, R>` (the inclusive-or known elsewhere as `Ior`/`These`) is a sealed type over `Left` | `Right` | `Both`, right-biased, with total `getLeft`/`getRight` accessors that return `Maybe` and never throw. Purely additive ([#551](https://github.com/higher-kinded-j/higher-kinded-j/issues/551)).
+`Either` and `Validated` are both *exclusive*: a result is a failure or a success, never both. Neither models a successful value that also carries accumulated, non-fatal problems: config that parses but reports deprecations, an import that yields records *and* a skipped-rows list. New `EitherOrBoth<L, R>` (the inclusive-or known elsewhere as `Ior`/`These`) is a sealed type over `Left` | `Right` | `Both`, right-biased, with total `getLeft`/`getRight` accessors that return `Maybe` and never throw. Purely additive ([#551](https://github.com/higher-kinded-j/higher-kinded-j/issues/551); landed in [#583](https://github.com/higher-kinded-j/higher-kinded-j/pull/583)).
 
 - **Accumulating `flatMap`:** `Left` short-circuits; a `Both` carries its warnings forward, combining them with a `Semigroup<L>` (default `NonEmptyList.semigroup()`). The companion `EitherOrBothMonad` is lawful for any associative semigroup. Note the monadic `ap` short-circuits: it is deliberately *not* `Validated`-style accumulation; that lives on the Path.
 - **Higher-kinded:** implements its `Kind`/`Kind2` directly (cast-free), with a right-biased `Functor`/`Monad`/`Traverse`/`Foldable` and a `Bifunctor`; the monad is reached via `Instances.eitherOrBoth(semigroup)`.
@@ -35,6 +35,10 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 **`hkj-spring` Jackson deserializers now resolve their generic element types**
 
 The `Either`, `Validated`, and `NonEmptyList` deserializers read inner values as `Object`, so a `TypeReference<…<CustomType>>` (or a typed field) produced `LinkedHashMap` elements and a `ClassCastException` on access. All three now implement Jackson 3.x contextual resolution (`ValueDeserializer.createContextual`), binding to the contained generic types taken from the property or `TypeReference`, so nested custom types round-trip to the real type, including end-to-end through a `Validated<NonEmptyList<Foo>, …>`. Raw `.class` reads keep the `Object` fallback ([#578](https://github.com/higher-kinded-j/higher-kinded-j/pull/578)).
+
+**Worked-example hardening: correct, idiomatic `order` & `market` showcases, with `hkj-test` throughout**
+
+The `example.order` and `example.market` showcases were reviewed and hardened so they demonstrate current HKJ functionality rather than the hand-written workarounds that sat beside it. Example- and documentation-only; no library API change.
 
 ---
 

--- a/hkj-examples/build.gradle.kts
+++ b/hkj-examples/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.assertj.core)
     testImplementation(libs.awaitility)
+    testImplementation(project(":hkj-test"))
 }
 
 tasks.named("javadoc") {

--- a/hkj-examples/src/main/java/org/higherkindedj/example/market/aggregation/WindowAggregator.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/market/aggregation/WindowAggregator.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.example.market.aggregation;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -76,44 +78,50 @@ public interface WindowAggregator {
       throw new IllegalArgumentException("window must not be empty");
     }
 
-    var firstSymbol = window.getFirst().tick().tick().symbol();
+    var first = window.getFirst();
+    var firstSymbol = first.tick().tick().symbol();
 
-    double totalVolumeWeightedPrice = 0.0;
+    // VWAP is accumulated in BigDecimal and best bid/ask are tracked via Price.compareTo, so the
+    // headline analytics keep the precision of the underlying Price type instead of round-tripping
+    // through double. best bid/ask are seeded from the first tick rather than
+    // Double.MIN_VALUE/MAX_VALUE: Double.MIN_VALUE is the smallest *positive* double, so a genuine
+    // bid below it could never win the running max — the sentinel approach hid a latent bug.
+    BigDecimal totalVolumeWeightedPrice = BigDecimal.ZERO;
     long totalVol = 0;
-    double bestBid = Double.MIN_VALUE;
-    double bestAsk = Double.MAX_VALUE;
+    Price bestBid = first.tick().tick().bid();
+    Price bestAsk = first.tick().tick().ask();
     double maxRisk = 0.0;
 
     for (RiskAssessment ra : window) {
-      double mid = ra.tick().midInUsd().toDouble();
+      Price mid = ra.tick().midInUsd();
       long vol = ra.tick().tick().volume().value();
 
-      totalVolumeWeightedPrice += mid * vol;
+      totalVolumeWeightedPrice =
+          totalVolumeWeightedPrice.add(mid.value().multiply(BigDecimal.valueOf(vol)));
       totalVol += vol;
 
-      double bidVal = ra.tick().tick().bid().toDouble();
-      double askVal = ra.tick().tick().ask().toDouble();
+      Price bid = ra.tick().tick().bid();
+      Price ask = ra.tick().tick().ask();
 
-      if (bidVal > bestBid) {
-        bestBid = bidVal;
+      if (bid.compareTo(bestBid) > 0) {
+        bestBid = bid;
       }
-      if (askVal < bestAsk) {
-        bestAsk = askVal;
+      if (ask.compareTo(bestAsk) < 0) {
+        bestAsk = ask;
       }
       if (ra.riskScore() > maxRisk) {
         maxRisk = ra.riskScore();
       }
     }
 
-    double vwap = totalVol > 0 ? totalVolumeWeightedPrice / totalVol : 0.0;
+    Price vwap =
+        totalVol > 0
+            ? new Price(
+                totalVolumeWeightedPrice.divide(
+                    BigDecimal.valueOf(totalVol), 4, RoundingMode.HALF_UP))
+            : new Price(BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP));
 
     return new AggregatedView(
-        firstSymbol,
-        Price.of(vwap),
-        Price.of(bestBid),
-        Price.of(bestAsk),
-        Volume.of(totalVol),
-        window.size(),
-        maxRisk);
+        firstSymbol, vwap, bestBid, bestAsk, Volume.of(totalVol), window.size(), maxRisk);
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/market/enrichment/TickEnricher.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/market/enrichment/TickEnricher.java
@@ -4,9 +4,12 @@ package org.higherkindedj.example.market.enrichment;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import java.util.function.Consumer;
+import org.higherkindedj.example.market.error.MarketError;
 import org.higherkindedj.example.market.model.EnrichedTick;
 import org.higherkindedj.example.market.model.Instrument;
 import org.higherkindedj.example.market.model.PriceTick;
+import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.hkt.vstream.VStream;
 import org.higherkindedj.hkt.vstream.VStreamPar;
 import org.higherkindedj.hkt.vtask.Par;
@@ -20,62 +23,93 @@ import org.higherkindedj.hkt.vtask.VTask;
  * <ul>
  *   <li>{@link Par#map2} - Fetches instrument data and FX rate <em>concurrently</em> per tick
  *   <li>{@link VStreamPar#parEvalMap} - Bounded concurrent enrichment across the stream
+ *   <li>{@link VStream#peek} - Surfaces a typed {@link MarketError} for each tick that fails to
+ *       enrich, before those failures are filtered out of the success stream
  * </ul>
  *
- * <p>The enrichment pipeline for each tick:
- *
- * <pre>{@code
- * tick ──→ Par.map2(lookupInstrument, lookupFxRate)
- *      ──→ EnrichedTick(tick, instrument, fxRate)
- * }</pre>
+ * <p>A lookup miss (unknown instrument or currency) is turned into a typed {@link
+ * MarketError.EnrichmentFailed} carrying the tick's symbol, rather than an uncaught exception
+ * propagating through the pipeline. Failed ticks are reported to the configured error handler and
+ * dropped from the enriched stream so a single bad symbol cannot abort the whole feed.
  */
 public class TickEnricher {
 
   private final ReferenceDataService refData;
   private final FxRateService fxService;
   private final int concurrency;
+  private final Consumer<MarketError> onEnrichmentError;
 
   /**
-   * Creates a tick enricher.
+   * Creates a tick enricher that silently drops ticks that fail to enrich.
    *
    * @param refData the reference data service
    * @param fxService the FX rate service
    * @param concurrency max concurrent enrichments (typically 4-16 for I/O-bound lookups)
    */
   public TickEnricher(ReferenceDataService refData, FxRateService fxService, int concurrency) {
+    this(refData, fxService, concurrency, _ -> {});
+  }
+
+  /**
+   * Creates a tick enricher that reports enrichment failures to the given handler.
+   *
+   * @param refData the reference data service
+   * @param fxService the FX rate service
+   * @param concurrency max concurrent enrichments (typically 4-16 for I/O-bound lookups)
+   * @param onEnrichmentError invoked with the typed {@link MarketError} for each tick that fails to
+   *     enrich (e.g. logging or metrics)
+   */
+  public TickEnricher(
+      ReferenceDataService refData,
+      FxRateService fxService,
+      int concurrency,
+      Consumer<MarketError> onEnrichmentError) {
     this.refData = Objects.requireNonNull(refData);
     this.fxService = Objects.requireNonNull(fxService);
     if (concurrency <= 0) {
       throw new IllegalArgumentException("concurrency must be positive");
     }
     this.concurrency = concurrency;
+    this.onEnrichmentError = Objects.requireNonNull(onEnrichmentError);
   }
 
   /**
    * Enriches a single tick by fetching instrument and FX data concurrently.
    *
-   * <p>Uses {@link Par#map2} to execute both lookups in parallel on virtual threads.
+   * <p>Uses {@link Par#map2} to execute both lookups in parallel on virtual threads. A failed
+   * lookup is recovered into a typed {@link MarketError.EnrichmentFailed} for this tick's symbol
+   * rather than propagating as an exception.
    *
    * @param tick the raw price tick
-   * @return a VTask producing the enriched tick
+   * @return a VTask producing either the enriched tick or a typed enrichment error
    */
-  public VTask<EnrichedTick> enrichOne(PriceTick tick) {
+  public VTask<Either<MarketError, EnrichedTick>> enrichOne(PriceTick tick) {
     VTask<Instrument> instrumentTask = refData.lookup(tick.symbol());
     VTask<BigDecimal> fxTask = fxService.rateToUsd(tick.exchange().currency());
 
     return Par.map2(
-        instrumentTask, fxTask, (instrument, fxRate) -> new EnrichedTick(tick, instrument, fxRate));
+            instrumentTask,
+            fxTask,
+            (instrument, fxRate) ->
+                Either.<MarketError, EnrichedTick>right(new EnrichedTick(tick, instrument, fxRate)))
+        .recover(
+            error ->
+                Either.left(new MarketError.EnrichmentFailed(tick.symbol(), error.getMessage())));
   }
 
   /**
    * Enriches a stream of ticks with bounded concurrency.
    *
-   * <p>Uses {@link VStreamPar#parEvalMap} to process up to {@code concurrency} ticks at once.
+   * <p>Uses {@link VStreamPar#parEvalMap} to process up to {@code concurrency} ticks at once. Ticks
+   * that fail to enrich are reported to the error handler and dropped, so the returned stream
+   * contains only successfully enriched ticks.
    *
    * @param ticks the raw tick stream
-   * @return a stream of enriched ticks
+   * @return a stream of successfully enriched ticks
    */
   public VStream<EnrichedTick> enrich(VStream<PriceTick> ticks) {
-    return VStreamPar.parEvalMap(ticks, concurrency, this::enrichOne);
+    return VStreamPar.parEvalMap(ticks, concurrency, this::enrichOne)
+        .peek(result -> result.ifLeft(onEnrichmentError))
+        .flatMap(result -> result.fold(_ -> VStream.empty(), VStream::of));
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/market/model/PriceTick.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/market/model/PriceTick.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.example.market.model;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.Objects;
 import org.higherkindedj.example.market.model.value.Price;
@@ -29,9 +31,15 @@ public record PriceTick(
     Objects.requireNonNull(timestamp, "timestamp must not be null");
   }
 
-  /** The mid-price between bid and ask. */
+  /**
+   * The mid-price between bid and ask.
+   *
+   * <p>Computed entirely in {@link BigDecimal} so the result keeps full decimal precision rather
+   * than round-tripping through {@code double}.
+   */
   public Price mid() {
-    return Price.of((bid.toDouble() + ask.toDouble()) / 2.0);
+    return new Price(
+        bid.value().add(ask.value()).divide(BigDecimal.valueOf(2), 4, RoundingMode.HALF_UP));
   }
 
   /** The spread between ask and bid. */

--- a/hkj-examples/src/main/java/org/higherkindedj/example/market/model/value/Symbol.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/market/model/value/Symbol.java
@@ -12,6 +12,9 @@ import java.util.Objects;
 public record Symbol(String value) {
   public Symbol {
     Objects.requireNonNull(value, "symbol value must not be null");
+    if (value.isBlank()) {
+      throw new IllegalArgumentException("symbol value must not be blank");
+    }
   }
 
   @Override

--- a/hkj-examples/src/main/java/org/higherkindedj/example/market/pipeline/MarketDataPipeline.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/market/pipeline/MarketDataPipeline.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.example.market.pipeline;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import org.higherkindedj.example.market.aggregation.WindowAggregator;
@@ -15,8 +16,10 @@ import org.higherkindedj.example.market.model.Alert;
 import org.higherkindedj.example.market.model.EnrichedTick;
 import org.higherkindedj.example.market.model.PriceTick;
 import org.higherkindedj.example.market.model.RiskAssessment;
+import org.higherkindedj.example.market.resilience.FeedResilience;
 import org.higherkindedj.example.market.risk.RiskPipeline;
 import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.hkt.vstream.VStreamThrottle;
 
 /**
  * The main market data pipeline that wires together all processing stages.
@@ -24,19 +27,25 @@ import org.higherkindedj.hkt.vstream.VStream;
  * <p>The pipeline processes data through these stages:
  *
  * <pre>{@code
- * Exchange Feeds ──→ Merge ──→ Enrich ──→ Risk ──→ Aggregate ──→ Detect ──→ Dispatch
- *  (VStreamPar.merge)  (Par.map2)  (parEvalMap)  (chunk+fold)  (flatMap)  (Scope.allSucceed)
+ * Exchange Feeds ──→ Merge ──→ Resilience+Throttle ──→ Enrich ──→ Risk ──→ Aggregate ──→ Detect ──→ Dispatch
+ *  (VStreamPar.merge)   (FeedResilience, throttle)    (parEvalMap)  (chunk)   (flatMap)  (Scope.allSucceed)
  * }</pre>
  *
  * <p><b>HKJ features demonstrated:</b>
  *
  * <ul>
  *   <li>{@link VStream#take} - Safety valve limiting total ticks processed
- *   <li>{@link VStream#peek} - Observation tap for monitoring/logging
- *   <li>{@link VStream#onFinalize} - Cleanup when pipeline shuts down
+ *   <li>{@link FeedResilience} - Falls back to an empty stream if a feed errors, so one bad
+ *       exchange cannot abort the pipeline
+ *   <li>{@link VStreamThrottle#throttle} - Rate-limits feed ingestion to a sustainable burst
  * </ul>
  */
 public class MarketDataPipeline {
+
+  /** Maximum ticks admitted per throttle window (a small burst to demonstrate rate limiting). */
+  private static final int FEED_THROTTLE_BURST = 10;
+
+  private static final Duration FEED_THROTTLE_WINDOW = Duration.ofMillis(1);
 
   private final List<ExchangeFeed> feeds;
   private final TickEnricher enricher;
@@ -44,6 +53,7 @@ public class MarketDataPipeline {
   private final AnomalyDetector anomalyDetector;
   private final AlertDispatcher alertDispatcher;
   private final PipelineConfig config;
+  private final FeedResilience feedResilience;
 
   public MarketDataPipeline(
       List<ExchangeFeed> feeds,
@@ -58,11 +68,19 @@ public class MarketDataPipeline {
     this.anomalyDetector = Objects.requireNonNull(anomalyDetector);
     this.alertDispatcher = Objects.requireNonNull(alertDispatcher);
     this.config = Objects.requireNonNull(config);
+    this.feedResilience = FeedResilience.withDefaults();
   }
 
-  /** Returns the merged raw tick stream from all feeds, limited by config. */
+  /**
+   * Returns the merged raw tick stream from all feeds, limited by config, with feed resilience and
+   * throttling applied on the live path.
+   */
   public VStream<PriceTick> mergedTicks() {
-    return FeedMerger.merge(feeds).take(config.maxTicks());
+    VStream<PriceTick> merged = FeedMerger.merge(feeds).take(config.maxTicks());
+    // Resilience on the live feed path: fall back to an empty stream if a feed errors (so one bad
+    // exchange cannot kill the pipeline), then throttle ingestion to a sustainable burst.
+    VStream<PriceTick> resilient = feedResilience.withFallback(merged, VStream.empty());
+    return VStreamThrottle.throttle(resilient, FEED_THROTTLE_BURST, FEED_THROTTLE_WINDOW);
   }
 
   /** Returns the enriched tick stream. */

--- a/hkj-examples/src/main/java/org/higherkindedj/example/market/risk/RiskPipeline.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/market/risk/RiskPipeline.java
@@ -14,8 +14,11 @@ import org.higherkindedj.hkt.vstream.VStreamPar;
  * <p><b>HKJ features demonstrated:</b>
  *
  * <ul>
- *   <li>{@link VStreamPar#parEvalMapUnordered} - Concurrent risk assessment where output order does
- *       not matter (risk results are independent of each other)
+ *   <li>{@link VStreamPar#parEvalMap} - Concurrent risk assessment with bounded concurrency that
+ *       <em>preserves input order</em>. Risk results are independent, but the downstream {@code
+ *       WindowAggregator} groups ticks into windows, so emission order must match arrival order for
+ *       a window to contain temporally adjacent ticks. Using the unordered variant here would feed
+ *       the windower a completion-order grab-bag and make per-window VWAP meaningless.
  * </ul>
  */
 public class RiskPipeline {
@@ -41,9 +44,9 @@ public class RiskPipeline {
    * Applies risk assessment across a stream of enriched ticks.
    *
    * @param enrichedTicks the input stream
-   * @return a stream of risk assessments (may arrive in any order)
+   * @return a stream of risk assessments in the same order as the input ticks
    */
   public VStream<RiskAssessment> assess(VStream<EnrichedTick> enrichedTicks) {
-    return VStreamPar.parEvalMapUnordered(enrichedTicks, concurrency, calculator::assess);
+    return VStreamPar.parEvalMap(enrichedTicks, concurrency, calculator::assess);
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/config/WorkflowConfig.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/config/WorkflowConfig.java
@@ -7,8 +7,11 @@ import java.time.Duration;
 /**
  * Configuration for the order workflow.
  *
- * <p>This record is used with {@code ReaderPath} to thread configuration through the workflow
- * without explicit parameter passing.
+ * <p>This config is supplied as a constructor dependency to the workflows (see {@link
+ * org.higherkindedj.example.order.workflow.OrderWorkflow} and friends); the workflow reads its
+ * fields directly. Per-request cross-cutting context (trace id, tenant, deadline) is propagated
+ * separately via {@link org.higherkindedj.example.order.context.OrderContext}'s {@code ScopedValue}
+ * bindings rather than threaded as configuration.
  *
  * @param retryConfig retry configuration for transient failures
  * @param timeoutConfig timeout configuration for external calls

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/model/InventoryReservation.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/model/InventoryReservation.java
@@ -17,6 +17,11 @@ import org.higherkindedj.optics.annotations.GenerateLenses;
 @GenerateLenses
 public record InventoryReservation(
     String reservationId, List<ReservedItem> items, Instant expiresAt) {
+  public InventoryReservation {
+    // Defensive copy: keep the reserved-items list immutable and caller-independent.
+    items = List.copyOf(items);
+  }
+
   /**
    * An individual item reservation.
    *

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/model/OrderRequest.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/model/OrderRequest.java
@@ -31,5 +31,7 @@ public record OrderRequest(
     if (lines == null || lines.isEmpty()) {
       throw new IllegalArgumentException("Order must have at least one line item");
     }
+    // Defensive copy: the request must not alias a list the caller can still mutate.
+    lines = List.copyOf(lines);
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/model/PartialFulfilmentResult.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/model/PartialFulfilmentResult.java
@@ -30,6 +30,11 @@ public record PartialFulfilmentResult(
     FulfilmentStatus status,
     Money fulfilledAmount,
     Money backOrderAmount) {
+  public PartialFulfilmentResult {
+    // Defensive copy: keep the back-orders list immutable and caller-independent.
+    backOrders = List.copyOf(backOrders);
+  }
+
   /**
    * Creates a result for complete fulfilment (no back-orders).
    *

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/model/SplitShipmentResult.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/model/SplitShipmentResult.java
@@ -23,6 +23,11 @@ public record SplitShipmentResult(
     List<ShipmentInfo> shipments,
     Instant latestEstimatedDelivery,
     Money totalShippingCost) {
+  public SplitShipmentResult {
+    // Defensive copy: keep the shipments list immutable and caller-independent.
+    shipments = List.copyOf(shipments);
+  }
+
   /**
    * Returns the number of shipments created.
    *

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/model/ValidatedOrder.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/model/ValidatedOrder.java
@@ -40,6 +40,11 @@ public record ValidatedOrder(
     PaymentMethod paymentMethod,
     Money subtotal,
     Instant createdAt) {
+  public ValidatedOrder {
+    // Defensive copy: the record must not alias a list the caller can still mutate.
+    lines = List.copyOf(lines);
+  }
+
   /**
    * Calculates the subtotal from the order lines.
    *

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.example.order.service.impl;
 
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -18,17 +20,21 @@ import org.higherkindedj.hkt.either.Either;
 /**
  * In-memory implementation of InventoryService for testing and examples.
  *
- * <p><strong>Thread Safety Note:</strong> While this implementation uses ConcurrentHashMap for
- * storage, the {@link #reserve} method is not fully atomic. It checks availability first, then
- * reserves stock in a separate operation. In a concurrent environment, this could lead to race
- * conditions (e.g., overselling). This is acceptable for testing and demonstration purposes but
- * would require proper synchronisation or database transactions in production.
+ * <p><strong>Thread Safety:</strong> {@link #reserve} decrements each product's stock with a single
+ * atomic {@link Map#compute} guarded by a floor, so stock can never oversell or go negative even
+ * under concurrent callers. A multi-line reservation is all-or-nothing: if any line is short the
+ * lines already taken are returned before failing. Expired holds are reclaimed lazily on the next
+ * reservation (see {@link #reclaimExpiredReservations()}), which is the only place {@code
+ * expiresAt} is consulted.
  */
 public class InMemoryInventoryService implements InventoryService {
 
   private final Map<String, Integer> stock = new ConcurrentHashMap<>();
   private final Map<String, String> productWarehouses = new ConcurrentHashMap<>();
   private final Map<String, InventoryReservation> reservations = new ConcurrentHashMap<>();
+
+  /** How long a reservation is held before it can be reclaimed. Adjustable for tests. */
+  private Duration reservationHold = Duration.ofMinutes(15);
 
   public InMemoryInventoryService() {
     // Pre-populate with sample stock across different warehouses
@@ -57,6 +63,11 @@ public class InMemoryInventoryService implements InventoryService {
     productWarehouses.put(productId, warehouseId);
   }
 
+  /** Overrides how long reservations are held; mainly a seam for exercising expiry in tests. */
+  public void setReservationHold(Duration reservationHold) {
+    this.reservationHold = reservationHold;
+  }
+
   @Override
   public Either<OrderError, InventoryCheckResult> checkAvailability(
       List<ValidatedOrderLine> lines) {
@@ -80,41 +91,29 @@ public class InMemoryInventoryService implements InventoryService {
   @Override
   public Either<OrderError, InventoryReservation> reserve(
       OrderId orderId, List<ValidatedOrderLine> lines) {
-    // Check availability first
-    var unavailable =
-        lines.stream()
-            .filter(
-                line -> {
-                  var available = stock.getOrDefault(line.productId().value(), 0);
-                  return available < line.quantity();
-                })
-            .map(line -> line.productId().value())
-            .toList();
+    reclaimExpiredReservations();
+
+    // Take each line atomically with a floor, rolling back the lines already taken if any line is
+    // short. This makes the whole reservation all-or-nothing and removes the check-then-act race:
+    // two callers can no longer both pass a check and then both subtract the same stock.
+    var taken = new ArrayList<InventoryReservation.ReservedItem>();
+    var unavailable = new ArrayList<String>();
+    for (var line : lines) {
+      if (tryTake(line.productId().value(), line.quantity())) {
+        taken.add(
+            new InventoryReservation.ReservedItem(
+                line.productId(), line.quantity(), warehouseOf(line.productId().value())));
+      } else {
+        unavailable.add(line.productId().value());
+      }
+    }
 
     if (!unavailable.isEmpty()) {
+      taken.forEach(item -> returnStock(item.productId().value(), item.quantity()));
       return Either.left(OrderError.InventoryError.outOfStock(unavailable));
     }
 
-    // Reserve the stock
-    var reservedItems =
-        lines.stream()
-            .map(
-                line -> {
-                  var productId = line.productId().value();
-                  stock.compute(productId, (k, v) -> (v == null ? 0 : v) - line.quantity());
-                  return new InventoryReservation.ReservedItem(
-                      line.productId(), line.quantity(), "WAREHOUSE-01");
-                })
-            .toList();
-
-    var reservationId = "RES-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
-    var reservation =
-        new InventoryReservation(
-            reservationId, reservedItems, Instant.now().plusSeconds(900) // 15 minute expiry
-            );
-
-    reservations.put(reservationId, reservation);
-    return Either.right(reservation);
+    return Either.right(storeReservation(taken));
   }
 
   @Override
@@ -173,35 +172,85 @@ public class InMemoryInventoryService implements InventoryService {
   @Override
   public Either<OrderError, InventoryReservation> reserveAvailable(
       OrderId orderId, List<ProductAvailability> availability) {
-    // Only reserve items that have some availability
-    var reservable = availability.stream().filter(a -> a.availableQty() > 0).toList();
+    reclaimExpiredReservations();
 
-    if (reservable.isEmpty()) {
+    // Best-effort partial reserve: take whatever each line can supply (up to the requested
+    // quantity), again using the atomic floored take so a concurrent caller cannot oversell.
+    var taken = new ArrayList<InventoryReservation.ReservedItem>();
+    for (var avail : availability) {
+      var qtyToReserve = Math.min(avail.requestedQty(), avail.availableQty());
+      if (qtyToReserve > 0 && tryTake(avail.productId().value(), qtyToReserve)) {
+        taken.add(
+            new InventoryReservation.ReservedItem(
+                avail.productId(), qtyToReserve, avail.warehouseId()));
+      }
+    }
+
+    if (taken.isEmpty()) {
       return Either.left(
           OrderError.InventoryError.outOfStock(
               availability.stream().map(a -> a.productId().value()).toList()));
     }
 
-    // Reserve the available quantities
-    var reservedItems =
-        reservable.stream()
-            .map(
-                avail -> {
-                  var productId = avail.productId().value();
-                  var qtyToReserve = Math.min(avail.requestedQty(), avail.availableQty());
-                  stock.compute(productId, (k, v) -> (v == null ? 0 : v) - qtyToReserve);
-                  return new InventoryReservation.ReservedItem(
-                      avail.productId(), qtyToReserve, avail.warehouseId());
-                })
-            .toList();
+    return Either.right(storeReservation(taken));
+  }
 
+  /**
+   * Atomically subtracts {@code quantity} from a product's stock, but only if at least that much is
+   * on hand. The floor inside {@link Map#compute} guarantees stock never goes negative and that two
+   * concurrent takes cannot both succeed against the same insufficient stock.
+   *
+   * @return {@code true} if the stock was taken, {@code false} if there was not enough
+   */
+  private boolean tryTake(String productId, int quantity) {
+    var took = new boolean[1];
+    stock.compute(
+        productId,
+        (_, onHand) -> {
+          int current = (onHand == null) ? 0 : onHand;
+          if (current >= quantity) {
+            took[0] = true;
+            return current - quantity;
+          }
+          return current;
+        });
+    return took[0];
+  }
+
+  /** Returns {@code quantity} units of a product to stock. */
+  private void returnStock(String productId, int quantity) {
+    stock.compute(productId, (_, onHand) -> (onHand == null ? 0 : onHand) + quantity);
+  }
+
+  /** Records a reservation for the given taken items and returns it. */
+  private InventoryReservation storeReservation(List<InventoryReservation.ReservedItem> items) {
     var reservationId = "RES-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
     var reservation =
-        new InventoryReservation(
-            reservationId, reservedItems, Instant.now().plusSeconds(900) // 15 minute expiry
-            );
-
+        new InventoryReservation(reservationId, items, Instant.now().plus(reservationHold));
     reservations.put(reservationId, reservation);
-    return Either.right(reservation);
+    return reservation;
+  }
+
+  /** Looks up the warehouse a product ships from, defaulting to the primary warehouse. */
+  private String warehouseOf(String productId) {
+    return productWarehouses.getOrDefault(productId, "WAREHOUSE-01");
+  }
+
+  /**
+   * Releases any reservation whose hold has expired, returning its stock. Called before each
+   * reserve so abandoned holds do not permanently strand inventory — and the one place {@code
+   * expiresAt} is actually read.
+   */
+  private void reclaimExpiredReservations() {
+    var now = Instant.now();
+    // Snapshot keys so we can mutate the map while iterating.
+    for (var reservationId : List.copyOf(reservations.keySet())) {
+      var reservation = reservations.get(reservationId);
+      if (reservation != null
+          && reservation.expiresAt().isBefore(now)
+          && reservations.remove(reservationId, reservation)) {
+        reservation.items().forEach(item -> returnStock(item.productId().value(), item.quantity()));
+      }
+    }
   }
 }

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
@@ -207,12 +207,14 @@ public class InMemoryInventoryService implements InventoryService {
     stock.compute(
         productId,
         (_, onHand) -> {
-          int current = (onHand == null) ? 0 : onHand;
-          if (current >= quantity) {
-            took[0] = true;
-            return current - quantity;
+          if (onHand == null) {
+            return null; // unknown product: leave it absent rather than inserting a 0 entry
           }
-          return current;
+          if (onHand >= quantity) {
+            took[0] = true;
+            return onHand - quantity;
+          }
+          return onHand;
         });
     return took[0];
   }
@@ -242,6 +244,12 @@ public class InMemoryInventoryService implements InventoryService {
    * expiresAt} is actually read.
    */
   private void reclaimExpiredReservations() {
+    // A production service would expire holds with a background sweeper or a time-ordered
+    // DelayQueue rather than scanning on the reserve path; for this in-memory demo a lazy scan is
+    // adequate, and the empty-map fast path keeps the common case allocation-free.
+    if (reservations.isEmpty()) {
+      return;
+    }
     var now = Instant.now();
     // Snapshot keys so we can mutate the map while iterating.
     for (var reservationId : List.copyOf(reservations.keySet())) {

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/ConfigurableOrderWorkflow.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/ConfigurableOrderWorkflow.java
@@ -29,6 +29,7 @@ import org.higherkindedj.example.order.service.NotificationService;
 import org.higherkindedj.example.order.service.PaymentService;
 import org.higherkindedj.example.order.service.ShippingService;
 import org.higherkindedj.example.order.service.WarehouseService;
+import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.effect.EitherPath;
 import org.higherkindedj.hkt.effect.Path;
 import org.jspecify.annotations.Nullable;
@@ -155,21 +156,65 @@ public class ConfigurableOrderWorkflow {
    */
   public EitherPath<OrderError, OrderResult> process(OrderRequest request) {
     var retryPolicy = createRetryPolicy();
+    var timeoutConfig = config.timeoutConfig();
 
-    // Calculate total timeout from all service timeouts
-    var totalTimeout =
-        config
-            .timeoutConfig()
+    // Resilience granularity: RETRY only the idempotent pre-flight reads (customer eligibility and
+    // shipping-address validation) — re-running those is always safe. The committing workflow
+    // (reserve -> payment -> shipment -> notification) is then run EXACTLY ONCE under a timeout and
+    // is never retried: payment is not idempotent, so retrying a commit that already charged the
+    // customer could double-charge. The previous code wrapped the whole workflow — payment
+    // included — in retry, and avoided double-charging only by accident (the default retry
+    // predicate happens not to match the business-error wrapper).
+    //
+    // Compensating a partially-applied commit (e.g. refunding a charge when a later step fails)
+    // would use a Saga across reserve -> pay -> ship; that needs an Either-aware Saga on the Path
+    // stack and is tracked as future work.
+    var preflightTimeout = timeoutConfig.inventoryTimeout();
+    var commitTimeout =
+        timeoutConfig
             .paymentTimeout()
-            .plus(config.timeoutConfig().inventoryTimeout())
-            .plus(config.timeoutConfig().shippingTimeout())
-            .plus(config.timeoutConfig().notificationTimeout());
+            .plus(timeoutConfig.shippingTimeout())
+            .plus(timeoutConfig.notificationTimeout());
 
-    return Resilience.resilient(
-        Path.io(() -> executeWorkflow(request)),
-        retryPolicy,
-        totalTimeout,
-        "ConfigurableOrderWorkflow.process");
+    EitherPath<OrderError, Unit> preflight =
+        Resilience.resilient(
+            Path.io(() -> runPreflight(request)),
+            retryPolicy,
+            preflightTimeout,
+            "ConfigurableOrderWorkflow.preflight");
+
+    return preflight.via(
+        _ ->
+            Resilience.withTimeout(
+                Path.io(() -> executeWorkflow(request)),
+                commitTimeout,
+                "ConfigurableOrderWorkflow.commit"));
+  }
+
+  /**
+   * Idempotent pre-flight validation that is safe to retry: confirms the customer exists and is
+   * eligible and that the shipping address is valid. A business failure throws {@link
+   * WorkflowException}, which the retry policy deliberately does not retry — only transient infra
+   * failures are retried.
+   */
+  private Unit runPreflight(OrderRequest request) {
+    var customerId = new CustomerId(request.customerId());
+    customerService
+        .findById(customerId)
+        .flatMap(customerService::validateEligibility)
+        .fold(
+            error -> {
+              throw new WorkflowException(error);
+            },
+            customer -> customer);
+    shippingService
+        .validateAddress(request.shippingAddress())
+        .fold(
+            error -> {
+              throw new WorkflowException(error);
+            },
+            address -> address);
+    return Unit.INSTANCE;
   }
 
   /**

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/EnhancedOrderWorkflow.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/EnhancedOrderWorkflow.java
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.example.order.workflow;
 
+import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
+import static org.higherkindedj.hkt.vtask.VTaskKindHelper.VTASK;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -37,13 +40,23 @@ import org.higherkindedj.example.order.service.InventoryService;
 import org.higherkindedj.example.order.service.NotificationService;
 import org.higherkindedj.example.order.service.PaymentService;
 import org.higherkindedj.example.order.service.ShippingService;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.VTaskPath;
 import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.either_t.EitherT;
+import org.higherkindedj.hkt.either_t.EitherTKind;
+import org.higherkindedj.hkt.either_t.EitherTMonad;
+import org.higherkindedj.hkt.expression.For;
+import org.higherkindedj.hkt.resilience.CircuitBreaker;
+import org.higherkindedj.hkt.resilience.RetryPolicy;
 import org.higherkindedj.hkt.trymonad.Try;
 import org.higherkindedj.hkt.vtask.Resource;
 import org.higherkindedj.hkt.vtask.Scope;
 import org.higherkindedj.hkt.vtask.VTask;
+import org.higherkindedj.hkt.vtask.VTaskKind;
+import org.higherkindedj.hkt.vtask.VTaskMonad;
 
 /**
  * Enhanced order workflow demonstrating recent HKJ innovations.
@@ -110,6 +123,14 @@ public class EnhancedOrderWorkflow {
   private final ShippingService shippingService;
   private final NotificationService notificationService;
   private final WorkflowConfig config;
+
+  // Library resilience (hkt.resilience) applied to the idempotent customer lookup. These are
+  // VTask-native, so they compose directly onto the VTaskPath via withCircuitBreaker/withRetry —
+  // no hand-rolled retry loop. The breaker is shared across calls so it can trip open on a
+  // persistently failing customer service.
+  private final RetryPolicy customerLookupRetry =
+      RetryPolicy.exponentialBackoff(3, Duration.ofMillis(50));
+  private final CircuitBreaker customerLookupBreaker = CircuitBreaker.withDefaults();
 
   /**
    * Creates an enhanced order workflow with the given services and config.
@@ -185,47 +206,44 @@ public class EnhancedOrderWorkflow {
   private VTaskPath<Either<OrderError, OrderResult>> processWithResources(
       OrderId orderId, CustomerId customerId, OrderRequest request) {
 
-    return validateShippingAddress(request.shippingAddress())
-        .via(addressResult -> continueWithAddress(orderId, customerId, request, addressResult));
+    // Async (VTask) and typed error (Either) are two stacked effects. EitherT combines them so the
+    // gather -> reserve pipeline reads as a linear `For` comprehension that short-circuits on the
+    // first Left, instead of the manual fold-and-relift chain (continueWithAddress/Customer/Order)
+    // this replaced. Each step is a VTaskPath<Either<OrderError, X>>, which already is a
+    // Kind<VTaskKind.Witness, Either<...>>, so it lifts straight into EitherT via fromKind (see
+    // #et).
+    var monad = new EitherTMonad<VTaskKind.Witness, OrderError>(VTaskMonad.INSTANCE);
+
+    Kind<EitherTKind.Witness<VTaskKind.Witness, OrderError>, OrderResult> program =
+        For.from(monad, et(validateShippingAddress(request.shippingAddress())))
+            .from(_ -> et(lookupAndValidateCustomer(customerId)))
+            .from(t -> et(buildValidatedOrder(orderId, request, t._2(), t._1())))
+            .from(t -> et(processWithReservation(t._3(), t._2())))
+            .yield((_, _, _, result) -> result);
+
+    return runToVTaskPath(program);
   }
 
-  /** Continues processing after address validation. */
-  private VTaskPath<Either<OrderError, OrderResult>> continueWithAddress(
-      OrderId orderId,
-      CustomerId customerId,
-      OrderRequest request,
-      Either<OrderError, ValidatedShippingAddress> addressResult) {
+  // =========================================================================
+  // EitherT bridge — combine the VTask (async) and Either (typed error) effects
+  // =========================================================================
 
-    return addressResult.fold(
-        error -> Path.vtaskPure(Either.left(error)),
-        validAddress ->
-            lookupAndValidateCustomer(customerId)
-                .via(
-                    customerResult ->
-                        continueWithCustomer(orderId, request, validAddress, customerResult)));
+  /**
+   * Lifts one async, fallible step into the {@code EitherT<VTask, OrderError, X>} stack so it can
+   * participate in a {@code For} comprehension. {@link VTaskPath#run()} hands back the wrapped
+   * (still lazy) {@link VTask}, which is widened into the {@code VTaskKind} the transformer's outer
+   * monad operates on; the inner {@link Either} is then lifted via {@link EitherT#fromKind}.
+   */
+  private static <X> Kind<EitherTKind.Witness<VTaskKind.Witness, OrderError>, X> et(
+      VTaskPath<Either<OrderError, X>> step) {
+    return EITHER_T.widen(EitherT.fromKind(VTASK.widen(step.run())));
   }
 
-  /** Continues processing after customer lookup. */
-  private VTaskPath<Either<OrderError, OrderResult>> continueWithCustomer(
-      OrderId orderId,
-      OrderRequest request,
-      ValidatedShippingAddress validAddress,
-      Either<OrderError, Customer> customerResult) {
-
-    return customerResult.fold(
-        error -> Path.vtaskPure(Either.left(error)),
-        customer ->
-            buildValidatedOrder(orderId, request, customer, validAddress)
-                .via(orderResult -> continueWithOrder(customer, orderResult)));
-  }
-
-  /** Continues processing after order validation. */
-  private VTaskPath<Either<OrderError, OrderResult>> continueWithOrder(
-      Customer customer, Either<OrderError, ValidatedOrder> orderResult) {
-
-    return orderResult.fold(
-        error -> Path.vtaskPure(Either.left(error)),
-        order -> processWithReservation(order, customer));
+  /** Runs an {@code EitherT<VTask, OrderError, ...>} program back down to a {@link VTaskPath}. */
+  private static <X> VTaskPath<Either<OrderError, X>> runToVTaskPath(
+      Kind<EitherTKind.Witness<VTaskKind.Witness, OrderError>, X> program) {
+    EitherT<VTaskKind.Witness, OrderError, X> result = EITHER_T.narrow(program);
+    return Path.vtaskPath(VTASK.narrow(result.value()));
   }
 
   /**
@@ -285,47 +303,24 @@ public class EnhancedOrderWorkflow {
   private VTaskPath<Either<OrderError, OrderResult>> processAfterReservation(
       ValidatedOrder order, Customer customer, InventoryReservation reservation) {
 
-    return applyDiscounts(order, customer)
-        .via(
-            discountResult ->
-                discountResult.fold(
-                    error -> Path.vtaskPure(Either.<OrderError, OrderResult>left(error)),
-                    discount ->
-                        processPayment(order, discount)
-                            .via(
-                                paymentResult ->
-                                    paymentResult.fold(
-                                        error ->
-                                            Path.vtaskPure(
-                                                Either.<OrderError, OrderResult>left(error)),
-                                        payment ->
-                                            createShipment(order)
-                                                .via(
-                                                    shipmentResult ->
-                                                        shipmentResult.fold(
-                                                            error ->
-                                                                Path.vtaskPure(
-                                                                    Either
-                                                                        .<OrderError, OrderResult>
-                                                                            left(error)),
-                                                            shipment ->
-                                                                sendNotifications(
-                                                                        order, customer, discount)
-                                                                    .map(
-                                                                        notificationResult ->
-                                                                            buildOrderResult(
-                                                                                order,
-                                                                                discount,
-                                                                                payment,
-                                                                                shipment,
-                                                                                reservation,
-                                                                                notificationResult
-                                                                                    .fold(
-                                                                                        err ->
-                                                                                            NotificationResult
-                                                                                                .none(),
-                                                                                        success ->
-                                                                                            success)))))))));
+    // The same EitherT-over-VTask railway as the gather phase: discount -> payment -> shipment ->
+    // notification, short-circuiting on the first Left. Notifications are non-critical and are
+    // recovered to a value inside #sendNotifications, so they never abort the order here. This
+    // replaced a nine-level nested via/fold pyramid.
+    var monad = new EitherTMonad<VTaskKind.Witness, OrderError>(VTaskMonad.INSTANCE);
+
+    Kind<EitherTKind.Witness<VTaskKind.Witness, OrderError>, OrderResult> program =
+        For.from(monad, et(applyDiscounts(order, customer)))
+            .from(discount -> et(processPayment(order, discount)))
+            .from(_ -> et(createShipment(order)))
+            // sendNotifications always yields a Right (failures are downgraded to none()), so the
+            // bound value is ignored with `_` — the step runs purely for its side effect.
+            .from(t -> et(sendNotifications(order, customer, t._1())))
+            .yield(
+                (discount, payment, shipment, _) ->
+                    buildOrderResultValue(order, discount, payment, shipment, reservation));
+
+    return runToVTaskPath(program);
   }
 
   // =========================================================================
@@ -425,13 +420,20 @@ public class EnhancedOrderWorkflow {
   }
 
   private VTaskPath<Either<OrderError, Customer>> lookupAndValidateCustomer(CustomerId customerId) {
+    // Idempotent read: protect it with the library circuit breaker + retry so a flaky customer
+    // service is retried with backoff and the breaker trips open after repeated failures. Retry
+    // engages only when the lookup *throws* (a transient infra failure); a business `Left` (e.g.
+    // customer-not-found) is returned as-is and never retried. Safe precisely because the lookup
+    // has no side effects — unlike payment, which §1.3 never retries.
     return Path.vtask(
-        () -> {
-          logSync("Looking up customer [trace=" + OrderContext.shortTraceId() + "]");
-          return customerService
-              .findById(customerId)
-              .flatMap(customer -> customerService.validateEligibility(customer));
-        });
+            () -> {
+              logSync("Looking up customer [trace=" + OrderContext.shortTraceId() + "]");
+              return customerService
+                  .findById(customerId)
+                  .flatMap(customerService::validateEligibility);
+            })
+        .withCircuitBreaker(customerLookupBreaker)
+        .withRetry(customerLookupRetry);
   }
 
   private VTaskPath<Either<OrderError, ValidatedOrder>> buildValidatedOrder(
@@ -531,11 +533,18 @@ public class EnhancedOrderWorkflow {
 
   private VTaskPath<Either<OrderError, NotificationResult>> sendNotifications(
       ValidatedOrder order, Customer customer, DiscountResult discount) {
-    // Notifications are non-critical - we recover from failures
+    // Notifications are non-critical: a failure (a Left result *or* a thrown error) is downgraded
+    // to
+    // NotificationResult.none() so it never short-circuits the order in the EitherT pipeline. The
+    // step therefore always yields a Right.
     return Path.vtask(
             () ->
                 notificationService.sendOrderConfirmation(
                     order.orderId(), customer, discount.finalTotal()))
+        .map(
+            result ->
+                Either.<OrderError, NotificationResult>right(
+                    result.fold(_ -> NotificationResult.none(), success -> success)))
         .handleError(
             error -> {
               logSync("Notification failed (non-critical): " + error.getMessage());
@@ -547,13 +556,12 @@ public class EnhancedOrderWorkflow {
   // Result Building
   // =========================================================================
 
-  private Either<OrderError, OrderResult> buildOrderResult(
+  private OrderResult buildOrderResultValue(
       ValidatedOrder order,
       DiscountResult discount,
       PaymentConfirmation payment,
       ShipmentInfo shipment,
-      InventoryReservation reservation,
-      NotificationResult notification) {
+      InventoryReservation reservation) {
 
     var auditLog =
         AuditLog.EMPTY
@@ -572,15 +580,14 @@ public class EnhancedOrderWorkflow {
             .append(AuditLog.of("PAYMENT_PROCESSED", "Transaction " + payment.transactionId()))
             .append(AuditLog.of("SHIPMENT_CREATED", "Tracking " + shipment.trackingNumber()));
 
-    return Either.right(
-        new OrderResult(
-            order.orderId(),
-            order.customerId(),
-            discount.finalTotal(),
-            payment.transactionId(),
-            shipment.trackingNumber(),
-            shipment.estimatedDelivery(),
-            auditLog));
+    return new OrderResult(
+        order.orderId(),
+        order.customerId(),
+        discount.finalTotal(),
+        payment.transactionId(),
+        shipment.trackingNumber(),
+        shipment.estimatedDelivery(),
+        auditLog);
   }
 
   // =========================================================================
@@ -588,24 +595,26 @@ public class EnhancedOrderWorkflow {
   // =========================================================================
 
   /** Checks if the deadline has been exceeded and fails fast if so. */
-  private VTaskPath<Either<OrderError, Void>> checkDeadline(String operation) {
+  private VTaskPath<Either<OrderError, Unit>> checkDeadline(String operation) {
     return Path.vtask(
         () -> {
           if (OrderContext.isDeadlineExceeded()) {
             return Either.left(SystemError.timeout(operation));
           }
-          return Either.right(null);
+          // Unit.INSTANCE rather than a null Right: success carries no value, but the success
+          // channel stays non-null and total.
+          return Either.right(Unit.INSTANCE);
         });
   }
 
   /** Logs a message with context information. */
-  private VTaskPath<Either<OrderError, Void>> logWithContext(String message, Map<String, ?> data) {
+  private VTaskPath<Either<OrderError, Unit>> logWithContext(String message, Map<String, ?> data) {
     return Path.vtask(
         () -> {
           String traceId = OrderContext.shortTraceId();
           String tenantId = OrderContext.TENANT_ID.isBound() ? OrderContext.TENANT_ID.get() : "?";
           System.out.printf("[%s] [tenant=%s] %s %s%n", traceId, tenantId, message, data);
-          return Either.right(null);
+          return Either.right(Unit.INSTANCE);
         });
   }
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflow.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflow.java
@@ -49,6 +49,7 @@ import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.hkt.either.EitherKind;
 import org.higherkindedj.hkt.expression.For;
 import org.higherkindedj.hkt.instances.Instances;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The main order processing workflow.
@@ -249,9 +250,11 @@ public class OrderWorkflow {
                 new OrderError.ValidationError("Order request validation failed", fieldErrors));
   }
 
+  // @Nullable so the null guard is a real check, not dead code: validation is the boundary where
+  // untrusted input (e.g. a deserialized request) can still defeat the @NullMarked contract.
   private ValidationPath<List<OrderError.FieldError>, String> validateCustomerId(
-      String customerId) {
-    if (customerId.isBlank()) {
+      @Nullable String customerId) {
+    if (customerId == null || customerId.isBlank()) {
       return Path.invalid(
           List.of(
               new OrderError.FieldError("customerId", "Customer id must not be blank", customerId)),
@@ -261,7 +264,12 @@ public class OrderWorkflow {
   }
 
   private ValidationPath<List<OrderError.FieldError>, List<OrderLineRequest>> validateLines(
-      List<OrderLineRequest> lines) {
+      @Nullable List<OrderLineRequest> lines) {
+    if (lines == null) {
+      return Path.invalid(
+          List.of(new OrderError.FieldError("lines", "Order lines must not be null", null)),
+          Semigroups.list());
+    }
     var fieldErrors =
         lines.stream()
             .filter(line -> line.productId().isBlank())

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflow.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/OrderWorkflow.java
@@ -15,6 +15,7 @@ import org.higherkindedj.example.order.model.Customer;
 import org.higherkindedj.example.order.model.DiscountResult;
 import org.higherkindedj.example.order.model.InventoryReservation;
 import org.higherkindedj.example.order.model.NotificationResult;
+import org.higherkindedj.example.order.model.OrderLineRequest;
 import org.higherkindedj.example.order.model.OrderRequest;
 import org.higherkindedj.example.order.model.OrderResult;
 import org.higherkindedj.example.order.model.PaymentConfirmation;
@@ -30,20 +31,24 @@ import org.higherkindedj.example.order.model.value.OrderId;
 import org.higherkindedj.example.order.model.value.ProductId;
 import org.higherkindedj.example.order.model.value.PromoCode;
 import org.higherkindedj.example.order.service.CustomerService;
+import org.higherkindedj.example.order.service.CustomerServicePaths;
 import org.higherkindedj.example.order.service.DiscountService;
+import org.higherkindedj.example.order.service.DiscountServicePaths;
 import org.higherkindedj.example.order.service.InventoryService;
 import org.higherkindedj.example.order.service.NotificationService;
 import org.higherkindedj.example.order.service.PaymentService;
 import org.higherkindedj.example.order.service.ShippingService;
+import org.higherkindedj.example.order.service.ShippingServicePaths;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.hkt.MonadError;
+import org.higherkindedj.hkt.Semigroups;
 import org.higherkindedj.hkt.effect.EitherPath;
 import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.ValidationPath;
 import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.hkt.either.EitherKind;
 import org.higherkindedj.hkt.expression.For;
 import org.higherkindedj.hkt.instances.Instances;
-import org.higherkindedj.optics.Lens;
 
 /**
  * The main order processing workflow.
@@ -82,12 +87,12 @@ import org.higherkindedj.optics.Lens;
  *     .from(t -> lift(buildValidatedOrder(..., t._2(), t._1())))
  *     .toState((address, customer, order) ->                   // bridge to ForState
  *         ProcessingState.initial(address, customer, order))
- *     .fromThen(s -> lift(reserveInventory(s.order())),        reservationLens)
- *     .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), discountLens)
- *     .fromThen(s -> lift(processPayment(s.order(), s.discount())), paymentLens)
- *     .fromThen(s -> lift(createShipment(s.order(), s.address())), shipmentLens)
+ *     .fromThen(s -> lift(reserveInventory(s.order())), ProcessingStateLenses.reservation())
+ *     .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), ProcessingStateLenses.discount())
+ *     .fromThen(s -> lift(processPayment(s.order(), s.discount())), ProcessingStateLenses.payment())
+ *     .fromThen(s -> lift(createShipment(s.order(), s.address())), ProcessingStateLenses.shipment())
  *     .fromThen(s -> lift(sendNotifications(s.order(), s.customer(), s.discount())),
- *         notificationLens)
+ *         ProcessingStateLenses.notification())
  *     .yield(OrderWorkflow::toOrderResult);
  * }</pre>
  *
@@ -98,133 +103,26 @@ import org.higherkindedj.optics.Lens;
  */
 public class OrderWorkflow {
 
-  private final CustomerService customerService;
+  // Reads go through the generated @GeneratePathBridge wrappers (CustomerServicePaths, …) instead
+  // of hand-written Path.either(service.call()). The raw services are still held where a call has
+  // no EitherPath bridge usage in this workflow (reserve, payment, the discount calculations,
+  // notifications).
+  private final CustomerServicePaths customerPaths;
   private final InventoryService inventoryService;
   private final DiscountService discountService;
+  private final DiscountServicePaths discountPaths;
   private final PaymentService paymentService;
   private final ShippingService shippingService;
+  private final ShippingServicePaths shippingPaths;
   private final NotificationService notificationService;
   private final WorkflowConfig config;
 
   // -------------------------------------------------------------------------
-  // Processing State — named record that replaces tuple positions
+  // Processing State
   // -------------------------------------------------------------------------
-
-  /**
-   * Immutable state record that accumulates workflow results with named fields.
-   *
-   * <p>Unlike tuple-based accumulation where values are accessed by position ({@code t._3()},
-   * {@code t._5()}), this record provides named accessors ({@code state.order()}, {@code
-   * state.discount()}) that are self-documenting and refactoring-safe.
-   *
-   * <p>Fields populated during the gather phase (address, customer, order) are always non-null.
-   * Fields populated during the enrich phase start as null and are set by {@code fromThen()} steps.
-   * The monadic short-circuit guarantees each field is populated before subsequent steps access it.
-   *
-   * @param address the validated shipping address (gather phase)
-   * @param customer the validated customer (gather phase)
-   * @param order the validated order (gather phase)
-   * @param reservation the inventory reservation (enrich phase)
-   * @param discount the discount calculation result (enrich phase)
-   * @param payment the payment confirmation (enrich phase)
-   * @param shipment the shipment info (enrich phase)
-   * @param notification the notification result (enrich phase)
-   */
-  public record ProcessingState(
-      ValidatedShippingAddress address,
-      Customer customer,
-      ValidatedOrder order,
-      InventoryReservation reservation,
-      DiscountResult discount,
-      PaymentConfirmation payment,
-      ShipmentInfo shipment,
-      NotificationResult notification) {
-
-    /**
-     * Creates the initial state from the three values gathered by the For comprehension. Remaining
-     * fields are null until populated by ForState steps.
-     */
-    static ProcessingState initial(
-        ValidatedShippingAddress address, Customer customer, ValidatedOrder order) {
-      return new ProcessingState(address, customer, order, null, null, null, null, null);
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Lenses — provide named, type-safe access for ForState operations
-  // -------------------------------------------------------------------------
-  // In production code, annotate ProcessingState with @GenerateLenses
-  // and the annotation processor generates these automatically.
-
-  static final Lens<ProcessingState, InventoryReservation> reservationLens =
-      Lens.of(
-          ProcessingState::reservation,
-          (s, v) ->
-              new ProcessingState(
-                  s.address(),
-                  s.customer(),
-                  s.order(),
-                  v,
-                  s.discount(),
-                  s.payment(),
-                  s.shipment(),
-                  s.notification()));
-
-  static final Lens<ProcessingState, DiscountResult> discountLens =
-      Lens.of(
-          ProcessingState::discount,
-          (s, v) ->
-              new ProcessingState(
-                  s.address(),
-                  s.customer(),
-                  s.order(),
-                  s.reservation(),
-                  v,
-                  s.payment(),
-                  s.shipment(),
-                  s.notification()));
-
-  static final Lens<ProcessingState, PaymentConfirmation> paymentLens =
-      Lens.of(
-          ProcessingState::payment,
-          (s, v) ->
-              new ProcessingState(
-                  s.address(),
-                  s.customer(),
-                  s.order(),
-                  s.reservation(),
-                  s.discount(),
-                  v,
-                  s.shipment(),
-                  s.notification()));
-
-  static final Lens<ProcessingState, ShipmentInfo> shipmentLens =
-      Lens.of(
-          ProcessingState::shipment,
-          (s, v) ->
-              new ProcessingState(
-                  s.address(),
-                  s.customer(),
-                  s.order(),
-                  s.reservation(),
-                  s.discount(),
-                  s.payment(),
-                  v,
-                  s.notification()));
-
-  static final Lens<ProcessingState, NotificationResult> notificationLens =
-      Lens.of(
-          ProcessingState::notification,
-          (s, v) ->
-              new ProcessingState(
-                  s.address(),
-                  s.customer(),
-                  s.order(),
-                  s.reservation(),
-                  s.discount(),
-                  s.payment(),
-                  s.shipment(),
-                  v));
+  // The accumulator is the top-level {@link ProcessingState} record, annotated with
+  // {@code @GenerateLenses}. The processor generates {@code ProcessingStateLenses} — one lens per
+  // field — used below by the {@code ForState} enrich phase, so there are no hand-written lenses.
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -239,11 +137,13 @@ public class OrderWorkflow {
       ShippingService shippingService,
       NotificationService notificationService,
       WorkflowConfig config) {
-    this.customerService = customerService;
+    this.customerPaths = new CustomerServicePaths(customerService);
     this.inventoryService = inventoryService;
     this.discountService = discountService;
+    this.discountPaths = new DiscountServicePaths(discountService);
     this.paymentService = paymentService;
     this.shippingService = shippingService;
+    this.shippingPaths = new ShippingServicePaths(shippingService);
     this.notificationService = notificationService;
     this.config = config;
   }
@@ -285,6 +185,13 @@ public class OrderWorkflow {
    * @return either an error or the successful order result
    */
   public EitherPath<OrderError, OrderResult> process(OrderRequest request) {
+    // Front door: accumulating field validation reports *all* structural problems at once via
+    // ValidationPath.zipWithAccum (rather than fail-fast on the first), then converts to EitherPath
+    // so the sequential pipeline below stays fail-fast.
+    return validateRequest(request).via(this::processValidated);
+  }
+
+  private EitherPath<OrderError, OrderResult> processValidated(OrderRequest request) {
     var orderId = OrderId.generate();
     var customerId = new CustomerId(request.customerId());
     MonadError<EitherKind.Witness<OrderError>, OrderError> monad = Instances.monadError(either());
@@ -300,19 +207,84 @@ public class OrderWorkflow {
             .toState(
                 (address, customer, order) -> ProcessingState.initial(address, customer, order))
 
-            // From here on, every value is accessed by name
+            // From here on, every value is accessed by name, and the field updates use the
+            // generated ProcessingStateLenses rather than hand-written lenses.
             .fromThen(
                 s -> lift(reserveInventory(s.order().orderId(), s.order().lines())),
-                reservationLens)
-            .fromThen(s -> lift(applyDiscounts(s.order(), s.customer())), discountLens)
-            .fromThen(s -> lift(processPayment(s.order(), s.discount())), paymentLens)
-            .fromThen(s -> lift(createShipment(s.order(), s.address())), shipmentLens)
+                ProcessingStateLenses.reservation())
+            .fromThen(
+                s -> lift(applyDiscounts(s.order(), s.customer())),
+                ProcessingStateLenses.discount())
+            .fromThen(
+                s -> lift(processPayment(s.order(), s.discount())), ProcessingStateLenses.payment())
+            .fromThen(
+                s -> lift(createShipment(s.order(), s.address())), ProcessingStateLenses.shipment())
             .fromThen(
                 s -> lift(sendNotifications(s.order(), s.customer(), s.discount())),
-                notificationLens)
+                ProcessingStateLenses.notification())
             .yield(OrderWorkflow::toOrderResult);
 
     return Path.either(EITHER.narrow(result));
+  }
+
+  // -------------------------------------------------------------------------
+  // Front-door accumulating validation
+  // -------------------------------------------------------------------------
+
+  /**
+   * Validates the request's structural fields, accumulating every problem (not failing fast) via
+   * {@code zipWithAccum}, then folding the collected {@link OrderError.FieldError}s into a single
+   * {@link OrderError.ValidationError} on the {@link EitherPath} the pipeline consumes. A malformed
+   * order therefore reports all its field errors at once instead of one per round-trip.
+   */
+  private EitherPath<OrderError, OrderRequest> validateRequest(OrderRequest request) {
+    return validateCustomerId(request.customerId())
+        .zipWithAccum(validateLines(request.lines()), (_, _) -> request)
+        .zipWithAccum(validatePromoCode(request.promoCode()), (_, _) -> request)
+        // Accumulation is done; fold the collected field errors into a single typed OrderError on
+        // the EitherPath (mapError on a still-accumulating ValidationPath is unsupported).
+        .toEitherPath()
+        .mapError(
+            fieldErrors ->
+                new OrderError.ValidationError("Order request validation failed", fieldErrors));
+  }
+
+  private ValidationPath<List<OrderError.FieldError>, String> validateCustomerId(
+      String customerId) {
+    if (customerId.isBlank()) {
+      return Path.invalid(
+          List.of(
+              new OrderError.FieldError("customerId", "Customer id must not be blank", customerId)),
+          Semigroups.list());
+    }
+    return Path.valid(customerId, Semigroups.list());
+  }
+
+  private ValidationPath<List<OrderError.FieldError>, List<OrderLineRequest>> validateLines(
+      List<OrderLineRequest> lines) {
+    var fieldErrors =
+        lines.stream()
+            .filter(line -> line.productId().isBlank())
+            .map(
+                line ->
+                    new OrderError.FieldError(
+                        "productId", "Product id must not be blank", line.productId()))
+            .toList();
+    return fieldErrors.isEmpty()
+        ? Path.valid(lines, Semigroups.list())
+        : Path.invalid(fieldErrors, Semigroups.list());
+  }
+
+  private ValidationPath<List<OrderError.FieldError>, Optional<String>> validatePromoCode(
+      Optional<String> promoCode) {
+    if (promoCode.isPresent() && promoCode.get().isBlank()) {
+      return Path.invalid(
+          List.of(
+              new OrderError.FieldError(
+                  "promoCode", "Promo code must not be blank when present", promoCode.get())),
+          Semigroups.list());
+    }
+    return Path.valid(promoCode, Semigroups.list());
   }
 
   // -------------------------------------------------------------------------
@@ -333,15 +305,15 @@ public class OrderWorkflow {
 
   private EitherPath<OrderError, ValidatedShippingAddress> validateShippingAddress(
       ShippingAddress address) {
-    return Path.either(shippingService.validateAddress(address));
+    return shippingPaths.validateAddress(address);
   }
 
   private EitherPath<OrderError, Customer> lookupCustomer(CustomerId customerId) {
-    return Path.either(customerService.findById(customerId));
+    return customerPaths.findById(customerId);
   }
 
   private EitherPath<OrderError, Customer> validateCustomerEligibility(Customer customer) {
-    return Path.either(customerService.validateEligibility(customer));
+    return customerPaths.validateEligibility(customer);
   }
 
   private EitherPath<OrderError, Customer> lookupAndValidateCustomer(CustomerId customerId) {
@@ -384,7 +356,7 @@ public class OrderWorkflow {
       Optional<String> promoCode) {
     return promoCode
         .<EitherPath<OrderError, Optional<PromoCode>>>map(
-            code -> Path.either(discountService.validatePromoCode(code)).map(Optional::of))
+            code -> discountPaths.validatePromoCode(code).map(Optional::of))
         .orElse(Path.right(Optional.empty()));
   }
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/PartialFulfilmentWorkflow.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/PartialFulfilmentWorkflow.java
@@ -71,13 +71,19 @@ public class PartialFulfilmentWorkflow {
    */
   private EitherPath<OrderError, PartialFulfilmentResult> processWithAvailability(
       ValidatedOrder order, List<ProductAvailability> availability) {
+    // An order may carry two lines for the same product; collapse them by keeping the first
+    // (same product -> same unit price), rather than letting toMap throw on the duplicate key.
     var unitPrices =
         order.lines().stream()
             .collect(
-                Collectors.toMap(ValidatedOrderLine::productId, ValidatedOrderLine::unitPrice));
+                Collectors.toMap(
+                    ValidatedOrderLine::productId,
+                    ValidatedOrderLine::unitPrice,
+                    (first, _) -> first));
     var linesById =
         order.lines().stream()
-            .collect(Collectors.toMap(ValidatedOrderLine::productId, line -> line));
+            .collect(
+                Collectors.toMap(ValidatedOrderLine::productId, line -> line, (first, _) -> first));
 
     var shippable = availability.stream().filter(a -> a.availableQty() > 0).toList();
     var backordered = availability.stream().filter(a -> a.shortageQty() > 0).toList();

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/PartialFulfilmentWorkflow.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/PartialFulfilmentWorkflow.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.higherkindedj.example.order.error.OrderError;
 import org.higherkindedj.example.order.model.*;
 import org.higherkindedj.example.order.model.value.Money;
+import org.higherkindedj.example.order.model.value.ProductId;
 import org.higherkindedj.example.order.service.InventoryService;
 import org.higherkindedj.example.order.service.NotificationService;
 import org.higherkindedj.example.order.service.PaymentService;
@@ -18,14 +19,14 @@ import org.higherkindedj.hkt.expression.ForPath;
 
 /**
  * Workflow for processing orders with partial fulfilment support. Ships available items immediately
- * and creates back-orders for unavailable items.
+ * and creates back-orders for the shortage.
  *
  * <p>Demonstrates ForPath comprehensions for complex conditional workflows:
  *
  * <ul>
- *   <li>Partitioning items by availability
- *   <li>Processing available subset
- *   <li>Creating back-orders for unavailable items
+ *   <li>Splitting each line into a ship-now quantity and a back-order quantity
+ *   <li>Shipping (and charging for) the available units of every line
+ *   <li>Back-ordering only the shortage, at the correct money
  *   <li>Calculating partial payments
  * </ul>
  */
@@ -48,11 +49,8 @@ public class PartialFulfilmentWorkflow {
   }
 
   /**
-   * Processes an order with partial fulfilment support. Ships available items and creates
-   * back-orders for unavailable ones.
-   *
-   * <p>Uses ForPath comprehension for composing workflow steps, with a helper method for
-   * intermediate partitioning logic.
+   * Processes an order with partial fulfilment support. Ships available units and creates
+   * back-orders for the shortage.
    *
    * @param order the validated order to process
    * @return either an error or the partial fulfilment result
@@ -63,26 +61,56 @@ public class PartialFulfilmentWorkflow {
   }
 
   /**
-   * Processes an order after availability information has been retrieved. Partitions items by
-   * availability and uses ForPath to compose the remaining workflow steps.
+   * Processes an order after availability information has been retrieved.
+   *
+   * <p>Splits <em>each</em> line into a ship-now quantity ({@code min(requested, available)}) and a
+   * back-order quantity (the shortage), rather than bucketing whole lines as available/unavailable.
+   * A partially-available line therefore ships and is charged for its available units, and
+   * back-orders only its shortage at the correct money — the previous boolean partition dropped a
+   * partial line's available units and back-ordered (and over-charged) the whole line.
    */
   private EitherPath<OrderError, PartialFulfilmentResult> processWithAvailability(
       ValidatedOrder order, List<ProductAvailability> availability) {
-    var partitioned = partitionByAvailability(availability);
-    var availableItems = partitioned.get(true);
-    var unavailableItems = partitioned.get(false);
-    var partialTotal = calculateAvailableTotal(order, availableItems);
-    var backOrderTotal = calculateBackOrderTotal(order, unavailableItems);
+    var unitPrices =
+        order.lines().stream()
+            .collect(
+                Collectors.toMap(ValidatedOrderLine::productId, ValidatedOrderLine::unitPrice));
+    var linesById =
+        order.lines().stream()
+            .collect(Collectors.toMap(ValidatedOrderLine::productId, line -> line));
 
-    return ForPath.from(validateAvailability(partitioned, order))
-        .from(validated -> reserveAvailableItems(order, availableItems))
-        .from(t -> processPartialPayment(order, partialTotal))
-        .from(t -> createShipmentForAvailable(order, availableItems))
-        .from(t -> createBackOrders(order, unavailableItems))
-        .from(t -> sendPartialFulfilmentNotification(order, t._4(), t._5(), partialTotal))
+    var shippable = availability.stream().filter(a -> a.availableQty() > 0).toList();
+    var backordered = availability.stream().filter(a -> a.shortageQty() > 0).toList();
+
+    var fulfilledAmount =
+        shippable.stream()
+            .map(a -> unitPriceOf(unitPrices, a).multiply(shipQty(a)))
+            .reduce(Money.ZERO_GBP, Money::add);
+    var backOrderAmount =
+        backordered.stream()
+            .map(a -> unitPriceOf(unitPrices, a).multiply(a.shortageQty()))
+            .reduce(Money.ZERO_GBP, Money::add);
+
+    return ForPath.from(validateHasAvailability(shippable, availability))
+        .from(_ -> reserveAvailableItems(order, availability))
+        .from(_ -> processPartialPayment(order, fulfilledAmount))
+        .from(_ -> createShipmentForAvailable(order, shippable, linesById))
+        .from(_ -> createBackOrders(order, backordered, unitPrices))
+        .from(_ -> sendPartialFulfilmentNotification(order, fulfilledAmount))
         .yield(
-            (validated, reservationId, payment, shipment, backOrders, notified) ->
-                buildResult(order, payment, shipment, backOrders, partialTotal, backOrderTotal));
+            (_, _, payment, shipment, backOrders, _) ->
+                buildResult(
+                    order, payment, shipment, backOrders, fulfilledAmount, backOrderAmount));
+  }
+
+  /** The quantity of a line that can ship now. */
+  private static int shipQty(ProductAvailability availability) {
+    return Math.min(availability.requestedQty(), availability.availableQty());
+  }
+
+  private static Money unitPriceOf(
+      Map<ProductId, Money> unitPrices, ProductAvailability availability) {
+    return unitPrices.getOrDefault(availability.productId(), Money.ZERO_GBP);
   }
 
   private EitherPath<OrderError, List<ProductAvailability>> getDetailedAvailability(
@@ -90,43 +118,23 @@ public class PartialFulfilmentWorkflow {
     return Path.either(inventoryService.getDetailedAvailability(lines));
   }
 
-  private Map<Boolean, List<ProductAvailability>> partitionByAvailability(
-      List<ProductAvailability> availability) {
-    return availability.stream()
-        .collect(Collectors.partitioningBy(ProductAvailability::isAvailable));
-  }
-
-  private EitherPath<OrderError, Map<Boolean, List<ProductAvailability>>> validateAvailability(
-      Map<Boolean, List<ProductAvailability>> partitioned, ValidatedOrder order) {
-    var available = partitioned.get(true);
-    var unavailable = partitioned.get(false);
-
-    // If nothing is available, that's an error
-    if (available.isEmpty()) {
+  /** Fails fast only when nothing at all can ship; a partial order is a success here. */
+  private EitherPath<OrderError, List<ProductAvailability>> validateHasAvailability(
+      List<ProductAvailability> shippable, List<ProductAvailability> all) {
+    if (shippable.isEmpty()) {
       return Path.left(
           OrderError.InventoryError.outOfStock(
-              unavailable.stream().map(a -> a.productId().value()).toList()));
+              all.stream().map(a -> a.productId().value()).toList()));
     }
-
-    return Path.right(partitioned);
+    return Path.right(shippable);
   }
 
   private EitherPath<OrderError, String> reserveAvailableItems(
-      ValidatedOrder order, List<ProductAvailability> available) {
+      ValidatedOrder order, List<ProductAvailability> availability) {
     return Path.either(
         inventoryService
-            .reserveAvailable(order.orderId(), available)
+            .reserveAvailable(order.orderId(), availability)
             .map(InventoryReservation::reservationId));
-  }
-
-  private Money calculateAvailableTotal(ValidatedOrder order, List<ProductAvailability> available) {
-    var availableProductIds =
-        available.stream().map(ProductAvailability::productId).collect(Collectors.toSet());
-
-    return order.lines().stream()
-        .filter(line -> availableProductIds.contains(line.productId()))
-        .map(ValidatedOrderLine::lineTotal)
-        .reduce(Money.ZERO_GBP, Money::add);
   }
 
   private EitherPath<OrderError, PaymentConfirmation> processPartialPayment(
@@ -136,39 +144,39 @@ public class PartialFulfilmentWorkflow {
   }
 
   private EitherPath<OrderError, ShipmentInfo> createShipmentForAvailable(
-      ValidatedOrder order, List<ProductAvailability> available) {
-    var availableProductIds =
-        available.stream().map(ProductAvailability::productId).collect(Collectors.toSet());
-
-    var availableLines =
-        order.lines().stream()
-            .filter(line -> availableProductIds.contains(line.productId()))
+      ValidatedOrder order,
+      List<ProductAvailability> shippable,
+      Map<ProductId, ValidatedOrderLine> linesById) {
+    // Ship the available quantity of each line, not the full requested line.
+    var shipLines =
+        shippable.stream()
+            .map(
+                a ->
+                    ValidatedOrderLine.of(
+                        a.productId(), linesById.get(a.productId()).product(), shipQty(a)))
             .toList();
 
     return Path.either(
-        shippingService.createShipment(order.orderId(), order.shippingAddress(), availableLines));
+        shippingService.createShipment(order.orderId(), order.shippingAddress(), shipLines));
   }
 
   private EitherPath<OrderError, List<BackOrder>> createBackOrders(
-      ValidatedOrder order, List<ProductAvailability> unavailable) {
-    if (unavailable.isEmpty()) {
+      ValidatedOrder order,
+      List<ProductAvailability> backordered,
+      Map<ProductId, Money> unitPrices) {
+    if (backordered.isEmpty()) {
       return Path.right(List.of());
     }
 
-    var productPrices =
-        order.lines().stream()
-            .collect(
-                Collectors.toMap(ValidatedOrderLine::productId, ValidatedOrderLine::unitPrice));
-
     var backOrders =
-        unavailable.stream()
+        backordered.stream()
             .map(
-                avail ->
+                a ->
                     BackOrder.create(
                         order.orderId(),
-                        avail.productId(),
-                        avail.shortageQty(),
-                        productPrices.getOrDefault(avail.productId(), Money.ZERO_GBP),
+                        a.productId(),
+                        a.shortageQty(),
+                        unitPriceOf(unitPrices, a),
                         14 // Estimated 14 days for restock
                         ))
             .toList();
@@ -176,28 +184,14 @@ public class PartialFulfilmentWorkflow {
     return Path.right(backOrders);
   }
 
-  private Money calculateBackOrderTotal(
-      ValidatedOrder order, List<ProductAvailability> unavailable) {
-    var unavailableProductIds =
-        unavailable.stream().map(ProductAvailability::productId).collect(Collectors.toSet());
-
-    return order.lines().stream()
-        .filter(line -> unavailableProductIds.contains(line.productId()))
-        .map(ValidatedOrderLine::lineTotal)
-        .reduce(Money.ZERO_GBP, Money::add);
-  }
-
   private EitherPath<OrderError, Boolean> sendPartialFulfilmentNotification(
-      ValidatedOrder order,
-      ShipmentInfo shipment,
-      List<BackOrder> backOrders,
-      Money fulfilledAmount) {
-    // Use the fulfilled amount (items charged) for the notification, not shipping cost
+      ValidatedOrder order, Money fulfilledAmount) {
+    // Use the fulfilled amount (items charged) for the notification, not shipping cost.
     return Path.either(
             notificationService
                 .sendOrderConfirmation(order.orderId(), order.customer(), fulfilledAmount)
                 .map(NotificationResult::emailSent))
-        .recoverWith(error -> Path.right(false));
+        .recoverWith(_ -> Path.right(false));
   }
 
   private PartialFulfilmentResult buildResult(

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/ProcessingState.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/workflow/ProcessingState.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.order.workflow;
+
+import org.higherkindedj.example.order.model.Customer;
+import org.higherkindedj.example.order.model.DiscountResult;
+import org.higherkindedj.example.order.model.InventoryReservation;
+import org.higherkindedj.example.order.model.NotificationResult;
+import org.higherkindedj.example.order.model.PaymentConfirmation;
+import org.higherkindedj.example.order.model.ShipmentInfo;
+import org.higherkindedj.example.order.model.ValidatedOrder;
+import org.higherkindedj.example.order.model.ValidatedShippingAddress;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+
+/**
+ * Immutable state record that accumulates {@link OrderWorkflow} results with named fields.
+ *
+ * <p>Promoted to a top-level record and annotated with {@link GenerateLenses} so the annotation
+ * processor generates {@code ProcessingStateLenses} — one lens per field — instead of the workflow
+ * hand-writing them. Unlike tuple-based accumulation where values are accessed by position ({@code
+ * t._3()}, {@code t._5()}), this record provides named accessors ({@code state.order()}, {@code
+ * state.discount()}) that are self-documenting and refactoring-safe.
+ *
+ * <p>Fields populated during the gather phase (address, customer, order) are always non-null.
+ * Fields populated during the enrich phase start as null and are set by {@code fromThen()} steps.
+ * The monadic short-circuit guarantees each field is populated before subsequent steps access it.
+ *
+ * @param address the validated shipping address (gather phase)
+ * @param customer the validated customer (gather phase)
+ * @param order the validated order (gather phase)
+ * @param reservation the inventory reservation (enrich phase)
+ * @param discount the discount calculation result (enrich phase)
+ * @param payment the payment confirmation (enrich phase)
+ * @param shipment the shipment info (enrich phase)
+ * @param notification the notification result (enrich phase)
+ */
+@GenerateLenses
+public record ProcessingState(
+    ValidatedShippingAddress address,
+    Customer customer,
+    ValidatedOrder order,
+    InventoryReservation reservation,
+    DiscountResult discount,
+    PaymentConfirmation payment,
+    ShipmentInfo shipment,
+    NotificationResult notification) {
+
+  /**
+   * Creates the initial state from the three values gathered by the For comprehension. Remaining
+   * fields are null until populated by ForState steps.
+   *
+   * @param address the validated shipping address
+   * @param customer the validated customer
+   * @param order the validated order
+   * @return a ProcessingState with only the gather-phase fields populated
+   */
+  static ProcessingState initial(
+      ValidatedShippingAddress address, Customer customer, ValidatedOrder order) {
+    return new ProcessingState(address, customer, order, null, null, null, null, null);
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/market/MarketDataPipelineTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/market/MarketDataPipelineTest.java
@@ -8,6 +8,7 @@ import static org.awaitility.Awaitility.await;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.higherkindedj.example.market.aggregation.WindowAggregator;
@@ -16,6 +17,7 @@ import org.higherkindedj.example.market.alert.AnomalyDetector;
 import org.higherkindedj.example.market.enrichment.InMemoryFxRateService;
 import org.higherkindedj.example.market.enrichment.InMemoryReferenceDataService;
 import org.higherkindedj.example.market.enrichment.TickEnricher;
+import org.higherkindedj.example.market.error.MarketError;
 import org.higherkindedj.example.market.feed.FeedMerger;
 import org.higherkindedj.example.market.feed.SimulatedExchangeFeed;
 import org.higherkindedj.example.market.model.AggregatedView;
@@ -193,6 +195,26 @@ class MarketDataPipelineTest {
       List<EnrichedTick> enriched = enricher.enrich(feed.ticks().take(20)).toList().run();
 
       assertThat(enriched).hasSize(20);
+    }
+
+    @Test
+    @DisplayName("surfaces a typed MarketError for an unknown symbol and drops the tick")
+    void surfacesTypedErrorForUnknownSymbol() {
+      var errors = new CopyOnWriteArrayList<MarketError>();
+      // "ZZZZ" has no reference data, so every tick fails enrichment with a typed error.
+      SimulatedExchangeFeed feed =
+          new SimulatedExchangeFeed(Exchange.NYSE, List.of(new Symbol("ZZZZ")), 150.0, 0.002, 42L);
+      TickEnricher enricher = new TickEnricher(refData, fxService, 4, errors::add);
+
+      List<EnrichedTick> enriched = enricher.enrich(feed.ticks().take(3)).toList().run();
+
+      // Failed ticks are reported through the typed channel and dropped, not thrown.
+      assertThat(enriched).isEmpty();
+      assertThat(errors)
+          .hasSize(3)
+          .allSatisfy(error -> assertThat(error).isInstanceOf(MarketError.EnrichmentFailed.class));
+      assertThat(((MarketError.EnrichmentFailed) errors.getFirst()).symbol())
+          .isEqualTo(new Symbol("ZZZZ"));
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/ConfigurableOrderWorkflowTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/ConfigurableOrderWorkflowTest.java
@@ -1,0 +1,181 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.higherkindedj.example.order.config.WorkflowConfig;
+import org.higherkindedj.example.order.config.WorkflowConfig.Environment;
+import org.higherkindedj.example.order.config.WorkflowConfig.FeatureFlags;
+import org.higherkindedj.example.order.config.WorkflowConfig.RetryConfig;
+import org.higherkindedj.example.order.config.WorkflowConfig.TimeoutConfig;
+import org.higherkindedj.example.order.error.OrderError;
+import org.higherkindedj.example.order.model.InventoryReservation;
+import org.higherkindedj.example.order.model.OrderLineRequest;
+import org.higherkindedj.example.order.model.OrderRequest;
+import org.higherkindedj.example.order.model.PaymentConfirmation;
+import org.higherkindedj.example.order.model.PaymentMethod;
+import org.higherkindedj.example.order.model.ShipmentInfo;
+import org.higherkindedj.example.order.model.ShippingAddress;
+import org.higherkindedj.example.order.model.ValidatedOrderLine;
+import org.higherkindedj.example.order.model.ValidatedShippingAddress;
+import org.higherkindedj.example.order.model.WarehouseInfo;
+import org.higherkindedj.example.order.model.value.Money;
+import org.higherkindedj.example.order.model.value.OrderId;
+import org.higherkindedj.example.order.service.PaymentService;
+import org.higherkindedj.example.order.service.ShippingService;
+import org.higherkindedj.example.order.service.impl.InMemoryCustomerService;
+import org.higherkindedj.example.order.service.impl.InMemoryDiscountService;
+import org.higherkindedj.example.order.service.impl.InMemoryInventoryService;
+import org.higherkindedj.example.order.service.impl.InMemoryNotificationService;
+import org.higherkindedj.example.order.service.impl.InMemoryPaymentService;
+import org.higherkindedj.example.order.service.impl.InMemoryShippingService;
+import org.higherkindedj.example.order.workflow.ConfigurableOrderWorkflow;
+import org.higherkindedj.hkt.either.Either;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ConfigurableOrderWorkflow} resilience granularity — the fix that stops the
+ * non-idempotent payment being retried. Retry now wraps only the idempotent pre-flight; the
+ * committing workflow (which charges the customer) runs exactly once.
+ */
+@DisplayName("ConfigurableOrderWorkflow — resilience granularity")
+class ConfigurableOrderWorkflowTest {
+
+  @Test
+  @DisplayName("a valid order succeeds and charges the customer exactly once")
+  void validOrderChargesOnce() {
+    var payments = new CountingPaymentService();
+    var workflow = workflowWith(payments, new InMemoryShippingService(), configWithRetries(3));
+
+    var result = workflow.process(request()).run();
+
+    assertThatEither(result).isRight();
+    assertThat(payments.calls()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("a transient failure after payment does NOT re-run the payment")
+  void transientFailureAfterPaymentDoesNotDoubleCharge() {
+    var payments = new CountingPaymentService();
+    // Shipping (which runs after payment) fails transiently. With maxRetries=3, the old code
+    // retried the whole workflow and would have charged three times.
+    var workflow = workflowWith(payments, new FailingShippingService(), configWithRetries(3));
+
+    var result = workflow.process(request()).run();
+
+    assertThatEither(result)
+        .isLeft()
+        .hasLeftSatisfying(error -> assertThat(error).isInstanceOf(OrderError.SystemError.class));
+    // The committing workflow ran once: payment was charged exactly once despite three allowed
+    // retries.
+    assertThat(payments.calls()).isEqualTo(1);
+  }
+
+  private static ConfigurableOrderWorkflow workflowWith(
+      PaymentService paymentService, ShippingService shippingService, WorkflowConfig config) {
+    return new ConfigurableOrderWorkflow(
+        new InMemoryCustomerService(),
+        new InMemoryInventoryService(),
+        new InMemoryDiscountService(),
+        paymentService,
+        shippingService,
+        new InMemoryNotificationService(),
+        config);
+  }
+
+  private static OrderRequest request() {
+    return new OrderRequest(
+        "CUST-001",
+        List.of(new OrderLineRequest("PROD-001", 1)),
+        Optional.empty(),
+        new ShippingAddress("Test User", "123 Test Street", "London", "SW1A 1AA", "GB"),
+        new PaymentMethod.CreditCard("4000000000000002", "12", "2025", "123"));
+  }
+
+  private static WorkflowConfig configWithRetries(int maxRetries) {
+    return new WorkflowConfig(
+        new RetryConfig(maxRetries, Duration.ofMillis(5), Duration.ofMillis(20), 2.0),
+        new TimeoutConfig(
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(2)),
+        // Partial fulfilment off: a failure must not be diverted to the partial-fulfilment path.
+        new FeatureFlags(false, false, false),
+        Environment.TESTING);
+  }
+
+  /**
+   * Counts how many times a payment is actually charged, delegating the work to the real service.
+   */
+  private static final class CountingPaymentService implements PaymentService {
+    private final PaymentService delegate = new InMemoryPaymentService();
+    private final AtomicInteger calls = new AtomicInteger();
+
+    int calls() {
+      return calls.get();
+    }
+
+    @Override
+    public Either<OrderError, PaymentConfirmation> processPayment(
+        OrderId orderId, Money amount, PaymentMethod paymentMethod) {
+      calls.incrementAndGet();
+      return delegate.processPayment(orderId, amount, paymentMethod);
+    }
+
+    @Override
+    public Either<OrderError, PaymentConfirmation> refundPayment(
+        String transactionId, Money amount) {
+      return delegate.refundPayment(transactionId, amount);
+    }
+
+    @Override
+    public Either<OrderError, PaymentMethod> validatePaymentMethod(PaymentMethod paymentMethod) {
+      return delegate.validatePaymentMethod(paymentMethod);
+    }
+  }
+
+  /** Shipping service whose {@code createShipment} fails transiently (runs after payment). */
+  private static final class FailingShippingService implements ShippingService {
+    private final ShippingService delegate = new InMemoryShippingService();
+
+    @Override
+    public Either<OrderError, ValidatedShippingAddress> validateAddress(ShippingAddress address) {
+      return delegate.validateAddress(address);
+    }
+
+    @Override
+    public Either<OrderError, ShipmentInfo> createShipment(
+        OrderId orderId, ValidatedShippingAddress address, List<ValidatedOrderLine> lines) {
+      throw new UncheckedIOException(new IOException("transient shipping outage"));
+    }
+
+    @Override
+    public Either<OrderError, Void> cancelShipment(String shipmentId) {
+      return delegate.cancelShipment(shipmentId);
+    }
+
+    @Override
+    public Either<OrderError, ShipmentStatus> getShipmentStatus(String trackingNumber) {
+      return delegate.getShipmentStatus(trackingNumber);
+    }
+
+    @Override
+    public Either<OrderError, ShipmentInfo> createShipmentFromWarehouse(
+        OrderId orderId,
+        WarehouseInfo warehouse,
+        List<InventoryReservation.ReservedItem> items,
+        ValidatedShippingAddress address) {
+      return delegate.createShipmentFromWarehouse(orderId, warehouse, items, address);
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/EnhancedOrderWorkflowTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/EnhancedOrderWorkflowTest.java
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.example.order.config.WorkflowConfig;
+import org.higherkindedj.example.order.context.OrderContext;
+import org.higherkindedj.example.order.error.OrderError;
+import org.higherkindedj.example.order.model.OrderLineRequest;
+import org.higherkindedj.example.order.model.OrderRequest;
+import org.higherkindedj.example.order.model.OrderResult;
+import org.higherkindedj.example.order.model.PaymentMethod;
+import org.higherkindedj.example.order.model.ShippingAddress;
+import org.higherkindedj.example.order.service.impl.InMemoryCustomerService;
+import org.higherkindedj.example.order.service.impl.InMemoryDiscountService;
+import org.higherkindedj.example.order.service.impl.InMemoryInventoryService;
+import org.higherkindedj.example.order.service.impl.InMemoryNotificationService;
+import org.higherkindedj.example.order.service.impl.InMemoryPaymentService;
+import org.higherkindedj.example.order.service.impl.InMemoryShippingService;
+import org.higherkindedj.example.order.workflow.EnhancedOrderWorkflow;
+import org.higherkindedj.hkt.either.Either;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EnhancedOrderWorkflow}, focused on its {@code EitherT<VTask, OrderError, _>}
+ * railway: the happy path threads through both {@code For} comprehensions (gather then
+ * discount/payment/shipment/notification), and a {@code Left} from any step short-circuits the rest
+ * of the pipeline.
+ */
+@DisplayName("EnhancedOrderWorkflow")
+class EnhancedOrderWorkflowTest {
+
+  private EnhancedOrderWorkflow workflow;
+
+  @BeforeEach
+  void setUp() {
+    // The in-memory services seed CUST-001 (GOLD, ACTIVE), PROD-001/PROD-002 stock, and a declined
+    // test card (4111…), so the scenarios below need no extra fixture wiring.
+    workflow =
+        new EnhancedOrderWorkflow(
+            new InMemoryCustomerService(),
+            new InMemoryInventoryService(),
+            new InMemoryDiscountService(),
+            new InMemoryPaymentService(),
+            new InMemoryShippingService(),
+            new InMemoryNotificationService(),
+            WorkflowConfig.defaults());
+  }
+
+  @Nested
+  @DisplayName("Happy Path")
+  class HappyPathTests {
+
+    @Test
+    @DisplayName("processes a valid order end-to-end through both For comprehensions")
+    void processesValidOrder() {
+      // CUST-001 (GOLD, ACTIVE) and PROD-001/PROD-002 are seeded by the in-memory services.
+      var request =
+          new OrderRequest(
+              "CUST-001",
+              List.of(new OrderLineRequest("PROD-001", 2), new OrderLineRequest("PROD-002", 1)),
+              Optional.empty(),
+              validAddress(),
+              acceptedCard());
+
+      var result = process(request);
+
+      assertThatEither(result)
+          .isRight()
+          .hasRightSatisfying(
+              orderResult -> {
+                assertThat(orderResult.orderId()).isNotNull();
+                assertThat(orderResult.trackingNumber()).isNotEmpty();
+                assertThat(orderResult.totalCharged()).isNotNull();
+                // The result is only built once the notification (final, non-critical) step has
+                // run, so a populated audit log proves the whole post-reservation railway
+                // completed.
+                assertThat(orderResult.auditLog().entries()).isNotEmpty();
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Short-Circuit Behaviour")
+  class ShortCircuitTests {
+
+    @Test
+    @DisplayName("short-circuits the gather phase when the customer is unknown")
+    void shortCircuitsOnUnknownCustomer() {
+      var request =
+          new OrderRequest(
+              "UNKNOWN-CUSTOMER",
+              List.of(new OrderLineRequest("PROD-001", 1)),
+              Optional.empty(),
+              validAddress(),
+              acceptedCard());
+
+      var result = process(request);
+
+      assertThatEither(result)
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error).isInstanceOf(OrderError.CustomerError.class);
+                assertThat(error.code()).isEqualTo("CUSTOMER_NOT_FOUND");
+              });
+    }
+
+    @Test
+    @DisplayName("short-circuits the post-reservation phase when payment is declined")
+    void shortCircuitsOnDeclinedPayment() {
+      var request =
+          new OrderRequest(
+              "CUST-001",
+              List.of(new OrderLineRequest("PROD-001", 1)),
+              Optional.empty(),
+              validAddress(),
+              new PaymentMethod.CreditCard("4111111111111111", "12", "2025", "123"));
+
+      var result = process(request);
+
+      assertThatEither(result)
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error).isInstanceOf(OrderError.PaymentError.class);
+                assertThat(error.code()).isEqualTo("PAYMENT_DECLINED");
+              });
+    }
+  }
+
+  /** Runs the workflow inside a bound {@link OrderContext} scope and unwraps the result. */
+  private Either<OrderError, OrderResult> process(OrderRequest request) {
+    return ScopedValue.where(OrderContext.TRACE_ID, OrderContext.generateTraceId())
+        .where(OrderContext.TENANT_ID, "test-tenant")
+        .where(OrderContext.DEADLINE, Instant.now().plus(Duration.ofSeconds(30)))
+        .call(() -> workflow.process(request).run().run());
+  }
+
+  private static ShippingAddress validAddress() {
+    return new ShippingAddress("Test User", "123 Test Street", "London", "SW1A 1AA", "GB");
+  }
+
+  private static PaymentMethod acceptedCard() {
+    return new PaymentMethod.CreditCard("4000000000000002", "12", "2025", "123");
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/FocusDSLExamplesTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/FocusDSLExamplesTest.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.example.order;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -212,8 +213,8 @@ class FocusDSLExamplesTest {
       var validResult = FocusDSLExamples.validatePaymentMethod(validCard);
 
       // Assert
-      assertThat(shortResult.run().isLeft()).isTrue();
-      assertThat(validResult.run().isRight()).isTrue();
+      assertThatEither(shortResult.run()).isLeft();
+      assertThatEither(validResult.run()).isRight();
     }
 
     @Test

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/InMemoryInventoryServiceTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/InMemoryInventoryServiceTest.java
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+import org.higherkindedj.example.order.error.OrderError;
+import org.higherkindedj.example.order.model.Product;
+import org.higherkindedj.example.order.model.ValidatedOrderLine;
+import org.higherkindedj.example.order.model.value.Money;
+import org.higherkindedj.example.order.model.value.OrderId;
+import org.higherkindedj.example.order.model.value.ProductId;
+import org.higherkindedj.example.order.service.impl.InMemoryInventoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link InMemoryInventoryService} reservation atomicity — the fix for the check-then-act
+ * race: stock must never oversell or go negative, multi-line reservations are all-or-nothing, and
+ * expired holds are reclaimed.
+ */
+@DisplayName("InMemoryInventoryService — atomic reservation")
+class InMemoryInventoryServiceTest {
+
+  private InMemoryInventoryService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new InMemoryInventoryService();
+  }
+
+  @Test
+  @DisplayName("concurrent single-unit reservations never oversell")
+  void concurrentReservationsNeverOversell() throws Exception {
+    service.setStock("PROD-RACE", 5);
+    int contenders = 50;
+
+    var start = new CountDownLatch(1);
+    try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+      List<Future<Boolean>> futures =
+          IntStream.range(0, contenders)
+              .mapToObj(
+                  _ ->
+                      pool.submit(
+                          (Callable<Boolean>)
+                              () -> {
+                                start.await();
+                                return service
+                                    .reserve(OrderId.generate(), List.of(line("PROD-RACE", 1)))
+                                    .isRight();
+                              }))
+              .toList();
+
+      start.countDown(); // release all contenders at once
+
+      long succeeded = 0;
+      for (var future : futures) {
+        if (future.get()) {
+          succeeded++;
+        }
+      }
+
+      // Exactly the available units are handed out — no more, no fewer — and stock bottoms at zero.
+      assertThat(succeeded).isEqualTo(5);
+      assertThat(stockOf("PROD-RACE")).isEqualTo(0);
+    }
+  }
+
+  @Test
+  @DisplayName("a multi-line reservation is all-or-nothing: a short line rolls back the rest")
+  void multiLineReservationIsAllOrNothing() {
+    // PROD-001 has stock 100, PROD-004 is out of stock (seeded by the service).
+    var result =
+        service.reserve(OrderId.generate(), List.of(line("PROD-001", 2), line("PROD-004", 1)));
+
+    assertThatEither(result)
+        .isLeft()
+        .hasLeftSatisfying(
+            error -> assertThat(error).isInstanceOf(OrderError.InventoryError.class));
+    // The available line was returned, not left short.
+    assertThat(stockOf("PROD-001")).isEqualTo(100);
+  }
+
+  @Test
+  @DisplayName("releasing a reservation returns its stock")
+  void releaseReturnsStock() {
+    var reservation = service.reserve(OrderId.generate(), List.of(line("PROD-001", 10))).getRight();
+    assertThat(stockOf("PROD-001")).isEqualTo(90);
+
+    service.releaseReservation(reservation.reservationId());
+    assertThat(stockOf("PROD-001")).isEqualTo(100);
+  }
+
+  @Test
+  @DisplayName("an expired hold is reclaimed on the next reservation")
+  void expiredHoldIsReclaimed() {
+    // Force every hold to be already expired, so the next reserve reclaims the prior one.
+    service.setReservationHold(Duration.ofSeconds(-1));
+
+    service.reserve(OrderId.generate(), List.of(line("PROD-001", 10)));
+    assertThat(stockOf("PROD-001")).isEqualTo(90);
+
+    // This second reservation reclaims the expired first one before taking its own stock.
+    service.reserve(OrderId.generate(), List.of(line("PROD-002", 1)));
+    assertThat(stockOf("PROD-001")).isEqualTo(100);
+  }
+
+  /** Reads true on-hand stock by requesting more than could exist and reading what is available. */
+  private int stockOf(String productId) {
+    var availability =
+        service.getDetailedAvailability(List.of(line(productId, 1_000_000))).getRight();
+    return availability.getFirst().availableQty();
+  }
+
+  private static ValidatedOrderLine line(String productId, int quantity) {
+    var id = new ProductId(productId);
+    var product =
+        new Product(id, "Product " + productId, "Description", Money.gbp("10.00"), "General", true);
+    return ValidatedOrderLine.of(id, product, quantity);
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/OrderWorkflowTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/OrderWorkflowTest.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.example.order;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.util.List;
 import java.util.Optional;
@@ -86,11 +87,13 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isRight()).isTrue();
-
-      var orderResult = result.run().getRight();
-      assertThat(orderResult.orderId()).isNotNull();
-      assertThat(orderResult.trackingNumber()).isNotEmpty();
+      assertThatEither(result.run())
+          .isRight()
+          .hasRightSatisfying(
+              orderResult -> {
+                assertThat(orderResult.orderId()).isNotNull();
+                assertThat(orderResult.trackingNumber()).isNotEmpty();
+              });
     }
 
     @Test
@@ -119,9 +122,9 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isRight()).isTrue();
-      var orderResult = result.run().getRight();
-      assertThat(orderResult.totalCharged()).isNotNull();
+      assertThatEither(result.run())
+          .isRight()
+          .hasRightSatisfying(orderResult -> assertThat(orderResult.totalCharged()).isNotNull());
     }
   }
 
@@ -145,10 +148,13 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isLeft()).isTrue();
-      var error = result.run().getLeft();
-      assertThat(error).isInstanceOf(OrderError.CustomerError.class);
-      assertThat(error.code()).isEqualTo("CUSTOMER_NOT_FOUND");
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error).isInstanceOf(OrderError.CustomerError.class);
+                assertThat(error.code()).isEqualTo("CUSTOMER_NOT_FOUND");
+              });
     }
 
     @Test
@@ -178,9 +184,10 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isLeft()).isTrue();
-      var error = result.run().getLeft();
-      assertThat(error).isInstanceOf(OrderError.InventoryError.class);
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> assertThat(error).isInstanceOf(OrderError.InventoryError.class));
     }
 
     @Test
@@ -218,9 +225,35 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isLeft()).isTrue();
-      var error = result.run().getLeft();
-      assertThat(error).isInstanceOf(OrderError.ShippingError.class);
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> assertThat(error).isInstanceOf(OrderError.ShippingError.class));
+    }
+
+    @Test
+    @DisplayName("accumulates all structural field errors at once")
+    void accumulatesStructuralFieldErrors() {
+      // A blank customer id AND a blank product id: both should be reported together.
+      var request =
+          new OrderRequest(
+              "",
+              List.of(new OrderLineRequest("", 1)),
+              Optional.empty(),
+              createValidAddress(),
+              new PaymentMethod.CreditCard("4000000000000002", "12", "2025", "123"));
+
+      var result = workflow.process(request);
+
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error).isInstanceOf(OrderError.ValidationError.class);
+                assertThat(((OrderError.ValidationError) error).fieldErrors())
+                    .extracting(OrderError.FieldError::field)
+                    .containsExactlyInAnyOrder("customerId", "productId");
+              });
     }
   }
 
@@ -255,10 +288,13 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isLeft()).isTrue();
-      var error = result.run().getLeft();
-      assertThat(error).isInstanceOf(OrderError.PaymentError.class);
-      assertThat(error.code()).isEqualTo("PAYMENT_DECLINED");
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error).isInstanceOf(OrderError.PaymentError.class);
+                assertThat(error.code()).isEqualTo("PAYMENT_DECLINED");
+              });
     }
   }
 
@@ -292,9 +328,9 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isRight()).isTrue();
-      var orderResult = result.run().getRight();
-      assertThat(orderResult.totalCharged()).isNotNull();
+      assertThatEither(result.run())
+          .isRight()
+          .hasRightSatisfying(orderResult -> assertThat(orderResult.totalCharged()).isNotNull());
     }
 
     @Test
@@ -323,9 +359,10 @@ class OrderWorkflowTest {
       var result = workflow.process(request);
 
       // Assert
-      assertThat(result.run().isLeft()).isTrue();
-      var error = result.run().getLeft();
-      assertThat(error).isInstanceOf(OrderError.DiscountError.class);
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> assertThat(error).isInstanceOf(OrderError.DiscountError.class));
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/PartialFulfilmentWorkflowTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/PartialFulfilmentWorkflowTest.java
@@ -1,0 +1,137 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.example.order.model.Customer;
+import org.higherkindedj.example.order.model.FulfilmentStatus;
+import org.higherkindedj.example.order.model.PaymentMethod;
+import org.higherkindedj.example.order.model.Product;
+import org.higherkindedj.example.order.model.ValidatedOrder;
+import org.higherkindedj.example.order.model.ValidatedOrderLine;
+import org.higherkindedj.example.order.model.ValidatedShippingAddress;
+import org.higherkindedj.example.order.model.value.CustomerId;
+import org.higherkindedj.example.order.model.value.Money;
+import org.higherkindedj.example.order.model.value.OrderId;
+import org.higherkindedj.example.order.model.value.ProductId;
+import org.higherkindedj.example.order.service.impl.InMemoryInventoryService;
+import org.higherkindedj.example.order.service.impl.InMemoryNotificationService;
+import org.higherkindedj.example.order.service.impl.InMemoryPaymentService;
+import org.higherkindedj.example.order.service.impl.InMemoryShippingService;
+import org.higherkindedj.example.order.workflow.PartialFulfilmentWorkflow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link PartialFulfilmentWorkflow} — the fix for the partial-line money/fulfilment bug:
+ * a partially-available line must ship (and be charged for) its available units and back-order only
+ * its shortage, instead of being dropped from the shipment and back-ordered (and over-charged) in
+ * full.
+ */
+@DisplayName("PartialFulfilmentWorkflow — ship N / back-order M")
+class PartialFulfilmentWorkflowTest {
+
+  private PartialFulfilmentWorkflow workflow;
+
+  @BeforeEach
+  void setUp() {
+    workflow =
+        new PartialFulfilmentWorkflow(
+            new InMemoryInventoryService(),
+            new InMemoryPaymentService(),
+            new InMemoryShippingService(),
+            new InMemoryNotificationService());
+  }
+
+  @Test
+  @DisplayName("a partial line ships its available units and back-orders only the shortage")
+  void partialLineShipsAvailableAndBackOrdersShortage() {
+    // PROD-001 (stock 100) is fully available; PROD-005 (stock 10) is short by 5 of the 15
+    // requested.
+    var order = orderWith(line("PROD-001", 2), line("PROD-005", 15));
+
+    var result = workflow.process(order).run();
+
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            fulfilment -> {
+              assertThat(fulfilment.status()).isEqualTo(FulfilmentStatus.PARTIAL);
+              assertThat(fulfilment.hasBackOrders()).isTrue();
+              assertThat(fulfilment.backOrderCount()).isEqualTo(1);
+
+              var backOrder = fulfilment.backOrders().getFirst();
+              assertThat(backOrder.productId()).isEqualTo(new ProductId("PROD-005"));
+              // Only the shortage is back-ordered, not the whole 15-unit line.
+              assertThat(backOrder.quantity()).isEqualTo(5);
+
+              // Charged now: 2 + 10 available units @ £10 = £120; back-order: 5 units @ £10 = £50.
+              assertThat(fulfilment.fulfilledAmount()).isEqualTo(Money.gbp("120.00"));
+              assertThat(fulfilment.backOrderAmount()).isEqualTo(Money.gbp("50.00"));
+              // The two amounts together equal the full order value (no money lost or
+              // double-counted).
+              assertThat(fulfilment.totalOrderValue()).isEqualTo(Money.gbp("170.00"));
+            });
+  }
+
+  @Test
+  @DisplayName("a fully available order completes with no back-orders")
+  void fullyAvailableOrderCompletes() {
+    var order = orderWith(line("PROD-001", 2), line("PROD-002", 1));
+
+    var result = workflow.process(order).run();
+
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            fulfilment -> {
+              assertThat(fulfilment.status()).isEqualTo(FulfilmentStatus.COMPLETE);
+              assertThat(fulfilment.isFullyFulfilled()).isTrue();
+              assertThat(fulfilment.fulfilledAmount()).isEqualTo(Money.gbp("30.00"));
+              assertThat(fulfilment.backOrderAmount().isZeroOrNegative()).isTrue();
+            });
+  }
+
+  private static ValidatedOrder orderWith(ValidatedOrderLine... lines) {
+    var lineList = List.of(lines);
+    var customer =
+        new Customer(
+            new CustomerId("CUST-001"),
+            "Alice",
+            "alice@example.com",
+            "555-0000",
+            Customer.CustomerStatus.ACTIVE,
+            Customer.LoyaltyTier.GOLD);
+    var address =
+        new ValidatedShippingAddress(
+            "Alice",
+            "1 Test Street",
+            "London",
+            "SW1A 1AA",
+            "GB",
+            ValidatedShippingAddress.ShippingZone.DOMESTIC);
+    return new ValidatedOrder(
+        OrderId.generate(),
+        customer.id(),
+        customer,
+        lineList,
+        Optional.empty(),
+        address,
+        new PaymentMethod.CreditCard("4000000000000002", "12", "2025", "123"),
+        ValidatedOrder.calculateSubtotal(lineList),
+        Instant.now());
+  }
+
+  private static ValidatedOrderLine line(String productId, int quantity) {
+    var id = new ProductId(productId);
+    var product =
+        new Product(id, "Product " + productId, "Description", Money.gbp("10.00"), "General", true);
+    return ValidatedOrderLine.of(id, product, quantity);
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/PartialFulfilmentWorkflowTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/PartialFulfilmentWorkflowTest.java
@@ -81,6 +81,24 @@ class PartialFulfilmentWorkflowTest {
   }
 
   @Test
+  @DisplayName("an order with duplicate product lines is handled, not crashed")
+  void handlesDuplicateProductLines() {
+    // Two lines for the same product must not blow up the unitPrices / linesById toMap.
+    var order = orderWith(line("PROD-001", 2), line("PROD-001", 3));
+
+    var result = workflow.process(order).run();
+
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            fulfilment -> {
+              assertThat(fulfilment.status()).isEqualTo(FulfilmentStatus.COMPLETE);
+              // Both lines (2 + 3 units @ £10) ship and are charged; nothing is back-ordered.
+              assertThat(fulfilment.fulfilledAmount()).isEqualTo(Money.gbp("50.00"));
+            });
+  }
+
+  @Test
   @DisplayName("a fully available order completes with no back-orders")
   void fullyAvailableOrderCompletes() {
     var order = orderWith(line("PROD-001", 2), line("PROD-002", 1));

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/ResilienceTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/ResilienceTest.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.example.order;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -143,8 +144,7 @@ class ResilienceTest {
 
       var result = Resilience.withTimeout(operation, Duration.ofSeconds(1), "quickOperation");
 
-      assertThat(result.run().isRight()).isTrue();
-      assertThat(result.run().getRight()).isEqualTo("quick result");
+      assertThatEither(result.run()).isRight().hasRight("quick result");
     }
 
     @Test
@@ -163,10 +163,13 @@ class ResilienceTest {
 
       var result = Resilience.withTimeout(slowOperation, Duration.ofMillis(50), "slowOperation");
 
-      assertThat(result.run().isLeft()).isTrue();
-      var error = result.run().getLeft();
-      assertThat(error).isInstanceOf(OrderError.SystemError.class);
-      assertThat(error.code()).isEqualTo("TIMEOUT");
+      assertThatEither(result.run())
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error).isInstanceOf(OrderError.SystemError.class);
+                assertThat(error.code()).isEqualTo("TIMEOUT");
+              });
     }
   }
 
@@ -193,8 +196,7 @@ class ResilienceTest {
       var result =
           Resilience.resilient(operation, policy, Duration.ofSeconds(5), "retryableOperation");
 
-      assertThat(result.run().isRight()).isTrue();
-      assertThat(result.run().getRight()).isEqualTo("success after retry");
+      assertThatEither(result.run()).isRight().hasRight("success after retry");
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialResource.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialResource.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,8 +93,7 @@ public class TutorialResource {
       // Use the resource and verify it gets closed
       VTask<String> task = connResource.useSync(TestConnection::query);
 
-      String result = task.run();
-      assertThat(result).isEqualTo("result");
+      assertThatVTask(task).whenRun().succeeds().hasValue("result");
       assertThat(closed.get()).as("Resource should be closed after use").isTrue();
     }
 
@@ -118,8 +119,7 @@ public class TutorialResource {
 
       VTask<String> task = resource.useSync(h -> h.toUpperCase());
 
-      String result = task.run();
-      assertThat(result).isEqualTo("HANDLE");
+      assertThatVTask(task).whenRun().succeeds().hasValue("HANDLE");
       assertThat(events).containsExactly("acquired", "released");
     }
   }
@@ -157,8 +157,7 @@ public class TutorialResource {
       // resource.use(value -> VTask.of(() -> value * 2))
       VTask<Integer> task = answerRequired();
 
-      Integer result = task.run();
-      assertThat(result).isEqualTo(42);
+      assertThatVTask(task).whenRun().succeeds().hasValue(42);
       assertThat(counter.get()).as("Resource should be released").isZero();
     }
 
@@ -188,7 +187,7 @@ public class TutorialResource {
       // TODO: Replace answerRequired() with: failingTask.runSafe()
       Try<String> result = answerRequired();
 
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
       assertThat(released.get()).as("Resource must be released even on failure").isTrue();
     }
   }
@@ -419,9 +418,7 @@ public class TutorialResource {
                         return "result-from-" + stmt;
                       }));
 
-      String result = query.run();
-
-      assertThat(result).isEqualTo("result-from-stmt-for-conn-1");
+      assertThatVTask(query).whenRun().succeeds().hasValue("result-from-stmt-for-conn-1");
       assertThat(events)
           .containsExactly("connect", "prepare", "execute", "close-stmt", "disconnect");
     }
@@ -464,7 +461,7 @@ public class TutorialResource {
                         }))
             .runSafe();
 
-    assertThat(result.isFailure()).isTrue();
+    assertThatTry(result).isFailure();
     assertThat(released.get()).isTrue();
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialScope.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialScope.java
@@ -3,6 +3,10 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
 
 import java.time.Duration;
 import java.util.List;
@@ -78,8 +82,11 @@ public class TutorialScope {
       //     .join()
       VTask<List<String>> scopeTask = answerRequired();
 
-      List<String> results = scopeTask.run();
-      assertThat(results).containsExactlyInAnyOrder("first", "second", "third");
+      assertThatVTask(scopeTask)
+          .whenRun()
+          .succeeds()
+          .hasValueSatisfying(
+              results -> assertThat(results).containsExactlyInAnyOrder("first", "second", "third"));
     }
 
     /**
@@ -114,8 +121,7 @@ public class TutorialScope {
       //     .join()
       VTask<String> scopeTask = answerRequired();
 
-      String result = scopeTask.run();
-      assertThat(result).isEqualTo("fast");
+      assertThatVTask(scopeTask).whenRun().succeeds().hasValue("fast");
     }
   }
 
@@ -159,8 +165,7 @@ public class TutorialScope {
       //     .join()
       VTask<String> scopeTask = answerRequired();
 
-      String result = scopeTask.run();
-      assertThat(result).isEqualTo("fast result");
+      assertThatVTask(scopeTask).whenRun().succeeds().hasValue("fast result");
     }
 
     /**
@@ -189,7 +194,7 @@ public class TutorialScope {
       VTask<Try<List<String>>> scopeTask = answerRequired();
 
       Try<List<String>> result = scopeTask.run();
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
     }
   }
 
@@ -303,7 +308,7 @@ public class TutorialScope {
       VTask<Try<List<String>>> scopeTask = answerRequired();
 
       Try<List<String>> result = scopeTask.run();
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
     }
 
     /**
@@ -328,7 +333,7 @@ public class TutorialScope {
       VTask<Either<Throwable, List<String>>> scopeTask = answerRequired();
 
       Either<Throwable, List<String>> result = scopeTask.run();
-      assertThat(result.isRight()).isTrue();
+      assertThatEither(result).isRight();
       List<String> values = result.fold(e -> List.of(), v -> v);
       assertThat(values).containsExactlyInAnyOrder("hello", "world");
     }
@@ -353,7 +358,7 @@ public class TutorialScope {
       VTask<Maybe<List<Integer>>> scopeTask = answerRequired();
 
       Maybe<List<Integer>> result = scopeTask.run();
-      assertThat(result.isJust()).isTrue();
+      assertThatMaybe(result).isJust();
       assertThat(result.orElse(List.of())).containsExactly(42);
     }
   }
@@ -415,7 +420,7 @@ public class TutorialScope {
       // Execute and handle result
       Try<List<String>> result = dashboard.run();
 
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
       assertThat(result.orElse(List.of()))
           .containsExactlyInAnyOrder("Alice", "Developer", "dark-mode");
     }
@@ -462,7 +467,7 @@ public class TutorialScope {
         Scope.<String>allSucceed().fork(failsFast).fork(slow).joinSafe();
 
     Try<List<String>> result = scoped.run();
-    assertThat(result.isFailure()).isTrue();
+    assertThatTry(result).isFailure();
     assertThat(counter.get()).isLessThan(5); // slow was cancelled before reaching 5
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamHKT.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamHKT.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.VStreamAssert.assertThatVStream;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
 
@@ -97,7 +98,7 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with VSTREAM.narrow(kind)
       VStream<String> stream = answerRequired();
 
-      assertThat(stream.toList().run()).containsExactly("hello", "world");
+      assertThatVStream(stream).producesElements("hello", "world");
     }
   }
 
@@ -126,7 +127,7 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with functor.map(i -> i * 2, stream)
       Kind<VStreamKind.Witness, Integer> doubled = answerRequired();
 
-      assertThat(VSTREAM.narrow(doubled).toList().run()).containsExactly(2, 4, 6);
+      assertThatVStream(doubled).producesElements(2, 4, 6);
     }
 
     /**
@@ -144,7 +145,7 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with applicative.of(42)
       Kind<VStreamKind.Witness, Integer> result = answerRequired();
 
-      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(42);
+      assertThatVStream(result).producesElements(42);
     }
 
     /**
@@ -169,7 +170,7 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with applicative.ap(fns, values)
       Kind<VStreamKind.Witness, String> result = answerRequired();
 
-      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("x1", "x2", "y1", "y2");
+      assertThatVStream(result).producesElements("x1", "x2", "y1", "y2");
     }
   }
 
@@ -199,7 +200,7 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with monad.flatMap(...)
       Kind<VStreamKind.Witness, Integer> result = answerRequired();
 
-      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 10, 2, 20, 3, 30);
+      assertThatVStream(result).producesElements(1, 10, 2, 20, 3, 30);
     }
   }
 
@@ -266,7 +267,7 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with alt.orElse(first, () -> second)
       Kind<VStreamKind.Witness, Integer> combined = answerRequired();
 
-      assertThat(VSTREAM.narrow(combined).toList().run()).containsExactly(1, 2, 3, 4);
+      assertThatVStream(combined).producesElements(1, 2, 3, 4);
     }
 
     /**
@@ -287,8 +288,8 @@ public class TutorialVStreamHKT {
       // TODO: Replace answerRequired() with alt.guard(false)
       Kind<VStreamKind.Witness, Unit> falseResult = answerRequired();
 
-      assertThat(VSTREAM.narrow(trueResult).toList().run()).containsExactly(Unit.INSTANCE);
-      assertThat(VSTREAM.narrow(falseResult).toList().run()).isEmpty();
+      assertThatVStream(trueResult).producesElements(Unit.INSTANCE);
+      assertThatVStream(falseResult).isEmpty();
     }
 
     /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamPath.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVStreamPath.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.VStreamPathAssert.assertThatVStreamPath;
 
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.VStreamPath;
@@ -66,7 +67,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with Path.vstreamOf(1, 2, 3)
       VStreamPath<Integer> path = answerRequired();
 
-      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
     }
 
     /**
@@ -82,7 +83,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with Path.vstreamRange(1, 6)
       VStreamPath<Integer> path = answerRequired();
 
-      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3, 4, 5);
+      assertThatVStreamPath(path).producesElements(1, 2, 3, 4, 5);
     }
 
     /**
@@ -98,7 +99,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with Path.vstreamIterate(10, n -> n + 10).take(4)
       VStreamPath<Integer> path = answerRequired();
 
-      assertThat(path.toList().unsafeRun()).containsExactly(10, 20, 30, 40);
+      assertThatVStreamPath(path).producesElements(10, 20, 30, 40);
     }
 
     /**
@@ -117,7 +118,7 @@ public class TutorialVStreamPath {
       //         : Optional.of(new VStream.Seed<>(state, state + 1)))
       VStreamPath<Integer> path = answerRequired();
 
-      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
     }
   }
 
@@ -144,7 +145,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with names.map(String::toUpperCase)
       VStreamPath<String> upper = answerRequired();
 
-      assertThat(upper.toList().unsafeRun()).containsExactly("ALICE", "BOB");
+      assertThatVStreamPath(upper).producesElements("ALICE", "BOB");
     }
 
     /**
@@ -162,7 +163,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with range.filter(n -> n % 2 == 0)
       VStreamPath<Integer> evens = answerRequired();
 
-      assertThat(evens.toList().unsafeRun()).containsExactly(2, 4, 6, 8, 10);
+      assertThatVStreamPath(evens).producesElements(2, 4, 6, 8, 10);
     }
 
     /**
@@ -180,7 +181,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with nums.flatMap(n -> Path.vstreamOf(n, n * 10))
       VStreamPath<Integer> expanded = answerRequired();
 
-      assertThat(expanded.toList().unsafeRun()).containsExactly(1, 10, 2, 20, 3, 30);
+      assertThatVStreamPath(expanded).producesElements(1, 10, 2, 20, 3, 30);
     }
 
     /**
@@ -197,7 +198,7 @@ public class TutorialVStreamPath {
       //   Path.vstreamRange(1, 100).filter(n -> n % 2 == 0).map(n -> "Even:" + n).take(3)
       VStreamPath<String> pipeline = answerRequired();
 
-      assertThat(pipeline.toList().unsafeRun()).containsExactly("Even:2", "Even:4", "Even:6");
+      assertThatVStreamPath(pipeline).producesElements("Even:2", "Even:4", "Even:6");
     }
   }
 
@@ -261,7 +262,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with nums.zipWith(labels, (n, s) -> n + s)
       VStreamPath<String> zipped = answerRequired();
 
-      assertThat(zipped.toList().unsafeRun()).containsExactly("1a", "2b", "3c");
+      assertThatVStreamPath(zipped).producesElements("1a", "2b", "3c");
     }
 
     /**
@@ -284,7 +285,7 @@ public class TutorialVStreamPath {
       // TODO: Replace answerRequired() with people.focus(nameFocus)
       VStreamPath<String> names = answerRequired();
 
-      assertThat(names.toList().unsafeRun()).containsExactly("Alice", "Bob");
+      assertThatVStreamPath(names).producesElements("Alice", "Bob");
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTask.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTask.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
 
 import java.util.List;
 import org.higherkindedj.hkt.trymonad.Try;
@@ -83,8 +85,7 @@ public class TutorialVTask {
 
       VTask<Integer> lengthTask = answerRequired();
 
-      Integer result = lengthTask.run();
-      assertThat(result).isEqualTo(13);
+      assertThatVTask(lengthTask).whenRun().succeeds().hasValue(13);
     }
 
     /**
@@ -103,11 +104,11 @@ public class TutorialVTask {
       VTask<Integer> failure = answerRequired();
 
       Try<Integer> successResult = success.runSafe();
-      assertThat(successResult.isSuccess()).isTrue();
-      assertThat(successResult.orElse(-1)).isEqualTo(42);
+      assertThatTry(successResult).isSuccess();
+      assertThatTry(successResult).hasValue(42);
 
       Try<Integer> failureResult = failure.runSafe();
-      assertThat(failureResult.isFailure()).isTrue();
+      assertThatTry(failureResult).isFailure();
     }
   }
 
@@ -135,8 +136,7 @@ public class TutorialVTask {
 
       VTask<Integer> length = answerRequired();
 
-      Integer result = length.run();
-      assertThat(result).isEqualTo(23);
+      assertThatVTask(length).whenRun().succeeds().hasValue(23);
     }
 
     /**
@@ -155,8 +155,7 @@ public class TutorialVTask {
 
       VTask<Integer> doubled = answerRequired();
 
-      Integer result = doubled.run();
-      assertThat(result).isEqualTo(42);
+      assertThatVTask(doubled).whenRun().succeeds().hasValue(42);
     }
   }
 
@@ -207,8 +206,7 @@ public class TutorialVTask {
 
       VTask<Integer> recovered = answerRequired();
 
-      Integer result = recovered.run();
-      assertThat(result).isEqualTo(-1);
+      assertThatVTask(recovered).whenRun().succeeds().hasValue(-1);
     }
   }
 
@@ -248,8 +246,7 @@ public class TutorialVTask {
 
       VTask<Integer> combined = answerRequired();
 
-      Integer result = combined.run();
-      assertThat(result).isEqualTo(42);
+      assertThatVTask(combined).whenRun().succeeds().hasValue(42);
     }
 
     /**
@@ -287,8 +284,7 @@ public class TutorialVTask {
 
       VTask<String> winner = answerRequired();
 
-      String result = winner.run();
-      assertThat(result).isEqualTo("fast");
+      assertThatVTask(winner).whenRun().succeeds().hasValue("fast");
     }
   }
 
@@ -360,8 +356,7 @@ public class TutorialVTask {
 
       VTask<String> safeProfile = profile.recover(error -> "Unknown user");
 
-      String result = safeProfile.run();
-      assertThat(result).isEqualTo("Alice (age 30)");
+      assertThatVTask(safeProfile).whenRun().succeeds().hasValue("Alice (age 30)");
 
       // Showing List import is used (suppressing unused warning).
       assertThat(List.of(safeProfile)).hasSize(1);

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTaskForPath.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTaskForPath.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -75,8 +76,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Hello, user-123!");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Hello, user-123!");
     }
 
     /**
@@ -101,8 +102,8 @@ public class TutorialVTaskForPath {
       VTaskPath<Integer> result = answerRequired();
 
       Try<Integer> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse(-1)).isEqualTo(30);
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue(30);
     }
   }
 
@@ -135,8 +136,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Original: 5, Result: 35");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Original: 5, Result: 35");
     }
 
     /**
@@ -162,8 +163,8 @@ public class TutorialVTaskForPath {
       VTaskPath<Double> result = answerRequired();
 
       Try<Double> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse(-1.0)).isEqualTo(33.0);
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue(33.0);
     }
   }
 
@@ -210,8 +211,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("London");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("London");
     }
 
     /**
@@ -240,8 +241,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Bob: Sunny in Paris");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Bob: Sunny in Paris");
     }
   }
 
@@ -276,7 +277,7 @@ public class TutorialVTaskForPath {
       VTaskPath<Integer> result = answerRequired();
 
       Try<Integer> tryResult = result.runSafe();
-      assertThat(tryResult.isFailure()).isTrue();
+      assertThatTry(tryResult).isFailure();
       String errorMessage = tryResult.foldFailureFirst(Throwable::getMessage, v -> "no error");
       assertThat(errorMessage).isEqualTo("Step 2 failed");
     }
@@ -302,8 +303,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("DEFAULT");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("DEFAULT");
     }
   }
 
@@ -354,8 +355,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Order confirmed: ORD-001");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Order confirmed: ORD-001");
     }
 
     /**
@@ -393,8 +394,8 @@ public class TutorialVTaskForPath {
       VTaskPath<String> result = answerRequired();
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Total: $24.30");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Total: $24.30");
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTaskPath.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/concurrency/TutorialVTaskPath.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
+import static org.higherkindedj.hkt.assertions.VTaskPathAssert.assertThatVTaskPath;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.higherkindedj.hkt.effect.Path;
@@ -69,8 +72,8 @@ public class TutorialVTaskPath {
 
       // Execute safely and verify
       Try<Integer> result = lengthPath.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse(-1)).isEqualTo(17);
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue(17);
     }
 
     /**
@@ -90,12 +93,12 @@ public class TutorialVTaskPath {
 
       // Verify pure path
       Try<String> pureResult = purePath.runSafe();
-      assertThat(pureResult.isSuccess()).isTrue();
-      assertThat(pureResult.orElse("default")).isEqualTo("success");
+      assertThatTry(pureResult).isSuccess();
+      assertThatTry(pureResult).hasValue("success");
 
       // Verify failed path
       Try<String> failedResult = failedPath.runSafe();
-      assertThat(failedResult.isFailure()).isTrue();
+      assertThatTry(failedResult).isFailure();
     }
   }
 
@@ -125,8 +128,8 @@ public class TutorialVTaskPath {
       VTaskPath<Integer> doubled = answerRequired();
 
       Try<Integer> result = doubled.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse(-1)).isEqualTo(42);
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue(42);
     }
 
     /**
@@ -149,7 +152,7 @@ public class TutorialVTaskPath {
       VTaskPath<Integer> debugged = answerRequired();
 
       Try<Integer> result = debugged.runSafe();
-      assertThat(result.orElse(-1)).isEqualTo(20);
+      assertThatTry(result).hasValue(20);
       assertThat(peekCount.get()).isEqualTo(2); // peek was called twice
     }
   }
@@ -186,8 +189,8 @@ public class TutorialVTaskPath {
       VTaskPath<String> withTimeout = answerRequired();
 
       Try<String> result = withTimeout.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse("error")).isEqualTo("timeout fallback");
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue("timeout fallback");
     }
 
     /**
@@ -221,8 +224,8 @@ public class TutorialVTaskPath {
       VTaskPath<String> resilient = answerRequired();
 
       Try<String> result = resilient.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse("error")).isEqualTo("fallback value");
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue("fallback value");
       assertThat(attemptCount.get()).isEqualTo(2); // Both primary and secondary were attempted
     }
   }
@@ -274,7 +277,7 @@ public class TutorialVTaskPath {
       VTaskPath<UserProfile> profile = answerRequired();
 
       Try<UserProfile> result = profile.runSafe();
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
 
       UserProfile user = result.orElse(null);
       assertThat(user).isNotNull();
@@ -330,7 +333,7 @@ public class TutorialVTaskPath {
       VTaskPath<Dashboard> dashboard = answerRequired();
 
       Try<Dashboard> result = dashboard.runSafe();
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
 
       Dashboard d = result.orElse(null);
       assertThat(d).isNotNull();
@@ -407,8 +410,8 @@ public class TutorialVTaskPath {
       VTask<Integer> backToVtask = path.run();
 
       // Both produce the same result
-      assertThat(path.runSafe().orElse(-1)).isEqualTo(42);
-      assertThat(backToVtask.runSafe().orElse(-1)).isEqualTo(42);
+      assertThatVTaskPath(path).hasValue(42);
+      assertThatVTask(backToVtask).whenRun().succeeds().hasValue(42);
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/context/Tutorial05_ContextWithVTask.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/context/Tutorial05_ContextWithVTask.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.List;
 import org.higherkindedj.hkt.context.Context;
@@ -74,7 +75,7 @@ public class Tutorial05_ContextWithVTask {
       Try<String> result =
           ScopedValue.where(RequestContext.TRACE_ID, traceId).call(() -> traceTask.runSafe());
 
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
       assertThat(result.orElse("error")).isEqualTo(traceId);
     }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/context/Tutorial06_AdvancedContextPatterns.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/context/Tutorial06_AdvancedContextPatterns.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 
 import java.security.Principal;
 import java.util.Set;
@@ -228,7 +229,7 @@ public class Tutorial06_AdvancedContextPatterns {
       // Note: toMaybe() runs the context, so call it within the scope
       Maybe<String> result = ScopedValue.where(CONFIG_VALUE, "value").call(() -> answerRequired());
 
-      assertThat(result.isJust()).isTrue();
+      assertThatMaybe(result).isJust();
       assertThat(result.orElse("none")).isEqualTo("value");
     }
 
@@ -247,7 +248,7 @@ public class Tutorial06_AdvancedContextPatterns {
       // TODO: Replace answerRequired() with failing.toMaybe()
       Maybe<String> result = answerRequired();
 
-      assertThat(result.isNothing()).isTrue();
+      assertThatMaybe(result).isNothing();
       assertThat(result.orElse("fallback")).isEqualTo("fallback");
     }
   }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial00_OneLineSixLayers.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial00_OneLineSixLayers.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -212,9 +213,8 @@ public class Tutorial00_OneLineSixLayers {
     EitherPath<RepoError, Item> presentEither = answerRequired();
     EitherPath<RepoError, Item> absentEither = answerRequired();
 
-    assertThat(presentEither.run().isRight()).isTrue();
-    assertThat(absentEither.run().isLeft()).isTrue();
-    assertThat(absentEither.run().getLeft()).isEqualTo(RepoError.NOT_FOUND);
+    assertThatEither(presentEither.run()).isRight();
+    assertThatEither(absentEither.run()).isLeft().hasLeft(RepoError.NOT_FOUND);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -274,8 +274,9 @@ public class Tutorial00_OneLineSixLayers {
     EitherPath<RepoError, Item> updated = answerRequired();
 
     Either<RepoError, Item> result = updated.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -307,8 +308,9 @@ public class Tutorial00_OneLineSixLayers {
     EitherPath<RepoError, Item> saved = answerRequired();
 
     Either<RepoError, Item> result = saved.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -340,8 +342,9 @@ public class Tutorial00_OneLineSixLayers {
     // TODO: replace answerRequired() with saved.run()
     Either<RepoError, Item> either = answerRequired();
 
-    assertThat(either.isRight()).isTrue();
-    assertThat(either.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(either)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -371,17 +374,20 @@ public class Tutorial00_OneLineSixLayers {
     // TODO: replace answerRequired() with the full one-line expression.
     Either<RepoError, Item> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo(idToUpdate);
-    assertThat(result.getRight().attributes()).containsEntry(key, newValue);
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            item -> {
+              assertThat(item.id()).isEqualTo(idToUpdate);
+              assertThat(item.attributes()).containsEntry(key, newValue);
+            });
 
     // Same shape, missing id — the whole pipeline collapses to NOT_FOUND.
     String missingId = "user-missing";
     // TODO: replace answerRequired() with the same expression but using missingId.
     Either<RepoError, Item> missing = answerRequired();
 
-    assertThat(missing.isLeft()).isTrue();
-    assertThat(missing.getLeft()).isEqualTo(RepoError.NOT_FOUND);
+    assertThatEither(missing).isLeft().hasLeft(RepoError.NOT_FOUND);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -428,15 +434,17 @@ public class Tutorial00_OneLineSixLayers {
     EitherPath<RepoError, Item> updated = answerRequired();
 
     Either<RepoError, Item> result = updated.via(Tutorial00_OneLineSixLayers::save).run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
 
     // Demonstrate that focus() *is* the right tool when narrowing is the goal.
     FocusPath<Item, Map<String, String>> attributesPath = FocusPath.of(attributesLens);
     EitherPath<RepoError, Map<String, String>> narrowed =
         wrapped.focus(attributesPath).map(addEntry("country", "GB"));
-    assertThat(narrowed.run().isRight()).isTrue();
-    assertThat(narrowed.run().getRight()).containsEntry("country", "GB");
+    assertThatEither(narrowed.run())
+        .isRight()
+        .hasRightSatisfying(attrs -> assertThat(attrs).containsEntry("country", "GB"));
   }
 
   // -------------------------------------------------------------------------

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial01_KindBasics.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial01_KindBasics.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 
 import java.util.List;
@@ -121,7 +122,7 @@ public class Tutorial01_KindBasics {
     Kind<EitherKind.Witness<String>, Integer> kind = answerRequired();
 
     // Sanity: narrow back and check the value survived the round-trip.
-    assertThat(EITHER.narrow(kind).getRight()).isEqualTo(42);
+    assertThatEither(EITHER.narrow(kind)).hasRight(42);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -149,8 +150,7 @@ public class Tutorial01_KindBasics {
 
     Either<String, Integer> either = answerRequired();
 
-    assertThat(either.isRight()).isTrue();
-    assertThat(either.getRight()).isEqualTo(100);
+    assertThatEither(either).isRight().hasRight(100);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -225,7 +225,7 @@ public class Tutorial01_KindBasics {
     Kind<EitherKind.Witness<String>, Boolean> kind = EITHER.widen(either);
 
     Either<String, Boolean> result = EITHER.narrow(kind);
-    assertThat(result.getRight()).isTrue();
+    assertThatEither(result).hasRight(true);
   }
 
   // ═════════════════════════════════════════════════════════════════════════

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial02_FunctorMapping.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial02_FunctorMapping.java
@@ -2,7 +2,8 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.tutorial.coretypes;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.ListAssert.assertThatList;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
@@ -99,8 +100,7 @@ public class Tutorial02_FunctorMapping {
 
     Either<String, String> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo("42");
+    assertThatEither(result).isRight().hasRight("42");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -131,8 +131,7 @@ public class Tutorial02_FunctorMapping {
 
     Either<String, String> result = error.map(i -> answerRequired());
 
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Error occurred");
+    assertThatEither(result).isLeft().hasLeft("Error occurred");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -162,7 +161,7 @@ public class Tutorial02_FunctorMapping {
 
     Kind<ListKind.Witness, Integer> doubled = answerRequired();
 
-    assertThat(LIST.narrow(doubled)).containsExactly(2, 4, 6, 8, 10);
+    assertThatList(doubled).containsExactly(2, 4, 6, 8, 10);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -193,7 +192,7 @@ public class Tutorial02_FunctorMapping {
 
     Either<String, String> result = answerRequired();
 
-    assertThat(result.getRight()).isEqualTo("25");
+    assertThatEither(result).hasRight("25");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -225,7 +224,7 @@ public class Tutorial02_FunctorMapping {
     Kind<EitherKind.Witness<String>, String> mapped = functor.map(i -> answerRequired(), kind);
 
     Either<String, String> result = EITHER.narrow(mapped);
-    assertThat(result.getRight()).isEqualTo("Value: 100");
+    assertThatEither(result).hasRight("Value: 100");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -255,7 +254,7 @@ public class Tutorial02_FunctorMapping {
 
     Kind<ListKind.Witness, String> uppercase = answerRequired();
 
-    assertThat(LIST.narrow(uppercase)).containsExactly("HELLO", "WORLD", "JAVA");
+    assertThatList(uppercase).containsExactly("HELLO", "WORLD", "JAVA");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -298,9 +297,9 @@ public class Tutorial02_FunctorMapping {
     // The result is nested: Either&lt;String, Either&lt;String, Integer&gt;&gt;.
     Either<String, Either<String, Integer>> nested = answerRequired();
 
-    assertThat(nested.isRight()).isTrue();
-    assertThat(nested.getRight().isRight()).isTrue();
-    assertThat(nested.getRight().getRight()).isEqualTo(42);
+    assertThatEither(nested)
+        .isRight()
+        .hasRightSatisfying(inner -> assertThatEither(inner).isRight().hasRight(42));
 
     // The next tutorial will show how flatMap collapses this to a single Either.
   }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial03_ApplicativeCombining.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial03_ApplicativeCombining.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
 import org.higherkindedj.hkt.MonadError;
@@ -99,8 +101,7 @@ public class Tutorial03_ApplicativeCombining {
   void exercise1_liftingValues() {
     Either<String, Integer> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(42);
+    assertThatEither(result).isRight().hasRight(42);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -130,7 +131,7 @@ public class Tutorial03_ApplicativeCombining {
 
     Either<String, Integer> result = answerRequired();
 
-    assertThat(result.getRight()).isEqualTo(30);
+    assertThatEither(result).hasRight(30);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -159,8 +160,7 @@ public class Tutorial03_ApplicativeCombining {
 
     Either<String, Integer> result = answerRequired();
 
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Error occurred");
+    assertThatEither(result).isLeft().hasLeft("Error occurred");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -192,10 +192,14 @@ public class Tutorial03_ApplicativeCombining {
 
     Either<String, Person> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().name()).isEqualTo("Alice");
-    assertThat(result.getRight().age()).isEqualTo(30);
-    assertThat(result.getRight().email()).isEqualTo("alice@example.com");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            person -> {
+              assertThat(person.name()).isEqualTo("Alice");
+              assertThat(person.age()).isEqualTo(30);
+              assertThat(person.email()).isEqualTo("alice@example.com");
+            });
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -234,7 +238,7 @@ public class Tutorial03_ApplicativeCombining {
 
     Validated<String, FormData> result = answerRequired();
 
-    assertThat(result.isInvalid()).isTrue();
+    assertThatValidated(result).isInvalid();
     // The accumulated error contains every individual message, joined by the Semigroup.
   }
 
@@ -269,12 +273,15 @@ public class Tutorial03_ApplicativeCombining {
 
     Either<String, Order> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    Order order = result.getRight();
-    assertThat(order.id()).isEqualTo("ORD-001");
-    assertThat(order.product()).isEqualTo("Laptop");
-    assertThat(order.quantity()).isEqualTo(2);
-    assertThat(order.price()).isEqualTo(999.99);
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            order -> {
+              assertThat(order.id()).isEqualTo("ORD-001");
+              assertThat(order.product()).isEqualTo("Laptop");
+              assertThat(order.quantity()).isEqualTo(2);
+              assertThat(order.price()).isEqualTo(999.99);
+            });
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -310,11 +317,14 @@ public class Tutorial03_ApplicativeCombining {
 
     Either<String, Address> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    Address address = result.getRight();
-    assertThat(address.street()).isEqualTo("123 Main St");
-    assertThat(address.city()).isEqualTo("Springfield");
-    assertThat(address.country()).isEqualTo("USA");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            address -> {
+              assertThat(address.street()).isEqualTo("123 Main St");
+              assertThat(address.city()).isEqualTo("Springfield");
+              assertThat(address.country()).isEqualTo("USA");
+            });
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -360,11 +370,12 @@ public class Tutorial03_ApplicativeCombining {
     MonadError<ValidatedKind.Witness<String>, String> app = Instances.validated(stringSemigroup);
 
     Validated<String, Pair> bothValid = answerRequired();
-    assertThat(bothValid.isValid()).isTrue();
-    assertThat(bothValid.get().name()).isEqualTo("Alice");
+    assertThatValidated(bothValid)
+        .isValid()
+        .hasValueSatisfying(pair -> "Alice".equals(pair.name()), "name is Alice");
 
     Validated<String, Pair> oneInvalid = answerRequired();
-    assertThat(oneInvalid.isInvalid()).isTrue();
+    assertThatValidated(oneInvalid).isInvalid();
   }
 
   /*

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial04_MonadChaining.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial04_MonadChaining.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.ListAssert.assertThatList;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 
@@ -116,8 +119,7 @@ public class Tutorial04_MonadChaining {
 
     Either<String, Integer> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(42);
+    assertThatEither(result).isRight().hasRight(42);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -158,8 +160,7 @@ public class Tutorial04_MonadChaining {
 
     Either<String, Double> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(20.0);
+    assertThatEither(result).isRight().hasRight(20.0);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -201,8 +202,7 @@ public class Tutorial04_MonadChaining {
 
     Either<String, Integer> result = input.flatMap(parse).flatMap(validatePositive);
 
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Must be positive");
+    assertThatEither(result).isLeft().hasLeft("Must be positive");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -238,7 +238,7 @@ public class Tutorial04_MonadChaining {
 
     Either<String, Integer> result = answerRequired();
 
-    assertThat(result.getRight()).isEqualTo(10);
+    assertThatEither(result).hasRight(10);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -275,8 +275,7 @@ public class Tutorial04_MonadChaining {
 
     Maybe<String> email = answerRequired();
 
-    assertThat(email.isJust()).isTrue();
-    assertThat(email.get()).isEqualTo("alice@example.com");
+    assertThatMaybe(email).isJust().hasValue("alice@example.com");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -306,7 +305,7 @@ public class Tutorial04_MonadChaining {
 
     Kind<ListKind.Witness, String> pairs = answerRequired();
 
-    assertThat(LIST.narrow(pairs)).containsExactly("1-10", "1-20", "2-10", "2-20");
+    assertThatList(pairs).containsExactly("1-10", "1-20", "2-10", "2-20");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -344,7 +343,7 @@ public class Tutorial04_MonadChaining {
               return answerRequired();
             });
 
-    assertThat(result.getRight()).isEqualTo("Age: 30, City: New York");
+    assertThatEither(result).hasRight("Age: 30, City: New York");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -381,9 +380,13 @@ public class Tutorial04_MonadChaining {
 
     Either<String, Pair> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().name()).isEqualTo("Alice");
-    assertThat(result.getRight().age()).isEqualTo(30);
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            pair -> {
+              assertThat(pair.name()).isEqualTo("Alice");
+              assertThat(pair.age()).isEqualTo(30);
+            });
   }
 
   /*

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial05_MonadErrorHandling.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial05_MonadErrorHandling.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
@@ -70,8 +72,7 @@ public class Tutorial05_MonadErrorHandling {
     Kind<EitherKind.Witness<String>, Integer> error = answerRequired();
 
     Either<String, Integer> result = EITHER.narrow(error);
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Invalid input");
+    assertThatEither(result).isLeft().hasLeft("Invalid input");
   }
 
   /**
@@ -214,8 +215,7 @@ public class Tutorial05_MonadErrorHandling {
     // Hint: primary.fold(err -> fallback, value -> Either.right(value))
     Either<String, String> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo("Fallback value");
+    assertThatEither(result).isRight().hasRight("Fallback value");
   }
 
   /**
@@ -242,14 +242,13 @@ public class Tutorial05_MonadErrorHandling {
     // Hint: Try.of(() -> riskyDivision.apply(0))
     Try<Integer> result = answerRequired();
 
-    assertThat(result.isFailure()).isTrue();
+    assertThatTry(result).isFailure();
 
     // TODO: Replace null with code that recovers from the exception
     // Hint: result.recover(ex -> -1)
     Try<Integer> recovered = answerRequired();
 
-    assertThat(recovered.isSuccess()).isTrue();
-    assertThat(recovered.get()).isEqualTo(-1);
+    assertThatTry(recovered).isSuccess().hasValue(-1);
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial06_ConcreteTypes.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial06_ConcreteTypes.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
 import java.util.List;
@@ -65,14 +68,11 @@ public class Tutorial06_ConcreteTypes {
           return answerRequired();
         };
 
-    assertThat(validateAge.apply(25).isRight()).isTrue();
-    assertThat(validateAge.apply(25).getRight()).isEqualTo(25);
+    assertThatEither(validateAge.apply(25)).isRight().hasRight(25);
 
-    assertThat(validateAge.apply(15).isLeft()).isTrue();
-    assertThat(validateAge.apply(15).getLeft()).isEqualTo("Too young");
+    assertThatEither(validateAge.apply(15)).isLeft().hasLeft("Too young");
 
-    assertThat(validateAge.apply(-5).isLeft()).isTrue();
-    assertThat(validateAge.apply(-5).getLeft()).isEqualTo("Invalid age");
+    assertThatEither(validateAge.apply(-5)).isLeft().hasLeft("Invalid age");
   }
 
   /**
@@ -96,11 +96,10 @@ public class Tutorial06_ConcreteTypes {
         };
 
     Maybe<String> found = lookup.apply("key1");
-    assertThat(found.isJust()).isTrue();
-    assertThat(found.get()).isEqualTo("value");
+    assertThatMaybe(found).isJust().hasValue("value");
 
     Maybe<String> notFound = lookup.apply("key2");
-    assertThat(notFound.isNothing()).isTrue();
+    assertThatMaybe(notFound).isNothing();
   }
 
   /**
@@ -185,7 +184,7 @@ public class Tutorial06_ConcreteTypes {
     // TODO: Replace null with code that combines the three validations using map3
     Validated<String, User> validUser = answerRequired();
 
-    assertThat(validUser.isValid()).isTrue();
+    assertThatValidated(validUser).isValid();
 
     // Invalid case - multiple errors
     Validated<String, String> invalidName = validateName.apply("A");
@@ -195,7 +194,7 @@ public class Tutorial06_ConcreteTypes {
     // TODO: Replace null with code that combines the invalid validations
     Validated<String, User> invalidUser = answerRequired();
 
-    assertThat(invalidUser.isInvalid()).isTrue();
+    assertThatValidated(invalidUser).isInvalid();
     // Validated accumulates errors (implementation-dependent on how Semigroup works)
   }
 
@@ -219,11 +218,9 @@ public class Tutorial06_ConcreteTypes {
     Either<String, String> either1 = answerRequired();
     Either<String, String> either2 = answerRequired();
 
-    assertThat(either1.isRight()).isTrue();
-    assertThat(either1.getRight()).isEqualTo("value");
+    assertThatEither(either1).isRight().hasRight("value");
 
-    assertThat(either2.isLeft()).isTrue();
-    assertThat(either2.getLeft()).isEqualTo("Not found");
+    assertThatEither(either2).isLeft().hasLeft("Not found");
   }
 
   /**
@@ -249,8 +246,8 @@ public class Tutorial06_ConcreteTypes {
               return answerRequired();
             };
 
-    assertThat(safeDivideEither.apply(10).apply(2).getRight()).isEqualTo(5);
-    assertThat(safeDivideEither.apply(10).apply(0).getLeft()).isEqualTo("Division by zero");
+    assertThatEither(safeDivideEither.apply(10).apply(2)).hasRight(5);
+    assertThatEither(safeDivideEither.apply(10).apply(0)).hasLeft("Division by zero");
 
     // Option 2: Use Maybe if you don't need an error message
     Function<Integer, Function<Integer, Maybe<Integer>>> safeDivideMaybe =
@@ -262,8 +259,8 @@ public class Tutorial06_ConcreteTypes {
               return answerRequired();
             };
 
-    assertThat(safeDivideMaybe.apply(10).apply(2).get()).isEqualTo(5);
-    assertThat(safeDivideMaybe.apply(10).apply(0).isNothing()).isTrue();
+    assertThatMaybe(safeDivideMaybe.apply(10).apply(2)).hasValue(5);
+    assertThatMaybe(safeDivideMaybe.apply(10).apply(0)).isNothing();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial07_RealWorld.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial07_RealWorld.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.util.List;
 import java.util.function.Function;
@@ -102,8 +103,9 @@ public class Tutorial07_RealWorld {
                                                 .apply(answerRequired())
                                                 .map(age -> answerRequired()))));
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().username()).isEqualTo("alice");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(reg -> assertThat(reg.username()).isEqualTo("alice"));
   }
 
   /**
@@ -250,16 +252,16 @@ public class Tutorial07_RealWorld {
         maybeUser.isJust() ? Either.right(maybeUser.get()) : Either.left("User not found");
     Either<String, User> result = eitherUser.flatMap(validateUser);
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().name()).isEqualTo("Alice");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(user -> assertThat(user.name()).isEqualTo("Alice"));
 
     // TODO: Replace null with code that handles a missing user
     Maybe<User> maybeMissing = findUser.apply(answerRequired());
     Either<String, User> missing =
         maybeMissing.isJust() ? Either.right(maybeMissing.get()) : Either.left("User not found");
 
-    assertThat(missing.isLeft()).isTrue();
-    assertThat(missing.getLeft()).isEqualTo("User not found");
+    assertThatEither(missing).isLeft().hasLeft("User not found");
   }
 
   /**
@@ -354,10 +356,13 @@ public class Tutorial07_RealWorld {
     // 2. Maps it through the processOrder function with config
     Either<String, ProcessedOrder> result = validateOrder.apply(order).map(o -> answerRequired());
 
-    assertThat(result.isRight()).isTrue();
-    ProcessedOrder processed = result.getRight();
-    assertThat(processed.subtotal()).isEqualTo(100.0);
-    assertThat(processed.total()).isEqualTo(118.0); // 100 + 8 (tax) + 10 (shipping)
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            processed -> {
+              assertThat(processed.subtotal()).isEqualTo(100.0);
+              assertThat(processed.total()).isEqualTo(118.0); // 100 + 8 (tax) + 10 (shipping)
+            });
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial08_NaturalTransformation.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial08_NaturalTransformation.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.ListAssert.assertThatList;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
@@ -77,12 +79,12 @@ public class Tutorial08_NaturalTransformation {
     // Test with Just
     Kind<MaybeKind.Witness, String> justHello = MAYBE.widen(Maybe.just("hello"));
     Kind<ListKind.Witness, String> listFromJust = maybeToList.apply(justHello);
-    assertThat(LIST.narrow(listFromJust)).containsExactly("hello");
+    assertThatList(listFromJust).containsExactly("hello");
 
     // Test with Nothing
     Kind<MaybeKind.Witness, String> nothing = MAYBE.widen(Maybe.nothing());
     Kind<ListKind.Witness, String> listFromNothing = maybeToList.apply(nothing);
-    assertThat(LIST.narrow(listFromNothing)).isEmpty();
+    assertThatList(listFromNothing).isEmpty();
   }
 
   /**
@@ -107,12 +109,12 @@ public class Tutorial08_NaturalTransformation {
     // Test with Right
     Kind<EitherKind.Witness<String>, Integer> right = EITHER.widen(Either.right(42));
     Kind<MaybeKind.Witness, Integer> maybeFromRight = eitherToMaybe.apply(right);
-    assertThat(MAYBE.narrow(maybeFromRight)).isEqualTo(Maybe.just(42));
+    assertThatMaybe(maybeFromRight).hasValue(42);
 
     // Test with Left
     Kind<EitherKind.Witness<String>, Integer> left = EITHER.widen(Either.left("error"));
     Kind<MaybeKind.Witness, Integer> maybeFromLeft = eitherToMaybe.apply(left);
-    assertThat(MAYBE.narrow(maybeFromLeft)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(maybeFromLeft).isNothing();
   }
 
   /**
@@ -137,12 +139,12 @@ public class Tutorial08_NaturalTransformation {
     // Test with non-empty list
     Kind<ListKind.Witness, String> nonEmpty = LIST.widen(List.of("first", "second"));
     Kind<MaybeKind.Witness, String> headNonEmpty = listHead.apply(nonEmpty);
-    assertThat(MAYBE.narrow(headNonEmpty)).isEqualTo(Maybe.just("first"));
+    assertThatMaybe(headNonEmpty).hasValue("first");
 
     // Test with empty list
     Kind<ListKind.Witness, String> empty = LIST.widen(List.of());
     Kind<MaybeKind.Witness, String> headEmpty = listHead.apply(empty);
-    assertThat(MAYBE.narrow(headEmpty)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(headEmpty).isNothing();
   }
 
   /**
@@ -185,12 +187,12 @@ public class Tutorial08_NaturalTransformation {
     // Test: Just(x) -> [x] -> Just(x)
     Kind<MaybeKind.Witness, String> justValue = MAYBE.widen(Maybe.just("test"));
     Kind<MaybeKind.Witness, String> result = composed.apply(justValue);
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.just("test"));
+    assertThatMaybe(result).hasValue("test");
 
     // Test: Nothing -> [] -> Nothing
     Kind<MaybeKind.Witness, String> nothing = MAYBE.widen(Maybe.nothing());
     Kind<MaybeKind.Witness, String> resultNothing = composed.apply(nothing);
-    assertThat(MAYBE.narrow(resultNothing)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(resultNothing).isNothing();
   }
 
   /**
@@ -218,7 +220,7 @@ public class Tutorial08_NaturalTransformation {
     Kind<MaybeKind.Witness, Integer> afterIdentity = identity.apply(original);
 
     // Should be unchanged
-    assertThat(MAYBE.narrow(afterIdentity)).isEqualTo(Maybe.just(42));
+    assertThatMaybe(afterIdentity).hasValue(42);
 
     // Should be the same reference (identity does nothing)
     assertThat(afterIdentity).isSameAs(original);

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial09_Coyoneda.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial09_Coyoneda.java
@@ -2,7 +2,8 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.tutorial.coretypes;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.ListAssert.assertThatList;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
@@ -86,7 +87,7 @@ public class Tutorial09_Coyoneda {
     MaybeFunctor functor = MaybeFunctor.INSTANCE;
     Kind<MaybeKind.Witness, Integer> lowered = coyo.lower(functor);
 
-    assertThat(MAYBE.narrow(lowered)).isEqualTo(Maybe.just(42));
+    assertThatMaybe(lowered).hasValue(42);
   }
 
   /**
@@ -115,7 +116,7 @@ public class Tutorial09_Coyoneda {
     MaybeFunctor functor = MaybeFunctor.INSTANCE;
     Kind<MaybeKind.Witness, String> result = upper.lower(functor);
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.just("HELLO"));
+    assertThatMaybe(result).hasValue("HELLO");
   }
 
   /**
@@ -145,7 +146,7 @@ public class Tutorial09_Coyoneda {
     Kind<ListKind.Witness, String> result = chained.lower(listFunctor);
 
     // Results: (1*2)+10=12, (2*2)+10=14, (3*2)+10=16, (4*2)+10=18, (5*2)+10=20
-    assertThat(LIST.narrow(result)).containsExactly("12", "14", "16", "18", "20");
+    assertThatList(result).containsExactly("12", "14", "16", "18", "20");
   }
 
   /**
@@ -174,7 +175,7 @@ public class Tutorial09_Coyoneda {
     Kind<MaybeKind.Witness, Integer> result = coyo.lower(functor);
 
     // Should still be Nothing
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(result).isNothing();
   }
 
   /**
@@ -204,7 +205,7 @@ public class Tutorial09_Coyoneda {
     MonadZero<ListKind.Witness> listFunctor = Instances.monadZero(list());
     Kind<ListKind.Witness, String> result = pipeline.lower(listFunctor);
 
-    assertThat(LIST.narrow(result)).containsExactly("[ALICE]", "[BOB]", "[CHARLIE]");
+    assertThatList(result).containsExactly("[ALICE]", "[BOB]", "[CHARLIE]");
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial10_FreeApplicative.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial10_FreeApplicative.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.IdAssert.assertThatId;
 import static org.higherkindedj.hkt.id.IdKindHelper.ID;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
@@ -74,7 +75,7 @@ public class Tutorial10_FreeApplicative {
     // Interpret to get the value
     Kind<IdKind.Witness, Integer> result = pureValue.foldMap(IDENTITY, ID_APP);
 
-    assertThat(ID.narrow(result).value()).isEqualTo(42);
+    assertThatId(result).hasValue(42);
   }
 
   /**
@@ -99,7 +100,7 @@ public class Tutorial10_FreeApplicative {
 
     Kind<IdKind.Witness, Integer> result = mapped.foldMap(IDENTITY, ID_APP);
 
-    assertThat(ID.narrow(result).value()).isEqualTo(50);
+    assertThatId(result).hasValue(50);
   }
 
   /**
@@ -126,7 +127,7 @@ public class Tutorial10_FreeApplicative {
 
     Kind<IdKind.Witness, String> result = combined.foldMap(IDENTITY, ID_APP);
 
-    assertThat(ID.narrow(result).value()).isEqualTo("Alice is 30 years old");
+    assertThatId(result).hasValue("Alice is 30 years old");
   }
 
   /**
@@ -154,7 +155,7 @@ public class Tutorial10_FreeApplicative {
 
     Kind<IdKind.Witness, Integer> result = sum.foldMap(IDENTITY, ID_APP);
 
-    assertThat(ID.narrow(result).value()).isEqualTo(60);
+    assertThatId(result).hasValue(60);
   }
 
   /**
@@ -181,7 +182,7 @@ public class Tutorial10_FreeApplicative {
 
     Kind<IdKind.Witness, String> result = dashboard.foldMap(IDENTITY, ID_APP);
 
-    assertThat(ID.narrow(result).value()).isEqualTo("User{id=1} has Posts{count=5}");
+    assertThatId(result).hasValue("User{id=1} has Posts{count=5}");
 
     // Key insight: A smart interpreter could execute fetchUser and fetchPosts
     // in parallel because neither needs the other's result.

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/TutorialCapstone_OneLineSixLayersGrowsUp.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/TutorialCapstone_OneLineSixLayersGrowsUp.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.util.List;
 import java.util.Map;
@@ -130,11 +131,12 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp {
     EitherPath<OrderError, Order> path = answerRequired();
 
     Either<OrderError, Order> result = path.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo("ord-1");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.id()).isEqualTo("ord-1"));
 
     EitherPath<OrderError, Order> missing = findOrder("missing").toEitherPath(OrderError.NOT_FOUND);
-    assertThat(missing.run().getLeft()).isEqualTo(OrderError.NOT_FOUND);
+    assertThatEither(missing.run()).hasLeft(OrderError.NOT_FOUND);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -157,8 +159,10 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp {
 
     EitherPath<OrderError, Order> doubled = answerRequired();
 
-    Order out = doubled.run().getRight();
-    assertThat(out.items()).extracting(Item::quantity).containsExactly(4, 2);
+    assertThatEither(doubled.run())
+        .isRight()
+        .hasRightSatisfying(
+            out -> assertThat(out.items()).extracting(Item::quantity).containsExactly(4, 2));
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -182,8 +186,9 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp {
     EitherPath<OrderError, Order> persisted = answerRequired();
 
     Either<OrderError, Order> result = persisted.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().status()).isEqualTo("RESERVED");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.status()).isEqualTo("RESERVED"));
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -210,9 +215,13 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp {
 
     Either<OrderError, Order> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo(id);
-    assertThat(result.getRight().status()).isEqualTo("RESERVED");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            order -> {
+              assertThat(order.id()).isEqualTo(id);
+              assertThat(order.status()).isEqualTo("RESERVED");
+            });
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -277,8 +286,9 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp {
 
     Either<OrderError, Order> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().status()).isEqualTo("RESERVED");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.status()).isEqualTo("RESERVED"));
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -306,8 +316,9 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp {
     EitherPath<OrderError, Order> path = answerRequired();
 
     Either<OrderError, Order> result = path.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo("default");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.id()).isEqualTo("default"));
   }
 
   /*

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/effect/Tutorial01_EffectPathBasics.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/effect/Tutorial01_EffectPathBasics.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.effect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.effect.EitherPath;
@@ -103,22 +106,22 @@ public class Tutorial01_EffectPathBasics {
   void exercise1_creatingMaybePath() {
     MaybePath<String> present = answerRequired();
 
-    assertThat(present.run().isJust()).isTrue();
+    assertThatMaybe(present.run()).isJust();
     assertThat(present.getOrElse("default")).isEqualTo("hello");
 
     MaybePath<String> absent = answerRequired();
 
-    assertThat(absent.run().isNothing()).isTrue();
+    assertThatMaybe(absent.run()).isNothing();
     assertThat(absent.getOrElse("default")).isEqualTo("default");
 
     String nullable = null;
     MaybePath<String> fromNullable = answerRequired();
 
-    assertThat(fromNullable.run().isNothing()).isTrue();
+    assertThatMaybe(fromNullable.run()).isNothing();
 
     // Sanity: non-null values become Just.
     MaybePath<String> fromNonNull = Path.maybe("world");
-    assertThat(fromNonNull.run().isJust()).isTrue();
+    assertThatMaybe(fromNonNull.run()).isJust();
   }
 
   /**
@@ -139,18 +142,16 @@ public class Tutorial01_EffectPathBasics {
   void exercise2_creatingEitherPath() {
     EitherPath<String, Integer> success = answerRequired();
 
-    assertThat(success.run().isRight()).isTrue();
-    assertThat(success.run().getRight()).isEqualTo(42);
+    assertThatEither(success.run()).isRight().hasRight(42);
 
     EitherPath<String, Integer> failure = answerRequired();
 
-    assertThat(failure.run().isLeft()).isTrue();
-    assertThat(failure.run().getLeft()).isEqualTo("Invalid input");
+    assertThatEither(failure.run()).isLeft().hasLeft("Invalid input");
 
     Either<String, Integer> either = Either.right(100);
     EitherPath<String, Integer> fromEither = answerRequired();
 
-    assertThat(fromEither.run().getRight()).isEqualTo(100);
+    assertThatEither(fromEither.run()).hasRight(100);
   }
 
   /**
@@ -173,12 +174,12 @@ public class Tutorial01_EffectPathBasics {
   void exercise3_tryPathAndIOPath() {
     TryPath<Integer> successTry = answerRequired();
 
-    assertThat(successTry.run().isSuccess()).isTrue();
+    assertThatTry(successTry.run()).isSuccess();
     assertThat(successTry.getOrElse(-1)).isEqualTo(42);
 
     // Sanity: invalid input becomes Failure.
     TryPath<Integer> failureTry = Path.tryOf(() -> Integer.parseInt("not a number"));
-    assertThat(failureTry.run().isFailure()).isTrue();
+    assertThatTry(failureTry.run()).isFailure();
 
     var counter = new int[] {0};
     IOPath<Integer> ioPath = answerRequired();
@@ -217,16 +218,16 @@ public class Tutorial01_EffectPathBasics {
 
     // Sanity: map on Nothing is a no-op.
     MaybePath<String> absent = Path.<String>nothing().map(String::toUpperCase);
-    assertThat(absent.run().isNothing()).isTrue();
+    assertThatMaybe(absent.run()).isNothing();
 
     EitherPath<String, Integer> success = Path.right(10);
     EitherPath<String, Integer> doubled = answerRequired();
 
-    assertThat(doubled.run().getRight()).isEqualTo(20);
+    assertThatEither(doubled.run()).hasRight(20);
 
     // Sanity: map on Left is a no-op.
     EitherPath<String, Integer> failure = Path.<String, Integer>left("error").map(n -> n * 2);
-    assertThat(failure.run().getLeft()).isEqualTo("error");
+    assertThatEither(failure.run()).hasLeft("error");
   }
 
   /**
@@ -264,16 +265,14 @@ public class Tutorial01_EffectPathBasics {
 
     EitherPath<String, Double> result = answerRequired();
 
-    assertThat(result.run().isRight()).isTrue();
-    assertThat(result.run().getRight()).isEqualTo(4.0);
+    assertThatEither(result.run()).isRight().hasRight(4.0);
 
     // Sanity: bad input short-circuits at the first failing step.
     EitherPath<String, String> invalidInput = Path.right("not-a-number");
     EitherPath<String, Double> failedResult =
         invalidInput.via(parseNumber).via(validatePositive).via(divideHundredBy);
 
-    assertThat(failedResult.run().isLeft()).isTrue();
-    assertThat(failedResult.run().getLeft()).isEqualTo("Not a number: not-a-number");
+    assertThatEither(failedResult.run()).isLeft().hasLeft("Not a number: not-a-number");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -306,24 +305,23 @@ public class Tutorial01_EffectPathBasics {
 
     EitherPath<String, Integer> recovered = answerRequired();
 
-    assertThat(recovered.run().isRight()).isTrue();
-    assertThat(recovered.run().getRight()).isEqualTo(-1);
+    assertThatEither(recovered.run()).isRight().hasRight(-1);
 
     EitherPath<String, Integer> recoveredWith = answerRequired();
 
-    assertThat(recoveredWith.run().getRight()).isEqualTo(0);
+    assertThatEither(recoveredWith.run()).hasRight(0);
 
     EitherPath<String, Integer> primary = Path.left("Primary failed");
     EitherPath<String, Integer> fallback = Path.right(42);
 
     EitherPath<String, Integer> withFallback = answerRequired();
 
-    assertThat(withFallback.run().getRight()).isEqualTo(42);
+    assertThatEither(withFallback.run()).hasRight(42);
 
     EitherPath<String, Integer> stringError = Path.left("error");
     EitherPath<Integer, Integer> intError = answerRequired();
 
-    assertThat(intError.run().getLeft()).isEqualTo(5);
+    assertThatEither(intError.run()).hasLeft(5);
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -360,14 +358,14 @@ public class Tutorial01_EffectPathBasics {
     // Sanity: if either input is Nothing, the result is Nothing.
     MaybePath<String> absentName = Path.nothing();
     MaybePath<User> partialUser = absentName.zipWith(agePath, User::new);
-    assertThat(partialUser.run().isNothing()).isTrue();
+    assertThatMaybe(partialUser.run()).isNothing();
 
     EitherPath<String, String> firstName = Path.right("Alice");
     EitherPath<String, String> lastName = Path.right("Smith");
 
     EitherPath<String, String> fullName = answerRequired();
 
-    assertThat(fullName.run().getRight()).isEqualTo("Alice Smith");
+    assertThatEither(fullName.run()).hasRight("Alice Smith");
   }
 
   /**
@@ -414,8 +412,9 @@ public class Tutorial01_EffectPathBasics {
     EitherPath<String, String> invalidWorkflow =
         Path.<String, String>right("u2").via(findUser).via(validateEmail).map(User::email);
 
-    assertThat(invalidWorkflow.run().isLeft()).isTrue();
-    assertThat(invalidWorkflow.run().getLeft()).contains("Email required");
+    assertThatEither(invalidWorkflow.run())
+        .isLeft()
+        .hasLeftSatisfying(error -> assertThat(error).contains("Email required"));
 
     // Sanity: missing user, recovered with a default.
     EitherPath<String, String> recoveredWorkflow =
@@ -424,7 +423,7 @@ public class Tutorial01_EffectPathBasics {
             .recover(err -> new User("default", "Guest", "guest@example.com"))
             .map(User::email);
 
-    assertThat(recoveredWorkflow.run().getRight()).isEqualTo("guest@example.com");
+    assertThatEither(recoveredWorkflow.run()).hasRight("guest@example.com");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -471,8 +470,7 @@ public class Tutorial01_EffectPathBasics {
     // TODO: replace answerRequired() with input.via(parseNumber).
     EitherPath<String, Integer> flattened = answerRequired();
 
-    assertThat(flattened.run().isRight()).isTrue();
-    assertThat(flattened.run().getRight()).isEqualTo(42);
+    assertThatEither(flattened.run()).isRight().hasRight(42);
 
     // For comparison: the wrong call shape, kept as a comment because it produces nested paths
     // that the type system cannot tell us are wrong:

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/effect/Tutorial02_EffectPathAdvanced.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/effect/Tutorial02_EffectPathAdvanced.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.effect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -121,7 +123,7 @@ public class Tutorial02_EffectPathAdvanced {
             .<Integer>from(a -> Path.nothing())
             .from(t -> Path.just(100))
             .yield((a, b, c) -> a + b + c);
-    assertThat(shortCircuit.run().isNothing()).isTrue();
+    assertThatMaybe(shortCircuit.run()).isNothing();
   }
 
   /**
@@ -155,7 +157,7 @@ public class Tutorial02_EffectPathAdvanced {
 
     EitherPath<String, String> workflow = answerRequired();
 
-    assertThat(workflow.run().getRight()).isEqualTo("Valid age: 25");
+    assertThatEither(workflow.run()).hasRight("Valid age: 25");
 
     // Sanity: invalid format short-circuits at parse.
     EitherPath<String, String> invalid =
@@ -163,8 +165,7 @@ public class Tutorial02_EffectPathAdvanced {
             .from(parseAge)
             .from(t -> validateRange.apply(t._2()))
             .yield((input, parsed, validated) -> "Valid age: " + validated);
-    assertThat(invalid.run().isLeft()).isTrue();
-    assertThat(invalid.run().getLeft()).isEqualTo("Invalid age format");
+    assertThatEither(invalid.run()).isLeft().hasLeft("Invalid age format");
 
     // Sanity: out-of-range short-circuits at validation.
     EitherPath<String, String> outOfRange =
@@ -172,8 +173,7 @@ public class Tutorial02_EffectPathAdvanced {
             .from(parseAge)
             .from(t -> validateRange.apply(t._2()))
             .yield((input, parsed, validated) -> "Valid age: " + validated);
-    assertThat(outOfRange.run().isLeft()).isTrue();
-    assertThat(outOfRange.run().getLeft()).isEqualTo("Age out of range");
+    assertThatEither(outOfRange.run()).isLeft().hasLeft("Age out of range");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -202,10 +202,10 @@ public class Tutorial02_EffectPathAdvanced {
     ErrorContext<?, String, Integer> failure = answerRequired();
 
     Either<String, Integer> successResult = success.runIO().unsafeRun();
-    assertThat(successResult.getRight()).isEqualTo(42);
+    assertThatEither(successResult).hasRight(42);
 
     Either<String, Integer> failureResult = failure.runIO().unsafeRun();
-    assertThat(failureResult.getLeft()).isEqualTo("Something went wrong");
+    assertThatEither(failureResult).hasLeft("Something went wrong");
 
     // Sanity: the same map / via / recover surface as the Path API.
     ErrorContext<?, String, String> workflow =
@@ -214,10 +214,10 @@ public class Tutorial02_EffectPathAdvanced {
             .map(String::toUpperCase);
 
     Either<String, String> workflowResult = workflow.runIO().unsafeRun();
-    assertThat(workflowResult.getRight()).isEqualTo("BIG: 10");
+    assertThatEither(workflowResult).hasRight("BIG: 10");
 
     Either<String, Integer> recovered = failure.recover(err -> -1).runIO().unsafeRun();
-    assertThat(recovered.getRight()).isEqualTo(-1);
+    assertThatEither(recovered).hasRight(-1);
   }
 
   /**
@@ -371,7 +371,7 @@ public class Tutorial02_EffectPathAdvanced {
 
     EitherPath<String, String> createResult =
         createUserPath.apply("Bob").map(User::name).map(name -> "Created: " + name);
-    assertThat(createResult.run().getRight()).isEqualTo("Created: Bob");
+    assertThatEither(createResult.run()).hasRight("Created: Bob");
   }
 
   /**
@@ -409,13 +409,12 @@ public class Tutorial02_EffectPathAdvanced {
 
     EitherPath<String, String> cityEffectPath = answerRequired();
 
-    assertThat(cityEffectPath.run().getRight()).isEqualTo("London");
+    assertThatEither(cityEffectPath.run()).hasRight("London");
 
     // Sanity: focus preserves errors.
     EitherPath<String, User> errorPath = Path.left("User not found");
     EitherPath<String, String> cityFromError = errorPath.focus(addressPath).focus(cityPath);
-    assertThat(cityFromError.run().isLeft()).isTrue();
-    assertThat(cityFromError.run().getLeft()).isEqualTo("User not found");
+    assertThatEither(cityFromError.run()).isLeft().hasLeft("User not found");
 
     // Sanity: ForPath + focus for richer compositions.
     MaybePath<String> complexResult =
@@ -454,8 +453,7 @@ public class Tutorial02_EffectPathAdvanced {
   void diagnostic_runOnlyAtTheBoundary() {
     Either<String, Integer> result = answerRequired();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(20);
+    assertThatEither(result).isRight().hasRight(20);
   }
 
   /*

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial01_ForStateBasics.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial01_ForStateBasics.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
@@ -225,8 +226,7 @@ public class Tutorial01_ForStateBasics {
             .update(processedLens, true)
             .yield();
 
-    assertThat(MAYBE.narrow(result))
-        .isEqualTo(Maybe.just(new OrderContext("ORD-400", true, true, null)));
+    assertThatMaybe(MAYBE.narrow(result)).hasValue(new OrderContext("ORD-400", true, true, null));
   }
 
   /**
@@ -252,7 +252,7 @@ public class Tutorial01_ForStateBasics {
             .update(processedLens, true)
             .yield();
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   // =========================================================================
@@ -299,8 +299,8 @@ public class Tutorial01_ForStateBasics {
             .matchThen(matchStatusLens, activeCodePrism, extractedCodeLens)
             .yield();
 
-    assertThat(MAYBE.narrow(result))
-        .isEqualTo(Maybe.just(new MatchContext(new Status.Active("A-001"), "A-001")));
+    assertThatMaybe(MAYBE.narrow(result))
+        .hasValue(new MatchContext(new Status.Active("A-001"), "A-001"));
   }
 
   /**
@@ -325,7 +325,7 @@ public class Tutorial01_ForStateBasics {
             .matchThen(matchStatusLens, activeCodePrism, extractedCodeLens)
             .yield();
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   // =========================================================================
@@ -446,7 +446,7 @@ public class Tutorial01_ForStateBasics {
             .fromThen(ctx -> MAYBE.just("CONF-" + ctx.orderId()), confirmationIdLens)
             .yield(ctx -> ctx.orderId() + ":" + ctx.confirmationId());
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.just("ORD-800:CONF-ORD-800"));
+    assertThatMaybe(MAYBE.narrow(result)).hasValue("ORD-800:CONF-ORD-800");
   }
 
   // =========================================================================
@@ -553,10 +553,14 @@ public class Tutorial01_ForStateBasics {
             .yield();
 
     Maybe<Dashboard> pass = MAYBE.narrow(passResult);
-    assertThat(pass.isJust()).isTrue();
-    assertThat(pass.get().user()).isEqualTo("Grace");
-    assertThat(pass.get().ready()).isTrue();
+    assertThatMaybe(pass)
+        .isJust()
+        .hasValueSatisfying(
+            dashboard -> {
+              assertThat(dashboard.user()).isEqualTo("Grace");
+              assertThat(dashboard.ready()).isTrue();
+            });
 
-    assertThat(MAYBE.narrow(failResult).isNothing()).isTrue();
+    assertThatMaybe(MAYBE.narrow(failResult)).isNothing();
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial02_ForPathParallel.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial02_ForPathParallel.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import org.higherkindedj.hkt.effect.EitherPath;
 import org.higherkindedj.hkt.effect.IOPath;
@@ -145,7 +146,7 @@ public class Tutorial02_ForPathParallel {
     // Hint: Use Path.<String, String>right(...) for type-safe EitherPath creation
     EitherPath<String, String> result = answerRequired();
 
-    assertThat(result.run().getRight()).isEqualTo("Alice is 42");
+    assertThatEither(result.run()).hasRight("Alice is 42");
   }
 
   // =========================================================================

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial03_ForTraverseComprehension.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial03_ForTraverseComprehension.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
@@ -127,8 +129,9 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(1, 2, 3);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(1, 2, 3));
     }
   }
 
@@ -161,7 +164,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isFalse();
+      assertThatMaybe(maybe).isNothing();
     }
   }
 
@@ -195,8 +198,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, String> result = answerRequired();
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("10 -> [20, 22, 24]");
+      assertThatMaybe(maybe).hasValue("10 -> [20, 22, 24]");
     }
   }
 
@@ -232,8 +234,9 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(10, 20, 30);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(10, 20, 30));
     }
   }
 
@@ -268,8 +271,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, String> result = answerRequired();
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("Total: 60");
+      assertThatMaybe(maybe).hasValue("Total: 60");
     }
   }
 
@@ -304,8 +306,9 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(10, 20, 30);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(10, 20, 30));
     }
 
     @Test
@@ -319,7 +322,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isFalse();
+      assertThatMaybe(maybe).isNothing();
     }
   }
 
@@ -354,8 +357,9 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(1, 10, 2, 20, 3, 30);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(1, 10, 2, 20, 3, 30));
     }
   }
 
@@ -389,8 +393,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, String> result = answerRequired();
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("Original: [a, b, c], Uppercased: [A, B, C]");
+      assertThatMaybe(maybe).hasValue("Original: [a, b, c], Uppercased: [A, B, C]");
     }
   }
 
@@ -424,8 +427,9 @@ public class Tutorial03_ForTraverseComprehension {
       MaybePath<List<Integer>> result = answerRequired();
 
       Maybe<List<Integer>> maybe = result.run();
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(2, 4, 6);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(2, 4, 6));
     }
   }
 
@@ -460,8 +464,9 @@ public class Tutorial03_ForTraverseComprehension {
       EitherPath<String, List<Integer>> result = answerRequired();
 
       Either<String, List<Integer>> either = result.run();
-      assertThat(either.isRight()).isTrue();
-      assertThat(either.getRight()).containsExactly(2, 4, 6);
+      assertThatEither(either)
+          .isRight()
+          .hasRightSatisfying(list -> assertThat(list).containsExactly(2, 4, 6));
     }
 
     @Test
@@ -475,7 +480,7 @@ public class Tutorial03_ForTraverseComprehension {
       EitherPath<String, List<Integer>> result = answerRequired();
 
       Either<String, List<Integer>> either = result.run();
-      assertThat(either.isLeft()).isTrue();
+      assertThatEither(either).isLeft();
     }
   }
 
@@ -520,8 +525,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, String> result = answerRequired();
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("Items: 3, Total: 70");
+      assertThatMaybe(maybe).hasValue("Items: 3, Total: 70");
     }
 
     @Test
@@ -540,7 +544,7 @@ public class Tutorial03_ForTraverseComprehension {
       Kind<MaybeKind.Witness, String> result = answerRequired();
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isFalse();
+      assertThatMaybe(maybe).isNothing();
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial04_EnhancedOpticsIntegration.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial04_EnhancedOpticsIntegration.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
@@ -148,8 +149,8 @@ public class Tutorial04_EnhancedOpticsIntegration {
     Kind<MaybeKind.Witness, List<Employee>> validResult = answerRequired();
     Kind<MaybeKind.Witness, List<Employee>> mixedResult = answerRequired();
 
-    assertThat(MAYBE.narrow(validResult)).isEqualTo(Maybe.just(validEmployees));
-    assertThat(MAYBE.narrow(mixedResult)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(validResult)).hasValue(validEmployees);
+    assertThatMaybe(MAYBE.narrow(mixedResult)).isNothing();
   }
 
   // =========================================================================
@@ -277,8 +278,8 @@ public class Tutorial04_EnhancedOpticsIntegration {
     // TODO: Same workflow but with "hi" (length 2), which should fail the filter.
     Kind<MaybeKind.Witness, String> failResult = answerRequired();
 
-    assertThat(MAYBE.narrow(passResult)).isEqualTo(Maybe.just("hello"));
-    assertThat(MAYBE.narrow(failResult)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(passResult)).hasValue("hello");
+    assertThatMaybe(MAYBE.narrow(failResult)).isNothing();
   }
 
   // =========================================================================
@@ -379,8 +380,8 @@ public class Tutorial04_EnhancedOpticsIntegration {
     //   Then .yield() to get the result.
     Kind<MaybeKind.Witness, List<Employee>> result = answerRequired();
 
-    assertThat(MAYBE.narrow(result))
-        .isEqualTo(Maybe.just(List.of(new Employee("ALICE", 55000), new Employee("BOB", 65000))));
+    assertThatMaybe(MAYBE.narrow(result))
+        .hasValue(List.of(new Employee("ALICE", 55000), new Employee("BOB", 65000)));
   }
 
   // =========================================================================
@@ -430,12 +431,15 @@ public class Tutorial04_EnhancedOpticsIntegration {
     Kind<MaybeKind.Witness, Department> result = answerRequired();
 
     Maybe<Department> maybeDept = MAYBE.narrow(result);
-    assertThat(maybeDept.isJust()).isTrue();
-    Department updated = maybeDept.get();
-    assertThat(updated.name()).isEqualTo("Engineering");
-    assertThat(updated.staff())
-        .containsExactly(new Employee("Alice", 80000), new Employee("Bob", 90000));
-    assertThat(updated.budgetInCents()).isEqualTo(550000);
+    assertThatMaybe(maybeDept)
+        .isJust()
+        .hasValueSatisfying(
+            updated -> {
+              assertThat(updated.name()).isEqualTo("Engineering");
+              assertThat(updated.staff())
+                  .containsExactly(new Employee("Alice", 80000), new Employee("Bob", 90000));
+              assertThat(updated.budgetInCents()).isEqualTo(550000);
+            });
   }
 
   // =========================================================================

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial05_ZoomAndMagnify.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/expression/Tutorial05_ZoomAndMagnify.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
@@ -218,7 +219,7 @@ public class Tutorial05_ZoomAndMagnify {
     Kind<MaybeKind.Witness, OptionalAddressCustomer> result = answerRequired();
 
     Maybe<OptionalAddressCustomer> outcome = MAYBE.narrow(result);
-    assertThat(outcome.isJust()).isTrue();
+    assertThatMaybe(outcome).isJust();
     Address updated = outcome.orElse(initial).address().orElseThrow();
     assertThat(updated.street()).isEqualTo("Oak Ave");
   }
@@ -254,7 +255,7 @@ public class Tutorial05_ZoomAndMagnify {
     //       The result should be Maybe.nothing() because the affine target is absent.
     Kind<MaybeKind.Witness, OptionalAddressCustomer> result = answerRequired();
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   // ═════════════════════════════════════════════════════════════════════════

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial09_FluentOpticsAPI.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial09_FluentOpticsAPI.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
 import java.util.List;
 import java.util.Optional;
@@ -347,8 +350,9 @@ public class Tutorial09_FluentOpticsAPI {
     // Hint: OpticOps.modifyEither(user, emailLens, validateEmail)
     Either<String, User> validResult = answerRequired();
 
-    assertThat(validResult.isRight()).isTrue();
-    assertThat(validResult.getRight().email()).isEqualTo("alice@example.com");
+    assertThatEither(validResult)
+        .isRight()
+        .hasRightSatisfying(u -> assertThat(u.email()).isEqualTo("alice@example.com"));
 
     // Test with invalid email
     User invalidUser = new User("user2", "notanemail");
@@ -356,8 +360,9 @@ public class Tutorial09_FluentOpticsAPI {
     // TODO: Replace null with OpticOps.modifyEither() on invalid email
     Either<String, User> invalidResult = answerRequired();
 
-    assertThat(invalidResult.isLeft()).isTrue();
-    assertThat(invalidResult.getLeft()).contains("missing @");
+    assertThatEither(invalidResult)
+        .isLeft()
+        .hasLeftSatisfying(error -> assertThat(error).contains("missing @"));
   }
 
   /**
@@ -399,7 +404,7 @@ public class Tutorial09_FluentOpticsAPI {
     // Hint: OpticOps.modifyMaybe(person, ageLens, validateAge)
     Maybe<Person> validResult = answerRequired();
 
-    assertThat(validResult.isJust()).isTrue();
+    assertThatMaybe(validResult).isJust();
 
     // Test with invalid age
     Person invalidPerson = new Person("Bob", 200);
@@ -407,7 +412,7 @@ public class Tutorial09_FluentOpticsAPI {
     // TODO: Replace null with OpticOps.modifyMaybe() on invalid age
     Maybe<Person> invalidResult = answerRequired();
 
-    assertThat(invalidResult.isNothing()).isTrue();
+    assertThatMaybe(invalidResult).isNothing();
   }
 
   /**
@@ -469,7 +474,7 @@ public class Tutorial09_FluentOpticsAPI {
     Validated<List<String>, Order> result = answerRequired();
 
     // Should be invalid because we have negative and zero prices
-    assertThat(result.isInvalid()).isTrue();
+    assertThatValidated(result).isInvalid();
     // Validated accumulates errors (at least 2 invalid prices)
     List<String> errors = result.fold(errorList -> errorList, valid -> List.of());
     assertThat(errors.size()).isGreaterThanOrEqualTo(1);
@@ -484,7 +489,7 @@ public class Tutorial09_FluentOpticsAPI {
     // TODO: Replace null with OpticOps.modifyAllValidated() on valid order
     Validated<List<String>, Order> validResult = answerRequired();
 
-    assertThat(validResult.isValid()).isTrue();
+    assertThatValidated(validResult).isValid();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial13_AdvancedFocusDSL.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial13_AdvancedFocusDSL.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
 import java.util.ArrayList;
@@ -173,8 +174,9 @@ public class Tutorial13_AdvancedFocusDSL {
 
     // The result should be Just(Config("ABC123")) because the key is valid
     Maybe<Config> maybeConfig = MaybeKindHelper.MAYBE.narrow(result);
-    assertThat(maybeConfig.isJust()).isTrue();
-    assertThat(maybeConfig.get().apiKey()).isEqualTo("ABC123");
+    assertThatMaybe(maybeConfig)
+        .isJust()
+        .hasValueSatisfying(cfg -> assertThat(cfg.apiKey()).isEqualTo("ABC123"));
 
     // Now test with an invalid key
     Config shortKeyConfig = new Config("abc");
@@ -183,7 +185,7 @@ public class Tutorial13_AdvancedFocusDSL {
     Kind<MaybeKind.Witness, Config> invalidResult = answerRequired();
 
     Maybe<Config> invalidMaybe = MaybeKindHelper.MAYBE.narrow(invalidResult);
-    assertThat(invalidMaybe.isNothing()).isTrue();
+    assertThatMaybe(invalidMaybe).isNothing();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_OpticBatching.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial21_OpticBatching.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
 
 import java.util.*;
@@ -298,10 +299,13 @@ public class Tutorial21_OpticBatching {
       // TODO: run program through the failing resolver with SafeFetch so it never throws.
       Either<Throwable, Fetch.RunResult<UserId, User>> outcome = answerRequired();
 
-      assertThat(outcome.isLeft()).isTrue();
-      assertThat(outcome.getLeft())
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("unavailable");
+      assertThatEither(outcome)
+          .isLeft()
+          .hasLeftSatisfying(
+              error ->
+                  assertThat(error)
+                      .isInstanceOf(IllegalStateException.class)
+                      .hasMessageContaining("unavailable"));
     }
 
     /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial22_OpticBatchingGuardrails.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial22_OpticBatchingGuardrails.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
 
 import java.util.ArrayList;
@@ -267,10 +268,13 @@ public class Tutorial22_OpticBatchingGuardrails {
       // TODO: run through SafeFetch with a maxKeysPerRound(3) guard.
       Either<Throwable, Fetch.RunResult<Integer, List<Integer>>> outcome = answerRequired();
 
-      assertThat(outcome.isLeft()).isTrue();
-      assertThat(outcome.getLeft())
-          .isInstanceOf(GuardViolationException.class)
-          .hasMessageContaining("keysPerRound=5");
+      assertThatEither(outcome)
+          .isLeft()
+          .hasLeftSatisfying(
+              error ->
+                  assertThat(error)
+                      .isInstanceOf(GuardViolationException.class)
+                      .hasMessageContaining("keysPerRound=5"));
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial01_CircuitBreaker.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial01_CircuitBreaker.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.time.Duration;
 import org.higherkindedj.hkt.resilience.CircuitBreaker;
@@ -176,7 +177,7 @@ public class Tutorial01_CircuitBreaker {
       // TODO: Protect the task and execute it with runSafe() to obtain Try<String>
       Try<String> result = answerRequired();
 
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
 
       // TODO: Extract the exception from the Try (hint: result.fold(value -> null, ex -> ex))
       Throwable error = answerRequired();

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial02_Saga.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial02_Saga.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.higherkindedj.hkt.Unit;
@@ -154,7 +156,7 @@ public class Tutorial02_Saga {
       // Execute safely - the saga should fail, triggering compensation
       var tryResult = saga.run().runSafe();
 
-      assertThat(tryResult.isFailure()).isTrue();
+      assertThatTry(tryResult).isFailure();
       assertThat(step1Compensated.get()).isTrue();
     }
   }
@@ -216,12 +218,14 @@ public class Tutorial02_Saga {
       Either<SagaError, String> result = answerRequired();
 
       // The result should be a Left containing the SagaError
-      assertThat(result.isLeft()).isTrue();
-
-      SagaError error = result.getLeft();
-      assertThat(error.originalError()).isInstanceOf(RuntimeException.class);
-      assertThat(error.originalError().getMessage()).isEqualTo("Network timeout");
-      assertThat(error.allCompensationsSucceeded()).isTrue();
+      assertThatEither(result)
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error.originalError()).isInstanceOf(RuntimeException.class);
+                assertThat(error.originalError().getMessage()).isEqualTo("Network timeout");
+                assertThat(error.allCompensationsSucceeded()).isTrue();
+              });
     }
   }
 
@@ -266,7 +270,7 @@ public class Tutorial02_Saga {
       Either<SagaError, String> result = orderSaga.runSafe().run();
 
       // Saga failed at shipping step
-      assertThat(result.isLeft()).isTrue();
+      assertThatEither(result).isLeft();
       SagaError error = result.getLeft();
       assertThat(error.failedStep()).isEqualTo("schedule-shipping");
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial04_PathResilience.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/resilience/Tutorial04_PathResilience.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.time.Duration;
 import java.util.List;
@@ -136,8 +139,7 @@ public class Tutorial04_PathResilience {
       VTaskPath<Either<String, String>> caught = answerRequired();
 
       Either<String, String> result = caught.unsafeRun();
-      assertThat(result.isLeft()).isTrue();
-      assertThat(result.getLeft()).isEqualTo("Connection refused");
+      assertThatEither(result).isLeft().hasLeft("Connection refused");
     }
 
     @Test
@@ -153,7 +155,7 @@ public class Tutorial04_PathResilience {
       VTaskPath<Maybe<String>> maybePath = answerRequired();
 
       Maybe<String> result = maybePath.unsafeRun();
-      assertThat(result.isNothing()).isTrue();
+      assertThatMaybe(result).isNothing();
     }
 
     @Test
@@ -169,7 +171,7 @@ public class Tutorial04_PathResilience {
       VTaskPath<Try<Integer>> tryPath = answerRequired();
 
       Try<Integer> result = tryPath.unsafeRun();
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
     }
   }
 
@@ -320,7 +322,7 @@ public class Tutorial04_PathResilience {
 
       // VTaskContext.run() returns Try<String>
       Try<String> result = ctx.run();
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
       assertThat(result.orElse("oops")).isEqualTo("context-result");
     }
   }
@@ -373,7 +375,7 @@ public class Tutorial04_PathResilience {
               .recover(error -> "RECOVERED")
               .run();
 
-      assertThat(contextResult.isSuccess()).isTrue();
+      assertThatTry(contextResult).isSuccess();
       assertThat(contextResult.orElse("fail")).isEqualTo("CONTEXT-VALUE");
 
       // VStreamPath with error recovery

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamAdvanced_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamAdvanced_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.VStreamAssert.assertThatVStream;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
 
@@ -244,9 +245,7 @@ public class TutorialVStreamAdvanced_Solution {
       // SOLUTION: toPublisher + fromPublisher for round-trip
       Flow.Publisher<Integer> publisher = VStreamReactive.toPublisher(original);
       VStream<Integer> roundTripped = VStreamReactive.fromPublisher(publisher, 16);
-      List<Integer> result = roundTripped.toList().run();
-
-      assertThat(result).containsExactly(1, 2, 3);
+      assertThatVStream(roundTripped).producesElements(1, 2, 3);
     }
   }
 
@@ -280,9 +279,7 @@ public class TutorialVStreamAdvanced_Solution {
       Kind<ListKind.Witness, String> listKind = LIST.widen(source);
       Kind<VStreamKind.Witness, String> vstreamKind = nt.apply(listKind);
       VStream<String> vstream = VSTREAM.narrow(vstreamKind);
-      List<String> result = vstream.toList().run();
-
-      assertThat(result).containsExactly("x", "y", "z");
+      assertThatVStream(vstream).producesElements("x", "y", "z");
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamHKT_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamHKT_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.VStreamAssert.assertThatVStream;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.vstream.VStreamKindHelper.VSTREAM;
 
@@ -91,7 +92,7 @@ public class TutorialVStreamHKT_Solution {
       // SOLUTION: Use VSTREAM.narrow() to convert back to VStream
       VStream<String> stream = VSTREAM.narrow(kind);
 
-      assertThat(stream.toList().run()).containsExactly("hello", "world");
+      assertThatVStream(stream).producesElements("hello", "world");
     }
   }
 
@@ -123,7 +124,7 @@ public class TutorialVStreamHKT_Solution {
       // SOLUTION: Use functor.map to double each element
       Kind<VStreamKind.Witness, Integer> doubled = functor.map(i -> i * 2, stream);
 
-      assertThat(VSTREAM.narrow(doubled).toList().run()).containsExactly(2, 4, 6);
+      assertThatVStream(doubled).producesElements(2, 4, 6);
     }
 
     /**
@@ -143,7 +144,7 @@ public class TutorialVStreamHKT_Solution {
       // SOLUTION: Use applicative.of to lift a value into VStream
       Kind<VStreamKind.Witness, Integer> result = applicative.of(42);
 
-      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(42);
+      assertThatVStream(result).producesElements(42);
     }
 
     /**
@@ -168,7 +169,7 @@ public class TutorialVStreamHKT_Solution {
       // SOLUTION: Use applicative.ap for Cartesian product
       Kind<VStreamKind.Witness, String> result = applicative.ap(fns, values);
 
-      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly("x1", "x2", "y1", "y2");
+      assertThatVStream(result).producesElements("x1", "x2", "y1", "y2");
     }
   }
 
@@ -200,7 +201,7 @@ public class TutorialVStreamHKT_Solution {
       Kind<VStreamKind.Witness, Integer> result =
           monad.flatMap(i -> VSTREAM.widen(VStream.of(i, i * 10)), stream);
 
-      assertThat(VSTREAM.narrow(result).toList().run()).containsExactly(1, 10, 2, 20, 3, 30);
+      assertThatVStream(result).producesElements(1, 10, 2, 20, 3, 30);
     }
   }
 
@@ -268,7 +269,7 @@ public class TutorialVStreamHKT_Solution {
       // SOLUTION: Use alt.orElse for concatenation
       Kind<VStreamKind.Witness, Integer> combined = alt.orElse(first, () -> second);
 
-      assertThat(VSTREAM.narrow(combined).toList().run()).containsExactly(1, 2, 3, 4);
+      assertThatVStream(combined).producesElements(1, 2, 3, 4);
     }
 
     /**
@@ -290,8 +291,8 @@ public class TutorialVStreamHKT_Solution {
       Kind<VStreamKind.Witness, Unit> trueResult = alt.guard(true);
       Kind<VStreamKind.Witness, Unit> falseResult = alt.guard(false);
 
-      assertThat(VSTREAM.narrow(trueResult).toList().run()).containsExactly(Unit.INSTANCE);
-      assertThat(VSTREAM.narrow(falseResult).toList().run()).isEmpty();
+      assertThatVStream(trueResult).producesElements(Unit.INSTANCE);
+      assertThatVStream(falseResult).isEmpty();
     }
 
     /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamPath_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVStreamPath_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.VStreamPathAssert.assertThatVStreamPath;
 
 import java.util.Optional;
 import org.higherkindedj.hkt.effect.Path;
@@ -60,7 +61,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use Path.vstreamOf() to create from varargs
       VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
 
-      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
     }
 
     /**
@@ -79,7 +80,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use Path.vstreamRange() to create an integer range
       VStreamPath<Integer> path = Path.vstreamRange(1, 6);
 
-      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3, 4, 5);
+      assertThatVStreamPath(path).producesElements(1, 2, 3, 4, 5);
     }
 
     /**
@@ -97,7 +98,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use Path.vstreamIterate() for an infinite stream and take(4)
       VStreamPath<Integer> path = Path.vstreamIterate(10, n -> n + 10).take(4);
 
-      assertThat(path.toList().unsafeRun()).containsExactly(10, 20, 30, 40);
+      assertThatVStreamPath(path).producesElements(10, 20, 30, 40);
     }
 
     /**
@@ -123,7 +124,7 @@ public class TutorialVStreamPath_Solution {
                           ? Optional.empty()
                           : Optional.of(new VStream.Seed<>(state, state + 1))));
 
-      assertThat(path.toList().unsafeRun()).containsExactly(1, 2, 3);
+      assertThatVStreamPath(path).producesElements(1, 2, 3);
     }
   }
 
@@ -153,7 +154,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use map to transform each element to uppercase
       VStreamPath<String> upper = names.map(String::toUpperCase);
 
-      assertThat(upper.toList().unsafeRun()).containsExactly("ALICE", "BOB");
+      assertThatVStreamPath(upper).producesElements("ALICE", "BOB");
     }
 
     /**
@@ -174,7 +175,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use filter to keep only even numbers
       VStreamPath<Integer> evens = range.filter(n -> n % 2 == 0);
 
-      assertThat(evens.toList().unsafeRun()).containsExactly(2, 4, 6, 8, 10);
+      assertThatVStreamPath(evens).producesElements(2, 4, 6, 8, 10);
     }
 
     /**
@@ -196,7 +197,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use flatMap to expand each element into [n, n*10]
       VStreamPath<Integer> expanded = nums.flatMap(n -> Path.vstreamOf(n, n * 10));
 
-      assertThat(expanded.toList().unsafeRun()).containsExactly(1, 10, 2, 20, 3, 30);
+      assertThatVStreamPath(expanded).producesElements(1, 10, 2, 20, 3, 30);
     }
 
     /**
@@ -216,7 +217,7 @@ public class TutorialVStreamPath_Solution {
       VStreamPath<String> pipeline =
           Path.vstreamRange(1, 100).filter(n -> n % 2 == 0).map(n -> "Even:" + n).take(3);
 
-      assertThat(pipeline.toList().unsafeRun()).containsExactly("Even:2", "Even:4", "Even:6");
+      assertThatVStreamPath(pipeline).producesElements("Even:2", "Even:4", "Even:6");
     }
   }
 
@@ -288,7 +289,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use zipWith to pair elements positionally
       VStreamPath<String> zipped = nums.zipWith(labels, (n, s) -> n + s);
 
-      assertThat(zipped.toList().unsafeRun()).containsExactly("1a", "2b", "3c");
+      assertThatVStreamPath(zipped).producesElements("1a", "2b", "3c");
     }
 
     /**
@@ -314,7 +315,7 @@ public class TutorialVStreamPath_Solution {
       // SOLUTION: Use focus() to extract names from each Person
       VStreamPath<String> names = people.focus(nameFocus);
 
-      assertThat(names.toList().unsafeRun()).containsExactly("Alice", "Bob");
+      assertThatVStreamPath(names).producesElements("Alice", "Bob");
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVTaskForPath_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVTaskForPath_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -68,8 +69,8 @@ public class TutorialVTaskForPath_Solution {
               .yield((id, greeting) -> greeting + ", " + id + "!");
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Hello, user-123!");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Hello, user-123!");
     }
 
     /**
@@ -95,8 +96,8 @@ public class TutorialVTaskForPath_Solution {
               .yield((base, doubled, sum) -> sum);
 
       Try<Integer> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse(-1)).isEqualTo(30);
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue(30);
     }
   }
 
@@ -132,8 +133,8 @@ public class TutorialVTaskForPath_Solution {
               .yield((v, squared, plus10) -> "Original: " + v + ", Result: " + plus10);
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Original: 5, Result: 35");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Original: 5, Result: 35");
     }
 
     /**
@@ -161,8 +162,8 @@ public class TutorialVTaskForPath_Solution {
               .yield((price, qty, subtotal, total) -> total);
 
       Try<Double> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse(-1.0)).isEqualTo(33.0);
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue(33.0);
     }
   }
 
@@ -207,8 +208,8 @@ public class TutorialVTaskForPath_Solution {
           ForPath.from(fetchUser).focus(addressPath).yield((u, addr) -> addr.city());
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("London");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("London");
     }
 
     /**
@@ -239,8 +240,8 @@ public class TutorialVTaskForPath_Solution {
               .yield((user1, address, weather) -> user1.name() + ": " + weather);
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Bob: Sunny in Paris");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Bob: Sunny in Paris");
     }
   }
 
@@ -277,7 +278,7 @@ public class TutorialVTaskForPath_Solution {
               .yield((a, b, c) -> a + b + c);
 
       Try<Integer> tryResult = result.runSafe();
-      assertThat(tryResult.isFailure()).isTrue();
+      assertThatTry(tryResult).isFailure();
       String errorMessage = tryResult.foldFailureFirst(Throwable::getMessage, v -> "no error");
       assertThat(errorMessage).isEqualTo("Step 2 failed");
     }
@@ -305,8 +306,8 @@ public class TutorialVTaskForPath_Solution {
               .handleError(ex -> "DEFAULT");
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("DEFAULT");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("DEFAULT");
     }
   }
 
@@ -358,8 +359,8 @@ public class TutorialVTaskForPath_Solution {
               .yield((validated, payment, confirmation) -> confirmation.message());
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Order confirmed: ORD-001");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Order confirmed: ORD-001");
     }
 
     /**
@@ -401,8 +402,8 @@ public class TutorialVTaskForPath_Solution {
                   (cart1, subtotal, afterDiscount, total) -> String.format("Total: $%.2f", total));
 
       Try<String> tryResult = result.runSafe();
-      assertThat(tryResult.isSuccess()).isTrue();
-      assertThat(tryResult.orElse("error")).isEqualTo("Total: $24.30");
+      assertThatTry(tryResult).isSuccess();
+      assertThatTry(tryResult).hasValue("Total: $24.30");
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVTaskPath_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVTaskPath_Solution.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.solutions.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
+import static org.higherkindedj.hkt.assertions.VTaskPathAssert.assertThatVTaskPath;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -67,8 +70,8 @@ public class TutorialVTaskPath_Solution {
       VTaskPath<Integer> lengthPath = Path.vtask(() -> input.length());
 
       Try<Integer> result = lengthPath.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse(-1)).isEqualTo(17);
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue(17);
     }
 
     /**
@@ -91,11 +94,11 @@ public class TutorialVTaskPath_Solution {
       VTaskPath<String> failedPath = Path.vtaskFail(new RuntimeException("Expected"));
 
       Try<String> pureResult = purePath.runSafe();
-      assertThat(pureResult.isSuccess()).isTrue();
-      assertThat(pureResult.orElse("default")).isEqualTo("success");
+      assertThatTry(pureResult).isSuccess();
+      assertThatTry(pureResult).hasValue("success");
 
       Try<String> failedResult = failedPath.runSafe();
-      assertThat(failedResult.isFailure()).isTrue();
+      assertThatTry(failedResult).isFailure();
     }
   }
 
@@ -127,8 +130,8 @@ public class TutorialVTaskPath_Solution {
           input.via(s -> Path.vtask(() -> Integer.parseInt(s))).via(n -> Path.vtaskPure(n * 2));
 
       Try<Integer> result = doubled.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse(-1)).isEqualTo(42);
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue(42);
     }
 
     /**
@@ -155,7 +158,7 @@ public class TutorialVTaskPath_Solution {
               .peek(v -> peekCount.incrementAndGet());
 
       Try<Integer> result = debugged.runSafe();
-      assertThat(result.orElse(-1)).isEqualTo(20);
+      assertThatTry(result).hasValue(20);
       assertThat(peekCount.get()).isEqualTo(2);
     }
   }
@@ -193,8 +196,8 @@ public class TutorialVTaskPath_Solution {
           slowOperation.timeout(Duration.ofMillis(100)).handleError(e -> "timeout fallback");
 
       Try<String> result = withTimeout.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse("error")).isEqualTo("timeout fallback");
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue("timeout fallback");
     }
 
     /**
@@ -230,8 +233,8 @@ public class TutorialVTaskPath_Solution {
           primary.handleErrorWith(e -> secondary).handleError(e -> "fallback value");
 
       Try<String> result = resilient.runSafe();
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.orElse("error")).isEqualTo("fallback value");
+      assertThatTry(result).isSuccess();
+      assertThatTry(result).hasValue("fallback value");
       assertThat(attemptCount.get()).isEqualTo(2);
     }
   }
@@ -285,7 +288,7 @@ public class TutorialVTaskPath_Solution {
           Path.vtaskPath(Par.map3(fetchName, fetchOrderCount, fetchStatus, UserProfile::new));
 
       Try<UserProfile> result = profile.runSafe();
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
 
       UserProfile user = result.orElse(null);
       assertThat(user).isNotNull();
@@ -335,7 +338,7 @@ public class TutorialVTaskPath_Solution {
               .handleError(e -> Dashboard.empty());
 
       Try<Dashboard> result = dashboard.runSafe();
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
 
       Dashboard d = result.orElse(null);
       assertThat(d).isNotNull();
@@ -407,8 +410,8 @@ public class TutorialVTaskPath_Solution {
 
       VTask<Integer> backToVtask = path.run();
 
-      assertThat(path.runSafe().orElse(-1)).isEqualTo(42);
-      assertThat(backToVtask.runSafe().orElse(-1)).isEqualTo(42);
+      assertThatVTaskPath(path).hasValue(42);
+      assertThatVTask(backToVtask).whenRun().succeeds().hasValue(42);
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVTask_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/concurrency/TutorialVTask_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
 
 import java.util.List;
 import org.higherkindedj.hkt.trymonad.Try;
@@ -36,7 +37,7 @@ public class TutorialVTask_Solution {
     void exercise1_createVTaskWithOf() {
       String input = "Hello, VTask!";
       VTask<Integer> lengthTask = VTask.of(() -> input.length());
-      assertThat(lengthTask.run()).isEqualTo(13);
+      assertThatVTask(lengthTask).whenRun().succeeds().hasValue(13);
     }
 
     /**
@@ -55,9 +56,9 @@ public class TutorialVTask_Solution {
       VTask<Integer> success = VTask.succeed(42);
       VTask<Integer> failure = VTask.fail(new RuntimeException("Expected failure"));
 
-      assertThat(success.runSafe().isSuccess()).isTrue();
-      assertThat(success.runSafe().orElse(-1)).isEqualTo(42);
-      assertThat(failure.runSafe().isFailure()).isTrue();
+      assertThatVTask(success).runSafeSucceeds();
+      assertThatVTask(success).whenRun().succeeds().hasValue(42);
+      assertThatVTask(failure).runSafeFails();
     }
   }
 
@@ -79,7 +80,7 @@ public class TutorialVTask_Solution {
     void exercise3_mapTransformation() {
       VTask<String> greeting = VTask.succeed("Hello, Virtual Threads!");
       VTask<Integer> length = greeting.map(String::length);
-      assertThat(length.run()).isEqualTo(23);
+      assertThatVTask(length).whenRun().succeeds().hasValue(23);
     }
 
     /**
@@ -97,7 +98,7 @@ public class TutorialVTask_Solution {
     void exercise4_flatMapChaining() {
       VTask<Integer> getNumber = VTask.succeed(21);
       VTask<Integer> doubled = getNumber.flatMap(n -> VTask.succeed(n * 2));
-      assertThat(doubled.run()).isEqualTo(42);
+      assertThatVTask(doubled).whenRun().succeeds().hasValue(42);
     }
   }
 
@@ -144,7 +145,7 @@ public class TutorialVTask_Solution {
     void exercise6_recoverFromFailure() {
       VTask<Integer> failingTask = VTask.fail(new RuntimeException("Computation failed"));
       VTask<Integer> recovered = failingTask.recover(error -> -1);
-      assertThat(recovered.run()).isEqualTo(-1);
+      assertThatVTask(recovered).whenRun().succeeds().hasValue(-1);
     }
   }
 
@@ -178,7 +179,7 @@ public class TutorialVTask_Solution {
                 return 22;
               });
       VTask<Integer> combined = Par.map2(taskA, taskB, Integer::sum);
-      assertThat(combined.run()).isEqualTo(42);
+      assertThatVTask(combined).whenRun().succeeds().hasValue(42);
     }
 
     /**
@@ -213,7 +214,7 @@ public class TutorialVTask_Solution {
                 return "fast";
               });
       VTask<String> winner = Par.race(List.of(slow, medium, fast));
-      assertThat(winner.run()).isEqualTo("fast");
+      assertThatVTask(winner).whenRun().succeeds().hasValue("fast");
     }
   }
 
@@ -282,7 +283,7 @@ public class TutorialVTask_Solution {
       VTask<String> profile =
           Par.map2(fetchUser, fetchAge, (name, age) -> name + " (age " + age + ")");
       VTask<String> safeProfile = profile.recover(error -> "Unknown user");
-      assertThat(safeProfile.run()).isEqualTo("Alice (age 30)");
+      assertThatVTask(safeProfile).whenRun().succeeds().hasValue("Alice (age 30)");
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/context/Tutorial05_ContextWithVTask_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/context/Tutorial05_ContextWithVTask_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.List;
 import org.higherkindedj.hkt.context.Context;
@@ -62,7 +63,7 @@ public class Tutorial05_ContextWithVTask_Solution {
       Try<String> result =
           ScopedValue.where(RequestContext.TRACE_ID, traceId).call(() -> traceTask.runSafe());
 
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
       assertThat(result.orElse("error")).isEqualTo(traceId);
     }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/context/Tutorial06_AdvancedContextPatterns_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/context/Tutorial06_AdvancedContextPatterns_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 
 import java.security.Principal;
 import java.util.Set;
@@ -215,7 +216,7 @@ public class Tutorial06_AdvancedContextPatterns_Solution {
       // SOLUTION: Call toMaybe() within the scope
       Maybe<String> result = ScopedValue.where(CONFIG_VALUE, "value").call(() -> getName.toMaybe());
 
-      assertThat(result.isJust()).isTrue();
+      assertThatMaybe(result).isJust();
       assertThat(result.orElse("none")).isEqualTo("value");
     }
 
@@ -238,7 +239,7 @@ public class Tutorial06_AdvancedContextPatterns_Solution {
       // SOLUTION: Use toMaybe() to convert failure to Nothing
       Maybe<String> result = failing.toMaybe();
 
-      assertThat(result.isNothing()).isTrue();
+      assertThatMaybe(result).isNothing();
       assertThat(result.orElse("fallback")).isEqualTo("fallback");
     }
   }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial00_OneLineSixLayers_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial00_OneLineSixLayers_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -124,9 +125,8 @@ public class Tutorial00_OneLineSixLayers_Solution {
     EitherPath<RepoError, Item> presentEither = presentMaybe.toEitherPath(RepoError.NOT_FOUND);
     EitherPath<RepoError, Item> absentEither = absentMaybe.toEitherPath(RepoError.NOT_FOUND);
 
-    assertThat(presentEither.run().isRight()).isTrue();
-    assertThat(absentEither.run().isLeft()).isTrue();
-    assertThat(absentEither.run().getLeft()).isEqualTo(RepoError.NOT_FOUND);
+    assertThatEither(presentEither.run()).isRight();
+    assertThatEither(absentEither.run()).isLeft().hasLeft(RepoError.NOT_FOUND);
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -177,8 +177,9 @@ public class Tutorial00_OneLineSixLayers_Solution {
         wrapped.map(item -> attributesLens.modify(addEntry("country", "GB"), item));
 
     Either<RepoError, Item> result = updated.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -206,8 +207,9 @@ public class Tutorial00_OneLineSixLayers_Solution {
     EitherPath<RepoError, Item> saved = wrapped.via(Tutorial00_OneLineSixLayers_Solution::save);
 
     Either<RepoError, Item> result = saved.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
   }
 
   // ─── Exercise 6 ────────────────────────────────────────────────────────────
@@ -236,8 +238,9 @@ public class Tutorial00_OneLineSixLayers_Solution {
 
     Either<RepoError, Item> either = saved.run();
 
-    assertThat(either.isRight()).isTrue();
-    assertThat(either.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(either)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
   }
 
   // ─── Exercise 7 ────────────────────────────────────────────────────────────
@@ -268,9 +271,13 @@ public class Tutorial00_OneLineSixLayers_Solution {
             .via(Tutorial00_OneLineSixLayers_Solution::save)
             .run();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo(idToUpdate);
-    assertThat(result.getRight().attributes()).containsEntry(key, newValue);
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            item -> {
+              assertThat(item.id()).isEqualTo(idToUpdate);
+              assertThat(item.attributes()).containsEntry(key, newValue);
+            });
 
     String missingId = "user-missing";
     Either<RepoError, Item> missing =
@@ -280,8 +287,7 @@ public class Tutorial00_OneLineSixLayers_Solution {
             .via(Tutorial00_OneLineSixLayers_Solution::save)
             .run();
 
-    assertThat(missing.isLeft()).isTrue();
-    assertThat(missing.getLeft()).isEqualTo(RepoError.NOT_FOUND);
+    assertThatEither(missing).isLeft().hasLeft(RepoError.NOT_FOUND);
   }
 
   // ─── Diagnostic ────────────────────────────────────────────────────────────
@@ -310,13 +316,15 @@ public class Tutorial00_OneLineSixLayers_Solution {
         wrapped.map(item -> attributesLens.modify(addEntry("country", "GB"), item));
 
     Either<RepoError, Item> result = updated.via(Tutorial00_OneLineSixLayers_Solution::save).run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().attributes()).containsEntry("country", "GB");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(item -> assertThat(item.attributes()).containsEntry("country", "GB"));
 
     FocusPath<Item, Map<String, String>> attributesPath = FocusPath.of(attributesLens);
     EitherPath<RepoError, Map<String, String>> narrowed =
         wrapped.focus(attributesPath).map(addEntry("country", "GB"));
-    assertThat(narrowed.run().isRight()).isTrue();
-    assertThat(narrowed.run().getRight()).containsEntry("country", "GB");
+    assertThatEither(narrowed.run())
+        .isRight()
+        .hasRightSatisfying(attrs -> assertThat(attrs).containsEntry("country", "GB"));
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial01_KindBasics_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial01_KindBasics_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 
@@ -60,7 +61,7 @@ public class Tutorial01_KindBasics_Solution {
 
     Kind<EitherKind.Witness<String>, Integer> kind = EITHER.widen(either);
 
-    assertThat(EITHER.narrow(kind).getRight()).isEqualTo(42);
+    assertThatEither(EITHER.narrow(kind)).hasRight(42);
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -84,8 +85,7 @@ public class Tutorial01_KindBasics_Solution {
 
     Either<String, Integer> either = EITHER.narrow(kind);
 
-    assertThat(either.isRight()).isTrue();
-    assertThat(either.getRight()).isEqualTo(100);
+    assertThatEither(either).isRight().hasRight(100);
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -138,7 +138,7 @@ public class Tutorial01_KindBasics_Solution {
     Kind<EitherKind.Witness<String>, Boolean> kind = EITHER.widen(either);
 
     Either<String, Boolean> result = EITHER.narrow(kind);
-    assertThat(result.getRight()).isTrue();
+    assertThatEither(result).hasRight(true);
   }
 
   // ─── Diagnostic ────────────────────────────────────────────────────────────

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial02_FunctorMapping_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial02_FunctorMapping_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
@@ -48,8 +49,7 @@ public class Tutorial02_FunctorMapping_Solution {
 
     Either<String, String> result = either.map(String::valueOf);
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo("42");
+    assertThatEither(result).isRight().hasRight("42");
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -73,8 +73,7 @@ public class Tutorial02_FunctorMapping_Solution {
 
     Either<String, String> result = error.map(i -> "won't run");
 
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Error occurred");
+    assertThatEither(result).isLeft().hasLeft("Error occurred");
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -124,7 +123,7 @@ public class Tutorial02_FunctorMapping_Solution {
 
     Either<String, String> result = value.map(n -> n * 2).map(n -> n + 5).map(String::valueOf);
 
-    assertThat(result.getRight()).isEqualTo("25");
+    assertThatEither(result).hasRight("25");
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -149,7 +148,7 @@ public class Tutorial02_FunctorMapping_Solution {
     Kind<EitherKind.Witness<String>, String> mapped = functor.map(i -> "Value: " + i, kind);
 
     Either<String, String> result = EITHER.narrow(mapped);
-    assertThat(result.getRight()).isEqualTo("Value: 100");
+    assertThatEither(result).hasRight("Value: 100");
   }
 
   // ─── Exercise 6 ────────────────────────────────────────────────────────────
@@ -205,8 +204,8 @@ public class Tutorial02_FunctorMapping_Solution {
 
     Either<String, Either<String, Integer>> nested = outer.map(parse);
 
-    assertThat(nested.isRight()).isTrue();
-    assertThat(nested.getRight().isRight()).isTrue();
-    assertThat(nested.getRight().getRight()).isEqualTo(42);
+    assertThatEither(nested)
+        .isRight()
+        .hasRightSatisfying(inner -> assertThatEither(inner).isRight().hasRight(42));
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial03_ApplicativeCombining_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial03_ApplicativeCombining_Solution.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
@@ -46,8 +48,7 @@ public class Tutorial03_ApplicativeCombining_Solution {
   void exercise1_liftingValues() {
     Either<String, Integer> result = Either.right(42);
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(42);
+    assertThatEither(result).isRight().hasRight(42);
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -75,7 +76,7 @@ public class Tutorial03_ApplicativeCombining_Solution {
     Either<String, Integer> result =
         EITHER.narrow(app.map2(EITHER.widen(value1), EITHER.widen(value2), (a, b) -> a + b));
 
-    assertThat(result.getRight()).isEqualTo(30);
+    assertThatEither(result).hasRight(30);
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -101,8 +102,7 @@ public class Tutorial03_ApplicativeCombining_Solution {
     Either<String, Integer> result =
         EITHER.narrow(app.map2(EITHER.widen(value1), EITHER.widen(error), (a, b) -> a + b));
 
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Error occurred");
+    assertThatEither(result).isLeft().hasLeft("Error occurred");
   }
 
   // ─── Exercise 4 ────────────────────────────────────────────────────────────
@@ -132,10 +132,14 @@ public class Tutorial03_ApplicativeCombining_Solution {
         EITHER.narrow(
             app.map3(EITHER.widen(name), EITHER.widen(age), EITHER.widen(email), Person::new));
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().name()).isEqualTo("Alice");
-    assertThat(result.getRight().age()).isEqualTo(30);
-    assertThat(result.getRight().email()).isEqualTo("alice@example.com");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            person -> {
+              assertThat(person.name()).isEqualTo("Alice");
+              assertThat(person.age()).isEqualTo(30);
+              assertThat(person.email()).isEqualTo("alice@example.com");
+            });
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -171,7 +175,7 @@ public class Tutorial03_ApplicativeCombining_Solution {
                 VALIDATED.widen(email),
                 FormData::new));
 
-    assertThat(result.isInvalid()).isTrue();
+    assertThatValidated(result).isInvalid();
   }
 
   // ─── Exercise 6 ────────────────────────────────────────────────────────────
@@ -205,12 +209,15 @@ public class Tutorial03_ApplicativeCombining_Solution {
                 EITHER.widen(price),
                 Order::new));
 
-    assertThat(result.isRight()).isTrue();
-    Order order = result.getRight();
-    assertThat(order.id()).isEqualTo("ORD-001");
-    assertThat(order.product()).isEqualTo("Laptop");
-    assertThat(order.quantity()).isEqualTo(2);
-    assertThat(order.price()).isEqualTo(999.99);
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            order -> {
+              assertThat(order.id()).isEqualTo("ORD-001");
+              assertThat(order.product()).isEqualTo("Laptop");
+              assertThat(order.quantity()).isEqualTo(2);
+              assertThat(order.price()).isEqualTo(999.99);
+            });
   }
 
   // ─── Exercise 7 ────────────────────────────────────────────────────────────
@@ -246,11 +253,14 @@ public class Tutorial03_ApplicativeCombining_Solution {
                 EITHER.widen(country),
                 Address::new));
 
-    assertThat(result.isRight()).isTrue();
-    Address address = result.getRight();
-    assertThat(address.street()).isEqualTo("123 Main St");
-    assertThat(address.city()).isEqualTo("Springfield");
-    assertThat(address.country()).isEqualTo("USA");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            address -> {
+              assertThat(address.street()).isEqualTo("123 Main St");
+              assertThat(address.city()).isEqualTo("Springfield");
+              assertThat(address.country()).isEqualTo("USA");
+            });
   }
 
   // ─── Diagnostic ────────────────────────────────────────────────────────────
@@ -281,11 +291,12 @@ public class Tutorial03_ApplicativeCombining_Solution {
 
     Validated<String, Pair> bothValid =
         VALIDATED.narrow(app.map2(VALIDATED.widen(nameOk), VALIDATED.widen(ageOk), Pair::new));
-    assertThat(bothValid.isValid()).isTrue();
-    assertThat(bothValid.get().name()).isEqualTo("Alice");
+    assertThatValidated(bothValid)
+        .isValid()
+        .hasValueSatisfying(pair -> "Alice".equals(pair.name()), "name is Alice");
 
     Validated<String, Pair> oneInvalid =
         VALIDATED.narrow(app.map2(VALIDATED.widen(nameOk), VALIDATED.widen(ageBad), Pair::new));
-    assertThat(oneInvalid.isInvalid()).isTrue();
+    assertThatValidated(oneInvalid).isInvalid();
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial04_MonadChaining_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial04_MonadChaining_Solution.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
@@ -58,8 +60,7 @@ public class Tutorial04_MonadChaining_Solution {
 
     Either<String, Integer> result = input.flatMap(parse);
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(42);
+    assertThatEither(result).isRight().hasRight(42);
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -97,8 +98,7 @@ public class Tutorial04_MonadChaining_Solution {
     Either<String, Double> result =
         input.flatMap(parse).flatMap(validatePositive).flatMap(divideHundredBy);
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(20.0);
+    assertThatEither(result).isRight().hasRight(20.0);
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -132,8 +132,7 @@ public class Tutorial04_MonadChaining_Solution {
 
     Either<String, Integer> result = input.flatMap(parse).flatMap(validatePositive);
 
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Must be positive");
+    assertThatEither(result).isLeft().hasLeft("Must be positive");
   }
 
   // ─── Exercise 4 ────────────────────────────────────────────────────────────
@@ -160,7 +159,7 @@ public class Tutorial04_MonadChaining_Solution {
 
     Either<String, Integer> result = value.flatMap(validate);
 
-    assertThat(result.getRight()).isEqualTo(10);
+    assertThatEither(result).hasRight(10);
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -193,8 +192,7 @@ public class Tutorial04_MonadChaining_Solution {
 
     Maybe<String> email = userId.flatMap(findUser).flatMap(User::email);
 
-    assertThat(email.isJust()).isTrue();
-    assertThat(email.get()).isEqualTo("alice@example.com");
+    assertThatMaybe(email).isJust().hasValue("alice@example.com");
   }
 
   // ─── Exercise 6 ────────────────────────────────────────────────────────────
@@ -260,7 +258,7 @@ public class Tutorial04_MonadChaining_Solution {
                       (a, c) -> "Age: " + a + ", City: " + c));
             });
 
-    assertThat(result.getRight()).isEqualTo("Age: 30, City: New York");
+    assertThatEither(result).hasRight("Age: 30, City: New York");
   }
 
   // ─── Diagnostic ────────────────────────────────────────────────────────────
@@ -288,8 +286,12 @@ public class Tutorial04_MonadChaining_Solution {
     Either<String, Pair> result =
         EITHER.narrow(app.map2(EITHER.widen(name), EITHER.widen(age), Pair::new));
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().name()).isEqualTo("Alice");
-    assertThat(result.getRight().age()).isEqualTo(30);
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            pair -> {
+              assertThat(pair.name()).isEqualTo("Alice");
+              assertThat(pair.age()).isEqualTo(30);
+            });
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial05_MonadErrorHandling_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial05_MonadErrorHandling_Solution.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
@@ -57,8 +59,7 @@ public class Tutorial05_MonadErrorHandling_Solution {
     Kind<EitherKind.Witness<String>, Integer> error = monad.raiseError("Invalid input");
 
     Either<String, Integer> result = EITHER.narrow(error);
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo("Invalid input");
+    assertThatEither(result).isLeft().hasLeft("Invalid input");
   }
 
   /**
@@ -203,8 +204,7 @@ public class Tutorial05_MonadErrorHandling_Solution {
     // Solution: Use fold to return fallback on error, or wrap success value
     Either<String, String> result = primary.fold(err -> fallback, value -> Either.right(value));
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo("Fallback value");
+    assertThatEither(result).isRight().hasRight("Fallback value");
   }
 
   /**
@@ -233,13 +233,12 @@ public class Tutorial05_MonadErrorHandling_Solution {
     // Solution: Wrap the risky operation in Try
     Try<Integer> result = Try.of(() -> riskyDivision.apply(0));
 
-    assertThat(result.isFailure()).isTrue();
+    assertThatTry(result).isFailure();
 
     // Solution: Recover from the exception with -1
     Try<Integer> recovered = result.recover(ex -> -1);
 
-    assertThat(recovered.isSuccess()).isTrue();
-    assertThat(recovered.get()).isEqualTo(-1);
+    assertThatTry(recovered).isSuccess().hasValue(-1);
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial06_ConcreteTypes_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial06_ConcreteTypes_Solution.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
 import java.util.List;
@@ -65,14 +68,11 @@ public class Tutorial06_ConcreteTypes_Solution {
           }
         };
 
-    assertThat(validateAge.apply(25).isRight()).isTrue();
-    assertThat(validateAge.apply(25).getRight()).isEqualTo(25);
+    assertThatEither(validateAge.apply(25)).isRight().hasRight(25);
 
-    assertThat(validateAge.apply(15).isLeft()).isTrue();
-    assertThat(validateAge.apply(15).getLeft()).isEqualTo("Too young");
+    assertThatEither(validateAge.apply(15)).isLeft().hasLeft("Too young");
 
-    assertThat(validateAge.apply(-5).isLeft()).isTrue();
-    assertThat(validateAge.apply(-5).getLeft()).isEqualTo("Invalid age");
+    assertThatEither(validateAge.apply(-5)).isLeft().hasLeft("Invalid age");
   }
 
   /**
@@ -102,11 +102,10 @@ public class Tutorial06_ConcreteTypes_Solution {
         };
 
     Maybe<String> found = lookup.apply("key1");
-    assertThat(found.isJust()).isTrue();
-    assertThat(found.get()).isEqualTo("value");
+    assertThatMaybe(found).isJust().hasValue("value");
 
     Maybe<String> notFound = lookup.apply("key2");
-    assertThat(notFound.isNothing()).isTrue();
+    assertThatMaybe(notFound).isNothing();
   }
 
   /**
@@ -200,7 +199,7 @@ public class Tutorial06_ConcreteTypes_Solution {
                 ValidatedKindHelper.VALIDATED.widen(validEmail),
                 User::new));
 
-    assertThat(validUser.isValid()).isTrue();
+    assertThatValidated(validUser).isValid();
 
     // Invalid case - multiple errors
     Validated<String, String> invalidName = validateName.apply("A");
@@ -216,7 +215,7 @@ public class Tutorial06_ConcreteTypes_Solution {
                 ValidatedKindHelper.VALIDATED.widen(invalidEmail),
                 User::new));
 
-    assertThat(invalidUser.isInvalid()).isTrue();
+    assertThatValidated(invalidUser).isInvalid();
     // Validated accumulates errors (implementation-dependent on how Semigroup works)
   }
 
@@ -246,11 +245,9 @@ public class Tutorial06_ConcreteTypes_Solution {
     Either<String, String> either2 =
         absent.isJust() ? Either.right(absent.get()) : Either.left("Not found");
 
-    assertThat(either1.isRight()).isTrue();
-    assertThat(either1.getRight()).isEqualTo("value");
+    assertThatEither(either1).isRight().hasRight("value");
 
-    assertThat(either2.isLeft()).isTrue();
-    assertThat(either2.getLeft()).isEqualTo("Not found");
+    assertThatEither(either2).isLeft().hasLeft("Not found");
   }
 
   /**
@@ -280,8 +277,8 @@ public class Tutorial06_ConcreteTypes_Solution {
               }
             };
 
-    assertThat(safeDivideEither.apply(10).apply(2).getRight()).isEqualTo(5);
-    assertThat(safeDivideEither.apply(10).apply(0).getLeft()).isEqualTo("Division by zero");
+    assertThatEither(safeDivideEither.apply(10).apply(2)).hasRight(5);
+    assertThatEither(safeDivideEither.apply(10).apply(0)).hasLeft("Division by zero");
 
     // Option 2: Use Maybe if you don't need an error message
     Function<Integer, Function<Integer, Maybe<Integer>>> safeDivideMaybe =
@@ -295,8 +292,8 @@ public class Tutorial06_ConcreteTypes_Solution {
               }
             };
 
-    assertThat(safeDivideMaybe.apply(10).apply(2).get()).isEqualTo(5);
-    assertThat(safeDivideMaybe.apply(10).apply(0).isNothing()).isTrue();
+    assertThatMaybe(safeDivideMaybe.apply(10).apply(2)).hasValue(5);
+    assertThatMaybe(safeDivideMaybe.apply(10).apply(0)).isNothing();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial07_RealWorld_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial07_RealWorld_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.util.List;
 import java.util.function.Function;
@@ -105,8 +106,9 @@ public class Tutorial07_RealWorld_Solution {
                                                         new Registration(
                                                             username, email, password, age)))));
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().username()).isEqualTo("alice");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(reg -> assertThat(reg.username()).isEqualTo("alice"));
   }
 
   /**
@@ -257,16 +259,16 @@ public class Tutorial07_RealWorld_Solution {
         maybeUser.isJust() ? Either.right(maybeUser.get()) : Either.left("User not found");
     Either<String, User> result = eitherUser.flatMap(validateUser);
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().name()).isEqualTo("Alice");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(user -> assertThat(user.name()).isEqualTo("Alice"));
 
     // Solution: Handle missing user by providing a user ID that doesn't exist
     Maybe<User> maybeMissing = findUser.apply("user999");
     Either<String, User> missing =
         maybeMissing.isJust() ? Either.right(maybeMissing.get()) : Either.left("User not found");
 
-    assertThat(missing.isLeft()).isTrue();
-    assertThat(missing.getLeft()).isEqualTo("User not found");
+    assertThatEither(missing).isLeft().hasLeft("User not found");
   }
 
   /**
@@ -365,10 +367,13 @@ public class Tutorial07_RealWorld_Solution {
     Either<String, ProcessedOrder> result =
         validateOrder.apply(order).map(o -> processOrder.apply(config).apply(o));
 
-    assertThat(result.isRight()).isTrue();
-    ProcessedOrder processed = result.getRight();
-    assertThat(processed.subtotal()).isEqualTo(100.0);
-    assertThat(processed.total()).isEqualTo(118.0); // 100 + 8 (tax) + 10 (shipping)
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            processed -> {
+              assertThat(processed.subtotal()).isEqualTo(100.0);
+              assertThat(processed.total()).isEqualTo(118.0); // 100 + 8 (tax) + 10 (shipping)
+            });
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial08_NaturalTransformation_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial08_NaturalTransformation_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.either.EitherKindHelper.EITHER;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
@@ -102,12 +103,12 @@ public class Tutorial08_NaturalTransformation_Solution {
     // Test with Right
     Kind<EitherKind.Witness<String>, Integer> right = EITHER.widen(Either.right(42));
     Kind<MaybeKind.Witness, Integer> maybeFromRight = eitherToMaybe.apply(right);
-    assertThat(MAYBE.narrow(maybeFromRight)).isEqualTo(Maybe.just(42));
+    assertThatMaybe(MAYBE.narrow(maybeFromRight)).hasValue(42);
 
     // Test with Left
     Kind<EitherKind.Witness<String>, Integer> left = EITHER.widen(Either.left("error"));
     Kind<MaybeKind.Witness, Integer> maybeFromLeft = eitherToMaybe.apply(left);
-    assertThat(MAYBE.narrow(maybeFromLeft)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(maybeFromLeft)).isNothing();
   }
 
   /**
@@ -139,12 +140,12 @@ public class Tutorial08_NaturalTransformation_Solution {
     // Test with non-empty list
     Kind<ListKind.Witness, String> nonEmpty = LIST.widen(List.of("first", "second"));
     Kind<MaybeKind.Witness, String> headNonEmpty = listHead.apply(nonEmpty);
-    assertThat(MAYBE.narrow(headNonEmpty)).isEqualTo(Maybe.just("first"));
+    assertThatMaybe(MAYBE.narrow(headNonEmpty)).hasValue("first");
 
     // Test with empty list
     Kind<ListKind.Witness, String> empty = LIST.widen(List.of());
     Kind<MaybeKind.Witness, String> headEmpty = listHead.apply(empty);
-    assertThat(MAYBE.narrow(headEmpty)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(headEmpty)).isNothing();
   }
 
   /**
@@ -186,12 +187,12 @@ public class Tutorial08_NaturalTransformation_Solution {
     // Test: Just(x) -> [x] -> Just(x)
     Kind<MaybeKind.Witness, String> justValue = MAYBE.widen(Maybe.just("test"));
     Kind<MaybeKind.Witness, String> result = composed.apply(justValue);
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.just("test"));
+    assertThatMaybe(MAYBE.narrow(result)).hasValue("test");
 
     // Test: Nothing -> [] -> Nothing
     Kind<MaybeKind.Witness, String> nothing = MAYBE.widen(Maybe.nothing());
     Kind<MaybeKind.Witness, String> resultNothing = composed.apply(nothing);
-    assertThat(MAYBE.narrow(resultNothing)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(resultNothing)).isNothing();
   }
 
   /**
@@ -217,7 +218,7 @@ public class Tutorial08_NaturalTransformation_Solution {
     Kind<MaybeKind.Witness, Integer> afterIdentity = identity.apply(original);
 
     // Should be unchanged
-    assertThat(MAYBE.narrow(afterIdentity)).isEqualTo(Maybe.just(42));
+    assertThatMaybe(MAYBE.narrow(afterIdentity)).hasValue(42);
 
     // Should be the same reference
     assertThat(afterIdentity).isSameAs(original);

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial09_Coyoneda_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial09_Coyoneda_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
@@ -61,7 +62,7 @@ public class Tutorial09_Coyoneda_Solution {
     MaybeFunctor functor = MaybeFunctor.INSTANCE;
     Kind<MaybeKind.Witness, Integer> lowered = coyo.lower(functor);
 
-    assertThat(MAYBE.narrow(lowered)).isEqualTo(Maybe.just(42));
+    assertThatMaybe(MAYBE.narrow(lowered)).hasValue(42);
   }
 
   /**
@@ -90,7 +91,7 @@ public class Tutorial09_Coyoneda_Solution {
     MaybeFunctor functor = MaybeFunctor.INSTANCE;
     Kind<MaybeKind.Witness, String> result = upper.lower(functor);
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.just("HELLO"));
+    assertThatMaybe(MAYBE.narrow(result)).hasValue("HELLO");
   }
 
   /**
@@ -146,7 +147,7 @@ public class Tutorial09_Coyoneda_Solution {
     Kind<MaybeKind.Witness, Integer> result = coyo.lower(functor);
 
     // Should still be Nothing
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/TutorialCapstone_OneLineSixLayersGrowsUp_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/TutorialCapstone_OneLineSixLayersGrowsUp_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.coretypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import java.time.Duration;
 import java.util.List;
@@ -108,8 +109,9 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp_Solution {
     EitherPath<OrderError, Order> path = findOrder("ord-1").toEitherPath(OrderError.NOT_FOUND);
 
     Either<OrderError, Order> result = path.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo("ord-1");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.id()).isEqualTo("ord-1"));
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -143,8 +145,10 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp_Solution {
                             .toList(),
                     o));
 
-    Order out = doubled.run().getRight();
-    assertThat(out.items()).extracting(Item::quantity).containsExactly(4, 2);
+    assertThatEither(doubled.run())
+        .isRight()
+        .hasRightSatisfying(
+            out -> assertThat(out.items()).extracting(Item::quantity).containsExactly(4, 2));
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -172,8 +176,9 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp_Solution {
             .via(TutorialCapstone_OneLineSixLayersGrowsUp_Solution::save);
 
     Either<OrderError, Order> result = persisted.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().status()).isEqualTo("RESERVED");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.status()).isEqualTo("RESERVED"));
   }
 
   // ─── Exercise 4 ────────────────────────────────────────────────────────────
@@ -211,9 +216,13 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp_Solution {
             .via(TutorialCapstone_OneLineSixLayersGrowsUp_Solution::save)
             .run();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo(id);
-    assertThat(result.getRight().status()).isEqualTo("RESERVED");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(
+            order -> {
+              assertThat(order.id()).isEqualTo(id);
+              assertThat(order.status()).isEqualTo("RESERVED");
+            });
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -282,8 +291,9 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp_Solution {
             .yield((idIn, found, reserved) -> reserved)
             .run();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().status()).isEqualTo("RESERVED");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.status()).isEqualTo("RESERVED"));
   }
 
   // ─── Exercise 7 ────────────────────────────────────────────────────────────
@@ -310,7 +320,8 @@ public class TutorialCapstone_OneLineSixLayersGrowsUp_Solution {
         findOrder(id).toEitherPath(OrderError.NOT_FOUND).recover(err -> defaultOrder);
 
     Either<OrderError, Order> result = path.run();
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight().id()).isEqualTo("default");
+    assertThatEither(result)
+        .isRight()
+        .hasRightSatisfying(order -> assertThat(order.id()).isEqualTo("default"));
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/effect/Tutorial01_EffectPathBasics_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/effect/Tutorial01_EffectPathBasics_Solution.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.solutions.effect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.function.Function;
 import org.higherkindedj.hkt.effect.EitherPath;
@@ -41,19 +44,19 @@ public class Tutorial01_EffectPathBasics_Solution {
   @DisplayName("Exercise 1: build MaybePath with just / nothing / maybe")
   void exercise1_creatingMaybePath() {
     MaybePath<String> present = Path.just("hello");
-    assertThat(present.run().isJust()).isTrue();
+    assertThatMaybe(present.run()).isJust();
     assertThat(present.getOrElse("default")).isEqualTo("hello");
 
     MaybePath<String> absent = Path.nothing();
-    assertThat(absent.run().isNothing()).isTrue();
+    assertThatMaybe(absent.run()).isNothing();
     assertThat(absent.getOrElse("default")).isEqualTo("default");
 
     String nullable = null;
     MaybePath<String> fromNullable = Path.maybe(nullable);
-    assertThat(fromNullable.run().isNothing()).isTrue();
+    assertThatMaybe(fromNullable.run()).isNothing();
 
     MaybePath<String> fromNonNull = Path.maybe("world");
-    assertThat(fromNonNull.run().isJust()).isTrue();
+    assertThatMaybe(fromNonNull.run()).isJust();
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -73,16 +76,14 @@ public class Tutorial01_EffectPathBasics_Solution {
   @DisplayName("Exercise 2: build EitherPath with right / left / either")
   void exercise2_creatingEitherPath() {
     EitherPath<String, Integer> success = Path.right(42);
-    assertThat(success.run().isRight()).isTrue();
-    assertThat(success.run().getRight()).isEqualTo(42);
+    assertThatEither(success.run()).isRight().hasRight(42);
 
     EitherPath<String, Integer> failure = Path.left("Invalid input");
-    assertThat(failure.run().isLeft()).isTrue();
-    assertThat(failure.run().getLeft()).isEqualTo("Invalid input");
+    assertThatEither(failure.run()).isLeft().hasLeft("Invalid input");
 
     Either<String, Integer> either = Either.right(100);
     EitherPath<String, Integer> fromEither = Path.either(either);
-    assertThat(fromEither.run().getRight()).isEqualTo(100);
+    assertThatEither(fromEither.run()).hasRight(100);
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -102,11 +103,11 @@ public class Tutorial01_EffectPathBasics_Solution {
   @DisplayName("Exercise 3: TryPath captures throw; IOPath defers a side effect")
   void exercise3_tryPathAndIOPath() {
     TryPath<Integer> successTry = Path.tryOf(() -> Integer.parseInt("42"));
-    assertThat(successTry.run().isSuccess()).isTrue();
+    assertThatTry(successTry.run()).isSuccess();
     assertThat(successTry.getOrElse(-1)).isEqualTo(42);
 
     TryPath<Integer> failureTry = Path.tryOf(() -> Integer.parseInt("not a number"));
-    assertThat(failureTry.run().isFailure()).isTrue();
+    assertThatTry(failureTry.run()).isFailure();
 
     var counter = new int[] {0};
     IOPath<Integer> ioPath =
@@ -144,14 +145,14 @@ public class Tutorial01_EffectPathBasics_Solution {
     assertThat(upperName.getOrElse("")).isEqualTo("ALICE");
 
     MaybePath<String> absent = Path.<String>nothing().map(String::toUpperCase);
-    assertThat(absent.run().isNothing()).isTrue();
+    assertThatMaybe(absent.run()).isNothing();
 
     EitherPath<String, Integer> success = Path.right(10);
     EitherPath<String, Integer> doubled = success.map(n -> n * 2);
-    assertThat(doubled.run().getRight()).isEqualTo(20);
+    assertThatEither(doubled.run()).hasRight(20);
 
     EitherPath<String, Integer> failure = Path.<String, Integer>left("error").map(n -> n * 2);
-    assertThat(failure.run().getLeft()).isEqualTo("error");
+    assertThatEither(failure.run()).hasLeft("error");
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -190,15 +191,13 @@ public class Tutorial01_EffectPathBasics_Solution {
     EitherPath<String, Double> result =
         input.via(parseNumber).via(validatePositive).via(divideHundredBy);
 
-    assertThat(result.run().isRight()).isTrue();
-    assertThat(result.run().getRight()).isEqualTo(4.0);
+    assertThatEither(result.run()).isRight().hasRight(4.0);
 
     EitherPath<String, String> invalidInput = Path.right("not-a-number");
     EitherPath<String, Double> failedResult =
         invalidInput.via(parseNumber).via(validatePositive).via(divideHundredBy);
 
-    assertThat(failedResult.run().isLeft()).isTrue();
-    assertThat(failedResult.run().getLeft()).isEqualTo("Not a number: not-a-number");
+    assertThatEither(failedResult.run()).isLeft().hasLeft("Not a number: not-a-number");
   }
 
   // ─── Exercise 6 ────────────────────────────────────────────────────────────
@@ -220,21 +219,20 @@ public class Tutorial01_EffectPathBasics_Solution {
     EitherPath<String, Integer> failure = Path.left("Not found");
 
     EitherPath<String, Integer> recovered = failure.recover(err -> -1);
-    assertThat(recovered.run().isRight()).isTrue();
-    assertThat(recovered.run().getRight()).isEqualTo(-1);
+    assertThatEither(recovered.run()).isRight().hasRight(-1);
 
     EitherPath<String, Integer> recoveredWith = failure.recoverWith(err -> Path.right(0));
-    assertThat(recoveredWith.run().getRight()).isEqualTo(0);
+    assertThatEither(recoveredWith.run()).hasRight(0);
 
     EitherPath<String, Integer> primary = Path.left("Primary failed");
     EitherPath<String, Integer> fallback = Path.right(42);
 
     EitherPath<String, Integer> withFallback = primary.orElse(() -> fallback);
-    assertThat(withFallback.run().getRight()).isEqualTo(42);
+    assertThatEither(withFallback.run()).hasRight(42);
 
     EitherPath<String, Integer> stringError = Path.left("error");
     EitherPath<Integer, Integer> intError = stringError.mapError(String::length);
-    assertThat(intError.run().getLeft()).isEqualTo(5);
+    assertThatEither(intError.run()).hasLeft(5);
   }
 
   // ─── Exercise 7 ────────────────────────────────────────────────────────────
@@ -266,13 +264,13 @@ public class Tutorial01_EffectPathBasics_Solution {
 
     MaybePath<String> absentName = Path.nothing();
     MaybePath<User> partialUser = absentName.zipWith(agePath, User::new);
-    assertThat(partialUser.run().isNothing()).isTrue();
+    assertThatMaybe(partialUser.run()).isNothing();
 
     EitherPath<String, String> firstName = Path.right("Alice");
     EitherPath<String, String> lastName = Path.right("Smith");
 
     EitherPath<String, String> fullName = firstName.zipWith(lastName, (f, l) -> f + " " + l);
-    assertThat(fullName.run().getRight()).isEqualTo("Alice Smith");
+    assertThatEither(fullName.run()).hasRight("Alice Smith");
   }
 
   // ─── Exercise 8 ────────────────────────────────────────────────────────────
@@ -322,15 +320,16 @@ public class Tutorial01_EffectPathBasics_Solution {
 
     EitherPath<String, String> invalidWorkflow =
         Path.<String, String>right("u2").via(findUser).via(validateEmail).map(User::email);
-    assertThat(invalidWorkflow.run().isLeft()).isTrue();
-    assertThat(invalidWorkflow.run().getLeft()).contains("Email required");
+    assertThatEither(invalidWorkflow.run())
+        .isLeft()
+        .hasLeftSatisfying(error -> assertThat(error).contains("Email required"));
 
     EitherPath<String, String> recoveredWorkflow =
         Path.<String, String>right("u999")
             .via(findUser)
             .recover(err -> new User("default", "Guest", "guest@example.com"))
             .map(User::email);
-    assertThat(recoveredWorkflow.run().getRight()).isEqualTo("guest@example.com");
+    assertThatEither(recoveredWorkflow.run()).hasRight("guest@example.com");
   }
 
   // ─── Diagnostic ────────────────────────────────────────────────────────────
@@ -362,7 +361,6 @@ public class Tutorial01_EffectPathBasics_Solution {
 
     EitherPath<String, Integer> flattened = input.via(parseNumber);
 
-    assertThat(flattened.run().isRight()).isTrue();
-    assertThat(flattened.run().getRight()).isEqualTo(42);
+    assertThatEither(flattened.run()).isRight().hasRight(42);
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/effect/Tutorial02_EffectPathAdvanced_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/effect/Tutorial02_EffectPathAdvanced_Solution.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.solutions.effect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -64,7 +66,7 @@ public class Tutorial02_EffectPathAdvanced_Solution {
             .<Integer>from(a -> Path.nothing())
             .from(t -> Path.just(100))
             .yield((a, b, c) -> a + b + c);
-    assertThat(shortCircuit.run().isNothing()).isTrue();
+    assertThatMaybe(shortCircuit.run()).isNothing();
   }
 
   // ─── Exercise 2 ────────────────────────────────────────────────────────────
@@ -100,23 +102,21 @@ public class Tutorial02_EffectPathAdvanced_Solution {
             .from(parseAge)
             .from(t -> validateRange.apply(t._2()))
             .yield((input, parsed, validated) -> "Valid age: " + validated);
-    assertThat(workflow.run().getRight()).isEqualTo("Valid age: 25");
+    assertThatEither(workflow.run()).hasRight("Valid age: 25");
 
     EitherPath<String, String> invalid =
         ForPath.from(Path.<String, String>right("abc"))
             .from(parseAge)
             .from(t -> validateRange.apply(t._2()))
             .yield((input, parsed, validated) -> "Valid age: " + validated);
-    assertThat(invalid.run().isLeft()).isTrue();
-    assertThat(invalid.run().getLeft()).isEqualTo("Invalid age format");
+    assertThatEither(invalid.run()).isLeft().hasLeft("Invalid age format");
 
     EitherPath<String, String> outOfRange =
         ForPath.from(Path.<String, String>right("200"))
             .from(parseAge)
             .from(t -> validateRange.apply(t._2()))
             .yield((input, parsed, validated) -> "Valid age: " + validated);
-    assertThat(outOfRange.run().isLeft()).isTrue();
-    assertThat(outOfRange.run().getLeft()).isEqualTo("Age out of range");
+    assertThatEither(outOfRange.run()).isLeft().hasLeft("Age out of range");
   }
 
   // ─── Exercise 3 ────────────────────────────────────────────────────────────
@@ -141,10 +141,10 @@ public class Tutorial02_EffectPathAdvanced_Solution {
     ErrorContext<?, String, Integer> failure = ErrorContext.failure("Something went wrong");
 
     Either<String, Integer> successResult = success.runIO().unsafeRun();
-    assertThat(successResult.getRight()).isEqualTo(42);
+    assertThatEither(successResult).hasRight(42);
 
     Either<String, Integer> failureResult = failure.runIO().unsafeRun();
-    assertThat(failureResult.getLeft()).isEqualTo("Something went wrong");
+    assertThatEither(failureResult).hasLeft("Something went wrong");
 
     ErrorContext<?, String, String> workflow =
         ErrorContext.<String, Integer>success(10)
@@ -152,10 +152,10 @@ public class Tutorial02_EffectPathAdvanced_Solution {
             .map(String::toUpperCase);
 
     Either<String, String> workflowResult = workflow.runIO().unsafeRun();
-    assertThat(workflowResult.getRight()).isEqualTo("BIG: 10");
+    assertThatEither(workflowResult).hasRight("BIG: 10");
 
     Either<String, Integer> recovered = failure.recover(err -> -1).runIO().unsafeRun();
-    assertThat(recovered.getRight()).isEqualTo(-1);
+    assertThatEither(recovered).hasRight(-1);
   }
 
   // ─── Exercise 4 ────────────────────────────────────────────────────────────
@@ -288,7 +288,7 @@ public class Tutorial02_EffectPathAdvanced_Solution {
 
     EitherPath<String, String> createResult =
         createUserPath.apply("Bob").map(User::name).map(name -> "Created: " + name);
-    assertThat(createResult.run().getRight()).isEqualTo("Created: Bob");
+    assertThatEither(createResult.run()).hasRight("Created: Bob");
   }
 
   // ─── Exercise 7 ────────────────────────────────────────────────────────────
@@ -322,12 +322,11 @@ public class Tutorial02_EffectPathAdvanced_Solution {
     EitherPath<String, User> userPath = Path.right(alice);
 
     EitherPath<String, String> cityEffectPath = userPath.focus(addressPath).focus(cityPath);
-    assertThat(cityEffectPath.run().getRight()).isEqualTo("London");
+    assertThatEither(cityEffectPath.run()).hasRight("London");
 
     EitherPath<String, User> errorPath = Path.left("User not found");
     EitherPath<String, String> cityFromError = errorPath.focus(addressPath).focus(cityPath);
-    assertThat(cityFromError.run().isLeft()).isTrue();
-    assertThat(cityFromError.run().getLeft()).isEqualTo("User not found");
+    assertThatEither(cityFromError.run()).isLeft().hasLeft("User not found");
 
     MaybePath<String> complexResult =
         ForPath.from(Path.just(alice))
@@ -362,7 +361,6 @@ public class Tutorial02_EffectPathAdvanced_Solution {
             .runIO()
             .unsafeRun();
 
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.getRight()).isEqualTo(20);
+    assertThatEither(result).isRight().hasRight(20);
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial01_ForStateBasics_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial01_ForStateBasics_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
@@ -16,7 +17,6 @@ import org.higherkindedj.hkt.id.Id;
 import org.higherkindedj.hkt.id.IdKind;
 import org.higherkindedj.hkt.id.IdKindHelper;
 import org.higherkindedj.hkt.instances.Instances;
-import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.hkt.maybe.MaybeKind;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.Prism;
@@ -182,8 +182,7 @@ public class Tutorial01_ForStateBasics_Solution {
             .update(processedLens, true)
             .yield();
 
-    assertThat(MAYBE.narrow(result))
-        .isEqualTo(Maybe.just(new OrderContext("ORD-400", true, true, null)));
+    assertThatMaybe(MAYBE.narrow(result)).hasValue(new OrderContext("ORD-400", true, true, null));
   }
 
   // --- Exercise 4b Solution ---
@@ -212,7 +211,7 @@ public class Tutorial01_ForStateBasics_Solution {
             .update(processedLens, true)
             .yield();
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   // --- Exercise 5a Solution ---
@@ -259,8 +258,8 @@ public class Tutorial01_ForStateBasics_Solution {
             .matchThen(matchStatusLens, activeCodePrism, extractedCodeLens)
             .yield();
 
-    assertThat(MAYBE.narrow(result))
-        .isEqualTo(Maybe.just(new MatchContext(new Status.Active("A-001"), "A-001")));
+    assertThatMaybe(MAYBE.narrow(result))
+        .hasValue(new MatchContext(new Status.Active("A-001"), "A-001"));
   }
 
   // --- Exercise 5b Solution ---
@@ -288,7 +287,7 @@ public class Tutorial01_ForStateBasics_Solution {
             .matchThen(matchStatusLens, activeCodePrism, extractedCodeLens)
             .yield();
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   // --- Exercise 6 Solution ---
@@ -407,6 +406,6 @@ public class Tutorial01_ForStateBasics_Solution {
             .fromThen(ctx -> MAYBE.just("CONF-" + ctx.orderId()), confirmationIdLens)
             .yield(ctx -> ctx.orderId() + ":" + ctx.confirmationId());
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.just("ORD-800:CONF-ORD-800"));
+    assertThatMaybe(MAYBE.narrow(result)).hasValue("ORD-800:CONF-ORD-800");
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial02_ForPathParallel_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial02_ForPathParallel_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
 import org.higherkindedj.hkt.effect.EitherPath;
 import org.higherkindedj.hkt.effect.IOPath;
@@ -143,7 +144,7 @@ public class Tutorial02_ForPathParallel_Solution {
         ForPath.par(Path.<String, String>right("Alice"), Path.<String, Integer>right(42))
             .yield((name, age) -> name + " is " + age);
 
-    assertThat(result.run().getRight()).isEqualTo("Alice is 42");
+    assertThatEither(result.run()).hasRight("Alice is 42");
   }
 
   // =========================================================================

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial03_ForTraverseComprehension_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial03_ForTraverseComprehension_Solution.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.solutions.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.list.ListKindHelper.LIST;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
@@ -102,8 +104,9 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(1, 2, 3);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(1, 2, 3));
     }
   }
 
@@ -139,7 +142,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isFalse();
+      assertThatMaybe(maybe).isNothing();
     }
   }
 
@@ -180,8 +183,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
                   });
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("10 -> [20, 22, 24]");
+      assertThatMaybe(maybe).hasValue("10 -> [20, 22, 24]");
     }
   }
 
@@ -221,8 +223,9 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, sequenced) -> LIST.narrow(sequenced));
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(10, 20, 30);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(10, 20, 30));
     }
   }
 
@@ -264,8 +267,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed, total) -> "Total: " + total);
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("Total: 60");
+      assertThatMaybe(maybe).hasValue("Total: 60");
     }
   }
 
@@ -308,8 +310,9 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(10, 20, 30);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(10, 20, 30));
     }
 
     /**
@@ -342,7 +345,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isFalse();
+      assertThatMaybe(maybe).isNothing();
     }
   }
 
@@ -384,8 +387,9 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Maybe<List<Integer>> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(1, 10, 2, 20, 3, 30);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(1, 10, 2, 20, 3, 30));
     }
   }
 
@@ -425,8 +429,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
                   });
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("Original: [a, b, c], Uppercased: [A, B, C]");
+      assertThatMaybe(maybe).hasValue("Original: [a, b, c], Uppercased: [A, B, C]");
     }
   }
 
@@ -462,8 +465,9 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Maybe<List<Integer>> maybe = result.run();
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).containsExactly(2, 4, 6);
+      assertThatMaybe(maybe)
+          .isJust()
+          .hasValueSatisfying(list -> assertThat(list).containsExactly(2, 4, 6));
     }
   }
 
@@ -503,8 +507,9 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Either<String, List<Integer>> either = result.run();
-      assertThat(either.isRight()).isTrue();
-      assertThat(either.getRight()).containsExactly(2, 4, 6);
+      assertThatEither(either)
+          .isRight()
+          .hasRightSatisfying(list -> assertThat(list).containsExactly(2, 4, 6));
     }
 
     /**
@@ -536,7 +541,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
               .yield((original, traversed) -> LIST.narrow(traversed));
 
       Either<String, List<Integer>> either = result.run();
-      assertThat(either.isLeft()).isTrue();
+      assertThatEither(either).isLeft();
     }
   }
 
@@ -591,8 +596,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
                       "Items: " + LIST.narrow(validated).size() + ", Total: " + total);
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isTrue();
-      assertThat(maybe.get()).isEqualTo("Items: 3, Total: 70");
+      assertThatMaybe(maybe).hasValue("Items: 3, Total: 70");
     }
 
     /**
@@ -637,7 +641,7 @@ public class Tutorial03_ForTraverseComprehension_Solution {
                       "Items: " + LIST.narrow(validated).size() + ", Total: " + total);
 
       Maybe<String> maybe = MAYBE.narrow(result);
-      assertThat(maybe.isJust()).isFalse();
+      assertThatMaybe(maybe).isNothing();
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial04_EnhancedOpticsIntegration_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial04_EnhancedOpticsIntegration_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
@@ -142,8 +143,8 @@ public class Tutorial04_EnhancedOpticsIntegration_Solution {
                 e -> e.salaryInCents() > 40000 ? MAYBE.just(e) : MAYBE.nothing())
             .yield();
 
-    assertThat(MAYBE.narrow(validResult)).isEqualTo(Maybe.just(validEmployees));
-    assertThat(MAYBE.narrow(mixedResult)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(validResult)).hasValue(validEmployees);
+    assertThatMaybe(MAYBE.narrow(mixedResult)).isNothing();
   }
 
   // --- Exercise 3 Solution ---
@@ -265,8 +266,8 @@ public class Tutorial04_EnhancedOpticsIntegration_Solution {
             .when(t -> t._2().inner().length() > 3)
             .yield((original, wrapped) -> original);
 
-    assertThat(MAYBE.narrow(passResult)).isEqualTo(Maybe.just("hello"));
-    assertThat(MAYBE.narrow(failResult)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(passResult)).hasValue("hello");
+    assertThatMaybe(MAYBE.narrow(failResult)).isNothing();
   }
 
   // --- Exercise 7 Solution ---
@@ -357,8 +358,8 @@ public class Tutorial04_EnhancedOpticsIntegration_Solution {
             .modifyThrough(Traversals.forList(), salaryLens, s -> s + 5000)
             .yield();
 
-    assertThat(MAYBE.narrow(result))
-        .isEqualTo(Maybe.just(List.of(new Employee("ALICE", 55000), new Employee("BOB", 65000))));
+    assertThatMaybe(MAYBE.narrow(result))
+        .hasValue(List.of(new Employee("ALICE", 55000), new Employee("BOB", 65000)));
   }
 
   // --- Exercise 10 Solution ---
@@ -403,11 +404,14 @@ public class Tutorial04_EnhancedOpticsIntegration_Solution {
             .yield();
 
     Maybe<Department> maybeDept = MAYBE.narrow(result);
-    assertThat(maybeDept.isJust()).isTrue();
-    Department updated = maybeDept.get();
-    assertThat(updated.name()).isEqualTo("Engineering");
-    assertThat(updated.staff())
-        .containsExactly(new Employee("Alice", 80000), new Employee("Bob", 90000));
-    assertThat(updated.budgetInCents()).isEqualTo(550000);
+    assertThatMaybe(maybeDept)
+        .isJust()
+        .hasValueSatisfying(
+            updated -> {
+              assertThat(updated.name()).isEqualTo("Engineering");
+              assertThat(updated.staff())
+                  .containsExactly(new Employee("Alice", 80000), new Employee("Bob", 90000));
+              assertThat(updated.budgetInCents()).isEqualTo(550000);
+            });
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial05_ZoomAndMagnify_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/expression/Tutorial05_ZoomAndMagnify_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.maybe.MaybeKindHelper.MAYBE;
 
@@ -178,7 +179,7 @@ public class Tutorial05_ZoomAndMagnify_Solution {
             .yield();
 
     Maybe<OptionalAddressCustomer> outcome = MAYBE.narrow(result);
-    assertThat(outcome.isJust()).isTrue();
+    assertThatMaybe(outcome).isJust();
     Address updated = outcome.orElse(initial).address().orElseThrow();
     assertThat(updated.street()).isEqualTo("Oak Ave");
   }
@@ -213,7 +214,7 @@ public class Tutorial05_ZoomAndMagnify_Solution {
             .endZoom()
             .yield();
 
-    assertThat(MAYBE.narrow(result)).isEqualTo(Maybe.nothing());
+    assertThatMaybe(MAYBE.narrow(result)).isNothing();
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial09_FluentOpticsAPI_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial09_FluentOpticsAPI_Solution.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.solutions.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
 import java.util.List;
 import java.util.Optional;
@@ -320,8 +323,9 @@ public class Tutorial09_FluentOpticsAPI_Solution {
     // Use OpticOps.modifyEither() to validate and normalise email
     Either<String, User> validResult = OpticOps.modifyEither(user, emailLens, validateEmail);
 
-    assertThat(validResult.isRight()).isTrue();
-    assertThat(validResult.getRight().email()).isEqualTo("alice@example.com");
+    assertThatEither(validResult)
+        .isRight()
+        .hasRightSatisfying(u -> assertThat(u.email()).isEqualTo("alice@example.com"));
 
     // Test with invalid email
     User invalidUser = new User("user2", "notanemail");
@@ -330,8 +334,9 @@ public class Tutorial09_FluentOpticsAPI_Solution {
     Either<String, User> invalidResult =
         OpticOps.modifyEither(invalidUser, emailLens, validateEmail);
 
-    assertThat(invalidResult.isLeft()).isTrue();
-    assertThat(invalidResult.getLeft()).contains("missing @");
+    assertThatEither(invalidResult)
+        .isLeft()
+        .hasLeftSatisfying(error -> assertThat(error).contains("missing @"));
   }
 
   /**
@@ -372,7 +377,7 @@ public class Tutorial09_FluentOpticsAPI_Solution {
     // Use OpticOps.modifyMaybe() to validate age
     Maybe<Person> validResult = OpticOps.modifyMaybe(person, ageLens, validateAge);
 
-    assertThat(validResult.isJust()).isTrue();
+    assertThatMaybe(validResult).isJust();
 
     // Test with invalid age
     Person invalidPerson = new Person("Bob", 200);
@@ -380,7 +385,7 @@ public class Tutorial09_FluentOpticsAPI_Solution {
     // Use OpticOps.modifyMaybe() on invalid age
     Maybe<Person> invalidResult = OpticOps.modifyMaybe(invalidPerson, ageLens, validateAge);
 
-    assertThat(invalidResult.isNothing()).isTrue();
+    assertThatMaybe(invalidResult).isNothing();
   }
 
   /**
@@ -441,7 +446,7 @@ public class Tutorial09_FluentOpticsAPI_Solution {
         OpticOps.modifyAllValidated(order, prices, validatePrice);
 
     // Should be invalid because we have negative and zero prices
-    assertThat(result.isInvalid()).isTrue();
+    assertThatValidated(result).isInvalid();
     // Validated accumulates errors (at least 2 invalid prices)
     List<String> errors = result.fold(errorList -> errorList, valid -> List.of());
     assertThat(errors.size()).isGreaterThanOrEqualTo(1);
@@ -457,7 +462,7 @@ public class Tutorial09_FluentOpticsAPI_Solution {
     Validated<List<String>, Order> validResult =
         OpticOps.modifyAllValidated(validOrder, validPrices, validatePrice);
 
-    assertThat(validResult.isValid()).isTrue();
+    assertThatValidated(validResult).isValid();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial13_AdvancedFocusDSL_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial13_AdvancedFocusDSL_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 
 import java.util.ArrayList;
@@ -136,8 +137,9 @@ public class Tutorial13_AdvancedFocusDSL_Solution {
         keyPath.modifyF(validateAndTransform, config, Instances.monadError(maybe()));
 
     Maybe<Config> maybeConfig = MaybeKindHelper.MAYBE.narrow(result);
-    assertThat(maybeConfig.isJust()).isTrue();
-    assertThat(maybeConfig.get().apiKey()).isEqualTo("ABC123");
+    assertThatMaybe(maybeConfig)
+        .isJust()
+        .hasValueSatisfying(cfg -> assertThat(cfg.apiKey()).isEqualTo("ABC123"));
 
     Config shortKeyConfig = new Config("abc");
     // SOLUTION: Invalid key returns Nothing
@@ -145,7 +147,7 @@ public class Tutorial13_AdvancedFocusDSL_Solution {
         keyPath.modifyF(validateAndTransform, shortKeyConfig, Instances.monadError(maybe()));
 
     Maybe<Config> invalidMaybe = MaybeKindHelper.MAYBE.narrow(invalidResult);
-    assertThat(invalidMaybe.isNothing()).isTrue();
+    assertThatMaybe(invalidMaybe).isNothing();
   }
 
   /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial21_OpticBatching_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial21_OpticBatching_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
 
 import java.util.*;
@@ -245,10 +246,13 @@ public class Tutorial21_OpticBatching_Solution {
       Either<Throwable, Fetch.RunResult<UserId, User>> outcome =
           SafeFetch.runCached(program, failing);
 
-      assertThat(outcome.isLeft()).isTrue();
-      assertThat(outcome.getLeft())
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("unavailable");
+      assertThatEither(outcome)
+          .isLeft()
+          .hasLeftSatisfying(
+              error ->
+                  assertThat(error)
+                      .isInstanceOf(IllegalStateException.class)
+                      .hasMessageContaining("unavailable"));
     }
 
     /**

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial22_OpticBatchingGuardrails_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial22_OpticBatchingGuardrails_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.optics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.optics.fetch.FetchKindHelper.FETCH;
 
 import java.util.ArrayList;
@@ -224,10 +225,13 @@ public class Tutorial22_OpticBatchingGuardrails_Solution {
           SafeFetch.runCachedWithGuard(
               FETCH.narrow(program), doubler(new AtomicInteger()), Guards.maxKeysPerRound(3));
 
-      assertThat(outcome.isLeft()).isTrue();
-      assertThat(outcome.getLeft())
-          .isInstanceOf(GuardViolationException.class)
-          .hasMessageContaining("keysPerRound=5");
+      assertThatEither(outcome)
+          .isLeft()
+          .hasLeftSatisfying(
+              error ->
+                  assertThat(error)
+                      .isInstanceOf(GuardViolationException.class)
+                      .hasMessageContaining("keysPerRound=5"));
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial01_CircuitBreaker_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial01_CircuitBreaker_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.time.Duration;
 import org.higherkindedj.hkt.resilience.CircuitBreaker;
@@ -148,7 +149,7 @@ public class Tutorial01_CircuitBreaker_Solution {
       // SOLUTION: Protect and run against the open circuit
       Try<String> result = breaker.protect(task).runSafe();
 
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
 
       // SOLUTION: Extract the exception using foldFailureFirst
       Throwable error = result.foldFailureFirst(ex -> ex, value -> null);

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial02_Saga_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial02_Saga_Solution.java
@@ -3,6 +3,8 @@
 package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -120,7 +122,7 @@ public class Tutorial02_Saga_Solution {
       // Execute safely - the saga should fail, triggering compensation
       var tryResult = saga.run().runSafe();
 
-      assertThat(tryResult.isFailure()).isTrue();
+      assertThatTry(tryResult).isFailure();
       assertThat(step1Compensated.get()).isTrue();
     }
   }
@@ -179,12 +181,14 @@ public class Tutorial02_Saga_Solution {
       Either<SagaError, String> result = failingSaga.runSafe().run();
 
       // The result should be a Left containing the SagaError
-      assertThat(result.isLeft()).isTrue();
-
-      SagaError error = result.getLeft();
-      assertThat(error.originalError()).isInstanceOf(RuntimeException.class);
-      assertThat(error.originalError().getMessage()).isEqualTo("Network timeout");
-      assertThat(error.allCompensationsSucceeded()).isTrue();
+      assertThatEither(result)
+          .isLeft()
+          .hasLeftSatisfying(
+              error -> {
+                assertThat(error.originalError()).isInstanceOf(RuntimeException.class);
+                assertThat(error.originalError().getMessage()).isEqualTo("Network timeout");
+                assertThat(error.allCompensationsSucceeded()).isTrue();
+              });
     }
   }
 
@@ -224,7 +228,7 @@ public class Tutorial02_Saga_Solution {
 
       Either<SagaError, String> result = orderSaga.runSafe().run();
 
-      assertThat(result.isLeft()).isTrue();
+      assertThatEither(result).isLeft();
       SagaError error = result.getLeft();
       assertThat(error.failedStep()).isEqualTo("schedule-shipping");
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial04_PathResilience_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/resilience/Tutorial04_PathResilience_Solution.java
@@ -3,6 +3,9 @@
 package org.higherkindedj.tutorial.solutions.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
+import static org.higherkindedj.hkt.assertions.TryAssert.assertThatTry;
 
 import java.time.Duration;
 import java.util.List;
@@ -109,8 +112,7 @@ public class Tutorial04_PathResilience_Solution {
       VTaskPath<Either<String, String>> caught = failing.catching(Throwable::getMessage);
 
       Either<String, String> result = caught.unsafeRun();
-      assertThat(result.isLeft()).isTrue();
-      assertThat(result.getLeft()).isEqualTo("Connection refused");
+      assertThatEither(result).isLeft().hasLeft("Connection refused");
     }
 
     /**
@@ -137,7 +139,7 @@ public class Tutorial04_PathResilience_Solution {
       VTaskPath<Maybe<String>> maybePath = failing.asMaybe();
 
       Maybe<String> result = maybePath.unsafeRun();
-      assertThat(result.isNothing()).isTrue();
+      assertThatMaybe(result).isNothing();
     }
 
     /**
@@ -164,7 +166,7 @@ public class Tutorial04_PathResilience_Solution {
       VTaskPath<Try<Integer>> tryPath = failing.asTry();
 
       Try<Integer> result = tryPath.unsafeRun();
-      assertThat(result.isFailure()).isTrue();
+      assertThatTry(result).isFailure();
     }
   }
 
@@ -309,7 +311,7 @@ public class Tutorial04_PathResilience_Solution {
 
       // VTaskContext.run() returns Try<String>
       Try<String> result = ctx.run();
-      assertThat(result.isSuccess()).isTrue();
+      assertThatTry(result).isSuccess();
       assertThat(result.orElse("oops")).isEqualTo("context-result");
     }
   }
@@ -357,7 +359,7 @@ public class Tutorial04_PathResilience_Solution {
               .recover(error -> "RECOVERED")
               .run();
 
-      assertThat(contextResult.isSuccess()).isTrue();
+      assertThatTry(contextResult).isSuccess();
       assertThat(contextResult.orElse("fail")).isEqualTo("CONTEXT-VALUE");
 
       // VStreamPath with error recovery

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial01_WhenPathIsNotEnough_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial01_WhenPathIsNotEnough_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
@@ -96,8 +97,8 @@ public class Tutorial01_WhenPathIsNotEnough_Solution {
           EitherT.fromKind(london);
 
       var report = FUTURE.join(wrapped.value());
-      assertThat(report.isRight()).isTrue();
-      assertThat(report.getRight().city()).isEqualTo("London");
+      assertThatEither(report).isRight();
+      assertThatEither(report).hasRightSatisfying(r -> assertThat(r.city()).isEqualTo("London"));
     }
 
     /**
@@ -119,7 +120,7 @@ public class Tutorial01_WhenPathIsNotEnough_Solution {
           wrapped.value();
 
       var report = FUTURE.join(underlying);
-      assertThat(report.getRight().city()).isEqualTo("Paris");
+      assertThatEither(report).hasRightSatisfying(r -> assertThat(r.city()).isEqualTo("Paris"));
     }
   }
 
@@ -148,7 +149,7 @@ public class Tutorial01_WhenPathIsNotEnough_Solution {
           EitherT.fromEither(futureMonad, validated);
 
       var result = FUTURE.join(lifted.value());
-      assertThat(result.getRight()).isEqualTo("Rome");
+      assertThatEither(result).hasRight("Rome");
     }
 
     /**
@@ -176,9 +177,13 @@ public class Tutorial01_WhenPathIsNotEnough_Solution {
                               report.temperature() < 10 ? "Pack a coat" : "Travel light"));
 
       var result = FUTURE.join(EITHER_T.narrow(workflow).value());
-      assertThat(result.isRight()).isTrue();
-      assertThat(result.getRight().city()).isEqualTo("Berlin");
-      assertThat(result.getRight().advice()).isEqualTo("Travel light");
+      assertThatEither(result).isRight();
+      assertThatEither(result)
+          .hasRightSatisfying(
+              advice -> {
+                assertThat(advice.city()).isEqualTo("Berlin");
+                assertThat(advice.advice()).isEqualTo("Travel light");
+              });
     }
 
     /**
@@ -201,8 +206,9 @@ public class Tutorial01_WhenPathIsNotEnough_Solution {
                   .yield(report -> new TravelAdvice(report.city(), "any advice"));
 
       var result = FUTURE.join(EITHER_T.narrow(workflow).value());
-      assertThat(result.isLeft()).isTrue();
-      assertThat(result.getLeft()).isInstanceOf(WeatherError.CityNotFound.class);
+      assertThatEither(result).isLeft();
+      assertThatEither(result)
+          .hasLeftSatisfying(err -> assertThat(err).isInstanceOf(WeatherError.CityNotFound.class));
     }
   }
 
@@ -239,8 +245,8 @@ public class Tutorial01_WhenPathIsNotEnough_Solution {
 
       var result = FUTURE.join(EITHER_T.narrow(recovered).value());
 
-      assertThat(result.isRight()).isTrue();
-      assertThat(result.getRight().city()).isEqualTo("Unknown");
+      assertThatEither(result).isRight();
+      assertThatEither(result).hasRightSatisfying(r -> assertThat(r.city()).isEqualTo("Unknown"));
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial02_AsyncWithAbsence_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial02_AsyncWithAbsence_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.optional_t.OptionalTKindHelper.OPTIONAL_T;
@@ -204,8 +205,8 @@ public class Tutorial02_AsyncWithAbsence_Solution {
       MaybeT<CompletableFutureKind.Witness, User> wrapped = MaybeT.fromKind(bob);
 
       var result = FUTURE.join(wrapped.value());
-      assertThat(result.isJust()).isTrue();
-      assertThat(result.get().name()).isEqualTo("Bob");
+      assertThatMaybe(result).isJust();
+      assertThatMaybe(result).hasValueSatisfying(u -> assertThat(u.name()).isEqualTo("Bob"));
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial03_StackingTransformers_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/transformers/Tutorial03_StackingTransformers_Solution.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.solutions.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
@@ -83,7 +84,7 @@ public class Tutorial03_StackingTransformers_Solution {
 
       Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(wrapped.value());
       assertThat(outer).isPresent();
-      assertThat(outer.get().getRight()).isEqualTo(42);
+      assertThatEither(outer.get()).hasRight(42);
     }
 
     /**
@@ -139,7 +140,7 @@ public class Tutorial03_StackingTransformers_Solution {
               .yield((a, b) -> a + b);
 
       Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(sum).value());
-      assertThat(outer.get().getRight()).isEqualTo(42);
+      assertThatEither(outer.get()).hasRight(42);
     }
 
     /**
@@ -167,8 +168,9 @@ public class Tutorial03_StackingTransformers_Solution {
 
       Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(result).value());
       assertThat(outer).isPresent();
-      assertThat(outer.get().isLeft()).isTrue();
-      assertThat(outer.get().getLeft()).isInstanceOf(AppError.InvalidInput.class);
+      assertThatEither(outer.get()).isLeft();
+      assertThatEither(outer.get())
+          .hasLeftSatisfying(err -> assertThat(err).isInstanceOf(AppError.InvalidInput.class));
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial01_WhenPathIsNotEnough.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial01_WhenPathIsNotEnough.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
@@ -147,8 +148,8 @@ public class Tutorial01_WhenPathIsNotEnough {
           answerRequired();
 
       var report = FUTURE.join(wrapped.value());
-      assertThat(report.isRight()).isTrue();
-      assertThat(report.getRight().city()).isEqualTo("London");
+      assertThatEither(report).isRight();
+      assertThatEither(report).hasRightSatisfying(r -> assertThat(r.city()).isEqualTo("London"));
     }
 
     /**
@@ -170,7 +171,7 @@ public class Tutorial01_WhenPathIsNotEnough {
           answerRequired();
 
       var report = FUTURE.join(underlying);
-      assertThat(report.getRight().city()).isEqualTo("Paris");
+      assertThatEither(report).hasRightSatisfying(r -> assertThat(r.city()).isEqualTo("Paris"));
     }
   }
 
@@ -200,7 +201,7 @@ public class Tutorial01_WhenPathIsNotEnough {
       EitherT<CompletableFutureKind.Witness, WeatherError, String> lifted = answerRequired();
 
       var result = FUTURE.join(lifted.value());
-      assertThat(result.getRight()).isEqualTo("Rome");
+      assertThatEither(result).hasRight("Rome");
     }
 
     /**
@@ -225,9 +226,13 @@ public class Tutorial01_WhenPathIsNotEnough {
           workflow = answerRequired();
 
       var result = FUTURE.join(EITHER_T.narrow(workflow).value());
-      assertThat(result.isRight()).isTrue();
-      assertThat(result.getRight().city()).isEqualTo("Berlin");
-      assertThat(result.getRight().advice()).isEqualTo("Travel light");
+      assertThatEither(result).isRight();
+      assertThatEither(result)
+          .hasRightSatisfying(
+              advice -> {
+                assertThat(advice.city()).isEqualTo("Berlin");
+                assertThat(advice.advice()).isEqualTo("Travel light");
+              });
     }
 
     /**
@@ -250,8 +255,9 @@ public class Tutorial01_WhenPathIsNotEnough {
           workflow = answerRequired();
 
       var result = FUTURE.join(EITHER_T.narrow(workflow).value());
-      assertThat(result.isLeft()).isTrue();
-      assertThat(result.getLeft()).isInstanceOf(WeatherError.CityNotFound.class);
+      assertThatEither(result).isLeft();
+      assertThatEither(result)
+          .hasLeftSatisfying(err -> assertThat(err).isInstanceOf(WeatherError.CityNotFound.class));
     }
   }
 
@@ -292,8 +298,8 @@ public class Tutorial01_WhenPathIsNotEnough {
 
       var result = FUTURE.join(EITHER_T.narrow(recovered).value());
 
-      assertThat(result.isRight()).isTrue();
-      assertThat(result.getRight().city()).isEqualTo("Unknown");
+      assertThatEither(result).isRight();
+      assertThatEither(result).hasRightSatisfying(r -> assertThat(r.city()).isEqualTo("Unknown"));
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial02_AsyncWithAbsence.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial02_AsyncWithAbsence.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.MaybeAssert.assertThatMaybe;
 import static org.higherkindedj.hkt.future.CompletableFutureKindHelper.FUTURE;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.optional_t.OptionalTKindHelper.OPTIONAL_T;
@@ -250,8 +251,8 @@ public class Tutorial02_AsyncWithAbsence {
       MaybeT<CompletableFutureKind.Witness, User> wrapped = answerRequired();
 
       var result = FUTURE.join(wrapped.value());
-      assertThat(result.isJust()).isTrue();
-      assertThat(result.get().name()).isEqualTo("Bob");
+      assertThatMaybe(result).isJust();
+      assertThatMaybe(result).hasValueSatisfying(u -> assertThat(u.name()).isEqualTo("Bob"));
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial03_StackingTransformers.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/transformers/Tutorial03_StackingTransformers.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.tutorial.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 import static org.higherkindedj.hkt.either_t.EitherTKindHelper.EITHER_T;
 import static org.higherkindedj.hkt.instances.Witnesses.*;
 import static org.higherkindedj.hkt.optional.OptionalKindHelper.OPTIONAL;
@@ -134,7 +135,7 @@ public class Tutorial03_StackingTransformers {
 
       Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(wrapped.value());
       assertThat(outer).isPresent();
-      assertThat(outer.get().getRight()).isEqualTo(42);
+      assertThatEither(outer.get()).hasRight(42);
     }
 
     /**
@@ -188,7 +189,7 @@ public class Tutorial03_StackingTransformers {
       Kind<EitherTKind.Witness<OptionalKind.Witness, AppError>, Integer> sum = answerRequired();
 
       Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(sum).value());
-      assertThat(outer.get().getRight()).isEqualTo(42);
+      assertThatEither(outer.get()).hasRight(42);
     }
 
     /**
@@ -213,8 +214,9 @@ public class Tutorial03_StackingTransformers {
 
       Optional<Either<AppError, Integer>> outer = OPTIONAL.narrow(EITHER_T.narrow(result).value());
       assertThat(outer).isPresent();
-      assertThat(outer.get().isLeft()).isTrue();
-      assertThat(outer.get().getLeft()).isInstanceOf(AppError.InvalidInput.class);
+      assertThatEither(outer.get()).isLeft();
+      assertThatEither(outer.get())
+          .hasLeftSatisfying(err -> assertThat(err).isInstanceOf(AppError.InvalidInput.class));
     }
   }
 


### PR DESCRIPTION
Review-driven correctness and integration work on the `example.order` and `example.market` showcases, a module-wide test modernisation, and the matching book/doc updates. **Example- and documentation-only; no library API change.** All 630 `hkj-examples` tests pass; spotless clean.

## Correctness fixes (each with tests)
- **Inventory reservation is atomic** with a floor and all-or-nothing rollback — no oversell or negative stock; expired holds are reclaimed.
- **Partial fulfilment** splits each line into a ship-now and a back-order quantity, so a partially-available line ships and is charged for its available units and back-orders only the shortage (the previous two-bucket partition lost money on both sides).
- **`ConfigurableOrderWorkflow`** retries only the idempotent pre-flight and runs the non-idempotent payment exactly once — closing the latent double-charge hazard of wrapping the whole workflow in retry.
- **Market pipeline** routes enrichment through a typed `MarketError` channel (a lookup miss is a value, not a thrown exception) and wires `FeedResilience` + `VStreamThrottle` into the live feed, with `parEvalMap` keeping ticks in arrival order before windowing.

## Integration with current HKJ functionality
- **`EnhancedOrderWorkflow`** protects its idempotent customer lookup with the library `CircuitBreaker` + `RetryPolicy` (`withCircuitBreaker`/`withRetry`).
- **`OrderWorkflow`** promotes `ProcessingState` to a top-level `@GenerateLenses` record — driving the `ForState` enrich phase with the generated `ProcessingStateLenses` (deleting ~110 lines of hand-written `Lens.of`) and routing read steps through the generated `*ServicePaths` bridges.
- **Accumulating validation front door** (`ValidationPath.zipWithAccum`) that reports every malformed field at once, then hands off to the fail-fast pipeline.
- `WorkflowConfig` docs reconciled to constructor injection.

## Tests
- `hkj-examples` now depends on `:hkj-test`; the order/market/payment tests and the tutorial + solution suites use the fluent `assertThatEither` / `assertThatMaybe` / `assertThatTry` / `assertThatVTask` / `assertThatVStream` / … assertions in place of unwrap-then-`assertThat`, which also removes the nullable `getRight()`/`getLeft()` deref warnings.
- New tests cover each correctness fix (inventory atomicity under contention, ship-N/back-order-M money, payment-charged-once, typed enrichment error).

## Docs
- `hkj-book` order and market chapters aligned (generated lenses, the validation front door, per-step resilience, typed-error enrichment).
- `release-history.md` updated; the EitherOrBoth note now also cites the landed PR.

> Future-work proposals (§3.1–§3.5: `ResultTaskPath`, path-native resilience, event-time `VStream` windows, typed-error ergonomics, typestate incremental state) are captured as draft issues under the gitignored `docs/plans/` working notes — intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)