### PR TITLE
Processor coverage hardening: 99% line / 97% branch module-wide, gate raised

### DIFF
--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -76,12 +76,12 @@ tasks.jacocoTestCoverageVerification {
             limit {
                 counter = "LINE"
                 value = "COVEREDRATIO"
-                minimum = "0.95".toBigDecimal()
+                minimum = "0.99".toBigDecimal()
             }
             limit {
                 counter = "BRANCH"
                 value = "COVEREDRATIO"
-                minimum = "0.87".toBigDecimal()
+                minimum = "0.97".toBigDecimal()
             }
         }
         // MappingProcessor is held at 100% (see PR #605).

--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -72,6 +72,9 @@ tasks.jacocoTestCoverageVerification {
     )
 
     violationRules {
+        // 99/97 (not 100): the residual is verified-unreachable - compiler-synthesised
+        // exhaustive-switch defaults, @Target-unproducible arms, and descriptor-table
+        // combos that cannot occur (see the coverage-hardening PR for the per-class list).
         rule {
             limit {
                 counter = "LINE"

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -489,17 +489,19 @@ public class FocusProcessor extends AbstractProcessor {
    * @param args the mutable list of JavaPoet arguments (for SPI import resolution)
    * @return the chained expression string
    */
-  private String buildWideningChainExpression(List<WideningStep> chain, List<Object> args) {
+  String buildWideningChainExpression(List<WideningStep> chain, List<Object> args) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < chain.size(); i++) {
       WideningStep step = chain.get(i);
       // Check if the next step requires argument type matching (SPI with parameters).
       // If so, the current no-arg step needs a type witness to help Java's type inference.
+      // A next step only exists because analyseNestedType recursed into a non-null inner
+      // type, so innerTypeMirror() is guaranteed non-null here.
       boolean nextStepNeedsTypeWitness =
           i + 1 < chain.size() && isParameterisedStep(chain.get(i + 1));
       switch (step.type()) {
         case OPTIONAL -> {
-          if (nextStepNeedsTypeWitness && step.innerTypeMirror() != null) {
+          if (nextStepNeedsTypeWitness) {
             sb.append(".<$T>some()");
             args.add(TypeName.get(step.innerTypeMirror()));
           } else {
@@ -507,7 +509,7 @@ public class FocusProcessor extends AbstractProcessor {
           }
         }
         case COLLECTION -> {
-          if (nextStepNeedsTypeWitness && step.innerTypeMirror() != null) {
+          if (nextStepNeedsTypeWitness) {
             sb.append(".<$T>each()");
             args.add(TypeName.get(step.innerTypeMirror()));
           } else {
@@ -552,7 +554,7 @@ public class FocusProcessor extends AbstractProcessor {
   }
 
   /** Represents the type of path widening to apply. */
-  private enum WideningType {
+  enum WideningType {
     /** No widening - standard FocusPath. */
     NONE,
     /** Optional/Maybe types - AffinePath via .some(). */
@@ -583,7 +585,7 @@ public class FocusProcessor extends AbstractProcessor {
    * @param spiGenerator SPI generator if this step is an SPI type (may be null)
    * @param innerTypeMirror the type produced by unwrapping this container (may be null)
    */
-  private record WideningStep(
+  record WideningStep(
       WideningType type,
       KindFieldInfo kindInfo,
       TraversableGenerator spiGenerator,
@@ -722,10 +724,9 @@ public class FocusProcessor extends AbstractProcessor {
           AFFINE_PATH_CLASS, innerType, WideningType.SPI_ZERO_OR_ONE, matchedGenerator);
     }
 
-    // When widenCollections is enabled, also widen ZERO_OR_MORE SPI types to TraversalPath
-    if (widenCollections
-        && matchedGenerator != null
-        && matchedGenerator.getCardinality() == Cardinality.ZERO_OR_MORE) {
+    // When widenCollections is enabled, also widen ZERO_OR_MORE SPI types to TraversalPath.
+    // A matched generator here is always ZERO_OR_MORE: ZERO_OR_ONE matches returned above.
+    if (widenCollections && matchedGenerator != null) {
       int typeArgIndex = matchedGenerator.getFocusTypeArgumentIndex();
       TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, typeArgIndex);
       Optional<PathTypeInfo> nested =
@@ -864,7 +865,8 @@ public class FocusProcessor extends AbstractProcessor {
       }
       return steps;
     }
-    if (widenCollections && gen != null && gen.getCardinality() == Cardinality.ZERO_OR_MORE) {
+    // A matched generator here is always ZERO_OR_MORE: ZERO_OR_ONE matches returned above.
+    if (widenCollections && gen != null) {
       List<WideningStep> steps = new ArrayList<>();
       TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, gen.getFocusTypeArgumentIndex());
       steps.add(new WideningStep(WideningType.SPI_ZERO_OR_MORE, null, gen, innerTypeMirror));
@@ -925,9 +927,9 @@ public class FocusProcessor extends AbstractProcessor {
     }
 
     if (chain.size() == 1) {
-      // Resolve wildcard bounds on the innermost type
-      TypeMirror resolved = ProcessorUtils.resolveWildcard(innerTypeMirror);
-      return resolved != null ? TypeName.get(resolved).box() : ClassName.get(Object.class);
+      // getTypeArgumentAt has already resolved wildcard bounds (returning null for
+      // unresolvable wildcards, handled above), so no re-resolution is needed here.
+      return TypeName.get(innerTypeMirror).box();
     }
 
     return resolveDeepInnerType(innerTypeMirror, chain.subList(1, chain.size()));

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -489,6 +489,7 @@ public class FocusProcessor extends AbstractProcessor {
    * @param args the mutable list of JavaPoet arguments (for SPI import resolution)
    * @return the chained expression string
    */
+  // Package-private for tests.
   String buildWideningChainExpression(List<WideningStep> chain, List<Object> args) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < chain.size(); i++) {
@@ -554,6 +555,7 @@ public class FocusProcessor extends AbstractProcessor {
   }
 
   /** Represents the type of path widening to apply. */
+  // Package-private for tests.
   enum WideningType {
     /** No widening - standard FocusPath. */
     NONE,
@@ -585,6 +587,7 @@ public class FocusProcessor extends AbstractProcessor {
    * @param spiGenerator SPI generator if this step is an SPI type (may be null)
    * @param innerTypeMirror the type produced by unwrapping this container (may be null)
    */
+  // Package-private for tests.
   record WideningStep(
       WideningType type,
       KindFieldInfo kindInfo,

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FoldProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FoldProcessor.java
@@ -206,10 +206,10 @@ public class FoldProcessor extends AbstractProcessor {
   }
 
   private TypeName getElementType(RecordComponentElement component) {
-    if (component.asType() instanceof DeclaredType containerType) {
-      if (!containerType.getTypeArguments().isEmpty()) {
-        return TypeName.get(containerType.getTypeArguments().getFirst()).box();
-      }
+    // Only called for iterable components, and isIterableType requires a declared type.
+    DeclaredType containerType = (DeclaredType) component.asType();
+    if (!containerType.getTypeArguments().isEmpty()) {
+      return TypeName.get(containerType.getTypeArguments().getFirst()).box();
     }
     return ClassName.get(Object.class);
   }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/GetterProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/GetterProcessor.java
@@ -23,6 +23,7 @@ import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Getter;
 import org.higherkindedj.optics.annotations.GenerateGetters;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /** Annotation processor that generates Getter optics for record types. */
 @AutoService(Processor.class)
@@ -152,7 +153,7 @@ public class GetterProcessor extends AbstractProcessor {
 
     String componentName = component.getSimpleName().toString();
     TypeName componentTypeName = TypeName.get(component.asType());
-    String methodName = "get" + capitalise(componentName);
+    String methodName = "get" + ProcessorUtils.capitalise(componentName);
     String gettersClassName = recordElement.getSimpleName().toString() + "Getters";
 
     MethodSpec.Builder methodBuilder =
@@ -189,13 +190,6 @@ public class GetterProcessor extends AbstractProcessor {
     }
 
     return methodBuilder.build();
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase() + s.substring(1);
   }
 
   private void error(String msg, Element e) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
@@ -122,13 +122,13 @@ public class ImportOpticsProcessor extends AbstractProcessor {
     note("Checking interfaces for: " + typeElement.getQualifiedName(), typeElement);
     for (TypeMirror superInterface : typeElement.getInterfaces()) {
       note("  Found super interface: " + superInterface, typeElement);
-      if (superInterface instanceof DeclaredType declaredType) {
-        TypeElement interfaceElement = (TypeElement) declaredType.asElement();
-        String fqn = interfaceElement.getQualifiedName().toString();
-        note("  Interface FQN: " + fqn + " (expected: " + OPTICS_SPEC_FQN + ")", typeElement);
-        if (fqn.equals(OPTICS_SPEC_FQN)) {
-          return true;
-        }
+      // Super-interfaces returned by getInterfaces() are always declared types.
+      DeclaredType declaredType = (DeclaredType) superInterface;
+      TypeElement interfaceElement = (TypeElement) declaredType.asElement();
+      String fqn = interfaceElement.getQualifiedName().toString();
+      note("  Interface FQN: " + fqn + " (expected: " + OPTICS_SPEC_FQN + ")", typeElement);
+      if (fqn.equals(OPTICS_SPEC_FQN)) {
+        return true;
       }
     }
     return false;
@@ -274,7 +274,7 @@ public class ImportOpticsProcessor extends AbstractProcessor {
    * <p>We cannot directly access the Class objects at compile time, so we use the annotation mirror
    * API to extract the TypeMirrors and convert them to TypeElements.
    */
-  private List<TypeElement> getClassArrayFromAnnotation(Element element) {
+  List<TypeElement> getClassArrayFromAnnotation(Element element) {
     List<TypeElement> result = new ArrayList<>();
 
     // Find the @ImportOptics annotation mirror

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ImportOpticsProcessor.java
@@ -274,6 +274,7 @@ public class ImportOpticsProcessor extends AbstractProcessor {
    * <p>We cannot directly access the Class objects at compile time, so we use the annotation mirror
    * API to extract the TypeMirrors and convert them to TypeElements.
    */
+  // Package-private for tests.
   List<TypeElement> getClassArrayFromAnnotation(Element element) {
     List<TypeElement> result = new ArrayList<>();
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/LensProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/LensProcessor.java
@@ -23,6 +23,7 @@ import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.annotations.GenerateLenses;
 import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /** Annotation processor that generates Lens optics for record types. */
 @AutoService(Processor.class)
@@ -188,8 +189,8 @@ public class LensProcessor extends AbstractProcessor {
 
     String componentName = component.getSimpleName().toString();
     TypeName componentTypeName = TypeName.get(component.asType());
-    String methodName = "with" + capitalise(componentName);
-    String parameterName = "new" + capitalise(componentName);
+    String methodName = "with" + ProcessorUtils.capitalise(componentName);
+    String parameterName = "new" + ProcessorUtils.capitalise(componentName);
     String lensesClassName = recordElement.getSimpleName().toString() + "Lenses";
 
     MethodSpec.Builder methodBuilder =
@@ -234,12 +235,5 @@ public class LensProcessor extends AbstractProcessor {
     }
 
     return methodBuilder.build();
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase() + s.substring(1);
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -331,7 +331,7 @@ public class NavigatorClassGenerator {
       PathKind pathKind) {
 
     String componentName = component.getSimpleName().toString();
-    String navigatorClassName = capitalise(componentName) + "Navigator";
+    String navigatorClassName = ProcessorUtils.capitalise(componentName) + "Navigator";
     TypeName targetTypeName = TypeName.get(targetRecord.asType());
 
     // Type parameter S for the source type in the navigator
@@ -756,7 +756,7 @@ public class NavigatorClassGenerator {
           if (fieldTypeElement != null) {
             // The navigator is a nested class of the target record's Focus class.
             // Use $T for the enclosing Focus class to ensure proper cross-package imports.
-            String fieldNavigatorClassName = capitalise(fieldName) + "Navigator";
+            String fieldNavigatorClassName = ProcessorUtils.capitalise(fieldName) + "Navigator";
             ClassName navigatorClass =
                 ClassName.get(targetPackage, targetFocusClassName, fieldNavigatorClassName);
             ParameterizedTypeName navigatorType =
@@ -848,7 +848,7 @@ public class NavigatorClassGenerator {
           && innerTypeElement != null
           && innerTypeElement.getAnnotation(GenerateFocus.class) != null) {
         wrapInNavigator = true;
-        String innerNavigatorClassName = capitalise(fieldName) + "Navigator";
+        String innerNavigatorClassName = ProcessorUtils.capitalise(fieldName) + "Navigator";
         navigatorFromTargetFocus =
             ClassName.get(targetPackage, targetFocusClassName, innerNavigatorClassName);
       }
@@ -1096,12 +1096,6 @@ public class NavigatorClassGenerator {
   }
 
   /** Capitalises the first letter of a string. */
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return Character.toUpperCase(s.charAt(0)) + s.substring(1);
-  }
 
   /**
    * Creates a method spec for a navigator-returning method (replaces the standard FocusPath
@@ -1164,7 +1158,7 @@ public class NavigatorClassGenerator {
     }
 
     // Navigator class name
-    String navigatorClassName = capitalise(componentName) + "Navigator";
+    String navigatorClassName = ProcessorUtils.capitalise(componentName) + "Navigator";
     String packageName =
         processingEnv.getElementUtils().getPackageOf(recordElement).getQualifiedName().toString();
     String focusClassName = recordElement.getSimpleName().toString() + "Focus";

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -1080,8 +1080,6 @@ public class NavigatorClassGenerator {
     return OPTIONAL_TYPES.contains(qualifiedName) || COLLECTION_TYPES.contains(qualifiedName);
   }
 
-  /** Capitalises the first letter of a string. */
-
   /**
    * Creates a method spec for a navigator-returning method (replaces the standard FocusPath
    * method).

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -244,16 +244,17 @@ public class NavigatorClassGenerator {
     generateNavigatorsWithPathKind(focusClassBuilder, recordElement, currentDepth, PathKind.FOCUS);
   }
 
-  /** Generates navigator inner classes with path kind tracking. */
+  /**
+   * Generates navigator inner classes with path kind tracking.
+   *
+   * <p>Depth limiting is handled by the navigation-method generation (via {@code currentDepth +
+   * 1}); this method is only entered at the root level.
+   */
   private void generateNavigatorsWithPathKind(
       TypeSpec.Builder focusClassBuilder,
       TypeElement recordElement,
       int currentDepth,
       PathKind currentPathKind) {
-
-    if (currentDepth >= maxDepth) {
-      return;
-    }
 
     List<? extends RecordComponentElement> components = recordElement.getRecordComponents();
 
@@ -750,24 +751,20 @@ public class NavigatorClassGenerator {
         final CodeBlock viaStatement =
             buildViaStatement(currentPathKind, widenedKind, fieldKind, targetFocusClass, fieldName);
 
-        // Check if the field type is also navigable and we haven't exceeded depth
+        // Check if the field type is also navigable and we haven't exceeded depth.
+        // Navigable types are always declared types, so no TypeElement re-check is needed.
         if (currentDepth < maxDepth && isNavigableType(fieldType)) {
-          TypeElement fieldTypeElement = getTypeElement(fieldType);
-          if (fieldTypeElement != null) {
-            // The navigator is a nested class of the target record's Focus class.
-            // Use $T for the enclosing Focus class to ensure proper cross-package imports.
-            String fieldNavigatorClassName = ProcessorUtils.capitalise(fieldName) + "Navigator";
-            ClassName navigatorClass =
-                ClassName.get(targetPackage, targetFocusClassName, fieldNavigatorClassName);
-            ParameterizedTypeName navigatorType =
-                ParameterizedTypeName.get(navigatorClass, sourceTypeVar);
+          // The navigator is a nested class of the target record's Focus class.
+          // Use $T for the enclosing Focus class to ensure proper cross-package imports.
+          String fieldNavigatorClassName = ProcessorUtils.capitalise(fieldName) + "Navigator";
+          ClassName navigatorClass =
+              ClassName.get(targetPackage, targetFocusClassName, fieldNavigatorClassName);
+          ParameterizedTypeName navigatorType =
+              ParameterizedTypeName.get(navigatorClass, sourceTypeVar);
 
-            methodBuilder.returns(navigatorType);
-            methodBuilder.addStatement(
-                "return new $T.$L<>($L)", targetFocusClass, fieldNavigatorClassName, viaStatement);
-          } else {
-            methodBuilder.addStatement("return $L", viaStatement);
-          }
+          methodBuilder.returns(navigatorType);
+          methodBuilder.addStatement(
+              "return new $T.$L<>($L)", targetFocusClass, fieldNavigatorClassName, viaStatement);
         } else {
           methodBuilder.addStatement("return $L", viaStatement);
         }
@@ -951,28 +948,16 @@ public class NavigatorClassGenerator {
       return null;
     }
     DeclaredType declaredType = (DeclaredType) type;
-    TypeElement typeElement = (TypeElement) declaredType.asElement();
-    String qualifiedName = typeElement.getQualifiedName().toString();
 
+    // The sole caller filters out hardcoded Optional/Collection types, so only SPI
+    // containers reach this point.
     TypeMirror innerType = null;
-
-    // Hardcoded Optional and Collection types
-    if (OPTIONAL_TYPES.contains(qualifiedName) || COLLECTION_TYPES.contains(qualifiedName)) {
+    TraversableGenerator generator = findSpiGenerator(type);
+    if (generator != null) {
+      int focusIdx = generator.getFocusTypeArgumentIndex();
       List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
-      if (!typeArgs.isEmpty()) {
-        innerType = ProcessorUtils.resolveWildcard(typeArgs.get(0));
-      }
-    }
-
-    // SPI types
-    if (innerType == null) {
-      TraversableGenerator generator = findSpiGenerator(type);
-      if (generator != null) {
-        int focusIdx = generator.getFocusTypeArgumentIndex();
-        List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
-        if (focusIdx < typeArgs.size()) {
-          innerType = ProcessorUtils.resolveWildcard(typeArgs.get(focusIdx));
-        }
+      if (focusIdx < typeArgs.size()) {
+        innerType = ProcessorUtils.resolveWildcard(typeArgs.get(focusIdx));
       }
     }
 
@@ -986,7 +971,7 @@ public class NavigatorClassGenerator {
    * to {@code targetFocusClass}, ensuring correct import generation even when the Focus class is in
    * a different package.
    */
-  private CodeBlock buildViaStatement(
+  CodeBlock buildViaStatement(
       PathKind currentKind,
       PathKind widenedKind,
       PathKind fieldKind,
@@ -1022,7 +1007,7 @@ public class NavigatorClassGenerator {
   }
 
   /** Checks if a type is navigable (has @GenerateFocus annotation). */
-  private boolean isNavigableType(TypeMirror type) {
+  boolean isNavigableType(TypeMirror type) {
     if (type.getKind() != TypeKind.DECLARED) {
       return false;
     }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -971,6 +971,7 @@ public class NavigatorClassGenerator {
    * to {@code targetFocusClass}, ensuring correct import generation even when the Focus class is in
    * a different package.
    */
+  // Package-private for tests.
   CodeBlock buildViaStatement(
       PathKind currentKind,
       PathKind widenedKind,

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/SetterProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/SetterProcessor.java
@@ -23,6 +23,7 @@ import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Setter;
 import org.higherkindedj.optics.annotations.GenerateSetters;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /** Annotation processor that generates Setter optics for record types. */
 @AutoService(Processor.class)
@@ -171,8 +172,8 @@ public class SetterProcessor extends AbstractProcessor {
 
     String componentName = component.getSimpleName().toString();
     TypeName componentTypeName = TypeName.get(component.asType());
-    String methodName = "with" + capitalise(componentName);
-    String parameterName = "new" + capitalise(componentName);
+    String methodName = "with" + ProcessorUtils.capitalise(componentName);
+    String parameterName = "new" + ProcessorUtils.capitalise(componentName);
     String settersClassName = recordElement.getSimpleName().toString() + "Setters";
 
     MethodSpec.Builder methodBuilder =
@@ -217,13 +218,6 @@ public class SetterProcessor extends AbstractProcessor {
     }
 
     return methodBuilder.build();
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase() + s.substring(1);
   }
 
   private void error(String msg, Element e) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessor.java
@@ -413,7 +413,7 @@ public class ComposeEffectsProcessor extends AbstractProcessor {
     }
   }
 
-  private TypeElement getHandlesAlgebraType(TypeElement interpreterType) {
+  TypeElement getHandlesAlgebraType(TypeElement interpreterType) {
     Handles annotation = interpreterType.getAnnotation(Handles.class);
     if (annotation == null) return null;
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessor.java
@@ -413,6 +413,7 @@ public class ComposeEffectsProcessor extends AbstractProcessor {
     }
   }
 
+  // Package-private for tests.
   TypeElement getHandlesAlgebraType(TypeElement interpreterType) {
     Handles annotation = interpreterType.getAnnotation(Handles.class);
     if (annotation == null) return null;

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathSourceProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathSourceProcessor.java
@@ -231,6 +231,7 @@ public class PathSourceProcessor extends AbstractProcessor {
     javaFile.writeTo(processingEnv.getFiler());
   }
 
+  // Package-private for tests.
   static TypeMirror getWitnessType(PathSource annotation) {
     try {
       annotation.witness();
@@ -240,6 +241,7 @@ public class PathSourceProcessor extends AbstractProcessor {
     }
   }
 
+  // Package-private for tests.
   static TypeMirror getErrorType(PathSource annotation) {
     try {
       annotation.errorType();

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathSourceProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathSourceProcessor.java
@@ -231,7 +231,7 @@ public class PathSourceProcessor extends AbstractProcessor {
     javaFile.writeTo(processingEnv.getFiler());
   }
 
-  private TypeMirror getWitnessType(PathSource annotation) {
+  static TypeMirror getWitnessType(PathSource annotation) {
     try {
       annotation.witness();
       throw new AssertionError("Should have thrown MirroredTypeException");
@@ -240,7 +240,7 @@ public class PathSourceProcessor extends AbstractProcessor {
     }
   }
 
-  private TypeMirror getErrorType(PathSource annotation) {
+  static TypeMirror getErrorType(PathSource annotation) {
     try {
       annotation.errorType();
       throw new AssertionError("Should have thrown MirroredTypeException");
@@ -256,18 +256,14 @@ public class PathSourceProcessor extends AbstractProcessor {
       TypeVariableName typeA) {
     List<TypeName> interfaces = new ArrayList<>();
 
-    // Note: Chainable is sealed, so generated classes implement Combinable instead
-    // but still provide via/flatMap/then methods
-    switch (capability) {
-      case COMPOSABLE -> interfaces.add(ParameterizedTypeName.get(COMPOSABLE, typeA));
-      case COMBINABLE, CHAINABLE, EFFECTFUL ->
-          interfaces.add(ParameterizedTypeName.get(COMBINABLE, typeA));
-      case RECOVERABLE, ACCUMULATING -> {
-        interfaces.add(ParameterizedTypeName.get(COMBINABLE, typeA));
-        // Note: Recoverable is also sealed, so we don't implement it
-        // but still provide recover/recoverWith/mapError methods
-      }
-    }
+    // Note: Chainable and Recoverable are sealed, so generated classes implement Combinable
+    // instead but still provide via/flatMap/then (and recover/recoverWith/mapError) methods.
+    interfaces.add(
+        switch (capability) {
+          case COMPOSABLE -> ParameterizedTypeName.get(COMPOSABLE, typeA);
+          case COMBINABLE, CHAINABLE, EFFECTFUL, RECOVERABLE, ACCUMULATING ->
+              ParameterizedTypeName.get(COMBINABLE, typeA);
+        });
 
     return interfaces;
   }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/CopyStrategyCodeGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/CopyStrategyCodeGenerator.java
@@ -4,10 +4,10 @@ package org.higherkindedj.optics.processing.external;
 
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.TypeName;
-import java.util.Locale;
 import javax.lang.model.type.TypeMirror;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.CopyStrategyInfo;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.CopyStrategyKind;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Generates code for lens setter lambdas based on copy strategy annotations.
@@ -232,13 +232,6 @@ public class CopyStrategyCodeGenerator {
    * @return the JavaBean getter method name
    */
   public String javaBeanGetterMethodName(String fieldName) {
-    return "get" + capitalise(fieldName);
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
+    return "get" + ProcessorUtils.capitalise(fieldName);
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
@@ -63,6 +63,22 @@ public class ExternalLensGenerator {
   }
 
   /**
+   * Creates a new ExternalLensGenerator with an explicit list of traversal generators.
+   *
+   * <p>Package-private; intended for tests that need to control the available generators.
+   *
+   * @param filer the filer for writing generated files
+   * @param messager the messager for reporting diagnostics
+   * @param traversalGenerators the traversal generators to use instead of SPI discovery
+   */
+  ExternalLensGenerator(
+      Filer filer, Messager messager, List<TraversableGenerator> traversalGenerators) {
+    this.filer = filer;
+    this.messager = messager;
+    this.traversalGenerators = List.copyOf(traversalGenerators);
+  }
+
+  /**
    * Generates a lenses class for an external record.
    *
    * @param analysis the type analysis for the record
@@ -290,7 +306,7 @@ public class ExternalLensGenerator {
     return methodBuilder.build();
   }
 
-  private MethodSpec createTraversalMethod(
+  MethodSpec createTraversalMethod(
       FieldInfo field,
       TypeElement recordElement,
       List<? extends RecordComponentElement> allComponents,
@@ -387,7 +403,7 @@ public class ExternalLensGenerator {
         .build();
   }
 
-  private TypeName getFocusType(TypeMirror type, TraversableGenerator generator) {
+  TypeName getFocusType(TypeMirror type, TraversableGenerator generator) {
     if (type instanceof ArrayType arrayType) {
       return TypeName.get(arrayType.getComponentType()).box();
     } else if (type instanceof DeclaredType declaredType) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
@@ -6,7 +6,6 @@ import com.palantir.javapoet.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -29,6 +28,7 @@ import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.Traversal;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Generates lens classes for external types (records and wither-based classes).
@@ -242,8 +242,8 @@ public class ExternalLensGenerator {
   private MethodSpec createWithMethod(FieldInfo field, TypeElement typeElement, TypeName typeName) {
 
     TypeName fieldTypeName = TypeName.get(field.type());
-    String methodName = "with" + capitalise(field.name());
-    String parameterName = "new" + capitalise(field.name());
+    String methodName = "with" + ProcessorUtils.capitalise(field.name());
+    String parameterName = "new" + ProcessorUtils.capitalise(field.name());
     String lensesClassName = typeElement.getSimpleName().toString() + "Lenses";
 
     MethodSpec.Builder methodBuilder =
@@ -430,12 +430,5 @@ public class ExternalLensGenerator {
       messager.printMessage(
           Diagnostic.Kind.ERROR, "Could not write generated file: " + e.getMessage());
     }
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
@@ -306,6 +306,7 @@ public class ExternalLensGenerator {
     return methodBuilder.build();
   }
 
+  // Package-private for tests.
   MethodSpec createTraversalMethod(
       FieldInfo field,
       TypeElement recordElement,
@@ -403,6 +404,7 @@ public class ExternalLensGenerator {
         .build();
   }
 
+  // Package-private for tests.
   TypeName getFocusType(TypeMirror type, TraversableGenerator generator) {
     if (type instanceof ArrayType arrayType) {
       return TypeName.get(arrayType.getComponentType()).box();

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -385,8 +385,13 @@ public class SpecInterfaceAnalyser {
     // Check for @InstanceOf
     AnnotationMirror instanceOf = findAnnotation(method, INSTANCE_OF_FQN);
     if (instanceOf != null) {
-      // @InstanceOf.value() is mandatory, so the mirror always carries a TypeMirror.
+      // @InstanceOf.value() is mandatory, but an unresolvable class constant (a typo, or a
+      // not-yet-generated type) is modelled as an erroneous attribute whose value is a String,
+      // not a TypeMirror - so this CAN be null and must fall through to the hint diagnostic.
       TypeMirror targetType = getAnnotationTypeMirror(instanceOf, "value");
+      if (targetType == null) {
+        return Optional.empty();
+      }
       // Validate subtype relationship (Decision 6)
       if (!typeUtils.isSubtype(targetType, sourceType)) {
         error(

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -118,7 +118,8 @@ public class SpecInterfaceAnalyser {
       if (method.isDefault()) {
         defaultMethods.add(method);
       } else if (method.getModifiers().contains(Modifier.ABSTRACT)) {
-        Optional<OpticMethodInfo> opticInfo = analyseOpticMethod(method, sourceType, specInterface);
+        Optional<OpticMethodInfo> opticInfo =
+            analyseOpticMethod(method, sourceType, sourceTypeElement, specInterface);
         if (opticInfo.isPresent()) {
           opticMethods.add(opticInfo.get());
         } else {
@@ -142,9 +143,8 @@ public class SpecInterfaceAnalyser {
    */
   private TypeMirror extractSourceType(TypeElement specInterface) {
     for (TypeMirror superInterface : specInterface.getInterfaces()) {
-      if (!(superInterface instanceof DeclaredType declaredType)) {
-        continue;
-      }
+      // Super-interfaces returned by getInterfaces() are always declared types.
+      DeclaredType declaredType = (DeclaredType) superInterface;
 
       TypeElement interfaceElement = (TypeElement) declaredType.asElement();
       if (interfaceElement.getQualifiedName().contentEquals(OPTICS_SPEC_FQN)) {
@@ -162,11 +162,15 @@ public class SpecInterfaceAnalyser {
    *
    * @param method the abstract method
    * @param sourceType the source type S
+   * @param sourceTypeElement the resolved element for the source type
    * @param specInterface the spec interface (for error reporting)
    * @return the optic method info, or empty if invalid
    */
   private Optional<OpticMethodInfo> analyseOpticMethod(
-      ExecutableElement method, TypeMirror sourceType, TypeElement specInterface) {
+      ExecutableElement method,
+      TypeMirror sourceType,
+      TypeElement sourceTypeElement,
+      TypeElement specInterface) {
 
     // Validate method signature: no parameters allowed
     if (!method.getParameters().isEmpty()) {
@@ -254,7 +258,7 @@ public class SpecInterfaceAnalyser {
         prismHintInfo = prismResult.get().info();
       }
       case TRAVERSAL -> {
-        var traversalResult = parseTraversalHint(method, sourceType, specInterface);
+        var traversalResult = parseTraversalHint(method, sourceTypeElement, specInterface);
         if (traversalResult.isEmpty()) {
           error(
               "Traversal method '"
@@ -381,26 +385,24 @@ public class SpecInterfaceAnalyser {
     // Check for @InstanceOf
     AnnotationMirror instanceOf = findAnnotation(method, INSTANCE_OF_FQN);
     if (instanceOf != null) {
+      // @InstanceOf.value() is mandatory, so the mirror always carries a TypeMirror.
       TypeMirror targetType = getAnnotationTypeMirror(instanceOf, "value");
-      if (targetType != null) {
-        // Validate subtype relationship (Decision 6)
-        if (!typeUtils.isSubtype(targetType, sourceType)) {
-          error(
-              "@InstanceOf target '"
-                  + targetType
-                  + "' is not a subtype of source type '"
-                  + sourceType
-                  + "'. "
-                  + "Only subtypes of '"
-                  + sourceType
-                  + "' can be used with @InstanceOf.",
-              method);
-          return Optional.empty();
-        }
-        return Optional.of(
-            new PrismHintResult(
-                PrismHintKind.INSTANCE_OF, PrismHintInfo.forInstanceOf(targetType)));
+      // Validate subtype relationship (Decision 6)
+      if (!typeUtils.isSubtype(targetType, sourceType)) {
+        error(
+            "@InstanceOf target '"
+                + targetType
+                + "' is not a subtype of source type '"
+                + sourceType
+                + "'. "
+                + "Only subtypes of '"
+                + sourceType
+                + "' can be used with @InstanceOf.",
+            method);
+        return Optional.empty();
       }
+      return Optional.of(
+          new PrismHintResult(PrismHintKind.INSTANCE_OF, PrismHintInfo.forInstanceOf(targetType)));
     }
 
     // Check for @MatchWhen
@@ -421,7 +423,7 @@ public class SpecInterfaceAnalyser {
   private record TraversalHintResult(TraversalHintKind kind, TraversalHintInfo info) {}
 
   private Optional<TraversalHintResult> parseTraversalHint(
-      ExecutableElement method, TypeMirror sourceType, TypeElement specInterface) {
+      ExecutableElement method, TypeElement sourceTypeElement, TypeElement specInterface) {
     // Check for @TraverseWith
     AnnotationMirror traverseWith = findAnnotation(method, TRAVERSE_WITH_FQN);
     if (traverseWith != null) {
@@ -440,7 +442,8 @@ public class SpecInterfaceAnalyser {
 
       // Auto-detect traversal if not specified
       if (traversal.isEmpty()) {
-        Optional<String> autoDetected = autoDetectTraversalForField(fieldName, sourceType, method);
+        Optional<String> autoDetected =
+            autoDetectTraversalForField(fieldName, sourceTypeElement, method);
         if (autoDetected.isEmpty()) {
           // Error already reported in autoDetectTraversalForField
           return Optional.empty();
@@ -461,23 +464,12 @@ public class SpecInterfaceAnalyser {
    * Auto-detects the appropriate traversal for a field based on its type.
    *
    * @param fieldName the name of the field to look up
-   * @param sourceType the source type containing the field
+   * @param sourceTypeElement the resolved element for the source type containing the field
    * @param method the method element (for error reporting)
    * @return the traversal reference string, or empty if detection failed
    */
   private Optional<String> autoDetectTraversalForField(
-      String fieldName, TypeMirror sourceType, ExecutableElement method) {
-
-    // Get the source type element
-    TypeElement sourceTypeElement = (TypeElement) typeUtils.asElement(sourceType);
-    if (sourceTypeElement == null) {
-      error(
-          "Cannot auto-detect traversal: source type '"
-              + sourceType
-              + "' is not a valid type element",
-          method);
-      return Optional.empty();
-    }
+      String fieldName, TypeElement sourceTypeElement, ExecutableElement method) {
 
     // Look up the field's type on the source type
     TypeMirror fieldType = findFieldType(sourceTypeElement, fieldName);
@@ -594,14 +586,14 @@ public class SpecInterfaceAnalyser {
     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
         annotation.getElementValues().entrySet()) {
       if (entry.getKey().getSimpleName().contentEquals(elementName)) {
-        Object value = entry.getValue().getValue();
-        return value != null ? value.toString() : defaultValue;
+        // getValue() never returns null for a present annotation element.
+        return entry.getValue().getValue().toString();
       }
     }
     return defaultValue;
   }
 
-  private String[] getAnnotationStringArray(AnnotationMirror annotation, String elementName) {
+  String[] getAnnotationStringArray(AnnotationMirror annotation, String elementName) {
     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
         annotation.getElementValues().entrySet()) {
       if (entry.getKey().getSimpleName().contentEquals(elementName)) {
@@ -616,7 +608,7 @@ public class SpecInterfaceAnalyser {
     return new String[0];
   }
 
-  private TypeMirror getAnnotationTypeMirror(AnnotationMirror annotation, String elementName) {
+  TypeMirror getAnnotationTypeMirror(AnnotationMirror annotation, String elementName) {
     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
         annotation.getElementValues().entrySet()) {
       if (entry.getKey().getSimpleName().contentEquals(elementName)) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -598,6 +598,7 @@ public class SpecInterfaceAnalyser {
     return defaultValue;
   }
 
+  // Package-private for tests.
   String[] getAnnotationStringArray(AnnotationMirror annotation, String elementName) {
     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
         annotation.getElementValues().entrySet()) {
@@ -613,6 +614,7 @@ public class SpecInterfaceAnalyser {
     return new String[0];
   }
 
+  // Package-private for tests.
   TypeMirror getAnnotationTypeMirror(AnnotationMirror annotation, String elementName) {
     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
         annotation.getElementValues().entrySet()) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -26,6 +26,7 @@ import org.higherkindedj.optics.processing.external.SpecAnalysis.PrismHintInfo;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.PrismHintKind;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.TraversalHintInfo;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.TraversalHintKind;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Analyses spec interfaces extending {@code OpticsSpec<S>} to determine what optics to generate.
@@ -539,8 +540,8 @@ public class SpecInterfaceAnalyser {
     }
 
     // Look for accessor method (record-style: fieldName() or JavaBean-style: getFieldName())
-    String getterName = "get" + capitalise(fieldName);
-    String isGetterName = "is" + capitalise(fieldName); // For booleans
+    String getterName = "get" + ProcessorUtils.capitalise(fieldName);
+    String isGetterName = "is" + ProcessorUtils.capitalise(fieldName); // For booleans
 
     for (var enclosed : typeElement.getEnclosedElements()) {
       if (enclosed.getKind() != ElementKind.METHOD) {
@@ -574,13 +575,6 @@ public class SpecInterfaceAnalyser {
     }
 
     return null;
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
   }
 
   // ----- Annotation Utility Methods -----

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
@@ -349,7 +349,7 @@ public class SpecInterfaceGenerator {
    * @param typeMirror the type mirror
    * @return the type name, parameterised if the type has type arguments
    */
-  private TypeName getParameterisedTypeName(TypeMirror typeMirror) {
+  TypeName getParameterisedTypeName(TypeMirror typeMirror) {
     if (typeMirror instanceof DeclaredType declaredType) {
       List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
       if (!typeArgs.isEmpty()) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
@@ -349,6 +349,7 @@ public class SpecInterfaceGenerator {
    * @param typeMirror the type mirror
    * @return the type name, parameterised if the type has type arguments
    */
+  // Package-private for tests.
   TypeName getParameterisedTypeName(TypeMirror typeMirror) {
     if (typeMirror instanceof DeclaredType declaredType) {
       List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/TypeKindAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/TypeKindAnalyser.java
@@ -18,6 +18,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Analyses external types to determine what kind of optics can be generated.
@@ -229,8 +230,8 @@ public class TypeKindAnalyser {
     // Try various getter naming conventions
     String[] getterCandidates = {
       fieldName, // record-style: year()
-      "get" + capitalise(fieldName), // JavaBean: getYear()
-      "is" + capitalise(fieldName) // boolean: isActive()
+      "get" + ProcessorUtils.capitalise(fieldName), // JavaBean: getYear()
+      "is" + ProcessorUtils.capitalise(fieldName) // boolean: isActive()
     };
 
     for (var enclosed : classElement.getEnclosedElements()) {
@@ -441,12 +442,5 @@ public class TypeKindAnalyser {
     }
 
     return Optional.empty();
-  }
-
-  private String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -32,6 +32,19 @@ public final class ProcessorUtils {
    * @return the resolved type, or null if the wildcard should be treated as Object
    * @since 0.4.0
    */
+  /**
+   * Capitalises the first character, locale-neutrally; null and empty inputs pass through.
+   *
+   * @param s the string, may be null
+   * @return the capitalised string, or {@code s} unchanged when null or empty
+   */
+  public static String capitalise(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
+  }
+
   public static TypeMirror resolveWildcard(TypeMirror type) {
     if (type instanceof WildcardType wildcard) {
       TypeMirror extendsBound = wildcard.getExtendsBound();

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -32,19 +32,6 @@ public final class ProcessorUtils {
    * @return the resolved type, or null if the wildcard should be treated as Object
    * @since 0.4.0
    */
-  /**
-   * Capitalises the first character, locale-neutrally; null and empty inputs pass through.
-   *
-   * @param s the string, may be null
-   * @return the capitalised string, or {@code s} unchanged when null or empty
-   */
-  public static String capitalise(String s) {
-    if (s == null || s.isEmpty()) {
-      return s;
-    }
-    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
-  }
-
   public static TypeMirror resolveWildcard(TypeMirror type) {
     if (type instanceof WildcardType wildcard) {
       TypeMirror extendsBound = wildcard.getExtendsBound();
@@ -120,5 +107,18 @@ public final class ProcessorUtils {
       }
     }
     return true;
+  }
+
+  /**
+   * Capitalises the first character, locale-neutrally; null and empty inputs pass through.
+   *
+   * @param s the string, may be null
+   * @return the capitalised string, or {@code s} unchanged when null or empty
+   */
+  public static String capitalise(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorKindFieldTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorKindFieldTest.java
@@ -453,4 +453,37 @@ public class FocusProcessorKindFieldTest {
           compilation, "com.example.UnknownKindRecordFocus", "FocusPath<UnknownKindRecord");
     }
   }
+
+  @Nested
+  @DisplayName("Raw Parameterised Witness")
+  class RawParameterisedWitness {
+
+    @Test
+    @DisplayName("should skip witness type arguments when a parameterised witness is used raw")
+    void shouldSkipWitnessTypeArgumentsForRawWitness() {
+      // EitherKind.Witness is registered as parameterised, but used RAW here so the generated
+      // traverseOver call carries no witness type arguments. The record itself does not compile
+      // (the raw witness violates Kind's WitnessArity bound), but annotation processing runs
+      // before that bound check, so the generation path is still exercised.
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.RawWitnessRecord",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.Kind;
+              import org.higherkindedj.hkt.either.EitherKind;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              @SuppressWarnings("rawtypes")
+              public record RawWitnessRecord(
+                  String name, Kind<EitherKind.Witness, Integer> outcome) {}
+              """);
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(sourceFile);
+
+      assertThat(compilation).hadErrorContaining("not within bounds");
+    }
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNestedContainerTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorNestedContainerTest.java
@@ -6,6 +6,7 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
 
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.jupiter.api.DisplayName;
@@ -613,6 +614,69 @@ public class FocusProcessorNestedContainerTest {
       var compilation = javac().withProcessors(new FocusProcessor()).compile(source);
       assertThat(compilation).succeeded();
       assertGeneratedCodeContains(compilation, "com.example.ConfigFocus", expectedReturn);
+    }
+  }
+
+  @Nested
+  @DisplayName("Raw and Wildcard Inner Containers")
+  class RawInnerContainers {
+
+    @Test
+    @DisplayName("raw inner containers should stop recursion and resolve to Object")
+    void rawInnerContainersShouldResolveToObject() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.RawNested",
+              """
+              package com.example;
+
+              import java.util.List;
+              import java.util.Optional;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              @SuppressWarnings("rawtypes")
+              public record RawNested(List<Optional> a, Optional<List> b) {}
+              """);
+
+      Compilation compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+
+      assertThat(compilation).succeeded();
+      // List<Optional>: the raw inner Optional stops recursion; deep inner type is Object.
+      assertGeneratedCodeContains(
+          compilation, "com.example.RawNestedFocus", "TraversalPath<RawNested, Object> a()");
+      // Optional<List>: the raw inner List stops recursion.
+      assertGeneratedCodeContains(
+          compilation, "com.example.RawNestedFocus", "TraversalPath<RawNested, Object> b()");
+    }
+
+    @Test
+    @DisplayName("widenCollections should compose nested SPI ZERO_OR_MORE chains")
+    void widenCollectionsShouldComposeNestedSpiChains() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.WidenNested",
+              """
+              package com.example;
+
+              import java.util.Map;
+              import java.util.Optional;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(widenCollections = true)
+              public record WidenNested(Optional<Map<String, Integer>> e) {}
+              """);
+
+      Compilation compilation = javac().withProcessors(new FocusProcessor()).compile(source);
+
+      assertThat(compilation).succeeded();
+      // Optional<Map<String, Integer>>: nested SPI ZERO_OR_MORE widens to a Traversal chain.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WidenNestedFocus", "TraversalPath<WidenNested, Integer> e()");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.WidenNestedFocus",
+          "some().each(EachInstances.mapValuesEach())");
     }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorWideningChainTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorWideningChainTest.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.javapoet.ClassName;
+import java.util.ArrayList;
+import java.util.List;
+import org.higherkindedj.optics.annotations.KindSemantics;
+import org.higherkindedj.optics.processing.FocusProcessor.WideningStep;
+import org.higherkindedj.optics.processing.FocusProcessor.WideningType;
+import org.higherkindedj.optics.processing.kind.KindFieldInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct unit tests for {@link FocusProcessor#buildWideningChainExpression}.
+ *
+ * <p>{@code analyseNestedType} only ever emits OPTIONAL, COLLECTION and SPI steps, so the NULLABLE,
+ * KIND and default arms of the chain switch are unreachable through compile-testing fixtures. The
+ * method is pure (no processing environment), so fabricated chains cover those arms directly.
+ */
+@DisplayName("FocusProcessor widening chain expression")
+class FocusProcessorWideningChainTest {
+
+  private final FocusProcessor processor = new FocusProcessor();
+
+  private static WideningStep step(WideningType type) {
+    return new WideningStep(type, null, null, null);
+  }
+
+  private static WideningStep kindStep(WideningType type, KindSemantics semantics) {
+    KindFieldInfo kindInfo =
+        KindFieldInfo.of("W", ClassName.get(String.class), "T.INSTANCE", semantics);
+    return new WideningStep(type, kindInfo, null, null);
+  }
+
+  private String build(WideningStep... steps) {
+    return processor.buildWideningChainExpression(List.of(steps), new ArrayList<>());
+  }
+
+  @Test
+  @DisplayName("should append .nullable() for a NULLABLE step")
+  void shouldAppendNullableForNullableStep() {
+    String expression = build(step(WideningType.OPTIONAL), step(WideningType.NULLABLE));
+
+    assertThat(expression).isEqualTo(".some().nullable()");
+  }
+
+  @Test
+  @DisplayName("should append traverseOver().headOption() for a KIND_ZERO_OR_ONE step")
+  void shouldAppendHeadOptionForKindZeroOrOne() {
+    String expression =
+        build(
+            step(WideningType.OPTIONAL),
+            kindStep(WideningType.KIND_ZERO_OR_ONE, KindSemantics.ZERO_OR_ONE));
+
+    assertThat(expression)
+        .isEqualTo(".some().<W, java.lang.String>traverseOver(T.INSTANCE).headOption()");
+  }
+
+  @Test
+  @DisplayName("should append traverseOver().headOption() for a KIND_EXACTLY_ONE step")
+  void shouldAppendHeadOptionForKindExactlyOne() {
+    String expression =
+        build(
+            step(WideningType.OPTIONAL),
+            kindStep(WideningType.KIND_EXACTLY_ONE, KindSemantics.EXACTLY_ONE));
+
+    assertThat(expression)
+        .isEqualTo(".some().<W, java.lang.String>traverseOver(T.INSTANCE).headOption()");
+  }
+
+  @Test
+  @DisplayName("should append traverseOver() for a KIND_ZERO_OR_MORE step")
+  void shouldAppendTraverseOverForKindZeroOrMore() {
+    String expression =
+        build(
+            step(WideningType.COLLECTION),
+            kindStep(WideningType.KIND_ZERO_OR_MORE, KindSemantics.ZERO_OR_MORE));
+
+    assertThat(expression).isEqualTo(".each().<W, java.lang.String>traverseOver(T.INSTANCE)");
+  }
+
+  @Test
+  @DisplayName("should ignore NONE and NESTED steps in a chain")
+  void shouldIgnoreNoneAndNestedSteps() {
+    String expression = build(step(WideningType.NONE), step(WideningType.NESTED));
+
+    assertThat(expression).isEmpty();
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FoldProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FoldProcessorIntegrationTest.java
@@ -7,6 +7,7 @@ import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
 
 import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class FoldProcessorIntegrationTest {
@@ -181,5 +182,28 @@ public class FoldProcessorIntegrationTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining("The @GenerateFolds annotation can only be applied to records.");
+  }
+
+  @Test
+  @DisplayName("a type-variable component bound to Iterable is a plain fold, not a crash")
+  void typeVariableComponentBoundToIterableIsNotTreatedAsIterable() {
+    // A TypeVariable never passes isIterableType's DeclaredType gate, so getElementType's
+    // documented cast invariant holds even for T extends Iterable<String>.
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.GenericHolder",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateFolds;
+
+            @GenerateFolds
+            public record GenericHolder<T extends Iterable<String>>(T items) {}
+            """);
+
+    var compilation = javac().withProcessors(new FoldProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.GenericHolderFolds").isNotNull();
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ForComprehensionProcessorGuardTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ForComprehensionProcessorGuardTest.java
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code @GenerateForComprehensions} is {@code @Target(PACKAGE)}, so javac cannot hand the
+ * processor a non-package element or a package it cannot read the annotation from — but another
+ * processor generating annotated sources in a later round could. These tests drive those guards
+ * directly (the same proxy pattern as the MappingProcessor filer-fallback test).
+ */
+@DisplayName("ForComprehensionProcessor guards against elements javac cannot produce")
+class ForComprehensionProcessorGuardTest {
+
+  private final List<String> errors = new ArrayList<>();
+
+  private <T> T proxy(Class<T> type, java.util.function.BiFunction<String, Object[], Object> impl) {
+    return type.cast(
+        Proxy.newProxyInstance(
+            getClass().getClassLoader(),
+            new Class<?>[] {type},
+            (p, method, args) ->
+                switch (method.getName()) {
+                  case "equals" -> p == args[0];
+                  case "hashCode" -> System.identityHashCode(p);
+                  default -> impl.apply(method.getName(), args);
+                }));
+  }
+
+  private Element element(ElementKind kind, String name, Object annotation) {
+    return proxy(
+        Element.class,
+        (m, args) ->
+            switch (m) {
+              case "getKind" -> kind;
+              case "toString" -> name;
+              case "getAnnotation" -> annotation;
+              default -> null;
+            });
+  }
+
+  @Test
+  @DisplayName("non-package elements, duplicate packages and unreadable annotations are skipped")
+  void guardsSkipUnprocessableElements() {
+    ForComprehensionProcessor processor = new ForComprehensionProcessor();
+    Messager messager =
+        proxy(
+            Messager.class,
+            (m, args) -> {
+              if ("printMessage".equals(m)) {
+                errors.add(String.valueOf(args[1]));
+              }
+              return null;
+            });
+    processor.init(
+        proxy(ProcessingEnvironment.class, (m, args) -> "getMessager".equals(m) ? messager : null));
+
+    TypeElement annotationType = proxy(TypeElement.class, (m, args) -> null);
+    Element nonPackage = element(ElementKind.CLASS, "com.example.NotAPackage", null);
+    Element unreadable = element(ElementKind.PACKAGE, "com.example.unreadable", null);
+    RoundEnvironment roundEnv =
+        proxy(
+            RoundEnvironment.class,
+            (m, args) ->
+                "getElementsAnnotatedWith".equals(m) ? Set.of(nonPackage, unreadable) : null);
+
+    boolean claimed = processor.process(Set.of(annotationType), roundEnv);
+
+    assertThat(claimed).isTrue();
+    assertThat(errors)
+        .anySatisfy(msg -> assertThat(msg).contains("can only be applied to packages"))
+        .anySatisfy(msg -> assertThat(msg).contains("Could not read @GenerateForComprehensions"));
+
+    // A second round presenting the same unreadable package name is skipped silently.
+    errors.clear();
+    Element duplicate = element(ElementKind.PACKAGE, "com.example.unreadable", null);
+    RoundEnvironment secondRound =
+        proxy(
+            RoundEnvironment.class,
+            (m, args) -> "getElementsAnnotatedWith".equals(m) ? Set.of(duplicate) : null);
+    processor.process(Set.of(annotationType), secondRound);
+    assertThat(errors).isEmpty();
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratorTestHelper.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratorTestHelper.java
@@ -53,6 +53,33 @@ public final class GeneratorTestHelper {
    * @param generatedFileName The fully qualified name of the generated file.
    * @param expectedCode The expected code snippet.
    */
+  /** Asserts the generated file exists but does NOT contain the given (normalised) snippet. */
+  public static void assertGeneratedCodeDoesNotContain(
+      final Compilation compilation, final String generatedFileName, final String unexpectedCode) {
+
+    Optional<JavaFileObject> generatedSourceFile =
+        compilation.generatedSourceFile(generatedFileName);
+
+    if (generatedSourceFile.isEmpty()) {
+      fail("Generated source file not found: " + generatedFileName);
+      return;
+    }
+
+    try {
+      final String actualGeneratedCode = generatedSourceFile.get().getCharContent(true).toString();
+      final String normalisedActual = normaliseCode(actualGeneratedCode);
+      final String normalisedUnexpected = normaliseCode(unexpectedCode);
+
+      assertTrue(
+          !normalisedActual.contains(normalisedUnexpected),
+          String.format(
+              "Expected generated code NOT to contain:%n---%n%s%n---%nBut was:%n---%n%s%n---",
+              unexpectedCode, actualGeneratedCode));
+    } catch (Exception e) {
+      fail("Could not read generated source file: " + e.getMessage());
+    }
+  }
+
   public static void assertGeneratedCodeContains(
       final Compilation compilation, final String generatedFileName, final String expectedCode) {
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
@@ -7,6 +7,9 @@ import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
 
 import com.google.testing.compile.JavaFileObjects;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -890,6 +893,7 @@ class ImportOpticsProcessorTest {
       var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(importerClass);
 
       assertThat(compilation).succeeded();
+      Assertions.assertThat(compilation.generatedSourceFiles()).isEmpty();
     }
 
     @Test
@@ -924,7 +928,7 @@ class ImportOpticsProcessorTest {
               public class Plain {}
               """);
 
-      final class HarnessProcessor extends javax.annotation.processing.AbstractProcessor {
+      final class HarnessProcessor extends AbstractProcessor {
         private java.util.List<javax.lang.model.element.TypeElement> classList;
 
         @Override
@@ -940,7 +944,7 @@ class ImportOpticsProcessorTest {
         @Override
         public boolean process(
             java.util.Set<? extends javax.lang.model.element.TypeElement> annotations,
-            javax.annotation.processing.RoundEnvironment roundEnv) {
+            RoundEnvironment roundEnv) {
           if (roundEnv.processingOver() || classList != null) {
             return false;
           }
@@ -960,7 +964,7 @@ class ImportOpticsProcessorTest {
       var compilation = javac().withProcessors(harness).compile(plainClass);
 
       assertThat(compilation).succeeded();
-      org.assertj.core.api.Assertions.assertThat(harness.classList).isEmpty();
+      Assertions.assertThat(harness.classList).isEmpty();
     }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
@@ -660,4 +660,307 @@ class ImportOpticsProcessorTest {
       assertThat(compilation).generatedSourceFile("com.myapp.ProductLenses").isNotNull();
     }
   }
+
+  @Nested
+  @DisplayName("Coverage Hardening")
+  class CoverageHardening {
+
+    @Test
+    @DisplayName("should generate array traversal for record with array component")
+    void shouldGenerateArrayTraversalForRecord() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Squad",
+              """
+              package com.external;
+
+              public record Squad(String name, String[] tags) {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Squad.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(compilation, "com.myapp.optics.SquadLenses", "tagsTraversal");
+    }
+
+    @Test
+    @DisplayName(
+        "should treat interface with non-OpticsSpec super-interface as a class-list importer")
+    void shouldTreatNonSpecInterfaceAsClassListImporter() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Widget",
+              """
+              package com.external;
+
+              public record Widget(String label) {}
+              """);
+
+      final var importerInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.WidgetImporter",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics({com.external.Widget.class})
+              public interface WidgetImporter extends java.io.Serializable {}
+              """);
+
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(externalRecord, importerInterface);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.myapp.WidgetLenses").isNotNull();
+    }
+
+    @Test
+    @DisplayName("should honour explicit targetPackage on a spec interface")
+    void shouldHonourExplicitTargetPackageOnSpecInterface() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Temp",
+              """
+              package com.external;
+
+              public class Temp {
+                  private final int celsius;
+                  public Temp(int celsius) { this.celsius = celsius; }
+                  public int celsius() { return celsius; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.TempOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaConstructor;
+              import com.external.Temp;
+
+              @ImportOptics(targetPackage = "com.custom.gen")
+              public interface TempOpticsSpec extends OpticsSpec<Temp> {
+
+                  @ViaConstructor(parameterOrder = {"celsius"})
+                  Lens<Temp, Integer> celsius();
+              }
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.custom.gen.TempOptics").isNotNull();
+    }
+
+    @Test
+    @DisplayName("should honour explicit targetPackage on a type-level importer")
+    void shouldHonourExplicitTargetPackageOnTypeImporter() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Gadget",
+              """
+              package com.external;
+
+              public record Gadget(String id) {}
+              """);
+
+      final var importerClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.GadgetImporter",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics(value = {com.external.Gadget.class}, targetPackage = "com.gen")
+              public class GadgetImporter {}
+              """);
+
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(externalRecord, importerClass);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.gen.GadgetLenses").isNotNull();
+    }
+
+    @Test
+    @DisplayName("should skip non-@ImportOptics annotation mirrors when reading the class list")
+    void shouldSkipOtherAnnotationMirrors() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Gizmo",
+              """
+              package com.external;
+
+              public record Gizmo(String id) {}
+              """);
+
+      final var importerClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.GizmoImporter",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @Deprecated
+              @ImportOptics({com.external.Gizmo.class})
+              public class GizmoImporter {}
+              """);
+
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(externalRecord, importerClass);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.myapp.GizmoLenses").isNotNull();
+    }
+
+    @Test
+    @DisplayName("should skip non-value annotation elements when reading the class list")
+    void shouldSkipNonValueAnnotationElements() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Doohickey",
+              """
+              package com.external;
+
+              public record Doohickey(String id) {}
+              """);
+
+      final var importerClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.DoohickeyImporter",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics(allowMutable = true, value = {com.external.Doohickey.class})
+              public class DoohickeyImporter {}
+              """);
+
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(externalRecord, importerClass);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.myapp.DoohickeyLenses").isNotNull();
+    }
+
+    @Test
+    @DisplayName("should generate nothing when the class list is absent")
+    void shouldGenerateNothingWhenClassListAbsent() {
+      // Only targetPackage is written, so the element-values loop never finds "value"
+      final var importerClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.NoValueImporter",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics(targetPackage = "com.gen2")
+              public class NoValueImporter {}
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(importerClass);
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should ignore class-list entries whose type has no element (primitives)")
+    void shouldIgnorePrimitiveClassListEntries() {
+      final var importerClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.PrimitiveImporter",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+
+              @ImportOptics({int.class})
+              public class PrimitiveImporter {}
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(importerClass);
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should return empty class list for element without @ImportOptics")
+    void shouldReturnEmptyClassListWithoutImportOptics() {
+      final var plainClass =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Plain",
+              """
+              package com.myapp;
+
+              public class Plain {}
+              """);
+
+      final class HarnessProcessor extends javax.annotation.processing.AbstractProcessor {
+        private java.util.List<javax.lang.model.element.TypeElement> classList;
+
+        @Override
+        public java.util.Set<String> getSupportedAnnotationTypes() {
+          return java.util.Set.of("*");
+        }
+
+        @Override
+        public javax.lang.model.SourceVersion getSupportedSourceVersion() {
+          return javax.lang.model.SourceVersion.RELEASE_25;
+        }
+
+        @Override
+        public boolean process(
+            java.util.Set<? extends javax.lang.model.element.TypeElement> annotations,
+            javax.annotation.processing.RoundEnvironment roundEnv) {
+          if (roundEnv.processingOver() || classList != null) {
+            return false;
+          }
+
+          var plain = processingEnv.getElementUtils().getTypeElement("com.myapp.Plain");
+          if (plain != null) {
+            ImportOpticsProcessor target = new ImportOpticsProcessor();
+            target.init(processingEnv);
+            classList = target.getClassArrayFromAnnotation(plain);
+          }
+
+          return false;
+        }
+      }
+
+      HarnessProcessor harness = new HarnessProcessor();
+      var compilation = javac().withProcessors(harness).compile(plainClass);
+
+      assertThat(compilation).succeeded();
+      org.assertj.core.api.Assertions.assertThat(harness.classList).isEmpty();
+    }
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorClassGeneratorUnitTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorClassGeneratorUnitTest.java
@@ -1,0 +1,136 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import com.palantir.javapoet.ClassName;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import org.higherkindedj.optics.processing.NavigatorClassGenerator.PathKind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct unit tests for {@link NavigatorClassGenerator} internals that are unreachable through
+ * compile-testing fixtures.
+ *
+ * <p>{@code buildViaStatement} is only ever called with {@code fieldKind == FOCUS} in production
+ * (so {@code widenedKind == currentKind}), leaving its conversion arms dead; the method is pure, so
+ * direct calls cover them. {@code isNavigableType}'s annotation fallback is dead in production
+ * because the FocusProcessor pre-populates {@code navigableTypes} with every {@code @GenerateFocus}
+ * record, so an empty set exercises it.
+ */
+@DisplayName("NavigatorClassGenerator internals")
+class NavigatorClassGeneratorUnitTest {
+
+  private static NavigatorClassGenerator bareGenerator() {
+    // Also covers the constructor's null-generators fallback arm.
+    return new NavigatorClassGenerator(null, Set.of(), 1, new String[0], new String[0], null);
+  }
+
+  @Test
+  @DisplayName("should apply .asTraversal() when widening from FOCUS to TRAVERSAL")
+  void shouldApplyAsTraversalConversion() {
+    NavigatorClassGenerator generator = bareGenerator();
+    ClassName targetFocus = ClassName.get("com.example", "TargetFocus");
+
+    String statement =
+        generator
+            .buildViaStatement(
+                PathKind.FOCUS, PathKind.TRAVERSAL, PathKind.TRAVERSAL, targetFocus, "f")
+            .toString();
+
+    assertThat(statement)
+        .isEqualTo("delegate.via(com.example.TargetFocus.f().toLens()).asTraversal()");
+  }
+
+  @Test
+  @DisplayName("should apply .asAffine() when widening from FOCUS to AFFINE")
+  void shouldApplyAsAffineConversion() {
+    NavigatorClassGenerator generator = bareGenerator();
+    ClassName targetFocus = ClassName.get("com.example", "TargetFocus");
+
+    String statement =
+        generator
+            .buildViaStatement(PathKind.FOCUS, PathKind.AFFINE, PathKind.AFFINE, targetFocus, "f")
+            .toString();
+
+    assertThat(statement)
+        .isEqualTo("delegate.via(com.example.TargetFocus.f().toLens()).asAffine()");
+  }
+
+  @Test
+  @DisplayName("should not apply any conversion when the path kind is unchanged")
+  void shouldNotApplyConversionForUnchangedKind() {
+    NavigatorClassGenerator generator = bareGenerator();
+    ClassName targetFocus = ClassName.get("com.example", "TargetFocus");
+
+    String statement =
+        generator
+            .buildViaStatement(PathKind.FOCUS, PathKind.FOCUS, PathKind.FOCUS, targetFocus, "f")
+            .toString();
+
+    assertThat(statement).isEqualTo("delegate.via(com.example.TargetFocus.f().toLens())");
+  }
+
+  @Test
+  @DisplayName("should recognise @GenerateFocus types via the annotation fallback")
+  void shouldRecogniseGenerateFocusViaAnnotationFallback() {
+    final var annotated =
+        JavaFileObjects.forSourceString(
+            "com.test.Annotated",
+            """
+            package com.test;
+            import org.higherkindedj.optics.annotations.GenerateFocus;
+            @GenerateFocus
+            public record Annotated(String value) {}
+            """);
+
+    final class NavigabilityProbeProcessor extends AbstractProcessor {
+      private Boolean navigable;
+
+      @Override
+      public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+      }
+
+      @Override
+      public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.RELEASE_25;
+      }
+
+      @Override
+      public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver() || navigable != null) {
+          return false;
+        }
+
+        TypeElement typeElement =
+            processingEnv.getElementUtils().getTypeElement("com.test.Annotated");
+        if (typeElement != null) {
+          NavigatorClassGenerator generator =
+              new NavigatorClassGenerator(
+                  processingEnv, Set.of(), 1, new String[0], new String[0], List.of());
+          navigable = generator.isNavigableType(typeElement.asType());
+        }
+
+        return false;
+      }
+    }
+
+    NavigabilityProbeProcessor probe = new NavigabilityProbeProcessor();
+    Compilation compilation = javac().withProcessors(probe).compile(annotated);
+
+    assertThat(compilation).succeeded();
+    assertThat(probe.navigable).isTrue();
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorCoverageTest.java
@@ -1015,4 +1015,167 @@ class NavigatorCoverageTest {
       assertGeneratedCodeContains(compilation, "com.example.MapOuterFocus", "data()");
     }
   }
+
+  @Nested
+  @DisplayName("SPI Containers Wrapping Navigable Types")
+  class SpiContainersWrappingNavigableTypes {
+
+    @Test
+    @DisplayName("should generate AFFINE and TRAVERSAL navigators for SPI-wrapped navigable types")
+    void shouldGenerateNavigatorsForSpiWrappedNavigableTypes() {
+      final JavaFileObject deptSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Dept",
+              """
+              package com.example;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              @GenerateFocus(generateNavigators = true)
+              public record Dept(String title) {}
+              """);
+
+      final JavaFileObject addressSource =
+          JavaFileObjects.forSourceString(
+              "com.example.Address",
+              """
+              package com.example;
+              import java.util.Map;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              @GenerateFocus(generateNavigators = true, maxNavigatorDepth = 3)
+              public record Address(String street, Map<String, Dept> depts) {}
+              """);
+
+      final JavaFileObject companySource =
+          JavaFileObjects.forSourceString(
+              "com.example.Company",
+              """
+              package com.example;
+              import java.util.Map;
+              import org.higherkindedj.hkt.either.Either;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              @GenerateFocus(generateNavigators = true, maxNavigatorDepth = 3)
+              public record Company(
+                  String name,
+                  Address hq,
+                  Either<String, Address> registered,
+                  Map<String, Address> branches) {}
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new FocusProcessor())
+              .compile(deptSource, addressSource, companySource);
+
+      assertThat(compilation).succeeded();
+
+      // Either<String, Address> wraps a navigable type: AFFINE navigator with AffinePath delegate.
+      assertGeneratedCodeContains(
+          compilation, "com.example.CompanyFocus", "class RegisteredNavigator<S>");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.CompanyFocus",
+          "private final AffinePath<S, Address> delegate;");
+
+      // Map<String, Address> wraps a navigable type: TRAVERSAL navigator with TraversalPath
+      // delegate methods (getAll/modifyAll from addTraversalPathDelegateMethods).
+      assertGeneratedCodeContains(
+          compilation, "com.example.CompanyFocus", "class BranchesNavigator<S>");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.CompanyFocus",
+          "private final TraversalPath<S, Address> delegate;");
+
+      // Inside HqNavigator, the Map<String, Dept> field is wrapped in the target Focus class's
+      // DeptsNavigator (SPI ZERO_OR_MORE wrapping a navigable inner type).
+      assertGeneratedCodeContains(
+          compilation, "com.example.CompanyFocus", "AddressFocus.DeptsNavigator<S> depts()");
+    }
+  }
+
+  @Nested
+  @DisplayName("Widened Navigator Target Fields")
+  class WidenedNavigatorTargetFields {
+
+    @Test
+    @DisplayName("should handle raw, wildcard, array and subtype container fields in navigators")
+    void shouldHandleRawWildcardArrayAndSubtypeContainerFields() {
+      final JavaFileObject nullableAnnotation =
+          JavaFileObjects.forSourceString(
+              "org.jspecify.annotations.Nullable",
+              """
+              package org.jspecify.annotations;
+              import java.lang.annotation.*;
+              @Target({ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.FIELD,
+                       ElementType.RECORD_COMPONENT})
+              @Retention(RetentionPolicy.RUNTIME)
+              public @interface Nullable {}
+              """);
+
+      final JavaFileObject targetSource =
+          JavaFileObjects.forSourceString(
+              "com.example.WideTarget",
+              """
+              package com.example;
+              import java.util.ArrayList;
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Optional;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.jspecify.annotations.Nullable;
+              @GenerateFocus(generateNavigators = true)
+              @SuppressWarnings("rawtypes")
+              public record WideTarget(
+                  String label,
+                  Optional rawOpt,
+                  Optional<?> wildOpt,
+                  @Nullable int[] scores,
+                  ArrayList<String> tags,
+                  ArrayList<?> wildTags,
+                  ArrayList rawTags,
+                  Map<String, String> attrs,
+                  List<List<List<String>>> deep) {}
+              """);
+
+      final JavaFileObject rootSource =
+          JavaFileObjects.forSourceString(
+              "com.example.WideRoot",
+              """
+              package com.example;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              @GenerateFocus(generateNavigators = true)
+              public record WideRoot(String name, WideTarget target) {}
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new FocusProcessor())
+              .compile(nullableAnnotation, targetSource, rootSource);
+
+      assertThat(compilation).succeeded();
+
+      // Raw Optional: no inner type argument, so the field type itself is the focus.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "AffinePath<S, Optional> rawOpt()");
+      // Optional<?>: the unbounded wildcard resolves to Object.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "AffinePath<S, Object> wildOpt()");
+      // @Nullable int[]: non-declared type, no inner extraction, widened via .nullable().
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "AffinePath<S, int[]> scores()");
+      // ArrayList<String>: Collection subtype resolved through the interface walk.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "TraversalPath<S, String> tags()");
+      // ArrayList<?>: wildcard element resolves to Object.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "TraversalPath<S, Object> wildTags()");
+      // Raw ArrayList: no type argument, the field type itself is the focus.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "TraversalPath<S, ArrayList> rawTags()");
+      // Map<String, String>: SPI widening with a real optic expression.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "TraversalPath<S, String> attrs()");
+      // List<List<List<String>>>: nesting beyond the depth cap still composes to TRAVERSAL.
+      assertGeneratedCodeContains(
+          compilation, "com.example.WideRootFocus", "TraversalPath<S, List<List<String>>> deep()");
+    }
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/PrismProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/PrismProcessorIntegrationTest.java
@@ -58,4 +58,26 @@ public class PrismProcessorIntegrationTest {
     assertGeneratedCodeContains(compilation, generatedClassName, expectedCirclePrism);
     assertGeneratedCodeContains(compilation, generatedClassName, expectedSquarePrism);
   }
+
+  @Test
+  void shouldGenerateEmptyPrismsClassForPlainInterface() {
+    // A non-sealed, non-enum interface is accepted by the processor but produces a Prisms class
+    // with no factory methods (neither the sealed nor the enum body applies).
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.Plain",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GeneratePrisms;
+
+            @GeneratePrisms
+            public interface Plain {}
+            """);
+
+    var compilation = javac().withProcessors(new PrismProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.PlainPrisms").isNotNull();
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceCoverageTest.java
@@ -1054,4 +1054,58 @@ class SpecInterfaceCoverageTest {
       assertGeneratedCodeContains(compilation, "com.myapp.TeamLenses", "Lens<Team, String> name()");
     }
   }
+
+  @Nested
+  @DisplayName("Default method copying")
+  class DefaultMethodCopying {
+
+    @Test
+    @DisplayName("should copy type parameters of a generic default method")
+    void shouldCopyTypeParametersOfGenericDefaultMethod() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Config",
+              """
+              package com.external;
+
+              public class Config {
+                  private final String host;
+                  public Config(String host) { this.host = host; }
+                  public String getHost() { return host; }
+                  public Config withHost(String host) { return new Config(host); }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ConfigOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.Wither;
+              import com.external.Config;
+
+              @ImportOptics
+              public interface ConfigOpticsSpec extends OpticsSpec<Config> {
+
+                  @Wither(value = "withHost", getter = "getHost")
+                  Lens<Config, String> host();
+
+                  default <T> Lens<Config, T> generic() {
+                      return null;
+                  }
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.ConfigOptics", "public static <T> Lens<Config, T> generic()");
+    }
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpiGeneratorConflictTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpiGeneratorConflictTest.java
@@ -1,0 +1,205 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests exercising the equal-priority SPI conflict warning and the empty-optic-expression
+ * fallbacks, using the test-scope marker generators registered in {@code META-INF/services} (see
+ * {@code org.higherkindedj.optics.processing.testspi.TestMarkerGenerators}).
+ *
+ * <p>The {@code Dup} marker is supported by two equal-priority generators plus one lower-priority
+ * generator, so resolving it warns about the conflict, picks the first match, and skips the
+ * lower-priority one. Neither {@code Dup} nor {@code Solo} generators provide an optic expression,
+ * so navigator widening falls back to the plain {@code .each()}/{@code .nullable()} forms.
+ */
+@DisplayName("SPI generator conflicts and fallbacks")
+class SpiGeneratorConflictTest {
+
+  private static final JavaFileObject DUP_MARKER =
+      JavaFileObjects.forSourceString(
+          "com.example.hkjtest.Dup",
+          """
+          package com.example.hkjtest;
+
+          public class Dup<T> {}
+          """);
+
+  private static final JavaFileObject SOLO_MARKER =
+      JavaFileObjects.forSourceString(
+          "com.example.hkjtest.Solo",
+          """
+          package com.example.hkjtest;
+
+          public class Solo<T> {}
+          """);
+
+  private static final JavaFileObject BOX_MARKER =
+      JavaFileObjects.forSourceString(
+          "com.example.hkjtest.Box",
+          """
+          package com.example.hkjtest;
+
+          public class Box<T> {}
+          """);
+
+  @Nested
+  @DisplayName("FocusProcessor conflict warning")
+  class FocusConflictWarning {
+
+    @Test
+    @DisplayName("should warn about equal-priority SPI providers and use the first match")
+    void shouldWarnAboutEqualPrioritySpiProviders() {
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Conflicted",
+              """
+              package com.example;
+
+              import com.example.hkjtest.Dup;
+              import java.util.Optional;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Conflicted(String x, Dup<String> d, Optional<Dup<String>> od) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(DUP_MARKER, source);
+
+      assertThat(compilation).succeeded();
+      // Two equal-priority Dup generators: warned for the direct field (with element context)
+      // and again for the nested Optional<Dup<String>> analysis (without element context).
+      assertThat(compilation)
+          .hadWarningContaining("Multiple TraversableGenerator SPI providers with equal priority");
+      // Dup is ZERO_OR_MORE and widenCollections is off, so the field stays a FocusPath.
+      assertGeneratedCodeContains(
+          compilation, "com.example.ConflictedFocus", "FocusPath<Conflicted, Dup<String>> d()");
+    }
+  }
+
+  @Nested
+  @DisplayName("Navigator conflict warning and widening fallbacks")
+  class NavigatorConflictAndFallbacks {
+
+    @Test
+    @DisplayName("should warn and fall back to plain widening for expression-less SPI containers")
+    void shouldWarnAndFallBackForExpressionLessSpiContainers() {
+      final JavaFileObject targetSource =
+          JavaFileObjects.forSourceString(
+              "com.example.NavTarget",
+              """
+              package com.example;
+
+              import com.example.hkjtest.Box;
+              import com.example.hkjtest.Dup;
+              import com.example.hkjtest.Solo;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              @SuppressWarnings("rawtypes")
+              public record NavTarget(
+                  String label, Dup<String> d, Solo<String> s, Dup rawDup, Dup<?> wildDup,
+                  Box<String> boxed) {}
+              """);
+
+      final JavaFileObject rootSource =
+          JavaFileObjects.forSourceString(
+              "com.example.NavRoot",
+              """
+              package com.example;
+
+              import com.example.hkjtest.Dup;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              @SuppressWarnings("rawtypes")
+              public record NavRoot(String name, NavTarget target, Dup rawTop) {}
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new FocusProcessor())
+              .compile(DUP_MARKER, SOLO_MARKER, BOX_MARKER, targetSource, rootSource);
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation)
+          .hadWarningContaining("Multiple TraversableGenerator SPI providers with equal priority");
+
+      // Dup (ZERO_OR_MORE, no optic expression) falls back to .each() inside the navigator.
+      assertGeneratedCodeContains(
+          compilation, "com.example.NavRootFocus", "TraversalPath<S, String> d()");
+      // Solo (ZERO_OR_ONE, no optic expression) falls back to .nullable().
+      assertGeneratedCodeContains(
+          compilation, "com.example.NavRootFocus", "AffinePath<S, String> s()");
+    }
+
+    @Test
+    @DisplayName("should stop nested recursion at raw SPI inner containers")
+    void shouldStopNestedRecursionAtRawSpiInnerContainers() {
+      // Optional<Solo> (raw inner ZERO_OR_ONE SPI type): the inner focus type is unknown, so
+      // recursion stops and the deep inner type falls back to Object. Optional<Dup> does the
+      // same for a ZERO_OR_MORE SPI type under widenCollections.
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.RawSpiInner",
+              """
+              package com.example;
+
+              import com.example.hkjtest.Dup;
+              import com.example.hkjtest.Solo;
+              import java.util.Optional;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(widenCollections = true)
+              @SuppressWarnings("rawtypes")
+              public record RawSpiInner(Optional<Solo> c, Optional<Dup> od) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(DUP_MARKER, SOLO_MARKER, source);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.RawSpiInnerFocus", "AffinePath<RawSpiInner, Object> c()");
+      assertGeneratedCodeContains(
+          compilation, "com.example.RawSpiInnerFocus", "TraversalPath<RawSpiInner, Object> od()");
+    }
+
+    @Test
+    @DisplayName("should widen Box fields to Object when the focus index has no type argument")
+    void shouldWidenBoxFieldsToObjectWhenFocusIndexOutOfRange() {
+      // BoxIndexOneGenerator focuses on type argument 1, which Box<T> never has, so the focus
+      // type falls back to Object throughout.
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.BoxWiden",
+              """
+              package com.example;
+
+              import com.example.hkjtest.Box;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(widenCollections = true)
+              public record BoxWiden(String name, Box<String> boxed) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(BOX_MARKER, source);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.BoxWidenFocus", "TraversalPath<BoxWiden, Object> boxed()");
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TraversalProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TraversalProcessorIntegrationTest.java
@@ -5,8 +5,10 @@ package org.higherkindedj.optics.processing;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeDoesNotContain;
 
 import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class TraversalProcessorIntegrationTest {
@@ -52,6 +54,7 @@ public class TraversalProcessorIntegrationTest {
   }
 
   @Test
+  @DisplayName("a component whose generator focus index exceeds its type arguments is skipped")
   void shouldSkipComponentWhenGeneratorFocusIndexExceedsTypeArguments() {
     // The test-scope BoxIndexOneGenerator supports com.example.hkjtest.Box but focuses on type
     // argument index 1, which a Box<T> never has, so the traversal method is skipped.
@@ -82,9 +85,11 @@ public class TraversalProcessorIntegrationTest {
 
     assertThat(compilation).succeeded();
     assertThat(compilation).generatedSourceFile("com.example.BoxRecordTraversals").isNotNull();
+    assertGeneratedCodeDoesNotContain(compilation, "com.example.BoxRecordTraversals", "boxed");
   }
 
   @Test
+  @DisplayName("a component that is neither an array nor a declared type is skipped")
   void shouldSkipComponentThatIsNeitherArrayNorDeclared() {
     // The test-scope TypeVariableGenerator supports type variables named TRAVMARKER, steering a
     // type-variable component into createTraversalMethod, which cannot handle it and skips it.
@@ -104,5 +109,6 @@ public class TraversalProcessorIntegrationTest {
 
     assertThat(compilation).succeeded();
     assertThat(compilation).generatedSourceFile("com.example.VarRecordTraversals").isNotNull();
+    assertGeneratedCodeDoesNotContain(compilation, "com.example.VarRecordTraversals", "value");
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TraversalProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TraversalProcessorIntegrationTest.java
@@ -50,4 +50,59 @@ public class TraversalProcessorIntegrationTest {
     final String generatedClassName = "com.example.PlaylistTraversals";
     assertGeneratedCodeContains(compilation, generatedClassName, expectedTraversal);
   }
+
+  @Test
+  void shouldSkipComponentWhenGeneratorFocusIndexExceedsTypeArguments() {
+    // The test-scope BoxIndexOneGenerator supports com.example.hkjtest.Box but focuses on type
+    // argument index 1, which a Box<T> never has, so the traversal method is skipped.
+    final var markerSource =
+        JavaFileObjects.forSourceString(
+            "com.example.hkjtest.Box",
+            """
+            package com.example.hkjtest;
+
+            public class Box<T> {}
+            """);
+
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.BoxRecord",
+            """
+            package com.example;
+
+            import com.example.hkjtest.Box;
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+
+            @GenerateTraversals
+            public record BoxRecord(Box<String> boxed) {}
+            """);
+
+    var compilation =
+        javac().withProcessors(new TraversalProcessor()).compile(markerSource, sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.BoxRecordTraversals").isNotNull();
+  }
+
+  @Test
+  void shouldSkipComponentThatIsNeitherArrayNorDeclared() {
+    // The test-scope TypeVariableGenerator supports type variables named TRAVMARKER, steering a
+    // type-variable component into createTraversalMethod, which cannot handle it and skips it.
+    final var sourceFile =
+        JavaFileObjects.forSourceString(
+            "com.example.VarRecord",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateTraversals;
+
+            @GenerateTraversals
+            public record VarRecord<TRAVMARKER>(TRAVMARKER value) {}
+            """);
+
+    var compilation = javac().withProcessors(new TraversalProcessor()).compile(sourceFile);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.VarRecordTraversals").isNotNull();
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessorTest.java
@@ -59,8 +59,8 @@ class ComposeEffectsProcessorTest {
         """);
   }
 
-  @org.junit.jupiter.api.Test
-  @org.junit.jupiter.api.DisplayName("@Handles with an unresolvable value type is rejected")
+  @Test
+  @DisplayName("@Handles with an unresolvable value type is rejected")
   void handlesWithUnresolvableValueRejected() {
     JavaFileObject bad =
         JavaFileObjects.forSourceString(

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/ComposeEffectsProcessorTest.java
@@ -6,6 +6,7 @@ import static com.google.testing.compile.Compiler.javac;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.testing.compile.Compilation;
+import com.google.testing.compile.CompilationSubject;
 import com.google.testing.compile.JavaFileObjects;
 import java.io.IOException;
 import java.util.Optional;
@@ -56,6 +57,26 @@ class ComposeEffectsProcessorTest {
             Long logging
         ) {}
         """);
+  }
+
+  @org.junit.jupiter.api.Test
+  @org.junit.jupiter.api.DisplayName("@Handles with an unresolvable value type is rejected")
+  void handlesWithUnresolvableValueRejected() {
+    JavaFileObject bad =
+        JavaFileObjects.forSourceString(
+            "test.pkg.BadInterpreter",
+            """
+            package test.pkg;
+
+            import org.higherkindedj.hkt.effect.annotation.Handles;
+
+            @Handles(int.class)
+            public final class BadInterpreter {}
+            """);
+    Compilation compilation = compile(bad);
+    CompilationSubject.assertThat(compilation).failed();
+    CompilationSubject.assertThat(compilation)
+        .hadErrorContaining("Cannot resolve @Handles value type");
   }
 
   private Compilation compile(JavaFileObject... sources) {

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/EffectAlgebraProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/EffectAlgebraProcessorTest.java
@@ -112,16 +112,16 @@ class EffectAlgebraProcessorTest {
         """);
   }
 
-  @org.junit.jupiter.api.Test
-  @org.junit.jupiter.api.DisplayName("a non-record permit is rejected")
+  @Test
+  @DisplayName("a non-record permit is rejected")
   void nonRecordPermitRejected() {
     Compilation compilation = compile(nonRecordPermitAlgebra());
     CompilationSubject.assertThat(compilation).failed();
     CompilationSubject.assertThat(compilation).hadErrorContaining("Permit must be a record type");
   }
 
-  @org.junit.jupiter.api.Test
-  @org.junit.jupiter.api.DisplayName("mapK detection skips unrelated methods by name")
+  @Test
+  @DisplayName("mapK detection skips unrelated methods by name")
   void mapKDetectionSkipsUnrelatedMethods() {
     Compilation compilation = compile(unrelatedMethodAlgebra());
     CompilationSubject.assertThat(compilation).succeeded();

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/EffectAlgebraProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/EffectAlgebraProcessorTest.java
@@ -6,6 +6,7 @@ import static com.google.testing.compile.Compiler.javac;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.testing.compile.Compilation;
+import com.google.testing.compile.CompilationSubject;
 import com.google.testing.compile.JavaFileObjects;
 import java.io.IOException;
 import java.util.Optional;
@@ -44,6 +45,42 @@ class EffectAlgebraProcessorTest {
         """);
   }
 
+  /** A permit that is a final class, not a record - must be rejected. */
+  private static JavaFileObject nonRecordPermitAlgebra() {
+    return JavaFileObjects.forSourceString(
+        "test.pkg.BadOp",
+        """
+        package test.pkg;
+
+        import org.higherkindedj.hkt.effect.annotation.EffectAlgebra;
+
+        @EffectAlgebra
+        public sealed interface BadOp<A> permits BadOp.NotARecord {
+            final class NotARecord<A> implements BadOp<A> {}
+        }
+        """);
+  }
+
+  /** An algebra with an unrelated method - mapK detection must skip it by name. */
+  private static JavaFileObject unrelatedMethodAlgebra() {
+    return JavaFileObjects.forSourceString(
+        "test.pkg.NamedOp",
+        """
+        package test.pkg;
+
+        import org.higherkindedj.hkt.effect.annotation.EffectAlgebra;
+
+        @EffectAlgebra
+        public sealed interface NamedOp<A> permits NamedOp.Fetch {
+            default String describe() {
+                return "NamedOp";
+            }
+
+            record Fetch<A>(String key) implements NamedOp<A> {}
+        }
+        """);
+  }
+
   /** Effect algebra with mapK (continuation-passing style). */
   private static JavaFileObject mapKEffectAlgebra() {
     return JavaFileObjects.forSourceString(
@@ -73,6 +110,21 @@ class EffectAlgebraProcessorTest {
             }
         }
         """);
+  }
+
+  @org.junit.jupiter.api.Test
+  @org.junit.jupiter.api.DisplayName("a non-record permit is rejected")
+  void nonRecordPermitRejected() {
+    Compilation compilation = compile(nonRecordPermitAlgebra());
+    CompilationSubject.assertThat(compilation).failed();
+    CompilationSubject.assertThat(compilation).hadErrorContaining("Permit must be a record type");
+  }
+
+  @org.junit.jupiter.api.Test
+  @org.junit.jupiter.api.DisplayName("mapK detection skips unrelated methods by name")
+  void mapKDetectionSkipsUnrelatedMethods() {
+    Compilation compilation = compile(unrelatedMethodAlgebra());
+    CompilationSubject.assertThat(compilation).succeeded();
   }
 
   private Compilation compile(JavaFileObject source) {

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/MirroredTypeGuardTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/MirroredTypeGuardTest.java
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.effect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import javax.lang.model.element.TypeElement;
+import org.higherkindedj.hkt.effect.annotation.Handles;
+import org.higherkindedj.hkt.effect.annotation.PathSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The annotation-Class accessors are only ever called inside javac, where {@code
+ * MirroredTypeException} is contractually thrown; these tests pin the loud failure if that contract
+ * is ever violated (a plain annotation instance returning normally).
+ */
+@DisplayName("MirroredTypeException guards fail loudly outside javac")
+class MirroredTypeGuardTest {
+
+  private static final PathSource PLAIN_PATH_SOURCE =
+      new PathSource() {
+        @Override
+        public Class<? extends Annotation> annotationType() {
+          return PathSource.class;
+        }
+
+        @Override
+        public Class<?> witness() {
+          return String.class;
+        }
+
+        @Override
+        public Class<?> errorType() {
+          return Void.class;
+        }
+
+        @Override
+        public Capability capability() {
+          return Capability.CHAINABLE;
+        }
+
+        @Override
+        public String targetPackage() {
+          return "";
+        }
+
+        @Override
+        public String suffix() {
+          return "Path";
+        }
+      };
+
+  @Test
+  @DisplayName("PathSource witness/errorType accessors reject a non-mirrored annotation")
+  void pathSourceAccessorsRejectPlainAnnotation() {
+    assertThatThrownBy(() -> PathSourceProcessor.getWitnessType(PLAIN_PATH_SOURCE))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("MirroredTypeException");
+    assertThatThrownBy(() -> PathSourceProcessor.getErrorType(PLAIN_PATH_SOURCE))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("MirroredTypeException");
+  }
+
+  @Test
+  @DisplayName("@Handles resolution returns null without the annotation and rejects a plain one")
+  void handlesResolutionGuards() {
+    Handles plainHandles =
+        new Handles() {
+          @Override
+          public Class<? extends Annotation> annotationType() {
+            return Handles.class;
+          }
+
+          @Override
+          public Class<?> value() {
+            return String.class;
+          }
+        };
+    TypeElement unannotated = typeElement(annotationClass -> null);
+    TypeElement plainAnnotated =
+        typeElement(annotationClass -> annotationClass == Handles.class ? plainHandles : null);
+
+    ComposeEffectsProcessor processor = new ComposeEffectsProcessor();
+    assertThat(processor.getHandlesAlgebraType(unannotated)).isNull();
+    assertThatThrownBy(() -> processor.getHandlesAlgebraType(plainAnnotated))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("MirroredTypeException");
+  }
+
+  private interface AnnotationLookup {
+    Object lookup(Class<?> annotationClass);
+  }
+
+  private static TypeElement typeElement(AnnotationLookup lookup) {
+    return (TypeElement)
+        Proxy.newProxyInstance(
+            MirroredTypeGuardTest.class.getClassLoader(),
+            new Class<?>[] {TypeElement.class},
+            (proxy, method, args) ->
+                "getAnnotation".equals(method.getName())
+                    ? lookup.lookup((Class<?>) args[0])
+                    : null);
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/PathSourceProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/PathSourceProcessorIntegrationTest.java
@@ -203,6 +203,52 @@ class PathSourceProcessorIntegrationTest {
     }
 
     @Test
+    @DisplayName("errorType with a non-recoverable capability generates no recovery surface")
+    void errorTypeWithNonRecoverableCapabilityHasNoRecovery() {
+      final var witnessSource =
+          JavaFileObjects.forSourceString(
+              "com.example.ChainErrKind",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.Kind;
+              import org.higherkindedj.hkt.TypeArity;
+              import org.higherkindedj.hkt.WitnessArity;
+
+              public interface ChainErrKind<A> extends Kind<ChainErrKind.Witness, A> {
+                  final class Witness implements WitnessArity<TypeArity.Unary> {}
+              }
+              """);
+
+      final var sourceFile =
+          JavaFileObjects.forSourceString(
+              "com.example.ChainErr",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.effect.annotation.PathSource;
+
+              @PathSource(
+                  witness = ChainErrKind.Witness.class,
+                  errorType = String.class,
+                  capability = PathSource.Capability.CHAINABLE
+              )
+              public interface ChainErr<A> {}
+              """);
+
+      var compilation =
+          javac().withProcessors(new PathSourceProcessor()).compile(witnessSource, sourceFile);
+
+      assertThat(compilation).succeeded();
+
+      final String generatedClassName = "com.example.ChainErrPath";
+      // errorType alone does not unlock recovery: the capability decides (truthful surface).
+      assertGeneratedCodeContains(compilation, generatedClassName, "implements Combinable<A>");
+      assertGeneratedCodeDoesNotContain(compilation, generatedClassName, "recover(");
+      assertGeneratedCodeDoesNotContain(compilation, generatedClassName, "mapError(");
+    }
+
+    @Test
     @DisplayName("generates path class with Composable capability only")
     void shouldGenerateComposableOnlyPathClass() {
       final var witnessSource =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/ExternalGeneratorsUnitTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/ExternalGeneratorsUnitTest.java
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.external;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.CodeBlock;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.TypeName;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct unit tests for the package-private helpers of {@link ExternalLensGenerator} and {@link
+ * SpecInterfaceGenerator}.
+ *
+ * <p>These exercise defensive branches that are unreachable through record fixtures because {@code
+ * TypeKindAnalyser.detectContainerType} only flags container fields that always have a matching SPI
+ * generator with an in-range focus index. A test-controlled generator list makes the guard arms
+ * reachable.
+ */
+@DisplayName("External generators package-private helpers")
+class ExternalGeneratorsUnitTest {
+
+  /** A stub generator that supports every type, with a configurable focus type argument index. */
+  private static final class StubGenerator implements TraversableGenerator {
+    private final int focusIndex;
+
+    StubGenerator(int focusIndex) {
+      this.focusIndex = focusIndex;
+    }
+
+    @Override
+    public boolean supports(TypeMirror type) {
+      return true;
+    }
+
+    @Override
+    public int getFocusTypeArgumentIndex() {
+      return focusIndex;
+    }
+
+    @Override
+    public CodeBlock generateModifyF(
+        RecordComponentElement component,
+        ClassName recordClassName,
+        List<? extends RecordComponentElement> allComponents) {
+      return CodeBlock.of("");
+    }
+  }
+
+  /**
+   * Runs the unit-level calls inside a real processing environment so that genuine {@code
+   * TypeMirror}s and {@code RecordComponentElement}s are available.
+   */
+  private static class GeneratorUnitTestProcessor extends AbstractProcessor {
+    private boolean invoked = false;
+
+    private MethodSpec traversalForUnknownField;
+    private MethodSpec traversalForRawContainerField;
+    private TypeName focusTypeForRawContainer;
+    private TypeName focusTypeForOutOfRangeIndex;
+    private TypeName focusTypeForPrimitive;
+    private TypeName parameterisedNameForPrimitive;
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+      return Set.of("*");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.RELEASE_25;
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      if (roundEnv.processingOver() || invoked) {
+        return false;
+      }
+
+      TypeElement basket = processingEnv.getElementUtils().getTypeElement("com.test.Basket");
+      TypeElement mixed = processingEnv.getElementUtils().getTypeElement("com.test.Mixed");
+      if (basket == null || mixed == null) {
+        return false;
+      }
+      invoked = true;
+
+      // 1. No generator available at all: the generator-search loop exits without a match and
+      // createTraversalMethod returns null, so generateForRecord skips the traversal method.
+      ExternalLensGenerator withoutGenerators =
+          new ExternalLensGenerator(
+              processingEnv.getFiler(), processingEnv.getMessager(), List.of());
+      TypeAnalysis basketAnalysis =
+          new TypeKindAnalyser(processingEnv.getTypeUtils()).analyseType(basket);
+      withoutGenerators.generateForRecord(basketAnalysis, "com.test.gen", basket);
+
+      ExternalLensGenerator withStub =
+          new ExternalLensGenerator(
+              processingEnv.getFiler(), processingEnv.getMessager(), List.of(new StubGenerator(0)));
+
+      List<? extends RecordComponentElement> components = mixed.getRecordComponents();
+      TypeMirror itemsType = components.get(0).asType(); // List<String>
+      TypeMirror rawItemsType = components.get(1).asType(); // raw List
+      TypeName mixedTypeName = ClassName.get(mixed);
+
+      // 2. Field name matching no record component: the component loop exits without a match.
+      traversalForUnknownField =
+          withStub.createTraversalMethod(
+              FieldInfo.forRecordComponent("phantom", itemsType), mixed, components, mixedTypeName);
+
+      // 3. Raw container field: getFocusType returns null, so the method is skipped.
+      traversalForRawContainerField =
+          withStub.createTraversalMethod(
+              FieldInfo.forRecordComponent("rawItems", rawItemsType),
+              mixed,
+              components,
+              mixedTypeName);
+
+      // 4. getFocusType guard arms.
+      focusTypeForRawContainer = withStub.getFocusType(rawItemsType, new StubGenerator(0));
+      focusTypeForOutOfRangeIndex = withStub.getFocusType(itemsType, new StubGenerator(1));
+      TypeMirror primitiveInt = processingEnv.getTypeUtils().getPrimitiveType(TypeKind.INT);
+      focusTypeForPrimitive = withStub.getFocusType(primitiveInt, new StubGenerator(0));
+
+      // 5. SpecInterfaceGenerator.getParameterisedTypeName with a non-declared type.
+      SpecInterfaceGenerator specGenerator =
+          new SpecInterfaceGenerator(processingEnv.getFiler(), processingEnv.getMessager());
+      parameterisedNameForPrimitive = specGenerator.getParameterisedTypeName(primitiveInt);
+
+      return false;
+    }
+  }
+
+  @Test
+  @DisplayName("should take the defensive null arms when generators or components do not match")
+  void shouldTakeDefensiveNullArms() {
+    var basket =
+        JavaFileObjects.forSourceString(
+            "com.test.Basket",
+            """
+            package com.test;
+            import java.util.List;
+            public record Basket(List<String> items) {}
+            """);
+
+    var mixed =
+        JavaFileObjects.forSourceString(
+            "com.test.Mixed",
+            """
+            package com.test;
+            import java.util.List;
+            @SuppressWarnings("rawtypes")
+            public record Mixed(List<String> items, List rawItems) {}
+            """);
+
+    GeneratorUnitTestProcessor processor = new GeneratorUnitTestProcessor();
+    Compilation compilation = javac().withProcessors(processor).compile(basket, mixed);
+
+    assertThat(compilation).succeeded();
+    assertThat(processor.invoked).isTrue();
+    assertThat(processor.traversalForUnknownField).isNull();
+    assertThat(processor.traversalForRawContainerField).isNull();
+    assertThat(processor.focusTypeForRawContainer).isNull();
+    assertThat(processor.focusTypeForOutOfRangeIndex).isNull();
+    assertThat(processor.focusTypeForPrimitive).isNull();
+    assertThat(processor.parameterisedNameForPrimitive).isEqualTo(TypeName.INT);
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -14,6 +14,7 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
 import javax.tools.JavaFileObject;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.CopyStrategyKind;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.OpticKind;
@@ -214,9 +215,8 @@ class SpecInterfaceAnalyserTest {
    * Like {@link #analyseSpec} but does not assert compilation success. Use for tests where the
    * analyser is expected to report errors that cause compilation to fail.
    */
-  @org.junit.jupiter.api.Test
-  @org.junit.jupiter.api.DisplayName(
-      "an unresolvable @InstanceOf class constant falls through cleanly, not an NPE")
+  @Test
+  @DisplayName("an unresolvable @InstanceOf class constant falls through cleanly, not an NPE")
   void unresolvableInstanceOfTargetFallsThrough() {
     JavaFileObject source =
         JavaFileObjects.forSourceString(
@@ -254,7 +254,7 @@ class SpecInterfaceAnalyserTest {
     // hint diagnostic instead of throwing NullPointerException on the erroneous constant.
     Optional<SpecAnalysis> result =
         analyseSpecAllowingErrors("com.example.ShapeSpec", source, circle, spec);
-    org.assertj.core.api.Assertions.assertThat(result).isEmpty();
+    assertThat(result).isEmpty();
   }
 
   private Optional<SpecAnalysis> analyseSpecAllowingErrors(
@@ -1021,8 +1021,7 @@ class SpecInterfaceAnalyserTest {
         }
         invoked = true;
 
-        var method =
-            javax.lang.model.util.ElementFilter.methodsIn(spec.getEnclosedElements()).get(0);
+        var method = ElementFilter.methodsIn(spec.getEnclosedElements()).get(0);
         var viaBuilderMirror = method.getAnnotationMirrors().get(0);
 
         SpecInterfaceAnalyser analyser =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -108,6 +108,33 @@ class SpecInterfaceAnalyserTest {
           }
           """);
 
+  private static final JavaFileObject VIA_CONSTRUCTOR =
+      JavaFileObjects.forSourceString(
+          "org.higherkindedj.optics.annotations.ViaConstructor",
+          """
+          package org.higherkindedj.optics.annotations;
+          import java.lang.annotation.*;
+          @Target(ElementType.METHOD)
+          @Retention(RetentionPolicy.CLASS)
+          public @interface ViaConstructor {
+              String[] parameterOrder() default {};
+          }
+          """);
+
+  private static final JavaFileObject THROUGH_FIELD =
+      JavaFileObjects.forSourceString(
+          "org.higherkindedj.optics.annotations.ThroughField",
+          """
+          package org.higherkindedj.optics.annotations;
+          import java.lang.annotation.*;
+          @Target(ElementType.METHOD)
+          @Retention(RetentionPolicy.CLASS)
+          public @interface ThroughField {
+              String field();
+              String traversal() default "";
+          }
+          """);
+
   private static final JavaFileObject TRAVERSE_WITH =
       JavaFileObjects.forSourceString(
           "org.higherkindedj.optics.annotations.TraverseWith",
@@ -783,6 +810,233 @@ class SpecInterfaceAnalyserTest {
           analyseSpecAllowingErrors("com.test.BadFocusSpec", person, spec);
 
       assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Coverage Hardening")
+  class CoverageHardening {
+
+    @Test
+    @DisplayName("should report error when source type is not a valid type element")
+    void shouldReportErrorForArraySourceType() {
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.BadSourceSpec",
+              """
+              package com.test;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              public interface BadSourceSpec extends OpticsSpec<String[]> {}
+              """);
+
+      Optional<SpecAnalysis> result = analyseSpecAllowingErrors("com.test.BadSourceSpec", spec);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should skip non-OpticsSpec super-interfaces when extracting the source type")
+    void shouldSkipNonOpticsSpecSuperInterfaces() {
+      var person =
+          JavaFileObjects.forSourceString(
+              "com.test.Person",
+              """
+              package com.test;
+              public record Person(String name) {}
+              """);
+
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.MixedSuperSpec",
+              """
+              package com.test;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaBuilder;
+
+              public interface MixedSuperSpec extends Runnable, OpticsSpec<Person> {
+                  @ViaBuilder
+                  Lens<Person, String> name();
+              }
+              """);
+
+      Optional<SpecAnalysis> result =
+          analyseSpec("com.test.MixedSuperSpec", person, spec, VIA_BUILDER);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().sourceType().toString()).isEqualTo("com.test.Person");
+    }
+
+    @Test
+    @DisplayName("should find field type via public field fallback for @ThroughField")
+    void shouldFindFieldTypeViaPublicField() {
+      var squad =
+          JavaFileObjects.forSourceString(
+              "com.test.Squad",
+              """
+              package com.test;
+              public class Squad {
+                  public java.util.List<String> members;
+                  public Squad() {}
+              }
+              """);
+
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.SquadSpec",
+              """
+              package com.test;
+              import org.higherkindedj.optics.Traversal;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ThroughField;
+
+              public interface SquadSpec extends OpticsSpec<Squad> {
+                  @ThroughField(field = "members")
+                  Traversal<Squad, String> members();
+              }
+              """);
+
+      Optional<SpecAnalysis> result = analyseSpec("com.test.SquadSpec", squad, spec, THROUGH_FIELD);
+
+      assertThat(result).isPresent();
+      var method = result.get().opticMethods().get(0);
+      assertThat(method.traversalHint()).isEqualTo(TraversalHintKind.THROUGH_FIELD);
+    }
+
+    @Test
+    @DisplayName("should return empty parameter order for default @ViaConstructor")
+    void shouldReturnEmptyParameterOrderForDefaultViaConstructor() {
+      var coord =
+          JavaFileObjects.forSourceString(
+              "com.test.Coord",
+              """
+              package com.test;
+              public record Coord(int x) {}
+              """);
+
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.CoordSpec",
+              """
+              package com.test;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaConstructor;
+
+              public interface CoordSpec extends OpticsSpec<Coord> {
+                  @ViaConstructor
+                  Lens<Coord, Integer> x();
+              }
+              """);
+
+      Optional<SpecAnalysis> result =
+          analyseSpec("com.test.CoordSpec", coord, spec, VIA_CONSTRUCTOR);
+
+      assertThat(result).isPresent();
+      var method = result.get().opticMethods().get(0);
+      assertThat(method.copyStrategy()).isEqualTo(CopyStrategyKind.VIA_CONSTRUCTOR);
+      assertThat(method.copyStrategyInfo().parameterOrder()).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Annotation Helper Methods")
+  class AnnotationHelperMethods {
+
+    /**
+     * A helper processor that calls the package-private annotation helper methods with a real
+     * {@code @ViaBuilder} mirror, capturing the results for assertion. Exercises the non-matching
+     * element-name arms and the non-List / non-TypeMirror value arms, which are unreachable via the
+     * production call sites.
+     */
+    private static class AnnotationHelperTestProcessor extends AbstractProcessor {
+      private String[] arrayForStringValue;
+      private String[] arrayForMissingElement;
+      private javax.lang.model.type.TypeMirror mirrorForStringValue;
+      private javax.lang.model.type.TypeMirror mirrorForMissingElement;
+      private boolean invoked = false;
+
+      @Override
+      public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+      }
+
+      @Override
+      public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.RELEASE_25;
+      }
+
+      @Override
+      public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver() || invoked) {
+          return false;
+        }
+
+        TypeElement spec = processingEnv.getElementUtils().getTypeElement("com.test.HelperSpec");
+        if (spec == null) {
+          return false;
+        }
+        invoked = true;
+
+        var method =
+            javax.lang.model.util.ElementFilter.methodsIn(spec.getEnclosedElements()).get(0);
+        var viaBuilderMirror = method.getAnnotationMirrors().get(0);
+
+        SpecInterfaceAnalyser analyser =
+            new SpecInterfaceAnalyser(
+                processingEnv.getTypeUtils(),
+                processingEnv.getElementUtils(),
+                processingEnv.getMessager());
+
+        // "getter" is present but its value is a String, not a List or TypeMirror
+        arrayForStringValue = analyser.getAnnotationStringArray(viaBuilderMirror, "getter");
+        mirrorForStringValue = analyser.getAnnotationTypeMirror(viaBuilderMirror, "getter");
+
+        // "missing" matches no element name at all
+        arrayForMissingElement = analyser.getAnnotationStringArray(viaBuilderMirror, "missing");
+        mirrorForMissingElement = analyser.getAnnotationTypeMirror(viaBuilderMirror, "missing");
+
+        return false;
+      }
+    }
+
+    @Test
+    @DisplayName("should fall back to defaults when element values do not match the expected shape")
+    void shouldFallBackWhenElementValuesDoNotMatch() {
+      var person =
+          JavaFileObjects.forSourceString(
+              "com.test.Person",
+              """
+              package com.test;
+              public record Person(String name) {}
+              """);
+
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.HelperSpec",
+              """
+              package com.test;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaBuilder;
+
+              public interface HelperSpec extends OpticsSpec<Person> {
+                  @ViaBuilder(getter = "getName")
+                  Lens<Person, String> name();
+              }
+              """);
+
+      AnnotationHelperTestProcessor processor = new AnnotationHelperTestProcessor();
+      Compilation compilation =
+          javac()
+              .withProcessors(processor)
+              .compile(OPTICS_SPEC, LENS, PRISM, TRAVERSAL, VIA_BUILDER, person, spec);
+      assertThat(compilation).succeeded();
+
+      assertThat(processor.arrayForStringValue).isEmpty();
+      assertThat(processor.arrayForMissingElement).isEmpty();
+      assertThat(processor.mirrorForStringValue).isNull();
+      assertThat(processor.mirrorForMissingElement).isNull();
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -214,6 +214,49 @@ class SpecInterfaceAnalyserTest {
    * Like {@link #analyseSpec} but does not assert compilation success. Use for tests where the
    * analyser is expected to report errors that cause compilation to fail.
    */
+  @org.junit.jupiter.api.Test
+  @org.junit.jupiter.api.DisplayName(
+      "an unresolvable @InstanceOf class constant falls through cleanly, not an NPE")
+  void unresolvableInstanceOfTargetFallsThrough() {
+    JavaFileObject source =
+        JavaFileObjects.forSourceString(
+            "com.example.Shape",
+            """
+            package com.example;
+
+            public sealed interface Shape permits Circle {}
+            """);
+    JavaFileObject circle =
+        JavaFileObjects.forSourceString(
+            "com.example.Circle",
+            """
+            package com.example;
+
+            public record Circle(double radius) implements Shape {}
+            """);
+    JavaFileObject spec =
+        JavaFileObjects.forSourceString(
+            "com.example.ShapeSpec",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.Prism;
+            import org.higherkindedj.optics.annotations.InstanceOf;
+            import org.higherkindedj.optics.annotations.OpticsSpec;
+
+            public interface ShapeSpec extends OpticsSpec<Shape> {
+              @InstanceOf(MissingType.class)
+              Prism<Shape, Circle> circle();
+            }
+            """);
+
+    // MissingType does not exist: compilation fails, but the analyser must degrade to its
+    // hint diagnostic instead of throwing NullPointerException on the erroneous constant.
+    Optional<SpecAnalysis> result =
+        analyseSpecAllowingErrors("com.example.ShapeSpec", source, circle, spec);
+    org.assertj.core.api.Assertions.assertThat(result).isEmpty();
+  }
+
   private Optional<SpecAnalysis> analyseSpecAllowingErrors(
       String typeName, JavaFileObject... additionalSources) {
     JavaFileObject[] allSources = new JavaFileObject[additionalSources.length + 4];

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/TypeKindAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/TypeKindAnalyserTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import java.lang.reflect.Proxy;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
@@ -1061,7 +1062,7 @@ class TypeKindAnalyserTest {
             var realElements = processingEnv.getElementUtils();
             var nullReturningElements =
                 (javax.lang.model.util.Elements)
-                    java.lang.reflect.Proxy.newProxyInstance(
+                    Proxy.newProxyInstance(
                         getClass().getClassLoader(),
                         new Class<?>[] {javax.lang.model.util.Elements.class},
                         (proxy, method, args) ->

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/TypeKindAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/TypeKindAnalyserTest.java
@@ -1003,6 +1003,89 @@ class TypeKindAnalyserTest {
     }
 
     @Test
+    @DisplayName("should return empty for primitive (non-declared) type")
+    void shouldReturnEmptyForPrimitiveType() {
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.WithPrimitive",
+              """
+              package com.test;
+
+              public record WithPrimitive(int value) {}
+              """);
+
+      var result = detectContainerType("com.test.WithPrimitive", "value", source);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return empty when container type elements cannot be resolved")
+    void shouldReturnEmptyWhenContainerElementsUnresolvable() {
+      // Exercises the defensive `getTypeElement(...) != null` arms for List, Set, Optional and
+      // Map, which never fail on a real JVM. A delegating Elements whose getTypeElement always
+      // returns null forces all four checks to fall through to the final empty return.
+      var source =
+          JavaFileObjects.forSourceString(
+              "com.test.NullElementsList",
+              """
+              package com.test;
+
+              import java.util.List;
+
+              public record NullElementsList(List<String> items) {}
+              """);
+
+      final class NullElementsProcessor extends AbstractProcessor {
+        private Optional<ContainerType> result;
+
+        @Override
+        public Set<String> getSupportedAnnotationTypes() {
+          return Set.of("*");
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+          return SourceVersion.RELEASE_25;
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+          if (roundEnv.processingOver() || result != null) {
+            return false;
+          }
+
+          TypeElement typeElement =
+              processingEnv.getElementUtils().getTypeElement("com.test.NullElementsList");
+          if (typeElement != null) {
+            var realElements = processingEnv.getElementUtils();
+            var nullReturningElements =
+                (javax.lang.model.util.Elements)
+                    java.lang.reflect.Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class<?>[] {javax.lang.model.util.Elements.class},
+                        (proxy, method, args) ->
+                            method.getName().equals("getTypeElement")
+                                ? null
+                                : method.invoke(realElements, args));
+
+            TypeKindAnalyser analyser = new TypeKindAnalyser(processingEnv.getTypeUtils());
+            result =
+                analyser.detectContainerTypeWithSubtypes(
+                    typeElement.getRecordComponents().getFirst().asType(), nullReturningElements);
+          }
+
+          return false;
+        }
+      }
+
+      NullElementsProcessor processor = new NullElementsProcessor();
+      Compilation compilation = javac().withProcessors(processor).compile(source);
+      assertThat(compilation).succeeded();
+      assertThat(processor.result).isEmpty();
+    }
+
+    @Test
     @DisplayName("should return empty for unrecognised container type (Queue)")
     void shouldReturnEmptyForUnrecognisedContainerType() {
       var source =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/kind/KindFieldAnalyserCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/kind/KindFieldAnalyserCoverageTest.java
@@ -298,6 +298,49 @@ class KindFieldAnalyserCoverageTest {
   }
 
   @Nested
+  @DisplayName("Registered parameterised witness used raw")
+  class RawParameterisedWitness {
+
+    @Test
+    @DisplayName("should skip type-argument injection when a parameterised witness is used raw")
+    void shouldSkipInjectionForRawParameterisedWitness() {
+      // EitherKind.Witness is registered in KindRegistry as parameterised, but here it is used
+      // RAW (no <...>), so extractWitnessTypeArgs returns "" and injectTypeArgs is skipped.
+      // A stub EitherKind shadows the real one so the raw witness satisfies the stub Kind's
+      // unbounded type parameter (the real Kind bounds F with WitnessArity, rejecting raw use).
+      var eitherKindStub =
+          JavaFileObjects.forSourceString(
+              "org.higherkindedj.hkt.either.EitherKind",
+              """
+              package org.higherkindedj.hkt.either;
+              public final class EitherKind {
+                  public static final class Witness<L> {}
+              }
+              """);
+
+      var record =
+          JavaFileObjects.forSourceString(
+              "com.test.RawEitherRecord",
+              """
+              package com.test;
+              import org.higherkindedj.hkt.Kind;
+              @SuppressWarnings("rawtypes")
+              public record RawEitherRecord(
+                  Kind<org.higherkindedj.hkt.either.EitherKind.Witness, Integer> value
+              ) {}
+              """);
+
+      List<Optional<KindFieldInfo>> results =
+          analyseRecord("com.test.RawEitherRecord", KIND_INTERFACE, eitherKindStub, record);
+
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0)).isPresent();
+      assertThat(results.get(0).get().isParameterised()).isTrue();
+      assertThat(results.get(0).get().witnessTypeArgs()).isEmpty();
+    }
+  }
+
+  @Nested
   @DisplayName("@TraverseField with parameterised witness")
   class TraverseFieldParameterisedWitness {
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/testspi/TestMarkerGenerators.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/testspi/TestMarkerGenerators.java
@@ -1,0 +1,136 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.testspi;
+
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.CodeBlock;
+import java.util.List;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.higherkindedj.optics.processing.spi.Cardinality;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+
+/**
+ * Test-only {@link TraversableGenerator} implementations registered via a test-scope {@code
+ * META-INF/services} file. Each generator only {@code supports()} a unique marker type that no
+ * production fixture or golden file uses, so their registration is additive and inert for all
+ * existing tests.
+ *
+ * <ul>
+ *   <li>{@code com.example.hkjtest.Dup}: supported by three generators (two of equal priority, one
+ *       lower) to exercise the equal-priority conflict warning and the lower-priority skip arm.
+ *   <li>{@code com.example.hkjtest.Solo}: a ZERO_OR_ONE generator with an empty optic expression,
+ *       exercising the simple-widening fallback.
+ *   <li>{@code com.example.hkjtest.Box}: a generator whose focus type argument index (1) exceeds
+ *       the marker's single type argument, exercising the not-enough-type-arguments guard.
+ *   <li>type variables named {@code TRAVMARKER}: exercising the neither-array-nor-declared guard.
+ * </ul>
+ */
+public final class TestMarkerGenerators {
+
+  private TestMarkerGenerators() {}
+
+  private static boolean isMarker(TypeMirror type, String fqn) {
+    return type instanceof DeclaredType declaredType
+        && declaredType.asElement() instanceof TypeElement typeElement
+        && typeElement.getQualifiedName().contentEquals(fqn);
+  }
+
+  private abstract static class MarkerGeneratorBase implements TraversableGenerator {
+    private final String markerFqn;
+
+    MarkerGeneratorBase(String markerFqn) {
+      this.markerFqn = markerFqn;
+    }
+
+    @Override
+    public boolean supports(TypeMirror type) {
+      return isMarker(type, markerFqn);
+    }
+
+    @Override
+    public CodeBlock generateModifyF(
+        RecordComponentElement component,
+        ClassName recordClassName,
+        List<? extends RecordComponentElement> allComponents) {
+      return CodeBlock.of("");
+    }
+  }
+
+  /** First equal-priority generator for the {@code Dup} marker. */
+  public static final class DupGeneratorAlpha extends MarkerGeneratorBase {
+    /** Creates the generator. */
+    public DupGeneratorAlpha() {
+      super("com.example.hkjtest.Dup");
+    }
+  }
+
+  /** Second equal-priority generator for the {@code Dup} marker. */
+  public static final class DupGeneratorBeta extends MarkerGeneratorBase {
+    /** Creates the generator. */
+    public DupGeneratorBeta() {
+      super("com.example.hkjtest.Dup");
+    }
+  }
+
+  /** Lower-priority generator for the {@code Dup} marker. */
+  public static final class DupGeneratorFallback extends MarkerGeneratorBase {
+    /** Creates the generator. */
+    public DupGeneratorFallback() {
+      super("com.example.hkjtest.Dup");
+    }
+
+    @Override
+    public int priority() {
+      return -50;
+    }
+  }
+
+  /** ZERO_OR_ONE generator for the {@code Solo} marker with no optic expression. */
+  public static final class SoloGenerator extends MarkerGeneratorBase {
+    /** Creates the generator. */
+    public SoloGenerator() {
+      super("com.example.hkjtest.Solo");
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+      return Cardinality.ZERO_OR_ONE;
+    }
+  }
+
+  /** Generator for the {@code Box} marker focusing on a type argument index that never exists. */
+  public static final class BoxIndexOneGenerator extends MarkerGeneratorBase {
+    /** Creates the generator. */
+    public BoxIndexOneGenerator() {
+      super("com.example.hkjtest.Box");
+    }
+
+    @Override
+    public int getFocusTypeArgumentIndex() {
+      return 1;
+    }
+  }
+
+  /** Generator that supports type variables named {@code TRAVMARKER}. */
+  public static final class TypeVariableGenerator implements TraversableGenerator {
+    /** Creates the generator. */
+    public TypeVariableGenerator() {}
+
+    @Override
+    public boolean supports(TypeMirror type) {
+      return type.getKind() == TypeKind.TYPEVAR && type.toString().equals("TRAVMARKER");
+    }
+
+    @Override
+    public CodeBlock generateModifyF(
+        RecordComponentElement component,
+        ClassName recordClassName,
+        List<? extends RecordComponentElement> allComponents) {
+      return CodeBlock.of("");
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ProcessorUtils - shared processor string helpers")
+class ProcessorUtilsTest {
+
+  @Test
+  @DisplayName("capitalise upper-cases the first character and leaves the rest alone")
+  void capitaliseUpperCasesFirstCharacter() {
+    assertThat(ProcessorUtils.capitalise("name")).isEqualTo("Name");
+    assertThat(ProcessorUtils.capitalise("alreadyUpper")).isEqualTo("AlreadyUpper");
+    assertThat(ProcessorUtils.capitalise("x")).isEqualTo("X");
+  }
+
+  @Test
+  @DisplayName("capitalise passes null and empty inputs through unchanged")
+  void capitalisePassesDegenerateInputsThrough() {
+    assertThat(ProcessorUtils.capitalise(null)).isNull();
+    assertThat(ProcessorUtils.capitalise("")).isEmpty();
+  }
+}

--- a/hkj-processor/src/test/resources/META-INF/services/org.higherkindedj.optics.processing.spi.TraversableGenerator
+++ b/hkj-processor/src/test/resources/META-INF/services/org.higherkindedj.optics.processing.spi.TraversableGenerator
@@ -1,0 +1,6 @@
+org.higherkindedj.optics.processing.testspi.TestMarkerGenerators$DupGeneratorAlpha
+org.higherkindedj.optics.processing.testspi.TestMarkerGenerators$DupGeneratorBeta
+org.higherkindedj.optics.processing.testspi.TestMarkerGenerators$DupGeneratorFallback
+org.higherkindedj.optics.processing.testspi.TestMarkerGenerators$SoloGenerator
+org.higherkindedj.optics.processing.testspi.TestMarkerGenerators$BoxIndexOneGenerator
+org.higherkindedj.optics.processing.testspi.TestMarkerGenerators$TypeVariableGenerator


### PR DESCRIPTION
Applies the MappingProcessor coverage methodology (PR #605) across the whole of hkj-processor: measure per-branch, test what is reachable, delete what is provably dead, accept (and document) only the genuinely unreachable.

## Result
- **hkj-processor: ~99.7% line / ~98.3% branch** (was ~97.7%/92.4%), gate raised **95/87 → 99/97** with a comment naming the verified-unreachable residual; MappingProcessor stays pinned at 100/100.
- 77 missed lines / 137 missed branches across 17 classes → **13 lines / 32 branches across 8 classes**, all documented as unreachable (compiler-synthesised exhaustive-switch defaults, @Target-unproducible arms, fixed descriptor-table combos, guards dominated by earlier validation).

## How
- **Reuse fix doubling as coverage fix:** `ProcessorUtils.capitalise` (locale-neutral, unit-tested) replaces eight drifted private copies — also a determinism fix (the Lens/Getter/Setter copies used default-locale `toUpperCase()`, which generates different identifiers on e.g. tr_TR JVMs).
- **Proxy-driven unit tests** for paths javac cannot produce: MirroredTypeException guards (PathSource/ComposeEffects), ForComprehension's non-package/duplicate/unreadable guards, and writeFile-style filer fallbacks.
- **Analysis-verified dead-guard deletions** (~a dozen), each with the dominating invariant traced; enum switch statements converted to exhaustive expressions where JaCoCo filters the implicit default.
- **Targeted fixtures** for every reachable diagnostic branch across the external/import cluster, Focus/Navigator, and the effect processors, including additive test-scope SPI TraversableGenerators (marker-typed, inert for real types and golden files).

