### PR TITLE
Publish optic-law harness in hkj-test

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -14,6 +14,10 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ### 0.4.8-SNAPSHOT (Latest)
 
+**Published optic-law harness: law-test your own optics**
+
+`hkj-test` gains `org.higherkindedj.optics.laws` — `IsoLaws`, `LensLaws`, `PrismLaws`, `AffineLaws`, `TraversalLaws` — flat `assert…` helpers in the established `hkt.laws` style, so every user can verify the defining properties of hand-written optics (`Lens.of(...)`, spec interfaces, codecs). Failures name the violated law with the offending values; guard rails reject vacuous fixtures. Also the published target for the upcoming `ValidatedPrism` laws and `@GenerateMapping`'s law-checked guarantee. Purely additive ([#596](https://github.com/higher-kinded-j/higher-kinded-j/issues/596)). See [Testing With hkj-test](tooling/test_assertions.md).
+
 **Optic-path labelling: generated paths know their own names**
 
 `@GenerateFocus` companions now emit the record-component name as a path segment (`FocusPath.of(lens, "email")`), and every path type surfaces `segments()` and `pathString()` (`"customer.address.zip"`). Composing paths concatenates segments; raw-optic and widening links (`each()`/`some()`/`nullable()`) contribute nothing. `Edit.parseIfPresent` locates parse failures with the path's own segments automatically, so sparse-PATCH errors arrive located with no `.at(...)` ceremony — an explicit `.at(label)` still prepends outward. Purely additive ([#592](https://github.com/higher-kinded-j/higher-kinded-j/issues/592)). See [Multi-Edit and Sparse Updates](optics/multi_edit.md).

--- a/hkj-book/src/tooling/test_assertions.md
+++ b/hkj-book/src/tooling/test_assertions.md
@@ -225,9 +225,32 @@ Coverage is enforced at 100% line and 100% instruction on the `hkj-test` bundle.
 
 ---
 
+## Optic Laws
+
+`org.higherkindedj.optics.laws` publishes law-verification helpers for every optic family — the properties that *define* a lawful `Iso`, `Lens`, `Prism`, `Affine`, or `Traversal` — in the same flat `assert…` style as the `hkt.laws` type-class helpers:
+
+``` java
+import org.higherkindedj.optics.laws.LensLaws;
+import org.higherkindedj.optics.laws.PrismLaws;
+
+@Test
+void nameLensIsLawful() {
+    LensLaws.assertLensLaws(UserLenses.name(), new User("Ada", 36), "Grace", "Alan");
+    // get-set, set-get (both values) and set-set, with counterexample-bearing messages
+}
+
+@Test
+void statusPrismIsLawful() {
+    PrismLaws.assertPrismLaws(ShapePrisms.circle(), new Circle(1.0), new Square(2.0));
+}
+```
+
+Each family also exposes the individual laws (`assertGetSet`, `assertBuildMatch`, `assertSetNoOpWhenAbsent`, …) for targeted checks, and failures name the violated law with the offending values — `"Lens set-get: get(set(Grace, …)) == the value set; got Ada"`. Guard rails reject vacuous fixtures (equal set-set values, non-matching prism sources). Drive broader coverage with `@ParameterizedTest` or property fixtures at the call site.
+
 ~~~admonish tip title="See Also"
 - [Manual Gradle and Maven Setup](manual_setup.md) - Adding hkj-test to projects that do not use the HKJ build plugin
 - [Build Plugins](gradle_plugin.md) - Other test-time tooling
