### PR TITLE
Add optic-path labelling: generated paths carry field-name segments

### DIFF
--- a/hkj-book/src/optics/multi_edit.md
+++ b/hkj-book/src/optics/multi_edit.md
@@ -82,7 +82,13 @@ Validated<NonEmptyList<FieldError>, Order> updated =
 // Invalid(NEL[ "email: not an address" ]) — or Valid(order') with only the present fields changed
 ```
 
-Errors accumulate in edit order on the `NonEmptyList` channel, exactly like the [accumulating assembly](../monads/validated_assembly.md) — but as a homogeneous fold, so there is **no arity ceiling**. For the railway, `applyPath(order)` is the `ValidationPath` twin of `apply(order)`, and `toValidated()` exposes the folded `Update` itself for reuse.
+Errors accumulate in edit order on the `NonEmptyList` channel, exactly like the [accumulating assembly](../monads/validated_assembly.md) — but as a homogeneous fold, so there is **no arity ceiling**.
+
+~~~admonish tip title="Generated paths label themselves"
+A path from a `@GenerateFocus` companion carries its record-component name as a **segment** (`OrderFocus.email()` → `"email"`); composing paths concatenates segments (`customer.via(address).via(zip)` → `"customer.address.zip"`, surfaced by `segments()`/`pathString()`), and `parseIfPresent` locates failures with them **automatically** — no `.at(...)` needed for generated paths. An explicit `.at(label)` still prepends outward, for hand-written optics or extra context.
+~~~
+
+For the railway, `applyPath(order)` is the `ValidationPath` twin of `apply(order)`, and `toValidated()` exposes the folded `Update` itself for reuse.
 
 ## Semantics: validate everything, then write once
 

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -14,6 +14,10 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ### 0.4.8-SNAPSHOT (Latest)
 
+**Optic-path labelling: generated paths know their own names**
+
+`@GenerateFocus` companions now emit the record-component name as a path segment (`FocusPath.of(lens, "email")`), and every path type surfaces `segments()` and `pathString()` (`"customer.address.zip"`). Composing paths concatenates segments; raw-optic and widening links (`each()`/`some()`/`nullable()`) contribute nothing. `Edit.parseIfPresent` locates parse failures with the path's own segments automatically, so sparse-PATCH errors arrive located with no `.at(...)` ceremony — an explicit `.at(label)` still prepends outward. Purely additive ([#592](https://github.com/higher-kinded-j/higher-kinded-j/issues/592)). See [Multi-Edit and Sparse Updates](optics/multi_edit.md).
+
 **`Edits`: sparse, accumulating multi-edit over optics**
 
 Apply N independent edits at different paths in one reusable operation. `Edits.combine` folds pure edits (`Edit.set`/`modify`/`setIfPresent`/`modifyIfPresent`, over a `FocusPath` or `Setter`) into a single `Update<S>` via `Monoids.update()`; `Edits.accumulate` adds the validated REST-`PATCH` shape — `parseIfPresent(path, raw, parser).at("email")` parses each incoming value independently, reports **every** bad field at once as located `FieldError`s in edit order (the `NonEmptyList` channel, with no arity ceiling), and applies the writes in one left-to-right pass only if everything validated. `…IfPresent` treats `null` as absent (the monoid identity), so sparse DTO fields land one-to-one with no `if` ceremony; a `ValidationPath` twin (`applyPath`) rides the railway. Purely additive ([#582](https://github.com/higher-kinded-j/higher-kinded-j/issues/582)). See [Multi-Edit and Sparse Updates](optics/multi_edit.md).

--- a/hkj-core/src/main/java/org/higherkindedj/optics/edit/Edit.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/edit/Edit.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.edit;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -276,7 +277,7 @@ public sealed interface Edit<S> extends FallibleEdit<S> permits Edit.Infallible 
     }
     Validated<NonEmptyList<FieldError>, A> parsed =
         Objects.requireNonNull(parser.apply(raw), "parser must not return null");
-    return parsedEdit(path::set, parsed);
+    return parsedEdit(path::set, locate(parsed, path.segments()));
   }
 
   /**
@@ -309,6 +310,28 @@ public sealed interface Edit<S> extends FallibleEdit<S> permits Edit.Infallible 
   }
 
   // Shared bodies: the FocusPath and Setter overloads differ only in the write target.
+
+  /**
+   * Locates parse failures with the path's own segments (generated paths carry their record
+   * component name), folding outermost-first segments through {@link FieldError#at}. An explicit
+   * {@link FallibleEdit#at} still prepends outer labels around these.
+   */
+  private static <A> Validated<NonEmptyList<FieldError>, A> locate(
+      Validated<NonEmptyList<FieldError>, A> parsed, List<String> segments) {
+    if (segments.isEmpty()) {
+      return parsed;
+    }
+    return parsed.mapError(
+        errors ->
+            errors.map(
+                error -> {
+                  FieldError located = error;
+                  for (int i = segments.size() - 1; i >= 0; i--) {
+                    located = located.at(segments.get(i));
+                  }
+                  return located;
+                }));
+  }
 
   private static <S> Edit<S> noOp() {
     return new Infallible<>(Update.identity());

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffineFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffineFocusPath.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.focus;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.higherkindedj.optics.Affine;
@@ -20,10 +21,13 @@ import org.jspecify.annotations.NullMarked;
  * @param <A> the focused type
  */
 @NullMarked
-record AffineFocusPath<S, A>(Affine<S, A> affine) implements AffinePath<S, A> {
+record AffineFocusPath<S, A>(Affine<S, A> affine, List<String> segments)
+    implements AffinePath<S, A> {
 
   AffineFocusPath {
     Objects.requireNonNull(affine, "affine must not be null");
+    Objects.requireNonNull(segments, "segments must not be null");
+    segments = List.copyOf(segments);
   }
 
   @Override
@@ -40,27 +44,27 @@ record AffineFocusPath<S, A>(Affine<S, A> affine) implements AffinePath<S, A> {
 
   @Override
   public <B> AffinePath<S, B> via(Lens<A, B> lens) {
-    return new AffineFocusPath<>(affine.andThen(lens));
+    return new AffineFocusPath<>(affine.andThen(lens), segments);
   }
 
   @Override
   public <B> AffinePath<S, B> via(Prism<A, B> prism) {
-    return new AffineFocusPath<>(affine.andThen(prism));
+    return new AffineFocusPath<>(affine.andThen(prism), segments);
   }
 
   @Override
   public <B> AffinePath<S, B> via(Affine<A, B> other) {
-    return new AffineFocusPath<>(affine.andThen(other));
+    return new AffineFocusPath<>(affine.andThen(other), segments);
   }
 
   @Override
   public <B> AffinePath<S, B> via(Iso<A, B> iso) {
-    return new AffineFocusPath<>(affine.andThen(iso));
+    return new AffineFocusPath<>(affine.andThen(iso), segments);
   }
 
   @Override
   public <B> TraversalPath<S, B> via(Traversal<A, B> traversal) {
-    return new TraversalFocusPath<>(affine.andThen(traversal));
+    return new TraversalFocusPath<>(affine.andThen(traversal), segments);
   }
 
   // ===== Conversion =====

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffinePath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/AffinePath.java
@@ -79,6 +79,29 @@ import org.jspecify.annotations.NullMarked;
 public sealed interface AffinePath<S, A> permits AffineFocusPath {
 
   /**
+   * The field-name segments this path carries, outermost first; empty when unlabelled.
+   *
+   * <p>Generated paths carry their record-component name as a segment, and composing paths
+   * concatenates segments ({@code customer.via(address).via(zip)} yields {@code ["customer",
+   * "address", "zip"]}). Composing with a raw optic contributes no segment.
+   *
+   * @return the segments (never null, possibly empty, immutable)
+   */
+  List<String> segments();
+
+  /**
+   * The dot-joined segments, for example {@code "customer.address.zip"}; empty when unlabelled.
+   *
+   * <p>The rendering matches {@link org.higherkindedj.hkt.validated.FieldError#pathString()}, so a
+   * label derived here lines up with located validation errors.
+   *
+   * @return the rendered path
+   */
+  default String pathString() {
+    return String.join(".", segments());
+  }
+
+  /**
    * Extracts the focused value if present.
    *
    * @param source the source structure
@@ -206,7 +229,8 @@ public sealed interface AffinePath<S, A> permits AffineFocusPath {
    * @return an AffinePath focusing on the composed target
    */
   default <B> AffinePath<S, B> via(FocusPath<A, B> other) {
-    return via(other.toLens());
+    return new AffineFocusPath<>(
+        toAffine().andThen(other.toLens()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -220,7 +244,8 @@ public sealed interface AffinePath<S, A> permits AffineFocusPath {
    * @return an AffinePath that may or may not focus on a value
    */
   default <B> AffinePath<S, B> via(AffinePath<A, B> other) {
-    return via(other.toAffine());
+    return new AffineFocusPath<>(
+        toAffine().andThen(other.toAffine()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -234,7 +259,8 @@ public sealed interface AffinePath<S, A> permits AffineFocusPath {
    * @return a TraversalPath focusing on multiple elements
    */
   default <B> TraversalPath<S, B> via(TraversalPath<A, B> other) {
-    return via(other.toTraversal());
+    return new TraversalFocusPath<>(
+        toAffine().andThen(other.toTraversal()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -833,7 +859,7 @@ public sealed interface AffinePath<S, A> permits AffineFocusPath {
    * @return a new AffinePath
    */
   static <S, A> AffinePath<S, A> of(Affine<S, A> affine) {
-    return new AffineFocusPath<>(affine);
+    return new AffineFocusPath<>(affine, List.of());
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/FocusPath.java
@@ -73,6 +73,29 @@ import org.jspecify.annotations.NullMarked;
 public sealed interface FocusPath<S, A> permits LensFocusPath {
 
   /**
+   * The field-name segments this path carries, outermost first; empty when unlabelled.
+   *
+   * <p>Generated paths carry their record-component name as a segment, and composing paths
+   * concatenates segments ({@code customer.via(address).via(zip)} yields {@code ["customer",
+   * "address", "zip"]}). Composing with a raw optic contributes no segment.
+   *
+   * @return the segments (never null, possibly empty, immutable)
+   */
+  List<String> segments();
+
+  /**
+   * The dot-joined segments, for example {@code "customer.address.zip"}; empty when unlabelled.
+   *
+   * <p>The rendering matches {@link org.higherkindedj.hkt.validated.FieldError#pathString()}, so a
+   * label derived here lines up with located validation errors.
+   *
+   * @return the rendered path
+   */
+  default String pathString() {
+    return String.join(".", segments());
+  }
+
+  /**
    * Extracts the focused value from the source.
    *
    * <p>This operation always succeeds because a FocusPath guarantees exactly one focused element.
@@ -167,7 +190,8 @@ public sealed interface FocusPath<S, A> permits LensFocusPath {
    * @return a new FocusPath focusing on the composed target
    */
   default <B> FocusPath<S, B> via(FocusPath<A, B> other) {
-    return via(other.toLens());
+    return new LensFocusPath<>(
+        toLens().andThen(other.toLens()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -181,7 +205,8 @@ public sealed interface FocusPath<S, A> permits LensFocusPath {
    * @return an AffinePath that may or may not focus on a value
    */
   default <B> AffinePath<S, B> via(AffinePath<A, B> other) {
-    return via(other.toAffine());
+    return new AffineFocusPath<>(
+        toLens().andThen(other.toAffine()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -195,7 +220,8 @@ public sealed interface FocusPath<S, A> permits LensFocusPath {
    * @return a TraversalPath focusing on multiple elements
    */
   default <B> TraversalPath<S, B> via(TraversalPath<A, B> other) {
-    return via(other.toTraversal());
+    return new TraversalFocusPath<>(
+        toLens().andThen(other.toTraversal()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -934,7 +960,26 @@ public sealed interface FocusPath<S, A> permits LensFocusPath {
    * @return a new FocusPath
    */
   static <S, A> FocusPath<S, A> of(Lens<S, A> lens) {
-    return new LensFocusPath<>(lens);
+    return new LensFocusPath<>(lens, List.of());
+  }
+
+  /**
+   * Creates a FocusPath from a Lens, labelled with one field-name segment.
+   *
+   * <p>This is the form the {@code @GenerateFocus} processor emits: the record-component name
+   * becomes the path's segment, so failures located through this path read {@code "email: ..."}.
+   * Composition concatenates segments; see {@link #segments()}.
+   *
+   * @param lens the lens to wrap; must not be null
+   * @param segment the field-name segment; must not be null
+   * @param <S> the source type
+   * @param <A> the focused type
+   * @return a labelled FocusPath (non-null)
+   * @throws NullPointerException if {@code lens} or {@code segment} is null
+   */
+  static <S, A> FocusPath<S, A> of(Lens<S, A> lens, String segment) {
+    java.util.Objects.requireNonNull(segment, "segment must not be null");
+    return new LensFocusPath<>(lens, List.of(segment));
   }
 
   /**

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/LensFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/LensFocusPath.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.focus;
 
+import java.util.List;
 import java.util.Objects;
 import org.higherkindedj.optics.Affine;
 import org.higherkindedj.optics.Iso;
@@ -19,10 +20,12 @@ import org.jspecify.annotations.NullMarked;
  * @param <A> the focused type
  */
 @NullMarked
-record LensFocusPath<S, A>(Lens<S, A> lens) implements FocusPath<S, A> {
+record LensFocusPath<S, A>(Lens<S, A> lens, List<String> segments) implements FocusPath<S, A> {
 
   LensFocusPath {
     Objects.requireNonNull(lens, "lens must not be null");
+    Objects.requireNonNull(segments, "segments must not be null");
+    segments = List.copyOf(segments);
   }
 
   @Override
@@ -39,27 +42,27 @@ record LensFocusPath<S, A>(Lens<S, A> lens) implements FocusPath<S, A> {
 
   @Override
   public <B> FocusPath<S, B> via(Lens<A, B> other) {
-    return new LensFocusPath<>(lens.andThen(other));
+    return new LensFocusPath<>(lens.andThen(other), segments);
   }
 
   @Override
   public <B> FocusPath<S, B> via(Iso<A, B> iso) {
-    return new LensFocusPath<>(lens.andThen(iso));
+    return new LensFocusPath<>(lens.andThen(iso), segments);
   }
 
   @Override
   public <B> AffinePath<S, B> via(Prism<A, B> prism) {
-    return new AffineFocusPath<>(lens.andThen(prism));
+    return new AffineFocusPath<>(lens.andThen(prism), segments);
   }
 
   @Override
   public <B> AffinePath<S, B> via(Affine<A, B> affine) {
-    return new AffineFocusPath<>(lens.andThen(affine));
+    return new AffineFocusPath<>(lens.andThen(affine), segments);
   }
 
   @Override
   public <B> TraversalPath<S, B> via(Traversal<A, B> traversal) {
-    return new TraversalFocusPath<>(lens.andThen(traversal));
+    return new TraversalFocusPath<>(lens.andThen(traversal), segments);
   }
 
   // ===== Conversion =====

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/Segments.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/Segments.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Package-private helper: concatenation of optic-path segment lists. */
+final class Segments {
+
+  private Segments() {}
+
+  static List<String> concat(List<String> left, List<String> right) {
+    if (left.isEmpty()) {
+      return right;
+    }
+    if (right.isEmpty()) {
+      return left;
+    }
+    List<String> combined = new ArrayList<>(left);
+    combined.addAll(right);
+    return List.copyOf(combined);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TracedTraversalFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TracedTraversalFocusPath.java
@@ -35,6 +35,11 @@ record TracedTraversalFocusPath<S, A>(
   }
 
   @Override
+  public List<String> segments() {
+    return underlying.segments();
+  }
+
+  @Override
   public List<A> getAll(S source) {
     List<A> result = underlying.getAll(source);
     observer.accept(source, result);

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalFocusPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalFocusPath.java
@@ -23,10 +23,13 @@ import org.jspecify.annotations.NullMarked;
  * @param <A> the focused type
  */
 @NullMarked
-record TraversalFocusPath<S, A>(Traversal<S, A> traversal) implements TraversalPath<S, A> {
+record TraversalFocusPath<S, A>(Traversal<S, A> traversal, List<String> segments)
+    implements TraversalPath<S, A> {
 
   TraversalFocusPath {
     Objects.requireNonNull(traversal, "traversal must not be null");
+    Objects.requireNonNull(segments, "segments must not be null");
+    segments = List.copyOf(segments);
   }
 
   @Override
@@ -46,37 +49,37 @@ record TraversalFocusPath<S, A>(Traversal<S, A> traversal) implements TraversalP
 
   @Override
   public TraversalPath<S, A> filter(Predicate<A> predicate) {
-    return new TraversalFocusPath<>(traversal.filtered(predicate));
+    return new TraversalFocusPath<>(traversal.filtered(predicate), segments);
   }
 
   // ===== Composition Methods =====
 
   @Override
   public <B> TraversalPath<S, B> via(Lens<A, B> lens) {
-    return new TraversalFocusPath<>(traversal.andThen(lens));
+    return new TraversalFocusPath<>(traversal.andThen(lens), segments);
   }
 
   @Override
   public <B> TraversalPath<S, B> via(Prism<A, B> prism) {
-    return new TraversalFocusPath<>(traversal.andThen(prism));
+    return new TraversalFocusPath<>(traversal.andThen(prism), segments);
   }
 
   @Override
   public <B> TraversalPath<S, B> via(Affine<A, B> affine) {
     // Traversal >>> Affine requires going through traversal composition
-    return new TraversalFocusPath<>(traversal.andThen(affine.asTraversal()));
+    return new TraversalFocusPath<>(traversal.andThen(affine.asTraversal()), segments);
   }
 
   @Override
   public <B> TraversalPath<S, B> via(Traversal<A, B> other) {
-    return new TraversalFocusPath<>(traversal.andThen(other));
+    return new TraversalFocusPath<>(traversal.andThen(other), segments);
   }
 
   @Override
   public <B> TraversalPath<S, B> via(Iso<A, B> iso) {
     // Compose via lens view of the iso
     Lens<A, B> lensView = Lens.of(iso::get, (a, b) -> iso.reverseGet(b));
-    return new TraversalFocusPath<>(traversal.andThen(lensView));
+    return new TraversalFocusPath<>(traversal.andThen(lensView), segments);
   }
 
   // ===== Conversion =====

--- a/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalPath.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/focus/TraversalPath.java
@@ -84,6 +84,29 @@ import org.jspecify.annotations.NullMarked;
 public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTraversalFocusPath {
 
   /**
+   * The field-name segments this path carries, outermost first; empty when unlabelled.
+   *
+   * <p>Generated paths carry their record-component name as a segment, and composing paths
+   * concatenates segments ({@code customer.via(address).via(zip)} yields {@code ["customer",
+   * "address", "zip"]}). Composing with a raw optic contributes no segment.
+   *
+   * @return the segments (never null, possibly empty, immutable)
+   */
+  List<String> segments();
+
+  /**
+   * The dot-joined segments, for example {@code "customer.address.zip"}; empty when unlabelled.
+   *
+   * <p>The rendering matches {@link org.higherkindedj.hkt.validated.FieldError#pathString()}, so a
+   * label derived here lines up with located validation errors.
+   *
+   * @return the rendered path
+   */
+  default String pathString() {
+    return String.join(".", segments());
+  }
+
+  /**
    * Extracts all focused values from the source.
    *
    * @param source the source structure
@@ -212,7 +235,8 @@ public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTr
    * @return a TraversalPath focusing on the composed targets
    */
   default <B> TraversalPath<S, B> via(FocusPath<A, B> other) {
-    return via(other.toLens());
+    return new TraversalFocusPath<>(
+        toTraversal().andThen(other.toLens()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -226,7 +250,9 @@ public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTr
    * @return a TraversalPath focusing on the composed targets
    */
   default <B> TraversalPath<S, B> via(AffinePath<A, B> other) {
-    return via(other.toAffine().asTraversal());
+    return new TraversalFocusPath<>(
+        toTraversal().andThen(other.toAffine().asTraversal()),
+        Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -241,7 +267,8 @@ public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTr
    * @return a TraversalPath focusing on all nested targets
    */
   default <B> TraversalPath<S, B> via(TraversalPath<A, B> other) {
-    return via(other.toTraversal());
+    return new TraversalFocusPath<>(
+        toTraversal().andThen(other.toTraversal()), Segments.concat(segments(), other.segments()));
   }
 
   /**
@@ -1012,6 +1039,6 @@ public sealed interface TraversalPath<S, A> permits TraversalFocusPath, TracedTr
    * @return a new TraversalPath
    */
   static <S, A> TraversalPath<S, A> of(Traversal<S, A> traversal) {
-    return new TraversalFocusPath<>(traversal);
+    return new TraversalFocusPath<>(traversal, List.of());
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/optics/edit/EditsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/edit/EditsTest.java
@@ -301,6 +301,38 @@ class EditsTest {
     }
 
     @Test
+    @DisplayName("a labelled path auto-locates failures; explicit at prepends around them")
+    void labelledPathAutoLocates() {
+      FocusPath<Order, String> labelled =
+          FocusPath.of(
+              Lens.of(Order::email, (o, e) -> new Order(e, o.sku(), o.quantity())), "email");
+
+      Validated<NonEmptyList<FieldError>, Order> auto =
+          Edits.accumulate(Edit.parseIfPresent(labelled, "nope", EditsTest::parseEmail))
+              .apply(ORDER);
+      assertThatValidated(auto).isInvalid();
+      assertThat(auto.getError().toJavaList()).singleElement().hasToString("email: not an address");
+
+      FocusPath<Order, String> nested =
+          FocusPath.of(Lens.<Order, Order>of(o -> o, (o, n) -> n), "customer").via(labelled);
+      Validated<NonEmptyList<FieldError>, Order> composed =
+          Edits.accumulate(Edit.parseIfPresent(nested, "nope", EditsTest::parseEmail)).apply(ORDER);
+      assertThatValidated(composed).isInvalid();
+      assertThat(composed.getError().toJavaList())
+          .singleElement()
+          .hasToString("customer.email: not an address");
+
+      Validated<NonEmptyList<FieldError>, Order> wrapped =
+          Edits.accumulate(
+                  Edit.parseIfPresent(labelled, "nope", EditsTest::parseEmail).at("account"))
+              .apply(ORDER);
+      assertThatValidated(wrapped).isInvalid();
+      assertThat(wrapped.getError().toJavaList())
+          .singleElement()
+          .hasToString("account.email: not an address");
+    }
+
+    @Test
     @DisplayName("should eagerly reject null arguments and a null-returning parser")
     void shouldRejectNulls() {
       assertThatNullPointerException()

--- a/hkj-core/src/test/java/org/higherkindedj/optics/focus/PathSegmentsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/focus/PathSegmentsTest.java
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.focus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.optics.Lens;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Optic-path segments - labelled paths and composition")
+class PathSegmentsTest {
+
+  record Address(String zip, List<String> lines) {}
+
+  record Customer(
+      String name, Address address, Optional<String> nickname, List<Address> branches) {}
+
+  private static final Lens<Customer, Address> ADDRESS_LENS =
+      Lens.of(Customer::address, (c, a) -> new Customer(c.name(), a, c.nickname(), c.branches()));
+  private static final Lens<Address, String> ZIP_LENS =
+      Lens.of(Address::zip, (a, z) -> new Address(z, a.lines()));
+
+  private static final FocusPath<Customer, Address> ADDRESS = FocusPath.of(ADDRESS_LENS, "address");
+  private static final FocusPath<Address, String> ZIP = FocusPath.of(ZIP_LENS, "zip");
+  private static final AffinePath<Address, String> ZIP_AFFINE = ZIP.nullable();
+  private static final TraversalPath<Address, String> LINES =
+      FocusPath.of(Lens.of(Address::lines, (a, l) -> new Address(a.zip(), l)), "lines").each();
+  private static final AffinePath<Customer, Address> ADDRESS_AFFINE = ADDRESS.nullable();
+  private static final TraversalPath<Customer, Address> BRANCHES =
+      FocusPath.of(
+              Lens.of(
+                  Customer::branches,
+                  (c, b) -> new Customer(c.name(), c.address(), c.nickname(), b)),
+              "branches")
+          .each();
+
+  private static final Customer CUSTOMER =
+      new Customer(
+          "Ada",
+          new Address("EH1", List.of("a", "b")),
+          Optional.of("ace"),
+          List.of(new Address("M1", List.of())));
+
+  @Nested
+  @DisplayName("Leaves and rendering")
+  class Leaves {
+
+    @Test
+    @DisplayName("of(lens) is unlabelled; of(lens, segment) carries one segment")
+    void leafSegments() {
+      assertThat(FocusPath.of(ADDRESS_LENS).segments()).isEmpty();
+      assertThat(FocusPath.of(ADDRESS_LENS).pathString()).isEmpty();
+      assertThat(ADDRESS.segments()).containsExactly("address");
+      assertThat(ADDRESS.pathString()).isEqualTo("address");
+    }
+
+    @Test
+    @DisplayName("of(lens, segment) rejects a null segment")
+    void ofRejectsNullSegment() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> FocusPath.of(ADDRESS_LENS, null))
+          .withMessage("segment must not be null");
+    }
+
+    @Test
+    @DisplayName("pathString joins segments with dots, matching FieldError.pathString")
+    void pathStringJoins() {
+      assertThat(ADDRESS.via(ZIP).pathString()).isEqualTo("address.zip");
+      assertThat(ADDRESS_AFFINE.via(ZIP).pathString()).isEqualTo("address.zip");
+      assertThat(BRANCHES.via(ZIP).pathString()).isEqualTo("branches.zip");
+    }
+  }
+
+  @Nested
+  @DisplayName("Path-with-path composition concatenates segments (3x3 matrix)")
+  class CompositionMatrix {
+
+    @Test
+    @DisplayName("FocusPath via FocusPath / AffinePath / TraversalPath")
+    void focusPathCompositions() {
+      assertThat(ADDRESS.via(ZIP).segments()).containsExactly("address", "zip");
+      assertThat(ADDRESS.via(ZIP_AFFINE).segments()).containsExactly("address", "zip");
+      assertThat(ADDRESS.via(LINES).segments()).containsExactly("address", "lines");
+    }
+
+    @Test
+    @DisplayName("AffinePath via FocusPath / AffinePath / TraversalPath")
+    void affinePathCompositions() {
+      assertThat(ADDRESS_AFFINE.via(ZIP).segments()).containsExactly("address", "zip");
+      assertThat(ADDRESS_AFFINE.via(ZIP_AFFINE).segments()).containsExactly("address", "zip");
+      assertThat(ADDRESS_AFFINE.via(LINES).segments()).containsExactly("address", "lines");
+    }
+
+    @Test
+    @DisplayName("TraversalPath via FocusPath / AffinePath / TraversalPath")
+    void traversalPathCompositions() {
+      assertThat(BRANCHES.via(ZIP).segments()).containsExactly("branches", "zip");
+      assertThat(BRANCHES.via(ZIP_AFFINE).segments()).containsExactly("branches", "zip");
+      assertThat(BRANCHES.via(LINES).segments()).containsExactly("branches", "lines");
+    }
+
+    @Test
+    @DisplayName("then(path) delegates to via(path), concatenating too")
+    void thenDelegates() {
+      assertThat(ADDRESS.then(ZIP).segments()).containsExactly("address", "zip");
+    }
+
+    @Test
+    @DisplayName("unlabelled links contribute nothing on either side")
+    void unlabelledLinks() {
+      FocusPath<Customer, Address> plain = FocusPath.of(ADDRESS_LENS);
+      FocusPath<Address, String> plainZip = FocusPath.of(ZIP_LENS);
+
+      assertThat(plain.via(ZIP).segments()).containsExactly("zip");
+      assertThat(ADDRESS.via(plainZip).segments()).containsExactly("address");
+      assertThat(plain.via(plainZip).segments()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("composed labelled paths still read and write correctly")
+    void composedPathStillWorks() {
+      FocusPath<Customer, String> zip = ADDRESS.via(ZIP);
+
+      assertThat(zip.get(CUSTOMER)).isEqualTo("EH1");
+      assertThat(zip.set("EH2", CUSTOMER).address().zip()).isEqualTo("EH2");
+    }
+  }
+
+  @Nested
+  @DisplayName("Raw-optic links and wrappers preserve segments")
+  class Preservation {
+
+    @Test
+    @DisplayName("composing with a raw optic keeps the left segments unchanged")
+    void rawOpticPreserves() {
+      assertThat(ADDRESS.via(ZIP_LENS).segments()).containsExactly("address");
+    }
+
+    @Test
+    @DisplayName("widening links (some / each / nullable) preserve segments")
+    void wideningPreserves() {
+      FocusPath<Customer, Optional<String>> nickname =
+          FocusPath.of(
+              Lens.of(
+                  Customer::nickname,
+                  (c, n) -> new Customer(c.name(), c.address(), n, c.branches())),
+              "nickname");
+
+      assertThat(nickname.some().segments()).containsExactly("nickname");
+      assertThat(LINES.segments()).containsExactly("lines");
+      assertThat(ZIP_AFFINE.segments()).containsExactly("zip");
+    }
+
+    @Test
+    @DisplayName("a traced traversal delegates segments to its underlying path")
+    void tracedDelegates() {
+      assertThat(BRANCHES.traced((source, focused) -> {}).segments()).containsExactly("branches");
+    }
+
+    @Test
+    @DisplayName("filter keeps the path's own segments")
+    void filterPreserves() {
+      assertThat(BRANCHES.filter(a -> true).segments()).containsExactly("branches");
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/EditsExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/EditsExample.java
@@ -11,6 +11,7 @@ import org.higherkindedj.hkt.Update;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.annotations.GenerateFocus;
 import org.higherkindedj.optics.annotations.GenerateLenses;
 import org.higherkindedj.optics.edit.Edits;
 import org.higherkindedj.optics.focus.FocusPath;
@@ -28,12 +29,14 @@ import org.jspecify.annotations.Nullable;
  *   <li>Sparse updates: {@code …IfPresent} treats {@code null} as absent, contributing the identity
  *       update, so nullable DTO fields land one-to-one with no {@code if} ceremony
  *   <li>{@code Edits.accumulate}: every incoming value validated independently, every bad field
- *       reported at once as located {@code FieldError}s
+ *       reported at once as located {@code FieldError}s - generated paths label failures
+ *       automatically; an explicit {@code .at(label)} still prepends outer context
  *   <li>Reuse: one accumulated patch, validated once, applied to many sources
  * </ul>
  */
 public final class EditsExample {
 
+  @GenerateFocus
   @GenerateLenses
   public record EditOrder(String email, String sku, int quantity) {}
 
@@ -41,10 +44,10 @@ public final class EditsExample {
   public record PatchRequest(
       @Nullable String email, @Nullable String sku, @Nullable Integer qtyDelta) {}
 
-  private static final FocusPath<EditOrder, String> EMAIL = FocusPath.of(EditOrderLenses.email());
-  private static final FocusPath<EditOrder, String> SKU = FocusPath.of(EditOrderLenses.sku());
-  private static final FocusPath<EditOrder, Integer> QUANTITY =
-      FocusPath.of(EditOrderLenses.quantity());
+  // Generated paths carry their component name as a segment, so failures self-locate.
+  private static final FocusPath<EditOrder, String> EMAIL = EditOrderFocus.email();
+  private static final FocusPath<EditOrder, String> SKU = EditOrderFocus.sku();
+  private static final FocusPath<EditOrder, Integer> QUANTITY = EditOrderFocus.quantity();
 
   public static void main(String[] args) {
     demonstratePureMultiEdit();
@@ -119,7 +122,7 @@ public final class EditsExample {
     System.out.println("=== Reusable Patch Example ===");
 
     Edits.Accumulated<EditOrder> renumber =
-        Edits.accumulate(parseIfPresent(SKU, "WH-9 ", EditsExample::parseSku).at("sku"));
+        Edits.accumulate(parseIfPresent(SKU, "WH-9 ", EditsExample::parseSku));
 
     EditOrder first = new EditOrder("a@example.com", "old-1", 1);
     EditOrder second = new EditOrder("b@example.com", "old-2", 2);
@@ -133,9 +136,10 @@ public final class EditsExample {
   /** Applies a sparse PATCH request: absent fields contribute the identity update. */
   private static Validated<NonEmptyList<FieldError>, EditOrder> patch(
       PatchRequest request, EditOrder order) {
+    // No .at(...) needed: the generated paths auto-locate failures ("email: ...", "sku: ...").
     return Edits.accumulate(
-            parseIfPresent(EMAIL, request.email(), EditsExample::parseEmail).at("email"),
-            parseIfPresent(SKU, request.sku(), EditsExample::parseSku).at("sku"),
+            parseIfPresent(EMAIL, request.email(), EditsExample::parseEmail),
+            parseIfPresent(SKU, request.sku(), EditsExample::parseSku),
             modifyIfPresent(QUANTITY, request.qtyDelta(), (delta, qty) -> qty + delta),
             setIfPresent(EMAIL, (String) null)) // a fully absent slot: contributes nothing
         .apply(order);

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial24_MultiEdit.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial24_MultiEdit.java
@@ -34,9 +34,8 @@ import org.junit.jupiter.api.Test;
  *   Validated&lt;NonEmptyList&lt;FieldError&gt;, Profile&gt; patched =
  *       Edits.accumulate(
  *               Edit.setIfPresent(NAME, request.name()),                       // null -&gt; no-op
- *               Edit.parseIfPresent(EMAIL, request.email(), Tutorial24_MultiEdit::parseEmail)
- *                   .at("email"))
- *           .apply(profile);
+ *               Edit.parseIfPresent(EMAIL, request.email(), Tutorial24_MultiEdit::parseEmail))
+ *           .apply(profile);  // labelled paths locate failures automatically
  * </pre>
  *
  * <p>Key concepts:
@@ -73,12 +72,16 @@ public class Tutorial24_MultiEdit {
 
   record Profile(String email, String displayName, int age) {}
 
+  // Labelled paths (a @GenerateFocus companion emits exactly this shape): failures self-locate.
   static final FocusPath<Profile, String> EMAIL =
-      FocusPath.of(Lens.of(Profile::email, (p, e) -> new Profile(e, p.displayName(), p.age())));
+      FocusPath.of(
+          Lens.of(Profile::email, (p, e) -> new Profile(e, p.displayName(), p.age())), "email");
   static final FocusPath<Profile, String> NAME =
-      FocusPath.of(Lens.of(Profile::displayName, (p, n) -> new Profile(p.email(), n, p.age())));
+      FocusPath.of(
+          Lens.of(Profile::displayName, (p, n) -> new Profile(p.email(), n, p.age())), "name");
   static final FocusPath<Profile, Integer> AGE =
-      FocusPath.of(Lens.of(Profile::age, (p, a) -> new Profile(p.email(), p.displayName(), a)));
+      FocusPath.of(
+          Lens.of(Profile::age, (p, a) -> new Profile(p.email(), p.displayName(), a)), "age");
 
   static Validated<NonEmptyList<FieldError>, String> parseEmail(String raw) {
     return raw.contains("@")
@@ -193,7 +196,8 @@ public class Tutorial24_MultiEdit {
      *
      * <pre>
      *   // Hint 1: {@code Edit.parseIfPresent(EMAIL, "  Dan@Example.COM ", Tutorial24_MultiEdit::parseEmail)}.
-     *   // Hint 2: tag it with {@code .at("email")} so failures are located.
+     *   // Hint 2: EMAIL is a labelled path, so failures self-locate as "email: ..." - no .at
+     *   //         needed. (.at("account") would still prepend outer context.)
      *   // Hint 3: {@code Edits.accumulate(...).apply(dan)} returns a Validated.
      * </pre>
      */
@@ -215,8 +219,9 @@ public class Tutorial24_MultiEdit {
      * result reports both failures, in edit order, each located by its label.
      *
      * <pre>
-     *   // Hint 1: {@code parseIfPresent(EMAIL, "nope", ...).at("email")} and
-     *   //         {@code parseIfPresent(AGE, "not-a-number", Tutorial24_MultiEdit::parseAge).at("age")}.
+     *   // Hint 1: {@code parseIfPresent(EMAIL, "nope", ...)} and
+     *   //         {@code parseIfPresent(AGE, "not-a-number", Tutorial24_MultiEdit::parseAge)} -
+     *   //         the labelled paths locate each failure automatically.
      *   // Hint 2: unlike flatMap chaining, accumulate does NOT short-circuit.
      *   // Hint 3: compare with Tutorial 12 - this is the same all-errors-at-once model, for
      *   //         updating instead of constructing.

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial24_MultiEdit_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial24_MultiEdit_Solution.java
@@ -31,12 +31,16 @@ public class Tutorial24_MultiEdit_Solution {
 
   record Profile(String email, String displayName, int age) {}
 
+  // Labelled paths (a @GenerateFocus companion emits exactly this shape): failures self-locate.
   static final FocusPath<Profile, String> EMAIL =
-      FocusPath.of(Lens.of(Profile::email, (p, e) -> new Profile(e, p.displayName(), p.age())));
+      FocusPath.of(
+          Lens.of(Profile::email, (p, e) -> new Profile(e, p.displayName(), p.age())), "email");
   static final FocusPath<Profile, String> NAME =
-      FocusPath.of(Lens.of(Profile::displayName, (p, n) -> new Profile(p.email(), n, p.age())));
+      FocusPath.of(
+          Lens.of(Profile::displayName, (p, n) -> new Profile(p.email(), n, p.age())), "name");
   static final FocusPath<Profile, Integer> AGE =
-      FocusPath.of(Lens.of(Profile::age, (p, a) -> new Profile(p.email(), p.displayName(), a)));
+      FocusPath.of(
+          Lens.of(Profile::age, (p, a) -> new Profile(p.email(), p.displayName(), a)), "age");
 
   static Validated<NonEmptyList<FieldError>, String> parseEmail(String raw) {
     return raw.contains("@")
@@ -125,7 +129,8 @@ public class Tutorial24_MultiEdit_Solution {
 
     /**
      * Why this is idiomatic: the parser stays a plain smart constructor (no path parameter); the
-     * location is attached around it with {@code .at("email")}, mirroring {@code FieldError.at}.
+     * labelled path locates the failure automatically, and {@code .at(label)} remains available to
+     * prepend outer context.
      */
     @Test
     @DisplayName("Exercise 4: a fallible edit parses, then writes")
@@ -135,8 +140,7 @@ public class Tutorial24_MultiEdit_Solution {
       Validated<NonEmptyList<FieldError>, Profile> patched =
           Edits.accumulate(
                   Edit.parseIfPresent(
-                          EMAIL, "  Dan@Example.COM ", Tutorial24_MultiEdit_Solution::parseEmail)
-                      .at("email"))
+                      EMAIL, "  Dan@Example.COM ", Tutorial24_MultiEdit_Solution::parseEmail))
               .apply(dan);
 
       assertThatValidated(patched).isValid().hasValue(new Profile("dan@example.com", "Dan", 52));
@@ -154,10 +158,8 @@ public class Tutorial24_MultiEdit_Solution {
 
       Validated<NonEmptyList<FieldError>, Profile> patched =
           Edits.accumulate(
-                  Edit.parseIfPresent(EMAIL, "nope", Tutorial24_MultiEdit_Solution::parseEmail)
-                      .at("email"),
-                  Edit.parseIfPresent(AGE, "not-a-number", Tutorial24_MultiEdit_Solution::parseAge)
-                      .at("age"))
+                  Edit.parseIfPresent(EMAIL, "nope", Tutorial24_MultiEdit_Solution::parseEmail),
+                  Edit.parseIfPresent(AGE, "not-a-number", Tutorial24_MultiEdit_Solution::parseAge))
               .apply(eve);
 
       assertThatValidated(patched).isInvalid();

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -337,11 +337,12 @@ public class FocusProcessor extends AbstractProcessor {
                         : "source." + c.getSimpleName() + "()")
             .collect(Collectors.joining(", "));
 
-    // Generate code based on path type widening
+    // Generate code based on path type widening. The component name rides along as the path's
+    // field-name segment, so generated paths self-locate (issue #592).
     String baseLens =
         String.format(
-            "$T.of($T.of($T::%s, (source, newValue) -> new $T(%s)))",
-            componentName, constructorArgs);
+            "$T.of($T.of($T::%s, (source, newValue) -> new $T(%s)), \"%s\")",
+            componentName, constructorArgs, componentName);
 
     switch (pathTypeInfo.wideningType) {
       case OPTIONAL ->

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorIntegrationTest.java
@@ -36,13 +36,13 @@ public class FocusProcessorIntegrationTest {
       final String expectedNameFocusPath =
           """
           public static FocusPath<User, String> name() {
-              return FocusPath.of(Lens.of(User::name, (source, newValue) -> new User(newValue, source.age())));
+              return FocusPath.of(Lens.of(User::name, (source, newValue) -> new User(newValue, source.age())), "name");
           }
           """;
       final String expectedAgeFocusPath =
           """
           public static FocusPath<User, Integer> age() {
-              return FocusPath.of(Lens.of(User::age, (source, newValue) -> new User(source.name(), newValue)));
+              return FocusPath.of(Lens.of(User::age, (source, newValue) -> new User(source.name(), newValue)), "age");
           }
           """;
 
@@ -73,7 +73,7 @@ public class FocusProcessorIntegrationTest {
       final String expectedStreetFocusPath =
           """
           public static FocusPath<Address, String> street() {
-              return FocusPath.of(Lens.of(Address::street, (source, newValue) -> new Address(newValue, source.city(), source.postcode())));
+              return FocusPath.of(Lens.of(Address::street, (source, newValue) -> new Address(newValue, source.city(), source.postcode())), "street");
           }
           """;
 
@@ -135,7 +135,7 @@ public class FocusProcessorIntegrationTest {
       final String expectedFirstNameFocusPath =
           """
           public static FocusPath<Person, String> firstName() {
-              return FocusPath.of(Lens.of(Person::firstName, (source, newValue) -> new Person(newValue, source.lastName())));
+              return FocusPath.of(Lens.of(Person::firstName, (source, newValue) -> new Person(newValue, source.lastName())), "firstName");
           }
           """;
 
@@ -169,13 +169,13 @@ public class FocusProcessorIntegrationTest {
       final String expectedValueFocusPath =
           """
           public static <T> FocusPath<Wrapper<T>, T> value() {
-              return FocusPath.of(Lens.of(Wrapper<T>::value, (source, newValue) -> new Wrapper<T>(newValue, source.label())));
+              return FocusPath.of(Lens.of(Wrapper<T>::value, (source, newValue) -> new Wrapper<T>(newValue, source.label())), "value");
           }
           """;
       final String expectedLabelFocusPath =
           """
           public static <T> FocusPath<Wrapper<T>, String> label() {
-              return FocusPath.of(Lens.of(Wrapper<T>::label, (source, newValue) -> new Wrapper<T>(source.value(), newValue)));
+              return FocusPath.of(Lens.of(Wrapper<T>::label, (source, newValue) -> new Wrapper<T>(source.value(), newValue)), "label");
           }
           """;
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNestedContainerTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNestedContainerTest.java
@@ -52,7 +52,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> tags() {
-              return FocusPath.of(Lens.of(Config::tags, (source, newValue) -> new Config(source.name(), newValue))).some().each();
+              return FocusPath.of(Lens.of(Config::tags, (source, newValue) -> new Config(source.name(), newValue)), "tags").some().each();
           }
           """;
 
@@ -81,7 +81,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> items() {
-              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).each().some();
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue)), "items").each().some();
           }
           """;
 
@@ -109,7 +109,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static AffinePath<Config, String> nested() {
-              return FocusPath.of(Lens.of(Config::nested, (source, newValue) -> new Config(source.name(), newValue))).some().some();
+              return FocusPath.of(Lens.of(Config::nested, (source, newValue) -> new Config(source.name(), newValue)), "nested").some().some();
           }
           """;
 
@@ -137,7 +137,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> matrix() {
-              return FocusPath.of(Lens.of(Config::matrix, (source, newValue) -> new Config(source.name(), newValue))).each().each();
+              return FocusPath.of(Lens.of(Config::matrix, (source, newValue) -> new Config(source.name(), newValue)), "matrix").each().each();
           }
           """;
 
@@ -166,7 +166,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> items() {
-              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).each().some();
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue)), "items").each().some();
           }
           """;
 
@@ -202,7 +202,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> deep() {
-              return FocusPath.of(Lens.of(Config::deep, (source, newValue) -> new Config(source.name(), newValue))).some().each().some();
+              return FocusPath.of(Lens.of(Config::deep, (source, newValue) -> new Config(source.name(), newValue)), "deep").some().each().some();
           }
           """;
 
@@ -231,7 +231,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> cube() {
-              return FocusPath.of(Lens.of(Config::cube, (source, newValue) -> new Config(source.name(), newValue))).each().each().each();
+              return FocusPath.of(Lens.of(Config::cube, (source, newValue) -> new Config(source.name(), newValue)), "cube").each().each().each();
           }
           """;
 
@@ -346,7 +346,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static AffinePath<Config, String> email() {
-              return FocusPath.of(Lens.of(Config::email, (source, newValue) -> new Config(source.name(), newValue))).some();
+              return FocusPath.of(Lens.of(Config::email, (source, newValue) -> new Config(source.name(), newValue)), "email").some();
           }
           """;
 
@@ -374,7 +374,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, String> items() {
-              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).each();
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue)), "items").each();
           }
           """;
 
@@ -401,7 +401,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static FocusPath<Config, String> name() {
-              return FocusPath.of(Lens.of(Config::name, (source, newValue) -> new Config(newValue)));
+              return FocusPath.of(Lens.of(Config::name, (source, newValue) -> new Config(newValue)), "name");
           }
           """;
 
@@ -437,7 +437,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static AffinePath<Config, Integer> result() {
-              return FocusPath.of(Lens.of(Config::result, (source, newValue) -> new Config(source.name(), newValue))).<Either<String, Integer>>some().some(Affines.eitherRight());
+              return FocusPath.of(Lens.of(Config::result, (source, newValue) -> new Config(source.name(), newValue)), "result").<Either<String, Integer>>some().some(Affines.eitherRight());
           }
           """;
 
@@ -468,7 +468,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, Integer> results() {
-              return FocusPath.of(Lens.of(Config::results, (source, newValue) -> new Config(source.name(), newValue))).<Either<String, Integer>>each().some(Affines.eitherRight());
+              return FocusPath.of(Lens.of(Config::results, (source, newValue) -> new Config(source.name(), newValue)), "results").<Either<String, Integer>>each().some(Affines.eitherRight());
           }
           """;
 
@@ -503,7 +503,7 @@ public class FocusProcessorNestedContainerTest {
       final String expectedMethod =
           """
           public static TraversalPath<Config, Integer> items() {
-              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue))).some(Affines.eitherRight()).each();
+              return FocusPath.of(Lens.of(Config::items, (source, newValue) -> new Config(source.name(), newValue)), "items").some(Affines.eitherRight()).each();
           }
           """;
 


### PR DESCRIPTION
Closes #592 — the last Phase-2 substrate item. Builds on #581 (`FieldError`) and #582 (`Edits`).

## What

- **Paths self-describe**: `FocusPath`/`AffinePath`/`TraversalPath` gain `segments()` (field-name segments, outermost first; empty = unlabelled) and `pathString()` (`"customer.address.zip"` — same rendering as `FieldError.pathString()`). The package-private impl records carry the segments; no public API break, and there is deliberately **no public type named `Path`** (Effect-Path collision).
- **Composition concatenates**: path-with-path `via`/`then` merges both sides' segments (all nine cross-type cases); raw-optic links and widening steps (`each()`/`some()`/`nullable()`/`at(i)`) contribute nothing; `filter` and `traced` preserve.
- **Codegen emits the name it already reads**: `@GenerateFocus` companions now produce `FocusPath.of(Lens.of(...), "email")` — one template change; widened methods label themselves because they compose from the labelled base.
- **`Edits` auto-locates**: `Edit.parseIfPresent(path, raw, parser)` folds the path's segments through `FieldError.at`, so a failure through a generated path reads `"email: not an address"` with **no explicit `.at(...)`**. An explicit `.at(label)` still prepends outward — auto-labels compose under it.

## Verification

- `:hkj-core:check` + `:hkj-processor:test` + `:hkj-examples:test` — BUILD SUCCESSFUL (ArchUnit, spotless, and the examples module regenerating its Focus companions against the new emission).
- **JaCoCo 100 %** on the `focus` and `edit` packages (a first pass caught two uncovered `pathString` defaults; now covered).
- Tests pin the 3×3 composition matrix, unlabelled-link/widening/traced/filter preservation, rendering, null guards, and the three Edits auto-label shapes (leaf, composed two-segment, explicit-`.at`-over-auto).
- Review gate: a deep correctness pass over the nine rewritten `via` defaults (vs the old delegation), record-equality impact, traced behaviour, the `locate` fold order, and the processor format string — zero findings.

## Deferred (per issue scope)

Sealed `PathSegment` model · index/key segments (`items[3]`) · labels on raw `Lens`/`Setter` · Navigator generator · **the `Edits` overlap debug check** (now feasible since paths have identity — natural follow-up) · hkj-spring 422 rendering (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)