### PR TITLE
Add what/why/fix processor diagnostics and adopt in Focus/Lens/ImportOptics

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -14,6 +14,10 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ### 0.4.8-SNAPSHOT (Latest)
 
+**Processor diagnostics: what / why / fix**
+
+Annotation-processor errors now follow a shared three-part format (`Diagnostics` in `hkj-processor`): **what** is wrong (naming the offending element and its kind), **why** (what the processor found or needs), and the exact **fix** — e.g. `@GenerateFocus: can only be applied to records, but 'Config' is a class. The processor derives FocusPath methods from record components. Move the annotation to a record, or use @ImportOptics with an OpticsSpec interface for types you cannot change.` Adopted across the `@GenerateFocus`, `@GenerateLenses`, and `@ImportOptics` error paths; the standard is in place for every future processor ([#601](https://github.com/higher-kinded-j/higher-kinded-j/issues/601)).
+
 **Codegen on-ramp: `-parameters` wired by both build plugins**
 
 The Gradle and Maven plugins now add `-parameters` to compilation automatically (parameter names in class files — used by copy strategies and the upcoming mapper), completing the one-line setup story: apply the plugin and dependencies, annotation processors, preview flags, `-parameters`, and compile-time checks are all configured. The quickstart and plugin pages state the full list ([#602](https://github.com/higher-kinded-j/higher-kinded-j/issues/602)).

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -31,6 +31,7 @@ import org.higherkindedj.optics.processing.kind.KindFieldAnalyser;
 import org.higherkindedj.optics.processing.kind.KindFieldInfo;
 import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
 import org.higherkindedj.optics.processing.util.OpticExpressionResolver;
 import org.higherkindedj.optics.processing.util.ProcessorUtils;
@@ -148,7 +149,18 @@ public class FocusProcessor extends AbstractProcessor {
       Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
       for (Element element : annotatedElements) {
         if (element.getKind() != ElementKind.RECORD) {
-          error("The @GenerateFocus annotation can only be applied to records.", element);
+          Diagnostics.error(
+              processingEnv.getMessager(),
+              element,
+              "@GenerateFocus",
+              "can only be applied to records, but '"
+                  + element.getSimpleName()
+                  + "' is a "
+                  + element.getKind().toString().toLowerCase(java.util.Locale.ROOT)
+                  + ".",
+              "The processor derives FocusPath methods from record components.",
+              "Move the annotation to a record, or use @ImportOptics with an OpticsSpec"
+                  + " interface for types you cannot change.");
           continue;
         }
         writeFocusFile((TypeElement) element, navigableTypes);
@@ -162,7 +174,13 @@ public class FocusProcessor extends AbstractProcessor {
     try {
       generateFocusFile(element, navigableTypes);
     } catch (IOException e) {
-      error("Could not generate focus file: " + e.getMessage(), element);
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          element,
+          "@GenerateFocus",
+          "could not write the generated Focus companion for '" + element.getSimpleName() + "'.",
+          "The filer reported: " + e.getMessage() + ".",
+          "Check build-output permissions and free disk space, then rebuild.");
     }
   }
 
@@ -982,9 +1000,5 @@ public class FocusProcessor extends AbstractProcessor {
       case NONE -> "get";
       case NESTED -> "get"; // handled above, unreachable
     };
-  }
-
-  private void error(String msg, Element e) {
-    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, e);
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
@@ -31,6 +31,7 @@ import org.higherkindedj.optics.processing.external.SpecInterfaceAnalyser;
 import org.higherkindedj.optics.processing.external.SpecInterfaceGenerator;
 import org.higherkindedj.optics.processing.external.TypeAnalysis;
 import org.higherkindedj.optics.processing.external.TypeKindAnalyser;
+import org.higherkindedj.optics.processing.util.Diagnostics;
 
 /**
  * Annotation processor for {@link ImportOptics}.
@@ -98,7 +99,14 @@ public class ImportOpticsProcessor extends AbstractProcessor {
       } else if (element.getKind() == ElementKind.CLASS) {
         processTypeAnnotation((TypeElement) element);
       } else {
-        error("@ImportOptics can only be applied to packages or types.", element);
+        Diagnostics.error(
+            processingEnv.getMessager(),
+            element,
+            "@ImportOptics",
+            "cannot be applied to '" + element.getSimpleName() + "'.",
+            "Optics are imported for a package (via package-info.java) or for a listed"
+                + " class/interface.",
+            "Move the annotation to a package-info.java or a type declaration.");
       }
     }
     return true;
@@ -220,14 +228,14 @@ public class ImportOpticsProcessor extends AbstractProcessor {
 
       case WITHER_CLASS -> {
         if (analysis.hasMutableFields() && !allowMutable) {
-          error(
-              "Type '"
-                  + typeElement.getQualifiedName()
-                  + "' has mutable fields (setters). "
-                  + "Lens laws may not hold for mutable types. "
-                  + "Either use allowMutable = true to acknowledge this limitation, "
-                  + "or create a spec interface for explicit control.",
-              sourceElement);
+          Diagnostics.error(
+              processingEnv.getMessager(),
+              sourceElement,
+              "@ImportOptics",
+              "type '" + typeElement.getQualifiedName() + "' has mutable fields (setters).",
+              "Lens laws may not hold for mutable types.",
+              "Use allowMutable = true to acknowledge the limitation, or create an OpticsSpec"
+                  + " interface for explicit control.");
           return;
         }
         lensGenerator.generateForWitherClass(analysis, targetPackage, sourceElement);
@@ -235,20 +243,26 @@ public class ImportOpticsProcessor extends AbstractProcessor {
 
       case UNSUPPORTED -> {
         if (analysis.hasMutableFields()) {
-          error(
-              "Type '"
+          Diagnostics.error(
+              processingEnv.getMessager(),
+              sourceElement,
+              "@ImportOptics",
+              "type '"
                   + typeElement.getQualifiedName()
-                  + "' is a mutable class without wither methods. "
-                  + "Cannot generate lenses for types that don't support immutable updates. "
-                  + "Consider using a spec interface to define custom copy logic.",
-              sourceElement);
+                  + "' is a mutable class without wither"
+                  + " methods.",
+              "Lenses require immutable updates, and no copy mechanism was found.",
+              "Define an OpticsSpec interface with custom copy logic, or add wither methods.");
         } else {
-          error(
-              "Type '"
+          Diagnostics.error(
+              processingEnv.getMessager(),
+              sourceElement,
+              "@ImportOptics",
+              "type '"
                   + typeElement.getQualifiedName()
-                  + "' is not a record, sealed interface, enum, or class with wither methods. "
-                  + "Cannot determine how to generate optics for this type.",
-              sourceElement);
+                  + "' is not a record, sealed interface, enum, or class with wither methods.",
+              "The processor cannot determine how to generate optics for this shape.",
+              "Make the type one of those shapes, or define an OpticsSpec interface for it.");
         }
       }
     }
@@ -304,10 +318,6 @@ public class ImportOpticsProcessor extends AbstractProcessor {
     }
 
     return result;
-  }
-
-  private void error(String msg, Element e) {
-    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, e);
   }
 
   private void note(String msg, Element e) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/LensProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/LensProcessor.java
@@ -19,9 +19,9 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
-import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
 
 /** Annotation processor that generates Lens optics for record types. */
@@ -43,7 +43,18 @@ public class LensProcessor extends AbstractProcessor {
       Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
       for (Element element : annotatedElements) {
         if (element.getKind() != ElementKind.RECORD) {
-          error("The @GenerateLenses annotation can only be applied to records.", element);
+          Diagnostics.error(
+              processingEnv.getMessager(),
+              element,
+              "@GenerateLenses",
+              "can only be applied to records, but '"
+                  + element.getSimpleName()
+                  + "' is a "
+                  + element.getKind().toString().toLowerCase(java.util.Locale.ROOT)
+                  + ".",
+              "The processor derives one Lens per record component.",
+              "Move the annotation to a record, or use @ImportOptics with an OpticsSpec"
+                  + " interface for types you cannot change.");
           continue;
         }
         writeLensesFile((TypeElement) element);
@@ -57,7 +68,13 @@ public class LensProcessor extends AbstractProcessor {
     try {
       generateLensesFile(element);
     } catch (IOException e) {
-      error("Could not generate lenses file: " + e.getMessage(), element);
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          element,
+          "@GenerateLenses",
+          "could not write the generated Lenses companion for '" + element.getSimpleName() + "'.",
+          "The filer reported: " + e.getMessage() + ".",
+          "Check build-output permissions and free disk space, then rebuild.");
     }
   }
 
@@ -224,9 +241,5 @@ public class LensProcessor extends AbstractProcessor {
       return s;
     }
     return s.substring(0, 1).toUpperCase() + s.substring(1);
-  }
-
-  private void error(String msg, Element e) {
-    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, e);
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/Diagnostics.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/Diagnostics.java
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.util;
+
+import java.util.Objects;
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Element;
+import javax.tools.Diagnostic;
+
+/**
+ * The shared what/why/fix diagnostic format for HKJ annotation processors.
+ *
+ * <p>Every processor-reported problem should tell the user three things: <b>what</b> is wrong
+ * (naming the offending element), <b>why</b> it is a problem (what the processor found or needs),
+ * and how to <b>fix</b> it (the exact remedy, as an imperative sentence). The reference shape:
+ *
+ * <pre>
+ * &#64;GenerateMapping: target field 'UserDto.fullName' has no source. Found on User:
+ * [name, email, age]. Add a &#64;MapField(to="fullName") method to the MappingSpec, supply a
+ * leaf-optic default method, or drop the field.
+ * </pre>
+ *
+ * <p>Callers pass the three parts as complete sentences; {@link #format} joins them after the
+ * annotation tag. New processors should use this from their first diagnostic; existing ones are
+ * migrated as they are touched.
+ */
+public final class Diagnostics {
+
+  private Diagnostics() {}
+
+  /**
+   * Reports an error in the what/why/fix format, attached to {@code element}.
+   *
+   * @param messager the processing-round messager; must not be null
+   * @param element the offending element; must not be null
+   * @param annotation the annotation tag, for example {@code "@GenerateFocus"}; must not be null
+   * @param what one sentence naming what is wrong; must not be null
+   * @param why one sentence of context: what was found or needed; must not be null
+   * @param fix one imperative sentence prescribing the remedy; must not be null
+   */
+  public static void error(
+      Messager messager, Element element, String annotation, String what, String why, String fix) {
+    Objects.requireNonNull(messager, "messager must not be null");
+    Objects.requireNonNull(element, "element must not be null");
+    messager.printMessage(Diagnostic.Kind.ERROR, format(annotation, what, why, fix), element);
+  }
+
+  /**
+   * Reports a warning in the what/why/fix format, attached to {@code element}.
+   *
+   * @param messager the processing-round messager; must not be null
+   * @param element the offending element; must not be null
+   * @param annotation the annotation tag; must not be null
+   * @param what one sentence naming what is wrong; must not be null
+   * @param why one sentence of context; must not be null
+   * @param fix one imperative sentence prescribing the remedy; must not be null
+   */
+  public static void warning(
+      Messager messager, Element element, String annotation, String what, String why, String fix) {
+    Objects.requireNonNull(messager, "messager must not be null");
+    Objects.requireNonNull(element, "element must not be null");
+    messager.printMessage(Diagnostic.Kind.WARNING, format(annotation, what, why, fix), element);
+  }
+
+  /**
+   * Joins the three parts after the annotation tag: {@code "@Tag: what why fix"}.
+   *
+   * @param annotation the annotation tag; must not be null
+   * @param what one sentence naming what is wrong; must not be null
+   * @param why one sentence of context; must not be null
+   * @param fix one imperative sentence prescribing the remedy; must not be null
+   * @return the formatted message (non-null)
+   */
+  public static String format(String annotation, String what, String why, String fix) {
+    Objects.requireNonNull(annotation, "annotation must not be null");
+    Objects.requireNonNull(what, "what must not be null");
+    Objects.requireNonNull(why, "why must not be null");
+    Objects.requireNonNull(fix, "fix must not be null");
+    return annotation
+        + ": "
+        + ensureSentence(what)
+        + " "
+        + ensureSentence(why)
+        + " "
+        + ensureSentence(fix);
+  }
+
+  /** Trims and guarantees sentence-ending punctuation, so sloppy callers still format cleanly. */
+  private static String ensureSentence(String part) {
+    String trimmed = part.trim();
+    if (trimmed.isEmpty()) {
+      return trimmed;
+    }
+    char last = trimmed.charAt(trimmed.length() - 1);
+    return (last == '.' || last == '?' || last == '!') ? trimmed : trimmed + ".";
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorIntegrationTest.java
@@ -108,8 +108,7 @@ public class FocusProcessorIntegrationTest {
       var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
 
       assertThat(compilation).failed();
-      assertThat(compilation)
-          .hadErrorContaining("@GenerateFocus annotation can only be applied to records");
+      assertThat(compilation).hadErrorContaining("@GenerateFocus: can only be applied to records");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
@@ -496,6 +496,71 @@ class ImportOpticsProcessorTest {
   }
 
   @Nested
+  @DisplayName("What/Why/Fix Diagnostics")
+  class WhatWhyFixDiagnostics {
+
+    @Test
+    @DisplayName("should reject @ImportOptics on an enum with the what/why/fix message")
+    void shouldRejectEnumPlacement() {
+      final var enumSource =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Colour",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics({java.lang.String.class})
+              public enum Colour { RED, GREEN }
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(enumSource);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("@ImportOptics: cannot be applied to 'Colour'");
+      assertThat(compilation)
+          .hadErrorContaining("Move the annotation to a package-info.java or a type declaration");
+    }
+
+    @Test
+    @DisplayName("should reject a mutable class without withers, prescribing the fix")
+    void shouldRejectMutableClassWithoutWithers() {
+      final var mutableClass =
+          JavaFileObjects.forSourceString(
+              "com.external.SetterOnly",
+              """
+              package com.external;
+
+              public class SetterOnly {
+                  private String name;
+
+                  public String getName() { return name; }
+                  public void setName(String name) { this.name = name; }
+              }
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.SetterOnly.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(mutableClass, packageInfo);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("is a mutable class without wither methods")
+          .inFile(packageInfo);
+      assertThat(compilation).hadErrorContaining("Define an OpticsSpec interface");
+    }
+  }
+
+  @Nested
   @DisplayName("Target Package Configuration")
   class TargetPackageConfiguration {
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/DiagnosticsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/DiagnosticsTest.java
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Element;
+import javax.tools.Diagnostic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Diagnostics - the shared what/why/fix processor message format")
+class DiagnosticsTest {
+
+  private record Printed(Diagnostic.Kind kind, String message, Element element) {}
+
+  private final List<Printed> printed = new ArrayList<>();
+
+  private final Messager messager =
+      (Messager)
+          Proxy.newProxyInstance(
+              getClass().getClassLoader(),
+              new Class<?>[] {Messager.class},
+              (proxy, method, args) -> {
+                if ("printMessage".equals(method.getName()) && args.length == 3) {
+                  printed.add(
+                      new Printed(
+                          (Diagnostic.Kind) args[0], args[1].toString(), (Element) args[2]));
+                }
+                return null;
+              });
+
+  private final Element element =
+      (Element)
+          Proxy.newProxyInstance(
+              getClass().getClassLoader(),
+              new Class<?>[] {Element.class},
+              (proxy, method, args) -> {
+                throw new UnsupportedOperationException(method.getName());
+              });
+
+  @Test
+  @DisplayName("format joins the annotation tag and the three sentences")
+  void formatJoinsParts() {
+    String message =
+        Diagnostics.format(
+            "@GenerateMapping",
+            "target field 'UserDto.fullName' has no source.",
+            "Found on User: [name, email, age].",
+            "Add a @MapField(to=\"fullName\") method to the MappingSpec.");
+
+    assertThat(message)
+        .isEqualTo(
+            "@GenerateMapping: target field 'UserDto.fullName' has no source."
+                + " Found on User: [name, email, age]."
+                + " Add a @MapField(to=\"fullName\") method to the MappingSpec.");
+  }
+
+  @Test
+  @DisplayName("error and warning print the formatted message against the element")
+  void errorAndWarningPrint() {
+    Diagnostics.error(messager, element, "@GenerateFocus", "what.", "why.", "fix.");
+    Diagnostics.warning(messager, element, "@GenerateFocus", "what.", "why.", "fix.");
+
+    assertThat(printed)
+        .containsExactly(
+            new Printed(Diagnostic.Kind.ERROR, "@GenerateFocus: what. why. fix.", element),
+            new Printed(Diagnostic.Kind.WARNING, "@GenerateFocus: what. why. fix.", element));
+  }
+
+  @Test
+  @DisplayName("format trims and guarantees sentence-ending punctuation")
+  void formatNormalisesSloppyInput() {
+    assertThat(Diagnostics.format("@A", "  what without stop  ", "why?", "fix!"))
+        .isEqualTo("@A: what without stop. why? fix!");
+    assertThat(Diagnostics.format("@A", "what.", "", "  ")).isEqualTo("@A: what.  ");
+  }
+
+  @Test
+  @DisplayName("all arguments are eagerly guarded")
+  void argumentsAreGuarded() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> Diagnostics.error(null, element, "@A", "w.", "y.", "f."))
+        .withMessage("messager must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> Diagnostics.warning(messager, null, "@A", "w.", "y.", "f."))
+        .withMessage("element must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> Diagnostics.format(null, "w.", "y.", "f."))
+        .withMessage("annotation must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> Diagnostics.format("@A", null, "y.", "f."))
+        .withMessage("what must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> Diagnostics.format("@A", "w.", null, "f."))
+        .withMessage("why must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> Diagnostics.format("@A", "w.", "y.", null))
+        .withMessage("fix must not be null");
+  }
+}


### PR DESCRIPTION
Closes #601 (A4) — the diagnostics standard, landed **before** any mapper processor exists so #600 meets the bar from its first line.

## What

- **`Diagnostics`** (`org.higherkindedj.optics.processing.util`): `error`/`warning`/`format` taking `(annotation, what, why, fix)` — the exact shape #601 specified: name the offending element, state what was found or needed, prescribe the remedy as an imperative sentence.
- **Audit pass on the three named processors**: `@GenerateFocus`/`@GenerateLenses` non-record errors upgrade from `"The @GenerateFocus annotation can only be applied to records."` to naming the element and its actual kind, the why (derivation from record components), and both remedies (move to a record, or `@ImportOptics` + `OpticsSpec` for types you cannot change). Filer `IOException`s gain context and a remedy. `@ImportOptics`' four sites reshaped into the shared format — their test-asserted substrings (`"has mutable fields"`, `"not a record, sealed interface, …"`) deliberately preserved.
- Remaining processors keep their current messages and migrate as touched, per the issue's scope.

## Verification

Full `:hkj-processor:check` green (all compile-testing suites, the coverage gate, arch rules). `DiagnosticsTest` covers `format`, both severities, and the eager guards using `reflect.Proxy` recorders — no new test dependencies. One compile-testing expectation tied to the old wording updated. Release-history entry with a worked example message.

## Note

`hkj-checker` message-consistency coordination is deliberately light here (its rules already follow an id-prefixed style); revisit when the mapper's exhaustiveness diagnostics land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)