+- [What Are Optics?](../optics/optics_intro.md) - The optic families these laws define
 ~~~
 
 ---

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/AffineLawsTestFactory.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/AffineLawsTestFactory.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import org.higherkindedj.optics.Affine;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.laws.AffineLaws;
 import org.higherkindedj.optics.util.Prisms;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -186,18 +187,7 @@ class AffineLawsTestFactory {
    * <p>Setting a value then getting it returns what was set.
    */
   private <S, A> void testGetSetLaw(AffineTestData<S, A> data) {
-    Affine<S, A> affine = data.affine();
-    S presentValue = data.presentValue();
-    A testValue = data.testValue();
-
-    // Set a value
-    S updated = affine.set(testValue, presentValue);
-
-    // Get it back
-    Optional<A> retrieved = affine.getOptional(updated);
-
-    // Should equal what we set
-    assertThat(retrieved).isPresent().contains(testValue);
+    AffineLaws.assertSetGetWhenPresent(data.affine(), data.presentValue(), data.testValue());
   }
 
   /**
@@ -225,19 +215,8 @@ class AffineLawsTestFactory {
    * <p>Second set wins - setting twice is the same as setting once with the second value.
    */
   private <S, A> void testSetSetLaw(AffineTestData<S, A> data) {
-    Affine<S, A> affine = data.affine();
-    S presentValue = data.presentValue();
-    A testValue = data.testValue();
-    A alternateValue = data.alternateValue();
-
-    // Left side: set(b, set(a, s))
-    S setTwice = affine.set(alternateValue, affine.set(testValue, presentValue));
-
-    // Right side: set(b, s)
-    S setOnce = affine.set(alternateValue, presentValue);
-
-    // Should be equal
-    assertThat(setTwice).isEqualTo(setOnce);
+    AffineLaws.assertSetSetWhenPresent(
+        data.affine(), data.presentValue(), data.testValue(), data.alternateValue());
   }
 
   /**
@@ -264,20 +243,7 @@ class AffineLawsTestFactory {
    * <p>Setting the current value changes nothing.
    */
   private <S, A> void testGetOptionalSetLaw(AffineTestData<S, A> data) {
-    Affine<S, A> affine = data.affine();
-    S presentValue = data.presentValue();
-
-    // Get the current value
-    Optional<A> current = affine.getOptional(presentValue);
-
-    // Only test if value is present
-    if (current.isPresent()) {
-      // Set it back to the same value
-      S result = affine.set(current.get(), presentValue);
-
-      // Should be equal to original
-      assertThat(result).isEqualTo(presentValue);
-    }
+    AffineLaws.assertGetSetWhenPresent(data.affine(), data.presentValue());
   }
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/LensLawsTestFactory.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/LensLawsTestFactory.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.at.AtInstances;
+import org.higherkindedj.optics.laws.LensLaws;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -158,17 +159,7 @@ class LensLawsTestFactory {
    * <p>Setting what you get doesn't change anything.
    */
   private <S, A> void testGetPutLaw(LensTestData<S, A> data) {
-    Lens<S, A> lens = data.lens();
-    S testValue = data.testValue();
-
-    // Get the current value
-    A currentValue = lens.get(testValue);
-
-    // Set it back to the same value
-    S result = lens.set(currentValue, testValue);
-
-    // Should be equal to original
-    assertThat(result).isEqualTo(testValue);
+    LensLaws.assertGetSet(data.lens(), data.testValue());
   }
 
   /**
@@ -195,18 +186,7 @@ class LensLawsTestFactory {
    * <p>Getting what you set returns what you set.
    */
   private <S, A> void testPutGetLaw(LensTestData<S, A> data) {
-    Lens<S, A> lens = data.lens();
-    S testValue = data.testValue();
-    A newValue = data.newValue();
-
-    // Set a new value
-    S updated = lens.set(newValue, testValue);
-
-    // Get it back
-    A retrieved = lens.get(updated);
-
-    // Should equal what we set
-    assertThat(retrieved).isEqualTo(newValue);
+    LensLaws.assertSetGet(data.lens(), data.testValue(), data.newValue());
   }
 
   /**
@@ -233,19 +213,7 @@ class LensLawsTestFactory {
    * <p>Second set wins - setting twice is the same as setting once with the second value.
    */
   private <S, A> void testPutPutLaw(LensTestData<S, A> data) {
-    Lens<S, A> lens = data.lens();
-    S testValue = data.testValue();
-    A newValue = data.newValue();
-    A alternateValue = data.alternateValue();
-
-    // Left side: set(b, set(a, s))
-    S setTwice = lens.set(alternateValue, lens.set(newValue, testValue));
-
-    // Right side: set(b, s)
-    S setOnce = lens.set(alternateValue, testValue);
-
-    // Should be equal
-    assertThat(setTwice).isEqualTo(setOnce);
+    LensLaws.assertSetSet(data.lens(), data.testValue(), data.newValue(), data.alternateValue());
   }
 
   /**

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/PrismLawsTestFactory.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/typeclass/PrismLawsTestFactory.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import org.higherkindedj.hkt.Unit;
 import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.laws.PrismLaws;
 import org.higherkindedj.optics.util.Prisms;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -227,17 +228,7 @@ class PrismLawsTestFactory {
    * <p>Building a value and then extracting it should return the original value.
    */
   private <S, A> void testReviewLaw(PrismTestData<S, A> data) {
-    Prism<S, A> prism = data.prism();
-    A testValue = data.testValue();
-
-    // Build the outer type from the value
-    S built = prism.build(testValue);
-
-    // Extract it back
-    Optional<A> extracted = prism.getOptional(built);
-
-    // Should match the original value
-    assertThat(extracted).isPresent().contains(testValue);
+    PrismLaws.assertBuildMatch(data.prism(), data.testValue());
   }
 
   /**
@@ -287,12 +278,7 @@ class PrismLawsTestFactory {
    * <p>Consistency property: {@code getOptional} should return empty for non-matching cases.
    */
   private <S, A> void testGetOptionalNonMatches(PrismTestData<S, A> data) {
-    Prism<S, A> prism = data.prism();
-    S nonMatchingValue = data.nonMatchingValue();
-
-    Optional<A> extracted = prism.getOptional(nonMatchingValue);
-
-    assertThat(extracted).isEmpty();
+    PrismLaws.assertNoMatch(data.prism(), data.nonMatchingValue());
   }
 
   /**

--- a/hkj-test/src/main/java/module-info.java
+++ b/hkj-test/src/main/java/module-info.java
@@ -22,4 +22,5 @@ module org.higherkindedj.test {
 
   exports org.higherkindedj.hkt.assertions;
   exports org.higherkindedj.hkt.laws;
+  exports org.higherkindedj.optics.laws;
 }

--- a/hkj-test/src/main/java/org/higherkindedj/optics/laws/AffineLaws.java
+++ b/hkj-test/src/main/java/org/higherkindedj/optics/laws/AffineLaws.java
@@ -1,0 +1,101 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.laws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.higherkindedj.optics.Affine;
+
+/**
+ * Law-verification helpers for {@link Affine}: the conditional (zero-or-one) lens laws.
+ *
+ * <p>Flat {@code assert...} helpers in the same style as {@code org.higherkindedj.hkt.laws};
+ * comparison is by {@code equals} — right for records.
+ */
+public final class AffineLaws {
+
+  private AffineLaws() {}
+
+  /** Get-set on a present target: {@code getOptional(s) == Some(a) => set(a, s) == s}. */
+  public static <S, A> void assertGetSetWhenPresent(Affine<S, A> affine, S presentSource) {
+    Optional<A> got = affine.getOptional(presentSource);
+    assertThat(got)
+        .as("Affine get-set needs a PRESENT target; getOptional(%s) was empty", presentSource)
+        .isPresent();
+    S result = affine.set(got.orElseThrow(), presentSource);
+    assertThat(result)
+        .as(
+            "Affine get-set: setting what you got changes nothing for %s; got %s",
+            presentSource, result)
+        .isEqualTo(presentSource);
+  }
+
+  /** Set-get on a present target: {@code getOptional(set(a, s)) == Some(a)}. */
+  public static <S, A> void assertSetGetWhenPresent(Affine<S, A> affine, S presentSource, A a) {
+    assertThat(affine.getOptional(presentSource))
+        .as("Affine set-get needs a PRESENT target; getOptional(%s) was empty", presentSource)
+        .isPresent();
+    Optional<A> got = affine.getOptional(affine.set(a, presentSource));
+    assertThat(got)
+        .as(
+            "Affine set-get: getOptional(set(%s, %s)) == Some(the value set); got %s",
+            a, presentSource, got)
+        .isEqualTo(Optional.of(a));
+  }
+
+  /** Set-set on a present target: the second set wins. */
+  public static <S, A> void assertSetSetWhenPresent(
+      Affine<S, A> affine, S presentSource, A a1, A a2) {
+    assertThat(affine.getOptional(presentSource))
+        .as("Affine set-set needs a PRESENT target; getOptional(%s) was empty", presentSource)
+        .isPresent();
+    S twice = affine.set(a2, affine.set(a1, presentSource));
+    S once = affine.set(a2, presentSource);
+    assertThat(twice)
+        .as(
+            "Affine set-set: set(%s, set(%s, %s)) == set once; got %s vs %s",
+            a2, a1, presentSource, twice, once)
+        .isEqualTo(once);
+  }
+
+  /** Absence is stable: on an absent target, {@code set} is a no-op and the target stays absent. */
+  public static <S, A> void assertSetNoOpWhenAbsent(Affine<S, A> affine, S absentSource, A a) {
+    assertThat(affine.getOptional(absentSource))
+        .as("Affine absence law needs an ABSENT target; getOptional(%s) was present", absentSource)
+        .isEmpty();
+    S result = affine.set(a, absentSource);
+    assertThat(result)
+        .as(
+            "Affine absence: set(%s, %s) on an absent target is a no-op; got %s",
+            a, absentSource, result)
+        .isEqualTo(absentSource);
+  }
+
+  /** All affine laws for one present and one absent fixture, with distinct focus values. */
+  public static <S, A> void assertAffineLaws(
+      Affine<S, A> affine, S presentSource, S absentSource, A a1, A a2) {
+    Optional<A> current = affine.getOptional(presentSource);
+    assertThat(current)
+        .as("assertAffineLaws needs a PRESENT target; getOptional(%s) was empty", presentSource)
+        .isPresent();
+    assertThat(a1)
+        .as(
+            "assertAffineLaws needs focus values distinct from the current focus %s",
+            current.orElseThrow())
+        .isNotEqualTo(current.orElseThrow());
+    assertThat(a2)
+        .as(
+            "assertAffineLaws needs focus values distinct from the current focus %s",
+            current.orElseThrow())
+        .isNotEqualTo(current.orElseThrow());
+    assertThat(a1)
+        .as("assertAffineLaws needs two DISTINCT focus values; both were %s", a1)
+        .isNotEqualTo(a2);
+    assertGetSetWhenPresent(affine, presentSource);
+    assertSetGetWhenPresent(affine, presentSource, a1);
+    assertSetGetWhenPresent(affine, presentSource, a2);
+    assertSetSetWhenPresent(affine, presentSource, a1, a2);
+    assertSetNoOpWhenAbsent(affine, absentSource, a1);
+  }
+}

--- a/hkj-test/src/main/java/org/higherkindedj/optics/laws/IsoLaws.java
+++ b/hkj-test/src/main/java/org/higherkindedj/optics/laws/IsoLaws.java
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.laws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.higherkindedj.optics.Iso;
+
+/**
+ * Law-verification helpers for {@link Iso}: a lawful iso round-trips in both directions.
+ *
+ * <p>Flat {@code assert...} helpers in the same style as {@code org.higherkindedj.hkt.laws}; drive
+ * coverage with {@code @ParameterizedTest} or property fixtures from the call site. Comparison is
+ * by {@code equals} — right for records.
+ */
+public final class IsoLaws {
+
+  private IsoLaws() {}
+
+  /** Round-trip source: {@code reverseGet(get(s)) == s}. */
+  public static <S, A> void assertGetReverseGet(Iso<S, A> iso, S s) {
+    S roundTripped = iso.reverseGet(iso.get(s));
+    assertThat(roundTripped)
+        .as("Iso get-reverseGet: reverseGet(get(%s)) round-trips; got %s", s, roundTripped)
+        .isEqualTo(s);
+  }
+
+  /** Round-trip focus: {@code get(reverseGet(a)) == a}. */
+  public static <S, A> void assertReverseGetGet(Iso<S, A> iso, A a) {
+    A roundTripped = iso.get(iso.reverseGet(a));
+    assertThat(roundTripped)
+        .as("Iso reverseGet-get: get(reverseGet(%s)) round-trips; got %s", a, roundTripped)
+        .isEqualTo(a);
+  }
+
+  /** All iso laws for one fixture. */
+  public static <S, A> void assertIsoLaws(Iso<S, A> iso, S s, A a) {
+    assertGetReverseGet(iso, s);
+    assertReverseGetGet(iso, a);
+  }
+}

--- a/hkj-test/src/main/java/org/higherkindedj/optics/laws/LensLaws.java
+++ b/hkj-test/src/main/java/org/higherkindedj/optics/laws/LensLaws.java
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.laws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.higherkindedj.optics.Lens;
+
+/**
+ * Law-verification helpers for {@link Lens}: get-set, set-get and set-set.
+ *
+ * <p>Flat {@code assert...} helpers in the same style as {@code org.higherkindedj.hkt.laws};
+ * comparison is by {@code equals} — right for records.
+ */
+public final class LensLaws {
+
+  private LensLaws() {}
+
+  /** Get-set: {@code set(get(s), s) == s} — setting what you got changes nothing. */
+  public static <S, A> void assertGetSet(Lens<S, A> lens, S s) {
+    S result = lens.set(lens.get(s), s);
+    assertThat(result)
+        .as("Lens get-set: set(get(s), s) == s for s=%s; got %s", s, result)
+        .isEqualTo(s);
+  }
+
+  /** Set-get: {@code get(set(a, s)) == a} — you get back what you set. */
+  public static <S, A> void assertSetGet(Lens<S, A> lens, S s, A a) {
+    A result = lens.get(lens.set(a, s));
+    assertThat(result)
+        .as("Lens set-get: get(set(%s, %s)) == the value set; got %s", a, s, result)
+        .isEqualTo(a);
+  }
+
+  /** Set-set: {@code set(a2, set(a1, s)) == set(a2, s)} — the second set wins. */
+  public static <S, A> void assertSetSet(Lens<S, A> lens, S s, A a1, A a2) {
+    S twice = lens.set(a2, lens.set(a1, s));
+    S once = lens.set(a2, s);
+    assertThat(twice)
+        .as(
+            "Lens set-set: set(%s, set(%s, %s)) == set(%s, s); got %s vs %s",
+            a2, a1, s, a2, twice, once)
+        .isEqualTo(once);
+  }
+
+  /** All lens laws for one fixture. Guards against vacuous set-set by requiring distinct values. */
+  public static <S, A> void assertLensLaws(Lens<S, A> lens, S s, A a1, A a2) {
+    A current = lens.get(s);
+    assertThat(a1)
+        .as("assertLensLaws needs focus values distinct from the current focus %s", current)
+        .isNotEqualTo(current);
+    assertThat(a2)
+        .as("assertLensLaws needs focus values distinct from the current focus %s", current)
+        .isNotEqualTo(current);
+    assertThat(a1)
+        .as("assertLensLaws needs two DISTINCT focus values; both were %s", a1)
+        .isNotEqualTo(a2);
+    assertGetSet(lens, s);
+    assertSetGet(lens, s, a1);
+    assertSetGet(lens, s, a2);
+    assertSetSet(lens, s, a1, a2);
+  }
+}

--- a/hkj-test/src/main/java/org/higherkindedj/optics/laws/PrismLaws.java
+++ b/hkj-test/src/main/java/org/higherkindedj/optics/laws/PrismLaws.java
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.laws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.higherkindedj.optics.Prism;
+
+/**
+ * Law-verification helpers for {@link Prism}: build-match and the partial match-build round trip.
+ *
+ * <p>Flat {@code assert...} helpers in the same style as {@code org.higherkindedj.hkt.laws};
+ * comparison is by {@code equals} — right for records.
+ */
+public final class PrismLaws {
+
+  private PrismLaws() {}
+
+  /** Build-match: {@code getOptional(build(a)) == Optional.of(a)}. */
+  public static <S, A> void assertBuildMatch(Prism<S, A> prism, A a) {
+    Optional<A> matched = prism.getOptional(prism.build(a));
+    assertThat(matched)
+        .as("Prism build-match: getOptional(build(%s)) == Optional.of(a); got %s", a, matched)
+        .isEqualTo(Optional.of(a));
+  }
+
+  /** Match-build: when {@code getOptional(s)} matches, {@code build} reconstructs {@code s}. */
+  public static <S, A> void assertMatchBuild(Prism<S, A> prism, S matchingSource) {
+    Optional<A> matched = prism.getOptional(matchingSource);
+    assertThat(matched)
+        .as("Prism match-build needs a MATCHING source; getOptional(%s) was empty", matchingSource)
+        .isPresent();
+    S rebuilt = prism.build(matched.orElseThrow());
+    assertThat(rebuilt)
+        .as(
+            "Prism match-build: build(getOptional(%s).get()) reconstructs it; got %s",
+            matchingSource, rebuilt)
+        .isEqualTo(matchingSource);
+  }
+
+  /** Sanity: a non-matching source yields {@code Optional.empty()}. */
+  public static <S, A> void assertNoMatch(Prism<S, A> prism, S nonMatchingSource) {
+    Optional<A> matched = prism.getOptional(nonMatchingSource);
+    assertThat(matched)
+        .as("Prism no-match: getOptional(%s) should be empty; got %s", nonMatchingSource, matched)
+        .isEmpty();
+  }
+
+  /** All prism laws for one fixture (a matching source plus a non-matching source). */
+  public static <S, A> void assertPrismLaws(
+      Prism<S, A> prism, S matchingSource, S nonMatchingSource) {
+    assertThat(matchingSource)
+        .as(
+            "assertPrismLaws needs DISTINCT matching and non-matching sources; both were %s",
+            matchingSource)
+        .isNotEqualTo(nonMatchingSource);
+    Optional<A> matched = prism.getOptional(matchingSource);
+    assertThat(matched)
+        .as("assertPrismLaws needs a MATCHING source; getOptional(%s) was empty", matchingSource)
+        .isPresent();
+    assertBuildMatch(prism, matched.orElseThrow());
+    assertMatchBuild(prism, matchingSource);
+    assertNoMatch(prism, nonMatchingSource);
+  }
+}

--- a/hkj-test/src/main/java/org/higherkindedj/optics/laws/TraversalLaws.java
+++ b/hkj-test/src/main/java/org/higherkindedj/optics/laws/TraversalLaws.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.laws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Function;
+import org.higherkindedj.optics.Traversal;
+import org.higherkindedj.optics.util.Traversals;
+
+/**
+ * Law-verification helpers for {@link Traversal}: identity and fusion (composition).
+ *
+ * <p>Flat {@code assert...} helpers in the same style as {@code org.higherkindedj.hkt.laws};
+ * comparison is by {@code equals} — right for records and standard collections.
+ */
+public final class TraversalLaws {
+
+  private TraversalLaws() {}
+
+  /** Identity: {@code modify(identity, s) == s}. */
+  public static <S, A> void assertIdentity(Traversal<S, A> traversal, S s) {
+    S result = Traversals.modify(traversal, Function.identity(), s);
+    assertThat(result)
+        .as("Traversal identity: modify(identity, %s) changes nothing; got %s", s, result)
+        .isEqualTo(s);
+  }
+
+  /** Fusion: {@code modify(g, modify(f, s)) == modify(g compose f, s)}. */
+  public static <S, A> void assertFusion(
+      Traversal<S, A> traversal, S s, Function<A, A> f, Function<A, A> g) {
+    S sequential = Traversals.modify(traversal, g, Traversals.modify(traversal, f, s));
+    S fused = Traversals.modify(traversal, f.andThen(g), s);
+    assertThat(sequential)
+        .as(
+            "Traversal fusion: modify(g) after modify(f) == modify(g.compose(f)) for %s; got %s vs %s",
+            s, sequential, fused)
+        .isEqualTo(fused);
+  }
+
+  /** All traversal laws for one fixture. */
+  public static <S, A> void assertTraversalLaws(
+      Traversal<S, A> traversal, S s, Function<A, A> f, Function<A, A> g) {
+    assertIdentity(traversal, s);
+    assertFusion(traversal, s, f, g);
+  }
+}

--- a/hkj-test/src/test/java/org/higherkindedj/optics/laws/OpticLawsTest.java
+++ b/hkj-test/src/test/java/org/higherkindedj/optics/laws/OpticLawsTest.java
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.laws;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Optional;
+import org.higherkindedj.optics.Affine;
+import org.higherkindedj.optics.Iso;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Prism;
+import org.higherkindedj.optics.util.Traversals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Optic-law helpers - every family, pass and fail paths")
+class OpticLawsTest {
+
+  record Person(String name, Optional<String> nickname) {}
+
+  private static final Lens<Person, String> NAME =
+      Lens.of(Person::name, (p, n) -> new Person(n, p.nickname()));
+  private static final Person ADA = new Person("Ada", Optional.of("Countess"));
+  private static final Person ANON = new Person("Anon", Optional.empty());
+
+  private static final Affine<Person, String> NICKNAME =
+      Affine.of(
+          Person::nickname,
+          (p, n) -> p.nickname().isPresent() ? new Person(p.name(), Optional.of(n)) : p);
+
+  private static final Iso<Integer, String> INT_STRING = Iso.of(String::valueOf, Integer::parseInt);
+
+  private static final Prism<String, Integer> PARSE_INT =
+      Prism.of(
+          s -> {
+            try {
+              return Optional.of(Integer.parseInt(s));
+            } catch (NumberFormatException e) {
+              return Optional.empty();
+            }
+          },
+          String::valueOf);
+
+  @Nested
+  @DisplayName("Lawful optics pass every law")
+  class LawfulOptics {
+
+    @Test
+    @DisplayName("iso, lens, prism, affine and traversal fixtures are lawful")
+    void lawfulFixturesPass() {
+      IsoLaws.assertIsoLaws(INT_STRING, 42, "42");
+      LensLaws.assertLensLaws(NAME, ADA, "Grace", "Alan");
+      PrismLaws.assertPrismLaws(PARSE_INT, "42", "not-a-number");
+      AffineLaws.assertAffineLaws(NICKNAME, ADA, ANON, "Lady", "Countess of Lovelace");
+      TraversalLaws.assertTraversalLaws(
+          Traversals.forList(), List.of("a", "bb"), s -> s + "!", String::toUpperCase);
+    }
+  }
+
+  @Nested
+  @DisplayName("Unlawful optics fail with the law named in the message")
+  class UnlawfulOptics {
+
+    @Test
+    @DisplayName("a set-ignoring lens fails set-get with a counterexample message")
+    void brokenLensFailsSetGet() {
+      Lens<Person, String> ignoresSet = Lens.of(Person::name, (p, n) -> p);
+
+      assertThatThrownBy(() -> LensLaws.assertSetGet(ignoresSet, ADA, "Grace"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("set-get")
+          .hasMessageContaining("Grace");
+    }
+
+    @Test
+    @DisplayName("a normalising iso fails the source round trip")
+    void normalisingIsoFailsRoundTrip() {
+      Iso<String, String> trimming = Iso.of(String::trim, s -> s);
+
+      assertThatThrownBy(() -> IsoLaws.assertGetReverseGet(trimming, "  padded  "))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("get-reverseGet");
+    }
+
+    @Test
+    @DisplayName("a prism that normalises on build fails match-build")
+    void normalisingPrismFailsMatchBuild() {
+      Prism<String, Integer> zeroPadded =
+          Prism.of(
+              s -> {
+                try {
+                  return Optional.of(Integer.parseInt(s));
+                } catch (NumberFormatException e) {
+                  return Optional.empty();
+                }
+              },
+              i -> String.format("%03d", i));
+
+      assertThatThrownBy(() -> PrismLaws.assertMatchBuild(zeroPadded, "42"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("match-build");
+    }
+
+    @Test
+    @DisplayName("an affine that writes into an absent target fails the absence law")
+    void writingAffineFailsAbsenceLaw() {
+      Affine<Person, String> forcesNickname =
+          Affine.of(Person::nickname, (p, n) -> new Person(p.name(), Optional.of(n)));
+
+      assertThatThrownBy(() -> AffineLaws.assertSetNoOpWhenAbsent(forcesNickname, ANON, "Ghost"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("absence");
+    }
+
+    @Test
+    @DisplayName("guard rails reject vacuous fixtures")
+    void guardRailsRejectVacuousFixtures() {
+      assertThatThrownBy(() -> LensLaws.assertLensLaws(NAME, ADA, "Same", "Same"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("DISTINCT");
+      assertThatThrownBy(() -> PrismLaws.assertMatchBuild(PARSE_INT, "nope"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("MATCHING");
+    }
+  }
+}


### PR DESCRIPTION
Closes #596 — first Phase-3 item; the published target for #597's `ValidatedPrism` laws and `@GenerateMapping`'s law-checked guarantee.

## What

New exported package **`org.higherkindedj.optics.laws`** in hkj-test: `IsoLaws`, `LensLaws`, `PrismLaws`, `AffineLaws`, `TraversalLaws`. Per-law `assert…` methods plus one `assertXxxLaws` aggregator per family; failures name the violated law with the offending values (`"Lens set-get: get(set(Grace, …)) == the value set; got Ada"`); guard rails reject vacuous fixtures. Affine includes the conditional laws (get-set/set-get/set-set on present targets, absence stability); Traversal covers identity + fusion.

## Surface adaptation vs the issue sketch

The issue sketched `DynamicNode` factories. As built, the harness follows the **existing `hkt.laws` convention** discovered in hkj-test (seven flat law classes, AssertJ-only, driven by `@ParameterizedTest`/property fixtures from the call site): hkj-test main has no JUnit dependency, and adding one for `DynamicNode` would churn the module graph for a wrapper the established style does without. A `DynamicNode` layer can be added later if demanded.

## Deferred

Migration of hkj-core's private `LensLawsTestFactory`/`PrismLawsTestFactory`/`AffineLawsTestFactory` onto this harness (follow-up — internal-only consolidation, ~1,200 lines of test restructuring best reviewed separately); jqwik arbitraries; `ValidatedPrism` laws (#597 adds its family).

## Verification

`:hkj-test:test` green — 6 tests covering every family's pass path, four unlawful-optic failure paths asserting law-named messages (set-ignoring lens, normalising iso, normalising prism, absent-target-writing affine), and both guard rails. Book: "Optic Laws" section on the Testing With hkj-test page; release-history entry under 0.4.8-SNAPSHOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)