### PR TITLE
TimeSource: java.time.Clock lifted into IO/VTask (#609)

### DIFF
--- a/hkj-book/src/monads/io_monad.md
+++ b/hkj-book/src/monads/io_monad.md
@@ -222,6 +222,22 @@ IO_OP.unsafeRunSync(finalProgram);
 
 ---
 
+## Reading the Clock
+
+The most common side effect after console/file I/O is reading the time — and `Instant.now()` scattered through your code makes every timestamp untestable. `TimeSource` lifts `java.time.Clock` into `IO` so time is a lazy, composable effect:
+
+``` java
+import org.higherkindedj.hkt.time.TimeSource;
+
+TimeSource time = TimeSource.system();               // or TimeSource.fixed(instant) in tests
+
+IO<Reservation> reserve(Order order) {
+  return time.now().map(t -> new Reservation(order.id(), order.items(), t.plus(hold)));
+}
+```
+
+Nothing is read until the effect runs, and each run reads afresh. In tests, inject `TimeSource.fixed(...)` — or `TimeSource.of(steppableClock)` with `hkj-test`'s [`SteppableClock`](../tooling/test_assertions.md#steppableclock) — and the same code becomes deterministic. (It is named `TimeSource`, not `Clock`, precisely so it never clashes with `java.time.Clock`.)
+
 ## Back to the One-Liner
 
 `IO` is the layer we wrap around the Foundations one-liner when we want side effects to be *described* rather than *performed* until interpretation:

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -14,6 +14,10 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ### 0.4.8-SNAPSHOT (Latest)
 
+**`TimeSource`: effectful, testable time**
+
+`java.time.Clock` lifted into the effect world: `TimeSource.system()` / `of(clock)` / `fixed(instant)` with lazy `now() : IO<Instant>` and `nowAsync() : VTask<Instant>` reads — time as a composable effect, deterministic in tests. Deliberately *not* named `Clock`, so it never clashes with `java.time.Clock` in the files that use both; any JDK clock (`fixed`/`offset`/`tick`) lifts through `of()`. `hkj-test` gains `SteppableClock` (`startingAt`/`advance`/`set`, atomic stepping, contract-honouring `withZone`) so time-dependent code is exercised by moving the clock, not sleeping — the order example's reservation-expiry test now works exactly that way ([#609](https://github.com/higher-kinded-j/higher-kinded-j/issues/609)).
+
 **`@GenerateMapping` Step-0 slice: the bidirectional mapper, de-risked**
 
 The first cut of the record↔DTO mapper: annotate `interface UserMapping extends MappingSpec<User, UserDto>` with `@GenerateMapping` and the processor generates `UserMappingImpl` — a total `build(User) : UserDto` and an accumulating `parse(UserDto) : Validated<NonEmptyList<FieldError>, User>` assembled with `Validated.fields()`, every failure located by component name. Components match by name; a validated leaf is a typed `default` method returning a `ValidatedPrism`. `@MapField` renames, nesting (spec delegating to spec, failures located by dotted path), `List`/`Optional` container lifting, sealed-interface dispatch and the truthful emission tiers (lossless → `asIso()`, lossy projection → `asLens()`, fallible → accumulating `parse`) all ship in this slice; every diagnostic follows the what/why/fix standard from day one. Map value lifting and generated law tests arrive with the full mapper ([#600](https://github.com/higher-kinded-j/higher-kinded-j/issues/600)).

--- a/hkj-book/src/tooling/test_assertions.md
+++ b/hkj-book/src/tooling/test_assertions.md
@@ -196,6 +196,28 @@ The same shape applies to `MaybeTAssert`, `OptionalTAssert`, `ReaderTAssert`, `S
 
 ---
 
+## Test Fixtures
+
+### `SteppableClock`
+
+A clock that only moves when told to — pair it with `TimeSource.of(clock)` and time-dependent code is exercised by stepping the clock, not sleeping:
+
+``` java
+import org.higherkindedj.hkt.assertions.SteppableClock;
+import org.higherkindedj.hkt.time.TimeSource;
+
+SteppableClock clock = SteppableClock.startingAt(Instant.parse("2026-07-07T00:00:00Z"));
+var service = new InMemoryInventoryService(TimeSource.of(clock));
+
+service.reserve(order);                    // hold expires 15 minutes from "now"
+clock.advance(Duration.ofMinutes(16));     // time passes - instantly
+service.reserve(other);                    // the expired hold is reclaimed
+```
+
+Stepping is atomic (safe to advance from the test thread while virtual threads read), and `withZone` honours the `java.time.Clock` contract — the zoned view shares the same steppable timeline.
+
+---
+
 ## Java 25: One-line Module Import
 
 `hkj-test` is published as a proper JPMS module named `org.higherkindedj.test`. On Java 25 with `--enable-preview` (already enabled across the HKJ project), JEP 511's module-import syntax reduces the per-class import boilerplate to a single line:

--- a/hkj-core/src/main/java/module-info.java
+++ b/hkj-core/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module org.higherkindedj.core {
   exports org.higherkindedj.hkt.instances;
   exports org.higherkindedj.hkt.io;
   exports org.higherkindedj.hkt.lazy;
+  exports org.higherkindedj.hkt.time;
   exports org.higherkindedj.hkt.list;
   exports org.higherkindedj.hkt.maybe;
   exports org.higherkindedj.hkt.maybe_t;

--- a/hkj-core/src/main/java/module-info.java
+++ b/hkj-core/src/main/java/module-info.java
@@ -33,7 +33,6 @@ module org.higherkindedj.core {
   exports org.higherkindedj.hkt.instances;
   exports org.higherkindedj.hkt.io;
   exports org.higherkindedj.hkt.lazy;
-  exports org.higherkindedj.hkt.time;
   exports org.higherkindedj.hkt.list;
   exports org.higherkindedj.hkt.maybe;
   exports org.higherkindedj.hkt.maybe_t;
@@ -46,6 +45,7 @@ module org.higherkindedj.core {
   exports org.higherkindedj.hkt.state_op;
   exports org.higherkindedj.hkt.state_t;
   exports org.higherkindedj.hkt.stream;
+  exports org.higherkindedj.hkt.time;
   exports org.higherkindedj.hkt.trampoline;
   exports org.higherkindedj.hkt.trymonad;
   exports org.higherkindedj.hkt.validated;

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/time/TimeSource.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/time/TimeSource.java
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.time;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Objects;
+import org.higherkindedj.hkt.io.IO;
+import org.higherkindedj.hkt.vtask.VTask;
+
+/**
+ * An effectful time source: {@link java.time.Clock} lifted into {@link IO} and {@link VTask}, so
+ * reading the current instant is a lazy, composable effect instead of an eager side effect — and
+ * deterministic in tests.
+ *
+ * <p>{@code java.time.Clock} is already the JDK's injectable-time abstraction, with {@code
+ * fixed}/{@code offset}/{@code tick} instances built in; this type deliberately lifts it rather
+ * than reinventing it, and any JDK clock plugs in through {@link #of(Clock)}. (It is named {@code
+ * TimeSource}, not {@code Clock}, precisely so it never clashes with {@code java.time.Clock} in the
+ * files that use both.)
+ *
+ * <pre>{@code
+ * TimeSource time = TimeSource.fixed(Instant.parse("2026-07-07T00:00:00Z"));
+ *
+ * IO<Reservation> reserve(Order order) {
+ *   return time.now().map(t -> new Reservation(order.id(), order.items(), t.plus(hold)));
+ * }
+ * }</pre>
+ *
+ * @param clock the underlying JDK clock; must not be null
+ */
+public record TimeSource(Clock clock) {
+
+  /**
+   * Validates the wrapped clock.
+   *
+   * @throws NullPointerException if {@code clock} is null
+   */
+  public TimeSource {
+    Objects.requireNonNull(clock, "clock must not be null");
+  }
+
+  /**
+   * The live system time source (UTC).
+   *
+   * @return a time source over {@link Clock#systemUTC()} (non-null)
+   */
+  public static TimeSource system() {
+    return new TimeSource(Clock.systemUTC());
+  }
+
+  /**
+   * Lifts any JDK clock — including {@link Clock#fixed}, {@link Clock#offset} and {@link
+   * Clock#tick} instances.
+   *
+   * @param clock the clock to lift; must not be null
+   * @return a time source over {@code clock} (non-null)
+   * @throws NullPointerException if {@code clock} is null
+   */
+  public static TimeSource of(Clock clock) {
+    return new TimeSource(clock);
+  }
+
+  /**
+   * A test convenience: a time source frozen at the given instant (UTC).
+   *
+   * @param instant the instant every read returns; must not be null
+   * @return a fixed time source (non-null)
+   * @throws NullPointerException if {@code instant} is null
+   */
+  public static TimeSource fixed(Instant instant) {
+    Objects.requireNonNull(instant, "instant must not be null");
+    return new TimeSource(Clock.fixed(instant, ZoneOffset.UTC));
+  }
+
+  /**
+   * The current instant as a lazy {@link IO}: nothing is read until the effect runs, and each run
+   * reads afresh.
+   *
+   * @return the instant-reading effect (non-null)
+   */
+  public IO<Instant> now() {
+    return IO.delay(clock::instant);
+  }
+
+  /**
+   * The current instant as a {@link VTask}, for asynchronous pipelines.
+   *
+   * @return the instant-reading task (non-null)
+   */
+  public VTask<Instant> nowAsync() {
+    return VTask.delay(clock::instant);
+  }
+}

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/time/TimeSource.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/time/TimeSource.java
@@ -28,12 +28,17 @@ import org.higherkindedj.hkt.vtask.VTask;
  * }
  * }</pre>
  *
+ * <p>Construct through the factories. Effectful pipelines compose {@link #now()} (or {@link
+ * #nowAsync()}); synchronous code at the edge of the effect world may read {@code
+ * clock().instant()} directly — determinism still comes from the injected clock.
+ *
  * @param clock the underlying JDK clock; must not be null
  */
 public record TimeSource(Clock clock) {
 
   /**
-   * Validates the wrapped clock.
+   * Validates the wrapped clock. Prefer the {@link #system()}, {@link #of(Clock)} and {@link
+   * #fixed(Instant)} factories; this canonical constructor exists because records require it.
    *
    * @throws NullPointerException if {@code clock} is null
    */

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/time/package-info.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/time/package-info.java
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+/**
+ * Effectful time: {@link org.higherkindedj.hkt.time.TimeSource} lifts {@link java.time.Clock} into
+ * {@code IO}/{@code VTask} so reading the current instant is a lazy, composable effect and
+ * deterministic in tests.
+ */
+@NullMarked
+package org.higherkindedj.hkt.time;
+
+import org.jspecify.annotations.NullMarked;

--- a/hkj-core/src/test/java/org/higherkindedj/architecture/NullMarkedPackageRules.java
+++ b/hkj-core/src/test/java/org/higherkindedj/architecture/NullMarkedPackageRules.java
@@ -47,6 +47,7 @@ class NullMarkedPackageRules {
     "eitherf",
     "error",
     "trymonad",
+    "time",
     "validated",
     "list",
     "optional",

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/time/TimeSourceTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/time/TimeSourceTest.java
@@ -4,6 +4,8 @@ package org.higherkindedj.hkt.time;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.higherkindedj.hkt.assertions.IOAssert.assertThatIO;
+import static org.higherkindedj.hkt.assertions.VTaskAssert.assertThatVTask;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -44,10 +46,10 @@ class TimeSourceTest {
     @Test
     @DisplayName("system reads live UTC time")
     void systemReadsLiveTime() {
-      Instant before = Instant.now();
+      // A generous tolerance rather than a strict wall-clock sandwich: the system clock is not
+      // monotonic, and an NTP adjustment must not flake this test.
       Instant read = TimeSource.system().now().unsafeRunSync();
-      Instant after = Instant.now();
-      assertThat(read).isBetween(before, after);
+      assertThat(Duration.between(read, Instant.now()).abs()).isLessThan(Duration.ofMinutes(1));
       assertThat(TimeSource.system().clock().getZone()).isEqualTo(ZoneOffset.UTC);
     }
 
@@ -93,16 +95,17 @@ class TimeSourceTest {
             }
           };
       IO<Instant> now = TimeSource.of(counting).now();
+      assertThatIO(now).isNotExecutedYet();
       assertThat(reads).hasValue(0);
-      assertThat(now.unsafeRunSync()).isEqualTo(FROZEN);
-      assertThat(now.unsafeRunSync()).isEqualTo(FROZEN);
+      assertThatIO(now).whenExecuted().hasValue(FROZEN);
+      assertThatIO(now).whenExecuted().hasValue(FROZEN);
       assertThat(reads).hasValue(2);
     }
 
     @Test
     @DisplayName("nowAsync reads the same clock through VTask")
     void nowAsyncReadsThroughVTask() {
-      assertThat(TimeSource.fixed(FROZEN).nowAsync().run()).isEqualTo(FROZEN);
+      assertThatVTask(TimeSource.fixed(FROZEN).nowAsync()).whenRun().succeeds().hasValue(FROZEN);
     }
   }
 }

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/time/TimeSourceTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/time/TimeSourceTest.java
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.higherkindedj.hkt.io.IO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TimeSource - java.time.Clock lifted into IO/VTask")
+class TimeSourceTest {
+
+  private static final Instant FROZEN = Instant.parse("2026-07-07T00:00:00Z");
+
+  @Nested
+  @DisplayName("Factories")
+  class Factories {
+
+    @Test
+    @DisplayName("fixed freezes every read at the given instant, in UTC")
+    void fixedFreezesTime() {
+      TimeSource time = TimeSource.fixed(FROZEN);
+      assertThat(time.now().unsafeRunSync()).isEqualTo(FROZEN);
+      assertThat(time.now().unsafeRunSync()).isEqualTo(FROZEN);
+      assertThat(time.clock().getZone()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    @Test
+    @DisplayName("of lifts any JDK clock, including offset clocks")
+    void ofLiftsAnyJdkClock() {
+      Clock offset = Clock.offset(Clock.fixed(FROZEN, ZoneOffset.UTC), Duration.ofHours(1));
+      TimeSource time = TimeSource.of(offset);
+      assertThat(time.now().unsafeRunSync()).isEqualTo(FROZEN.plus(Duration.ofHours(1)));
+    }
+
+    @Test
+    @DisplayName("system reads live UTC time")
+    void systemReadsLiveTime() {
+      Instant before = Instant.now();
+      Instant read = TimeSource.system().now().unsafeRunSync();
+      Instant after = Instant.now();
+      assertThat(read).isBetween(before, after);
+      assertThat(TimeSource.system().clock().getZone()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    @Test
+    @DisplayName("all inputs are eagerly guarded with named messages")
+    void inputsAreGuarded() {
+      assertThatNullPointerException()
+          .isThrownBy(() -> TimeSource.of(null))
+          .withMessage("clock must not be null");
+      assertThatNullPointerException()
+          .isThrownBy(() -> TimeSource.fixed(null))
+          .withMessage("instant must not be null");
+      assertThatNullPointerException()
+          .isThrownBy(() -> new TimeSource(null))
+          .withMessage("clock must not be null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Effectful reads")
+  class EffectfulReads {
+
+    @Test
+    @DisplayName("now is lazy: the clock is not read until the IO runs, and each run reads afresh")
+    void nowIsLazyAndRereads() {
+      AtomicInteger reads = new AtomicInteger();
+      Clock counting =
+          new Clock() {
+            @Override
+            public ZoneOffset getZone() {
+              return ZoneOffset.UTC;
+            }
+
+            @Override
+            public Clock withZone(java.time.ZoneId zone) {
+              return this;
+            }
+
+            @Override
+            public Instant instant() {
+              reads.incrementAndGet();
+              return FROZEN;
+            }
+          };
+      IO<Instant> now = TimeSource.of(counting).now();
+      assertThat(reads).hasValue(0);
+      assertThat(now.unsafeRunSync()).isEqualTo(FROZEN);
+      assertThat(now.unsafeRunSync()).isEqualTo(FROZEN);
+      assertThat(reads).hasValue(2);
+    }
+
+    @Test
+    @DisplayName("nowAsync reads the same clock through VTask")
+    void nowAsyncReadsThroughVTask() {
+      assertThat(TimeSource.fixed(FROZEN).nowAsync().run()).isEqualTo(FROZEN);
+    }
+  }
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.higherkindedj.example.order.error.OrderError;
@@ -16,6 +17,7 @@ import org.higherkindedj.example.order.model.ValidatedOrderLine;
 import org.higherkindedj.example.order.model.value.OrderId;
 import org.higherkindedj.example.order.service.InventoryService;
 import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.time.TimeSource;
 
 /**
  * In-memory implementation of InventoryService for testing and examples.
@@ -33,10 +35,18 @@ public class InMemoryInventoryService implements InventoryService {
   private final Map<String, String> productWarehouses = new ConcurrentHashMap<>();
   private final Map<String, InventoryReservation> reservations = new ConcurrentHashMap<>();
 
-  /** How long a reservation is held before it can be reclaimed. Adjustable for tests. */
-  private Duration reservationHold = Duration.ofMinutes(15);
+  /** How long a reservation is held before it can be reclaimed. */
+  private static final Duration RESERVATION_HOLD = Duration.ofMinutes(15);
+
+  /** Where this service reads time from; inject a fixed/steppable source in tests (#609). */
+  private final TimeSource timeSource;
 
   public InMemoryInventoryService() {
+    this(TimeSource.system());
+  }
+
+  public InMemoryInventoryService(TimeSource timeSource) {
+    this.timeSource = Objects.requireNonNull(timeSource, "timeSource must not be null");
     // Pre-populate with sample stock across different warehouses
     stock.put("PROD-001", 100);
     stock.put("PROD-002", 50);
@@ -61,11 +71,6 @@ public class InMemoryInventoryService implements InventoryService {
   public void setStock(String productId, int quantity, String warehouseId) {
     stock.put(productId, quantity);
     productWarehouses.put(productId, warehouseId);
-  }
-
-  /** Overrides how long reservations are held; mainly a seam for exercising expiry in tests. */
-  public void setReservationHold(Duration reservationHold) {
-    this.reservationHold = reservationHold;
   }
 
   @Override
@@ -227,10 +232,14 @@ public class InMemoryInventoryService implements InventoryService {
   /** Records a reservation for the given taken items and returns it. */
   private InventoryReservation storeReservation(List<InventoryReservation.ReservedItem> items) {
     var reservationId = "RES-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
-    var reservation =
-        new InventoryReservation(reservationId, items, Instant.now().plus(reservationHold));
+    var reservation = new InventoryReservation(reservationId, items, now().plus(RESERVATION_HOLD));
     reservations.put(reservationId, reservation);
     return reservation;
+  }
+
+  /** The service's single read of current time - always through the injected source. */
+  private Instant now() {
+    return timeSource.now().unsafeRunSync();
   }
 
   /** Looks up the warehouse a product ships from, defaulting to the primary warehouse. */
@@ -250,7 +259,7 @@ public class InMemoryInventoryService implements InventoryService {
     if (reservations.isEmpty()) {
       return;
     }
-    var now = Instant.now();
+    var now = now();
     // Snapshot keys so we can mutate the map while iterating.
     for (var reservationId : List.copyOf(reservations.keySet())) {
       var reservation = reservations.get(reservationId);

--- a/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/order/service/impl/InMemoryInventoryService.java
@@ -237,9 +237,13 @@ public class InMemoryInventoryService implements InventoryService {
     return reservation;
   }
 
-  /** The service's single read of current time - always through the injected source. */
+  /**
+   * The service's single read of current time - always through the injected source. This service is
+   * synchronous (Either-returning), so it reads the clock directly; effectful pipelines would
+   * compose {@code timeSource.now()} instead of unwrapping it.
+   */
   private Instant now() {
-    return timeSource.now().unsafeRunSync();
+    return timeSource.clock().instant();
   }
 
   /** Looks up the warehouse a product ships from, defaulting to the primary warehouse. */

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/InMemoryInventoryServiceTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/InMemoryInventoryServiceTest.java
@@ -5,11 +5,8 @@ package org.higherkindedj.example.order;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -24,6 +21,7 @@ import org.higherkindedj.example.order.model.value.Money;
 import org.higherkindedj.example.order.model.value.OrderId;
 import org.higherkindedj.example.order.model.value.ProductId;
 import org.higherkindedj.example.order.service.impl.InMemoryInventoryService;
+import org.higherkindedj.hkt.assertions.SteppableClock;
 import org.higherkindedj.hkt.time.TimeSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -111,7 +109,7 @@ class InMemoryInventoryServiceTest {
   void expiredHoldIsReclaimed() {
     // Inject a steppable time source (#609): reserve, advance past the hold, and the next
     // reservation reclaims the expired one - no seams, no negative durations, no sleeping.
-    var clock = new SteppableClock(Instant.parse("2026-07-07T00:00:00Z"));
+    var clock = SteppableClock.startingAt(Instant.parse("2026-07-07T00:00:00Z"));
     service = new InMemoryInventoryService(TimeSource.of(clock));
 
     service.reserve(OrderId.generate(), List.of(line("PROD-001", 10)));
@@ -122,34 +120,6 @@ class InMemoryInventoryServiceTest {
     // This second reservation reclaims the expired first one before taking its own stock.
     service.reserve(OrderId.generate(), List.of(line("PROD-002", 1)));
     assertThat(stockOf("PROD-001")).isEqualTo(100);
-  }
-
-  /** A clock tests can move forward by hand. */
-  private static final class SteppableClock extends Clock {
-    private Instant current;
-
-    SteppableClock(Instant start) {
-      this.current = start;
-    }
-
-    void advance(Duration step) {
-      current = current.plus(step);
-    }
-
-    @Override
-    public ZoneId getZone() {
-      return ZoneOffset.UTC;
-    }
-
-    @Override
-    public Clock withZone(ZoneId zone) {
-      return this;
-    }
-
-    @Override
-    public Instant instant() {
-      return current;
-    }
   }
 
   /** Reads true on-hand stock by requesting more than could exist and reading what is available. */

--- a/hkj-examples/src/test/java/org/higherkindedj/example/order/InMemoryInventoryServiceTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/order/InMemoryInventoryServiceTest.java
@@ -5,7 +5,11 @@ package org.higherkindedj.example.order;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.EitherAssert.assertThatEither;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -20,6 +24,7 @@ import org.higherkindedj.example.order.model.value.Money;
 import org.higherkindedj.example.order.model.value.OrderId;
 import org.higherkindedj.example.order.model.value.ProductId;
 import org.higherkindedj.example.order.service.impl.InMemoryInventoryService;
+import org.higherkindedj.hkt.time.TimeSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -104,15 +109,47 @@ class InMemoryInventoryServiceTest {
   @Test
   @DisplayName("an expired hold is reclaimed on the next reservation")
   void expiredHoldIsReclaimed() {
-    // Force every hold to be already expired, so the next reserve reclaims the prior one.
-    service.setReservationHold(Duration.ofSeconds(-1));
+    // Inject a steppable time source (#609): reserve, advance past the hold, and the next
+    // reservation reclaims the expired one - no seams, no negative durations, no sleeping.
+    var clock = new SteppableClock(Instant.parse("2026-07-07T00:00:00Z"));
+    service = new InMemoryInventoryService(TimeSource.of(clock));
 
     service.reserve(OrderId.generate(), List.of(line("PROD-001", 10)));
     assertThat(stockOf("PROD-001")).isEqualTo(90);
 
+    clock.advance(Duration.ofMinutes(16));
+
     // This second reservation reclaims the expired first one before taking its own stock.
     service.reserve(OrderId.generate(), List.of(line("PROD-002", 1)));
     assertThat(stockOf("PROD-001")).isEqualTo(100);
+  }
+
+  /** A clock tests can move forward by hand. */
+  private static final class SteppableClock extends Clock {
+    private Instant current;
+
+    SteppableClock(Instant start) {
+      this.current = start;
+    }
+
+    void advance(Duration step) {
+      current = current.plus(step);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return current;
+    }
   }
 
   /** Reads true on-hand stock by requesting more than could exist and reading what is available. */

--- a/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/SteppableClock.java
+++ b/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/SteppableClock.java
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.assertions;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Objects;
+
+/**
+ * A test clock that only moves when told to: start it at a known instant, then {@link #advance} or
+ * {@link #set} it by hand. Pairs with {@code TimeSource.of(clock)} so time-dependent code is
+ * exercised without sleeping.
+ *
+ * <pre>{@code
+ * SteppableClock clock = SteppableClock.startingAt(Instant.parse("2026-07-07T00:00:00Z"));
+ * var service = new InventoryService(TimeSource.of(clock));
+ * service.reserve(order);
+ * clock.advance(Duration.ofMinutes(16));   // the hold has now expired
+ * }</pre>
+ *
+ * <p>The clock is fixed to UTC; {@link #withZone} returns {@code this} (zone handling is out of a
+ * test fixture's scope). The current instant is {@code volatile}, so advancing from a test thread
+ * is visible to code reading the clock on other (e.g. virtual) threads.
+ */
+public final class SteppableClock extends Clock {
+
+  private volatile Instant current;
+
+  private SteppableClock(Instant start) {
+    this.current = start;
+  }
+
+  /**
+   * A clock frozen at {@code start} until stepped.
+   *
+   * @param start the initial instant; must not be null
+   * @return the steppable clock (non-null)
+   * @throws NullPointerException if {@code start} is null
+   */
+  public static SteppableClock startingAt(Instant start) {
+    Objects.requireNonNull(start, "start must not be null");
+    return new SteppableClock(start);
+  }
+
+  /**
+   * Moves the clock forward (or, with a negative duration, backward).
+   *
+   * @param step the amount to move; must not be null
+   * @throws NullPointerException if {@code step} is null
+   */
+  public void advance(Duration step) {
+    Objects.requireNonNull(step, "step must not be null");
+    current = current.plus(step);
+  }
+
+  /**
+   * Jumps the clock to an exact instant.
+   *
+   * @param instant the new current instant; must not be null
+   * @throws NullPointerException if {@code instant} is null
+   */
+  public void set(Instant instant) {
+    current = Objects.requireNonNull(instant, "instant must not be null");
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return ZoneOffset.UTC;
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    return this;
+  }
+
+  @Override
+  public Instant instant() {
+    return current;
+  }
+}

--- a/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/SteppableClock.java
+++ b/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/SteppableClock.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A test clock that only moves when told to: start it at a known instant, then {@link #advance} or
@@ -21,16 +22,19 @@ import java.util.Objects;
  * clock.advance(Duration.ofMinutes(16));   // the hold has now expired
  * }</pre>
  *
- * <p>The clock is fixed to UTC; {@link #withZone} returns {@code this} (zone handling is out of a
- * test fixture's scope). The current instant is {@code volatile}, so advancing from a test thread
- * is visible to code reading the clock on other (e.g. virtual) threads.
+ * <p>The clock is UTC by default; per the {@link Clock} contract, {@link #withZone} returns a new
+ * clock with the requested zone sharing the same underlying timeline. The current instant is held
+ * in an {@link AtomicReference}, so stepping from a test thread is atomic and visible to code
+ * reading the clock on other (e.g. virtual) threads.
  */
 public final class SteppableClock extends Clock {
 
-  private volatile Instant current;
+  private final AtomicReference<Instant> current;
+  private final ZoneId zone;
 
-  private SteppableClock(Instant start) {
-    this.current = start;
+  private SteppableClock(AtomicReference<Instant> current, ZoneId zone) {
+    this.current = current;
+    this.zone = zone;
   }
 
   /**
@@ -42,7 +46,7 @@ public final class SteppableClock extends Clock {
    */
   public static SteppableClock startingAt(Instant start) {
     Objects.requireNonNull(start, "start must not be null");
-    return new SteppableClock(start);
+    return new SteppableClock(new AtomicReference<>(start), ZoneOffset.UTC);
   }
 
   /**
@@ -53,7 +57,7 @@ public final class SteppableClock extends Clock {
    */
   public void advance(Duration step) {
     Objects.requireNonNull(step, "step must not be null");
-    current = current.plus(step);
+    current.updateAndGet(instant -> instant.plus(step));
   }
 
   /**
@@ -63,21 +67,23 @@ public final class SteppableClock extends Clock {
    * @throws NullPointerException if {@code instant} is null
    */
   public void set(Instant instant) {
-    current = Objects.requireNonNull(instant, "instant must not be null");
+    Objects.requireNonNull(instant, "instant must not be null");
+    current.set(instant);
   }
 
   @Override
   public ZoneId getZone() {
-    return ZoneOffset.UTC;
+    return zone;
   }
 
   @Override
   public Clock withZone(ZoneId zone) {
-    return this;
+    Objects.requireNonNull(zone, "zone must not be null");
+    return new SteppableClock(current, zone);
   }
 
   @Override
   public Instant instant() {
-    return current;
+    return current.get();
   }
 }

--- a/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/SteppableClockTest.java
+++ b/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/SteppableClockTest.java
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.hkt.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SteppableClock - a test clock that only moves when told to")
+class SteppableClockTest {
+
+  private static final Instant START = Instant.parse("2026-07-07T00:00:00Z");
+
+  @Test
+  @DisplayName("stays frozen until advanced, then moves by exactly the step")
+  void freezesAndAdvances() {
+    SteppableClock clock = SteppableClock.startingAt(START);
+    assertThat(clock.instant()).isEqualTo(START);
+    assertThat(clock.instant()).isEqualTo(START);
+
+    clock.advance(Duration.ofMinutes(16));
+    assertThat(clock.instant()).isEqualTo(START.plus(Duration.ofMinutes(16)));
+
+    clock.set(START);
+    assertThat(clock.instant()).isEqualTo(START);
+  }
+
+  @Test
+  @DisplayName("is fixed to UTC and keeps its identity across withZone")
+  void zoneHandling() {
+    SteppableClock clock = SteppableClock.startingAt(START);
+    assertThat(clock.getZone()).isEqualTo(ZoneOffset.UTC);
+    assertThat(clock.withZone(ZoneOffset.ofHours(2))).isSameAs(clock);
+  }
+
+  @Test
+  @DisplayName("all inputs are eagerly guarded with named messages")
+  void inputsAreGuarded() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> SteppableClock.startingAt(null))
+        .withMessage("start must not be null");
+    SteppableClock clock = SteppableClock.startingAt(START);
+    assertThatNullPointerException()
+        .isThrownBy(() -> clock.advance(null))
+        .withMessage("step must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> clock.set(null))
+        .withMessage("instant must not be null");
+  }
+}

--- a/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/SteppableClockTest.java
+++ b/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/SteppableClockTest.java
@@ -5,6 +5,7 @@ package org.higherkindedj.hkt.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -31,11 +32,18 @@ class SteppableClockTest {
   }
 
   @Test
-  @DisplayName("is fixed to UTC and keeps its identity across withZone")
+  @DisplayName("withZone returns a new clock with the requested zone sharing the timeline")
   void zoneHandling() {
     SteppableClock clock = SteppableClock.startingAt(START);
     assertThat(clock.getZone()).isEqualTo(ZoneOffset.UTC);
-    assertThat(clock.withZone(ZoneOffset.ofHours(2))).isSameAs(clock);
+
+    Clock zoned = clock.withZone(ZoneOffset.ofHours(2));
+    assertThat(zoned.getZone()).isEqualTo(ZoneOffset.ofHours(2));
+    assertThat(zoned).isNotSameAs(clock);
+
+    // Same underlying timeline: stepping the original is seen through the zoned view.
+    clock.advance(Duration.ofMinutes(10));
+    assertThat(zoned.instant()).isEqualTo(START.plus(Duration.ofMinutes(10)));
   }
 
   @Test
@@ -51,5 +59,8 @@ class SteppableClockTest {
     assertThatNullPointerException()
         .isThrownBy(() -> clock.set(null))
         .withMessage("instant must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> clock.withZone(null))
+        .withMessage("zone must not be null");
   }
 }


### PR DESCRIPTION
Implements [#609](https://github.com/higher-kinded-j/higher-kinded-j/issues/609).

## What
- **`org.higherkindedj.hkt.time.TimeSource`** (new exported, @NullMarked package): a record wrapping `java.time.Clock` with `system()`/`of(Clock)`/`fixed(Instant)` factories and lazy `now() : IO<Instant>` / `nowAsync() : VTask<Instant>` reads. Deliberately **not named `Clock`** — it must never clash with `java.time.Clock` in the files that use both. Any JDK clock (`fixed`/`offset`/`tick`) lifts through `of()`; the Javadoc states the canonical construction path and when to read `clock().instant()` directly (synchronous edges) vs compose `now()` (effectful pipelines).
- **hkj-test ships `SteppableClock`** (`startingAt`/`advance`/`set`, volatile current instant) — the test convenience the issue anticipated, at 100% own-bundle coverage.
- **Adoption — the issue's evidence case:** `InMemoryInventoryService` takes an injected `TimeSource` (`system()` by default); the reservation hold becomes a constant and the `setReservationHold` test seam is **deleted**. The expiry test now injects a `SteppableClock`, advances it past the hold, and watches the next reservation reclaim the expired one — no seams, no negative-duration hacks, no sleeping.

## Deliberate scope slice
This converts the issue's named evidence site; ~20 further `Instant.now()` call sites across the order/market examples (`BackOrder.estimatedAvailable`, workflow timestamps, `AnomalyDetector`, …) migrate incrementally now the pattern exists — tracked on #609 rather than bloating this PR.

