### PR TITLE
Wire -parameters automatically in the Gradle and Maven plugins

### DIFF
--- a/hkj-book/src/quickstart.md
+++ b/hkj-book/src/quickstart.md
@@ -27,7 +27,7 @@ plugins {
 }
 ```
 
-This single line configures dependencies, preview features, annotation processors, and compile-time Path type checking automatically. See the [Gradle Plugin](tooling/gradle_plugin.md) documentation for the full DSL reference.
+This single line configures dependencies, preview features, annotation processors, `-parameters` (parameter names for copy strategies and the upcoming mapper), and compile-time Path type checking automatically. See the [Gradle Plugin](tooling/gradle_plugin.md) documentation for the full DSL reference.
 
 For **SNAPSHOT** versions of the plugin, add the Sonatype snapshots repository to your `settings.gradle.kts`:
 

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -14,6 +14,10 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ### 0.4.8-SNAPSHOT (Latest)
 
+**Codegen on-ramp: `-parameters` wired by both build plugins**
+
+The Gradle and Maven plugins now add `-parameters` to compilation automatically (parameter names in class files — used by copy strategies and the upcoming mapper), completing the one-line setup story: apply the plugin and dependencies, annotation processors, preview flags, `-parameters`, and compile-time checks are all configured. The quickstart and plugin pages state the full list ([#602](https://github.com/higher-kinded-j/higher-kinded-j/issues/602)).
+
 **`ValidatedPrism`: the smart-constructor optic for parse-don't-validate boundaries**
 
 A `Prism` whose match accumulates reasons: `parse` returns `Validated<NonEmptyList<FieldError>, A>` (every failure, located), `build` is total. Nested composition short-circuits while sibling fields accumulate through the assembly builders or `Edits`; only build-preserving compositions exist (`ValidatedPrism`, `Iso`, `Prism`-with-a-reason — a `Lens` cell is deliberately absent because no total build survives it). Bridges: `fromIso`/`fromPrism(reason)`, reason-forgetting `toPrism()`/`toAffine()`, and `parsePath` onto the railway. Both round-trip laws ship as `ValidatedPrismLaws` in `hkj-test` — the law harness's first extension. Purely additive ([#597](https://github.com/higher-kinded-j/higher-kinded-j/issues/597)). See [Validated Prisms](optics/validated_prism.md).

--- a/hkj-book/src/tooling/gradle_plugin.md
+++ b/hkj-book/src/tooling/gradle_plugin.md
@@ -26,7 +26,7 @@ plugins {
 }
 ```
 
-That is it. The plugin handles dependencies, preview flags, compile-time checks, and Javadoc configuration automatically.
+That is it. The plugin handles dependencies, preview flags, `-parameters` (parameter names in class files, used by copy strategies and the upcoming mapper), compile-time checks, and Javadoc configuration automatically.
 
 ### Using SNAPSHOT Versions
 
@@ -95,6 +95,7 @@ With default settings, the plugin adds:
 - `hkj-processor-plugins` to `annotationProcessor`
 - `hkj-checker` to `annotationProcessor`
 - `--enable-preview` to `JavaCompile`, `Test`, `JavaExec`, and `Javadoc` tasks
+- `-parameters` to every `JavaCompile` task (unconditional)
 - `-Xplugin:HKJChecker` to compiler arguments
 
 ---

--- a/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJPlugin.java
+++ b/plugins/hkj-gradle-plugin/src/main/java/org/higherkindedj/gradle/HKJPlugin.java
@@ -76,6 +76,19 @@ public class HKJPlugin implements Plugin<Project> {
                 sourceSet.getAnnotationProcessorConfigurationName(),
                 GROUP_ID + ":hkj-processor-plugins:" + version));
 
+    // Record parameter names in class files: some copy strategies and future mapper
+    // features read them, and the flag is harmless otherwise.
+    project
+        .getTasks()
+        .withType(JavaCompile.class)
+        .configureEach(
+            task -> {
+              List<String> args = task.getOptions().getCompilerArgs();
+              if (!args.contains("-parameters")) {
+                args.add("-parameters");
+              }
+            });
+
     // Preview features
     if (Boolean.TRUE.equals(extension.getPreview().get())) {
       configurePreviewFeatures(project);

--- a/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginTest.java
+++ b/plugins/hkj-gradle-plugin/src/test/java/org/higherkindedj/gradle/HKJPluginTest.java
@@ -101,6 +101,19 @@ class HKJPluginTest {
     }
 
     @Test
+    @DisplayName("adds -parameters to JavaCompile tasks unconditionally")
+    void plugin_addsParametersFlag_always() {
+      applyPlugin();
+      evaluateProject();
+
+      project
+          .getTasks()
+          .withType(JavaCompile.class)
+          .configureEach(
+              task -> assertThat(task.getOptions().getCompilerArgs()).contains("-parameters"));
+    }
+
+    @Test
     @DisplayName("adds --enable-preview to JavaCompile tasks when preview is enabled")
     void plugin_addsPreviewFlags_whenEnabled() {
       applyPlugin();

--- a/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJLifecycleParticipant.java
+++ b/plugins/hkj-maven-plugin/src/main/java/org/higherkindedj/maven/HKJLifecycleParticipant.java
@@ -105,9 +105,7 @@ public class HKJLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     // compilerArgs. These are the defaults for both the compile and testCompile goals
     // (testCompile falls back to them when the test-specific overrides aren't set).
     addHkjProcessorPaths(pluginConfig, "annotationProcessorPaths", config, /* create= */ true);
-    if (config.pathTypeMismatch()) {
-      addHkjCompilerArg(pluginConfig, "compilerArgs", /* create= */ true);
-    }
+    addHkjCompilerArgs(pluginConfig, "compilerArgs", config, /* create= */ true);
 
     // Defensively patch any user-declared test-specific overrides. When
     // <testAnnotationProcessorPaths> / <testCompilerArgs> are set (at the plugin level or
@@ -122,9 +120,7 @@ public class HKJLifecycleParticipant extends AbstractMavenLifecycleParticipant {
       }
       addHkjProcessorPaths(
           executionConfig, "annotationProcessorPaths", config, /* create= */ false);
-      if (config.pathTypeMismatch()) {
-        addHkjCompilerArg(executionConfig, "compilerArgs", /* create= */ false);
-      }
+      addHkjCompilerArgs(executionConfig, "compilerArgs", config, /* create= */ false);
       applyTestOverrides(executionConfig, config);
     }
   }
@@ -134,9 +130,7 @@ public class HKJLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     // the fallback to annotationProcessorPaths / compilerArgs and risk clobbering any
     // user-defined test-only processors or args.
     addHkjProcessorPaths(configNode, "testAnnotationProcessorPaths", config, /* create= */ false);
-    if (config.pathTypeMismatch()) {
-      addHkjCompilerArg(configNode, "testCompilerArgs", /* create= */ false);
-    }
+    addHkjCompilerArgs(configNode, "testCompilerArgs", config, /* create= */ false);
   }
 
   private void addHkjProcessorPaths(
@@ -152,13 +146,19 @@ public class HKJLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
   }
 
-  private void addHkjCompilerArg(Xpp3Dom configNode, String childName, boolean create) {
+  private void addHkjCompilerArgs(
+      Xpp3Dom configNode, String childName, HKJConfiguration config, boolean create) {
     Xpp3Dom args =
         create ? getOrCreateChild(configNode, childName) : configNode.getChild(childName);
     if (args == null) {
       return;
     }
-    addArgIfMissing(args, "-Xplugin:HKJChecker");
+    // -parameters is unconditional (matching the Gradle plugin); the checker arg only
+    // applies when the path-type-mismatch check is enabled.
+    addArgIfMissing(args, "-parameters");
+    if (config.pathTypeMismatch()) {
+      addArgIfMissing(args, "-Xplugin:HKJChecker");
+    }
   }
 
   private void configureSurefirePlugin(MavenProject project, HKJConfiguration config) {

--- a/plugins/hkj-maven-plugin/src/test/java/org/higherkindedj/maven/HKJLifecycleParticipantTest.java
+++ b/plugins/hkj-maven-plugin/src/test/java/org/higherkindedj/maven/HKJLifecycleParticipantTest.java
@@ -113,7 +113,7 @@ class HKJLifecycleParticipantTest {
       Xpp3Dom cfg = (Xpp3Dom) compilerPlugin().getConfiguration();
       assertThat(processorArtifactIds(cfg, "annotationProcessorPaths"))
           .contains("hkj-processor-plugins", "hkj-checker");
-      assertThat(argValues(cfg, "compilerArgs")).contains("-Xplugin:HKJChecker");
+      assertThat(argValues(cfg, "compilerArgs")).contains("-Xplugin:HKJChecker", "-parameters");
     }
 
     @Test
@@ -149,7 +149,7 @@ class HKJLifecycleParticipantTest {
 
       Xpp3Dom finalCfg = (Xpp3Dom) compilerPlugin().getConfiguration();
       assertThat(argValues(finalCfg, "testCompilerArgs"))
-          .containsExactlyInAnyOrder("--user-test-arg", "-Xplugin:HKJChecker");
+          .containsExactlyInAnyOrder("--user-test-arg", "-Xplugin:HKJChecker", "-parameters");
     }
 
     @Test
@@ -216,7 +216,7 @@ class HKJLifecycleParticipantTest {
       Xpp3Dom finalExecConfig =
           (Xpp3Dom) compilerPlugin().getExecutions().get(0).getConfiguration();
       assertThat(argValues(finalExecConfig, "compilerArgs"))
-          .containsExactlyInAnyOrder("--user-arg", "-Xplugin:HKJChecker");
+          .containsExactlyInAnyOrder("--user-arg", "-Xplugin:HKJChecker", "-parameters");
     }
 
     @Test
@@ -258,8 +258,12 @@ class HKJLifecycleParticipantTest {
       assertThat(processorArtifactIds(finalCfg, "testAnnotationProcessorPaths"))
           .contains("hkj-processor-plugins")
           .doesNotContain("hkj-checker");
-      assertThat(argValues(finalCfg, "testCompilerArgs")).doesNotContain("-Xplugin:HKJChecker");
-      assertThat(finalCfg.getChild("compilerArgs")).isNull();
+      assertThat(argValues(finalCfg, "testCompilerArgs"))
+          .contains("-parameters")
+          .doesNotContain("-Xplugin:HKJChecker");
+      assertThat(argValues(finalCfg, "compilerArgs"))
+          .contains("-parameters")
+          .doesNotContain("-Xplugin:HKJChecker");
     }
   }
 }


### PR DESCRIPTION
Closes #602 (A5) — run in parallel with #603.

## Honest scoping

Surveying the plugins showed most of A5 already shipped since the issue was drafted: the **Gradle plugin** registers `hkj-processor-plugins` on every source set's annotationProcessor configuration, the **Maven lifecycle participant** patches `annotationProcessorPaths`/`compilerArgs` at plugin level, execution level, and test overrides, and the book's top-level **Quickstart already leads with the one-line plugin setup**. This PR closes the residual gaps the issue names explicitly.

## What

- **Gradle**: `-parameters` added to every `JavaCompile` task (unconditional, idempotent) — parameter names in class files are read by copy strategies and the upcoming `@GenerateMapping` work (#600).
- **Maven**: `-parameters` added alongside `-Xplugin:HKJChecker` in every `compilerArgs` location the participant already patches, so it inherits the same plugin-level/execution-level/test-override coverage.
- **Docs**: quickstart and gradle-plugin pages now state the complete configured list; release-history entry.

## Verification

Both plugins' full `check` tasks green. New Gradle test asserts the flag on all compile tasks; Maven's exact-list `compilerArgs` assertions extended across the plugin-level, execution-override, and test-override cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)