### PR TITLE
Change tracking for hkj-book: margin line + word-level diff vs a baseline release

### DIFF
--- a/.github/scripts/hkj_changes_preprocessor.py
+++ b/.github/scripts/hkj_changes_preprocessor.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""mdBook preprocessor: mark content that is new/changed relative to a baseline.
+
+For every chapter the preprocessor compares the current markdown source against
+a baseline version (the previous release, typically) and injects lightweight
+HTML markers around the blocks that were added or edited. A companion CSS/JS
+pair (`theme/change-tracking.css`, `theme/change-tracking.js`) turns those
+markers into a vertical margin line plus a faint underline of the individual
+words that changed, with a three-state header toggle.
+
+Design notes
+------------
+* We never wrap markdown in a `<div>` (pulldown-cmark would stop parsing the
+  markdown inside it). Instead we emit an *empty* marker `<div>` on its own
+  line immediately before each changed block. The block still renders as normal
+  markdown; the runtime JS uses each marker's `nextElementSibling` as "the
+  block" and does the DOM wrapping / word underlining safely on rendered HTML.
+* Block-level classification (`new` vs `modified`) and the per-block word diff
+  are computed here, at build time, and shipped to the browser as marker data
+  attributes. The browser only has to *match* tokens, never diff.
+
+Baseline resolution (first that is set wins):
+* ``HKJ_CHANGES_BASELINE_DIR`` — a directory holding a snapshot of the book
+  ``src`` tree. Handy for local testing.
+* ``HKJ_CHANGES_BASE`` — a git ref (tag/commit). Baseline content is read with
+  ``git show <ref>:<repo-path>``.
+
+If neither is set (or a lookup fails), the preprocessor is a no-op and passes
+the book through unchanged, so it is always safe to leave enabled.
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+from difflib import SequenceMatcher
+
+# Repository path to the book source, used to build `git show` targets.
+SRC_PREFIX = os.environ.get("HKJ_CHANGES_SRC_PREFIX", "hkj-book/src")
+
+BASELINE_DIR = os.environ.get("HKJ_CHANGES_BASELINE_DIR", "").strip()
+BASELINE_REF = os.environ.get("HKJ_CHANGES_BASE", "").strip()
+SINCE_LABEL = os.environ.get("HKJ_CHANGES_SINCE_LABEL", BASELINE_REF).strip()
+
+# Chapters to skip. The deploy workflow copies these root files into src at
+# build time, so they never exist under `<baseline>:hkj-book/src/` and would
+# otherwise be flagged as "new" on every deploy. Override with a comma-
+# separated HKJ_CHANGES_EXCLUDE list.
+_DEFAULT_EXCLUDE = "CONTRIBUTING.md,LICENSE.md,CODE_OF_CONDUCT.md"
+EXCLUDE_PATHS = frozenset(
+    p.strip()
+    for p in os.environ.get("HKJ_CHANGES_EXCLUDE", _DEFAULT_EXCLUDE).split(",")
+    if p.strip()
+)
+
+MARK_CLASS = "hkj-ct-mark"
+
+
+def enabled():
+    return bool(BASELINE_DIR or BASELINE_REF)
+
+
+def baseline_source(chapter_path):
+    """Return the baseline markdown for `chapter_path`, or None if it is new."""
+    if not chapter_path:
+        return None
+    if BASELINE_DIR:
+        candidate = os.path.join(BASELINE_DIR, chapter_path)
+        try:
+            with open(candidate, "r", encoding="utf-8") as handle:
+                return handle.read()
+        except FileNotFoundError:
+            return None
+    if BASELINE_REF:
+        target = "{ref}:{prefix}/{path}".format(
+            ref=BASELINE_REF, prefix=SRC_PREFIX, path=chapter_path
+        )
+        try:
+            result = subprocess.run(
+                ["git", "show", target],
+                capture_output=True,
+                encoding="utf-8",
+                check=False,
+            )
+        except OSError:
+            return None
+        if result.returncode != 0:
+            return None  # File did not exist in baseline -> treat chapter as new.
+        return result.stdout
+    return None
+
+
+# --- block segmentation -----------------------------------------------------
+
+def _fence_marker(line):
+    """Return (char, length) if `line` opens/closes a fenced block, else None."""
+    stripped = line.lstrip()
+    for ch in ("`", "~"):
+        if stripped.startswith(ch * 3):
+            run = len(stripped) - len(stripped.lstrip(ch))
+            return ch, run
+    return None
+
+
+def split_blocks(text):
+    """Split markdown into top-level blocks.
+
+    Blank lines separate blocks, except inside fenced regions (``` code ```
+    and ~~~admonish ... ~~~), which are kept atomic. Returns a list of dicts
+    with the block text and its 0-based start/end line indices.
+    """
+    lines = text.splitlines()
+    blocks = []
+    current = []
+    start = 0
+    fence = None  # (char, length) when inside a fence.
+
+    def flush(end_idx):
+        nonlocal current, start
+        if current and any(l.strip() for l in current):
+            blocks.append(
+                {
+                    "text": "\n".join(current),
+                    "start": start,
+                    "end": end_idx,
+                }
+            )
+        current = []
+
+    for i, line in enumerate(lines):
+        marker = _fence_marker(line)
+        if fence is None:
+            if marker is not None:
+                # Opening a fence: flush any preceding text first so the fence
+                # is its own block even when no blank line separates them.
+                if current:
+                    flush(i)
+                start = i
+                fence = marker
+                current.append(line)
+                continue
+            if line.strip() == "":
+                flush(i)
+                start = i + 1
+            else:
+                if not current:
+                    start = i
+                current.append(line)
+        else:
+            current.append(line)
+            # A closing fence uses the same char and at least the same length.
+            if marker is not None and marker[0] == fence[0] and marker[1] >= fence[1]:
+                fence = None
+                # Flush the fenced block so following text (with no blank line)
+                # becomes a separate block.
+                flush(i + 1)
+                start = i + 1
+    flush(len(lines))
+    return blocks
+
+
+def normalize_block(text):
+    """Whitespace-insensitive key so reflowed-but-identical blocks still match."""
+    return " ".join(text.split())
+
+
+# --- word diff --------------------------------------------------------------
+
+def tokenize_words(text):
+    """Split a block into word tokens for the intra-block diff.
+
+    We strip common markdown punctuation from the edges so the runtime, which
+    matches against *rendered* text, sees comparable tokens.
+    """
+    raw = text.split()
+    words = []
+    for tok in raw:
+        cleaned = tok.strip("`*_[](){}#>-.,:;!?\"'")
+        if cleaned:
+            words.append(cleaned)
+    return words
+
+
+def changed_words(old_text, new_text):
+    """Tokens present on the new side of an insert/replace (the edited words)."""
+    old_words = tokenize_words(old_text)
+    new_words = tokenize_words(new_text)
+    matcher = SequenceMatcher(a=old_words, b=new_words, autojunk=False)
+    changed = []
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag in ("insert", "replace"):
+            changed.extend(new_words[j1:j2])
+    return changed
+
+
+# --- chapter processing -----------------------------------------------------
+
+def make_marker(kind, words, run_pos):
+    payload = ""
+    if words:
+        raw = json.dumps(words, ensure_ascii=False).encode("utf-8")
+        payload = base64.b64encode(raw).decode("ascii")
+    attrs = [
+        'class="{cls}"'.format(cls=MARK_CLASS),
+        'data-kind="{kind}"'.format(kind=kind),
+        'data-run="{run}"'.format(run=run_pos),
+    ]
+    if payload:
+        attrs.append('data-words="{payload}"'.format(payload=payload))
+    if SINCE_LABEL:
+        attrs.append('data-since="{since}"'.format(since=SINCE_LABEL))
+    return "<div {attrs}></div>".format(attrs=" ".join(attrs))
+
+
+def classify_blocks(new_blocks, old_blocks):
+    """Return {new_block_index: (kind, baseline_text_or_None)} for changed blocks."""
+    old_keys = [normalize_block(b["text"]) for b in old_blocks]
+    new_keys = [normalize_block(b["text"]) for b in new_blocks]
+    matcher = SequenceMatcher(a=old_keys, b=new_keys, autojunk=False)
+    changed = {}
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        if tag == "insert":
+            for j in range(j1, j2):
+                changed[j] = ("new", None)
+        elif tag == "replace":
+            old_slice = old_blocks[i1:i2]
+            for offset, j in enumerate(range(j1, j2)):
+                if offset < len(old_slice):
+                    changed[j] = ("modified", old_slice[offset]["text"])
+                else:
+                    changed[j] = ("new", None)
+        # 'delete' removes only from the old side -> nothing to mark.
+    return changed
+
+
+def annotate(content, blocks, changed):
+    """Rebuild the markdown with marker divs inserted before changed blocks."""
+    lines = content.splitlines()
+    # Map each block's start line to its marker html; compute run positions.
+    indices = sorted(changed.keys())
+    run_pos = {}
+    for pos, idx in enumerate(indices):
+        prev_in_run = (idx - 1) in changed
+        next_in_run = (idx + 1) in changed
+        if prev_in_run and next_in_run:
+            run_pos[idx] = "mid"
+        elif next_in_run:
+            run_pos[idx] = "start"
+        elif prev_in_run:
+            run_pos[idx] = "end"
+        else:
+            run_pos[idx] = "solo"
+
+    # Insert markers from the bottom up so earlier line indices stay valid.
+    for idx in sorted(indices, reverse=True):
+        kind, old_text = changed[idx]
+        words = changed_words(old_text, blocks[idx]["text"]) if kind == "modified" else []
+        marker = make_marker(kind, words, run_pos[idx])
+        at = blocks[idx]["start"]
+        # Marker must be its own HTML block: blank line before (unless at top)
+        # and after so pulldown-cmark treats it as standalone.
+        insertion = [marker, ""]
+        lines[at:at] = insertion
+    return "\n".join(lines)
+
+
+def path_to_html(path):
+    """Chapter source path -> rendered html path (optics/lenses.md -> .html)."""
+    if path.endswith(".md"):
+        return path[: -len(".md")] + ".html"
+    return path
+
+
+def process_chapter(chapter):
+    """Annotate a chapter's changed blocks. Returns True if anything changed."""
+    content = chapter.get("content")
+    path = chapter.get("path")
+    if not content or not path:
+        return False
+    if path in EXCLUDE_PATHS:
+        return False
+    old = baseline_source(path)
+    new_blocks = split_blocks(content)
+    if old is None:
+        # Whole chapter is new: mark every block as new.
+        changed = {i: ("new", None) for i in range(len(new_blocks))}
+    else:
+        old_blocks = split_blocks(old)
+        changed = classify_blocks(new_blocks, old_blocks)
+    if not changed:
+        return False
+    chapter["content"] = annotate(content, new_blocks, changed)
+    return True
+
+
+def walk(items, changed_paths):
+    for item in items:
+        chapter = item.get("Chapter") if isinstance(item, dict) else None
+        if chapter is None:
+            continue
+        if process_chapter(chapter):
+            changed_paths.append(path_to_html(chapter["path"]))
+        sub = chapter.get("sub_items")
+        if sub:
+            walk(sub, changed_paths)
+
+
+def make_manifest(changed_paths):
+    """Compact per-page payload the runtime reads to decorate the sidebar TOC."""
+    data = json.dumps(sorted(set(changed_paths)), ensure_ascii=False).encode("utf-8")
+    payload = base64.b64encode(data).decode("ascii")
+    attrs = ['id="hkj-ct-manifest"', 'hidden', 'data-changed="{0}"'.format(payload)]
+    if SINCE_LABEL:
+        attrs.append('data-since="{0}"'.format(SINCE_LABEL))
+    return "<div {0}></div>".format(" ".join(attrs))
+
+
+def inject_manifest(items, manifest):
+    """Prepend the manifest to every chapter so the sidebar can be decorated
+    no matter which page the reader is on."""
+    for item in items:
+        chapter = item.get("Chapter") if isinstance(item, dict) else None
+        if chapter is None:
+            continue
+        if chapter.get("content") is not None and chapter.get("path"):
+            chapter["content"] = manifest + "\n\n" + chapter["content"]
+        sub = chapter.get("sub_items")
+        if sub:
+            inject_manifest(sub, manifest)
+
+
+def main():
+    # `supports <renderer>` handshake: we only touch markdown, so accept all.
+    if len(sys.argv) > 1 and sys.argv[1] == "supports":
+        sys.exit(0)
+
+    # mdBook speaks UTF-8 JSON over stdio; on Windows the default is the active
+    # code page (e.g. cp1252), so force UTF-8 to avoid decode/encode errors.
+    if hasattr(sys.stdin, "reconfigure"):
+        sys.stdin.reconfigure(encoding="utf-8")
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+    context_and_book = json.load(sys.stdin)
+    _context, book = context_and_book
+
+    if enabled():
+        try:
+            sections = book.get("sections", [])
+            changed_paths = []
+            walk(sections, changed_paths)
+            inject_manifest(sections, make_manifest(changed_paths))
+        except Exception as exc:  # never break the build over annotation errors
+            sys.stderr.write("hkj-changes: skipped ({0})\n".format(exc))
+
+    json.dump(book, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -111,8 +111,36 @@ jobs:
           EOF
         shell: bash
 
+      - name: Determine change-tracking baseline
+        id: baseline
+        run: |
+          # The version being deployed decides which baseline "new content" is
+          # measured against:
+          #   * tagged release vX.Y.Z -> the previous tag
+          #   * latest/snapshot        -> the most recent tag
+          VERSION="${{ steps.version.outputs.version }}"
+          BASE=""
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            BASE="$(git describe --tags --abbrev=0 "${VERSION}^" 2>/dev/null || true)"
+          else
+            BASE="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          fi
+
+          if [[ -n "$BASE" ]]; then
+            echo "Change tracking baseline: ${BASE}"
+          else
+            echo "No baseline tag found; change tracking will be a no-op"
+          fi
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "since_label=${BASE}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Build mdBook
         working-directory: ./${{ env.BOOK_ROOT_DIR }}
+        env:
+          # Empty values make the change-tracking preprocessor a no-op.
+          HKJ_CHANGES_BASE: ${{ steps.baseline.outputs.base }}
+          HKJ_CHANGES_SINCE_LABEL: ${{ steps.baseline.outputs.since_label }}
         run: mdbook build
 
       - name: Generate Sitemap

--- a/.github/workflows/preview-change-tracking.yml
+++ b/.github/workflows/preview-change-tracking.yml
@@ -1,0 +1,104 @@
+name: Preview mdBook Change Tracking
+
+# Build the book with change tracking enabled against a chosen baseline and
+# upload it as an artifact. This never touches the published site — it is a
+# safe, on-demand way for maintainers to preview the margin line + word-level
+# change highlighting before a release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (branch/tag/commit)'
+        required: false
+        default: 'main'
+      baseline:
+        description: 'Baseline ref to diff against (tag/commit). Leave blank to auto-pick (previous tag of a tagged ref, else latest tag).'
+        required: false
+        default: ''
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_ADMONISH_VERSION: "1.19.0"
+      MDBOOK_ALERTS_VERSION: "0.7.0"
+      BOOK_ROOT_DIR: "hkj-book"
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout requested ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0  # need full history + tags for baseline resolution
+
+      - name: Determine change-tracking baseline
+        id: baseline
+        run: |
+          REF="${{ github.event.inputs.ref }}"
+          BASE="${{ github.event.inputs.baseline }}"
+
+          if [[ -z "$BASE" ]]; then
+            # Auto-pick: previous tag when building a tag, else the latest tag.
+            if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+              BASE="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
+            else
+              BASE="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+            fi
+          fi
+
+          if [[ -z "$BASE" ]]; then
+            echo "::warning::No baseline tag found; change tracking will be a no-op."
+          elif ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+            echo "::error::Baseline ref '${BASE}' not found."
+            exit 1
+          else
+            echo "Change tracking baseline: ${BASE}"
+          fi
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.4.51'
+
+      - name: Install 'mdbook-admonish'
+        run: cargo install mdbook-admonish --version ${{ env.MDBOOK_ADMONISH_VERSION }} --locked
+
+      - name: Install 'mdbook-alerts'
+        run: cargo install mdbook-alerts --version ${{ env.MDBOOK_ALERTS_VERSION }} --locked
+
+      - name: Setup mdbook-admonish assets
+        working-directory: ./${{ env.BOOK_ROOT_DIR }}
+        run: mdbook-admonish install .
+
+      - name: Build mdBook with change tracking
+        working-directory: ./${{ env.BOOK_ROOT_DIR }}
+        env:
+          HKJ_CHANGES_BASE: ${{ steps.baseline.outputs.base }}
+          HKJ_CHANGES_SINCE_LABEL: ${{ steps.baseline.outputs.base }}
+        run: mdbook build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: change-tracking-preview
+          path: ${{ env.BOOK_ROOT_DIR }}/book
+          if-no-files-found: error
+
+      - name: Summary
+        run: |
+          {
+            echo "### Change-tracking preview built"
+            echo ""
+            echo "- **Built ref:** \`${{ github.event.inputs.ref }}\`"
+            echo "- **Baseline:** \`${{ steps.baseline.outputs.base }}\`"
+            echo ""
+            echo "Download the **change-tracking-preview** artifact above, unzip,"
+            echo "and open \`index.html\` (or serve the folder) to review the"
+            echo "margin line and word-level highlighting. Use the header toggle"
+            echo "to switch between full / lines-only / off."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/hkj-book/book.toml
+++ b/hkj-book/book.toml
@@ -6,8 +6,8 @@ language = "en"
 multilingual = false
 src = "src"
 [output.html]
-additional-css = ["./mdbook-admonish.css", "./theme/catppuccin.css", "./theme/catppuccin-admonish.css", "./theme/catppuccin-alerts.css", "./theme/additional-hkj.css"]
-additional-js = ["./theme/version-switcher.js", "./theme/sidebar-nav-link.js", "./theme/chapter-title.js"]
+additional-css = ["./mdbook-admonish.css", "./theme/catppuccin.css", "./theme/catppuccin-admonish.css", "./theme/catppuccin-alerts.css", "./theme/additional-hkj.css", "./theme/change-tracking.css"]
+additional-js = ["./theme/version-switcher.js", "./theme/sidebar-nav-link.js", "./theme/chapter-title.js", "./theme/change-tracking.js"]
 default-theme = "latte"
 preferred-dark-theme = "macchiato"
 site-url = "https://higher-kinded-j.github.io"
@@ -30,4 +30,12 @@ level = 1
 [preprocessor.admonish]
 command = "mdbook-admonish"
 assets_version = "3.0.3" # do not edit: managed by `mdbook-admonish install`
+
+# Marks content that is new/changed vs a baseline release. No-op unless
+# HKJ_CHANGES_BASE (a git ref) or HKJ_CHANGES_BASELINE_DIR is set, so it is
+# safe to leave enabled for local builds. Runs before admonish/alerts so it
+# sees the original markdown source.
+[preprocessor.hkj-changes]
+command = "python3 ../.github/scripts/hkj_changes_preprocessor.py"
+before = ["admonish", "alerts"]
 

--- a/hkj-book/preview-changes.sh
+++ b/hkj-book/preview-changes.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Preview hkj-book change tracking locally against a baseline git ref.
+#
+# The change-tracking preprocessor marks content that is new/changed relative
+# to a baseline (see .github/scripts/hkj_changes_preprocessor.py). This script
+# wires that up for a local `mdbook serve` so maintainers can see the margin
+# line + word underlines before anything is deployed.
+#
+# Usage:
+#   ./preview-changes.sh [BASELINE_REF] [PORT]
+#
+#   BASELINE_REF   Tag or commit to diff the current working tree against.
+#                  Defaults to the most recent tag (git describe).
+#   PORT           Port for `mdbook serve`. Defaults to 3000.
+#
+# Examples:
+#   ./preview-changes.sh                 # working tree vs latest tag
+#   ./preview-changes.sh v0.4.7          # working tree vs v0.4.7
+#   ./preview-changes.sh v0.4.6 3001     # ...on port 3001
+#
+# To preview what a *released* version added (tag vs previous tag):
+#   git checkout v0.4.7
+#   ./preview-changes.sh v0.4.6
+#   git checkout -            # restore your branch afterwards
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+BASE="${1:-}"
+PORT="${2:-3000}"
+
+if [[ -z "$BASE" ]]; then
+  BASE="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+  if [[ -z "$BASE" ]]; then
+    echo "error: no tags found; pass a baseline ref explicitly, e.g." >&2
+    echo "       ./preview-changes.sh <tag-or-commit>" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+  echo "error: baseline ref '${BASE}' not found in this repository." >&2
+  exit 1
+fi
+
+if ! command -v mdbook >/dev/null 2>&1; then
+  echo "error: mdbook not found. Install with: cargo install mdbook --version 0.4.51 --locked" >&2
+  exit 1
+fi
+
+# Refresh mdbook-admonish assets if the binary is available (safe to re-run).
+if command -v mdbook-admonish >/dev/null 2>&1; then
+  mdbook-admonish install . >/dev/null 2>&1 || true
+fi
+
+echo "Change-tracking preview:"
+echo "  new:      current working tree"
+echo "  baseline: ${BASE}"
+echo "  serving:  http://localhost:${PORT}"
+echo
+
+export HKJ_CHANGES_BASE="${BASE}"
+export HKJ_CHANGES_SINCE_LABEL="${BASE}"
+exec mdbook serve --open --port "${PORT}"

--- a/hkj-book/theme/change-tracking.css
+++ b/hkj-book/theme/change-tracking.css
@@ -1,0 +1,132 @@
+/* Change tracking: highlight content that is new/changed vs a baseline release.
+ *
+ * Two visual signals, controlled by a three-state header toggle:
+ *   - a vertical line in the left margin marking a run of new/changed blocks
+ *   - a faint underline on the individual words that changed within a block
+ *
+ * State is a class on <html> set by change-tracking.js:
+ *   .hkj-ct-full  -> margin line + word underlines   (default)
+ *   .hkj-ct-lines -> margin line only
+ *   .hkj-ct-off   -> nothing shown
+ */
+
+/* Change-tracking accent, tuned per theme to the book's mauve brand accent
+ * (the Catppuccin "mauve" of each flavour, same hue used for headings and the
+ * active sidebar item in additional-hkj.css). Falls back to --links for any
+ * theme not listed. */
+:root {
+  --hkj-ct-accent: var(--links, #8839ef);
+}
+html.latte     { --hkj-ct-accent: #8839ef; } /* mauve (light) */
+html.frappe    { --hkj-ct-accent: #ca9ee6; } /* mauve (frappe) */
+html.macchiato { --hkj-ct-accent: #c6a0f6; } /* mauve (macchiato) */
+html.mocha     { --hkj-ct-accent: #cba6f7; } /* mauve (mocha) */
+
+/* The runtime wraps each run of changed blocks in this container. */
+.hkj-new-content {
+  position: relative;
+  border-left: 3px solid var(--hkj-ct-accent);
+  padding-left: 1rem;
+  margin-left: -1rem;
+  border-radius: 2px;
+}
+
+/* Keep the empty marker divs out of the flow before JS consumes them. */
+.hkj-ct-mark {
+  display: none;
+}
+
+/* Faint underline on changed words (only meaningful inside a modified block). */
+.hkj-word-changed {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 1px;
+  text-decoration-color: color-mix(in srgb, var(--hkj-ct-accent) 55%, transparent);
+  text-underline-offset: 3px;
+}
+
+/* --- toggle states -------------------------------------------------------- */
+
+/* Lines-only: keep the margin line, drop the word underline. */
+.hkj-ct-lines .hkj-word-changed {
+  text-decoration: none;
+}
+
+/* Off: hide both signals but leave the DOM intact so toggling back is instant. */
+.hkj-ct-off .hkj-new-content {
+  border-left-color: transparent;
+}
+.hkj-ct-off .hkj-word-changed {
+  text-decoration: none;
+}
+
+/* --- sidebar TOC change indicators --------------------------------------- */
+
+/* The per-page manifest element must never take up space. */
+#hkj-ct-manifest {
+  display: none !important;
+}
+
+/* Solid dot on changed chapters/sections and on their ancestor sections
+ * (so a collapsed group still signals that something inside it changed). */
+.sidebar .hkj-ct-changed::after,
+.sidebar .hkj-ct-changed-descendant::after {
+  content: "";
+  display: inline-block;
+  width: 0.45em;
+  height: 0.45em;
+  margin-left: 0.4em;
+  border-radius: 50%;
+  background: var(--hkj-ct-accent);
+  vertical-align: middle;
+}
+
+/* Sidebar dots follow the toggle: hidden when change tracking is off. */
+.hkj-ct-off .sidebar .hkj-ct-changed::after,
+.hkj-ct-off .sidebar .hkj-ct-changed-descendant::after {
+  display: none;
+}
+
+/* --- header toggle button ------------------------------------------------- */
+
+#hkj-ct-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-size: 0.8rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+#hkj-ct-toggle .hkj-ct-dot {
+  width: 0.6em;
+  height: 0.6em;
+  border-radius: 50%;
+  background: var(--hkj-ct-accent);
+  display: inline-block;
+}
+
+.hkj-ct-lines #hkj-ct-toggle .hkj-ct-dot {
+  background: color-mix(in srgb, var(--hkj-ct-accent) 55%, transparent);
+}
+.hkj-ct-off #hkj-ct-toggle .hkj-ct-dot {
+  background: transparent;
+  border: 1px solid var(--icons, currentColor);
+}
+
+#hkj-ct-toggle .hkj-ct-label {
+  font-weight: 500;
+}
+
+/* On narrow viewports keep only the coloured dot so the label can't crowd
+   the header menu bar; the tooltip still explains the button. */
+@media (max-width: 600px) {
+  #hkj-ct-toggle .hkj-ct-label {
+    display: none;
+  }
+}
+
+/* Hide the toggle entirely on builds/pages that carry no change data. */
+#hkj-ct-toggle[hidden] {
+  display: none;
+}

--- a/hkj-book/theme/change-tracking.js
+++ b/hkj-book/theme/change-tracking.js
@@ -1,0 +1,303 @@
+// Change tracking runtime.
+//
+// The mdBook preprocessor (`hkj_changes_preprocessor.py`) injects empty marker
+// divs (`.hkj-ct-mark`) immediately before each new/changed block, carrying:
+//   data-kind  = "new" | "modified"
+//   data-run   = "solo" | "start" | "mid" | "end"   (position in a change run)
+//   data-words = base64(JSON array of changed word tokens)  (modified only)
+//   data-since = baseline version label (e.g. "v0.4.7")
+//
+// This script:
+//   1. groups marker+block sequences into runs and wraps each run in a
+//      `.hkj-new-content` container (the vertical margin line),
+//   2. underlines the changed words inside modified blocks,
+//   3. installs a three-state header toggle (full / lines / off), persisted.
+//
+// All DOM work happens on already-rendered HTML, so markdown is never touched.
+
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'hkj-ct-state';
+  var STATES = ['full', 'lines', 'off'];
+  var STATE_META = {
+    full: { label: 'Changes: full', title: 'Change tracking: margin line + changed words' },
+    lines: { label: 'Changes: lines', title: 'Change tracking: margin line only' },
+    off: { label: 'Changes: off', title: 'Change tracking: hidden' }
+  };
+  var STRIP = /^[`*_\[\](){}#>\-.,:;!?"']+|[`*_\[\](){}#>\-.,:;!?"']+$/g;
+
+  // --- state persistence ----------------------------------------------------
+
+  function readState() {
+    try {
+      var stored = window.localStorage.getItem(STORAGE_KEY);
+      if (STATES.indexOf(stored) !== -1) return stored;
+    } catch (e) { /* localStorage may be unavailable */ }
+    return 'full';
+  }
+
+  function applyState(state) {
+    var root = document.documentElement;
+    STATES.forEach(function (s) { root.classList.remove('hkj-ct-' + s); });
+    root.classList.add('hkj-ct-' + state);
+    try { window.localStorage.setItem(STORAGE_KEY, state); } catch (e) { /* ignore */ }
+  }
+
+  // --- word underlining -----------------------------------------------------
+
+  function decodeWords(mark) {
+    var raw = mark.getAttribute('data-words');
+    if (!raw) return null;
+    try {
+      var json = decodeURIComponent(escape(window.atob(raw)));
+      var arr = JSON.parse(json);
+      return Array.isArray(arr) ? arr : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function underlineWords(el, words) {
+    if (!words || !words.length) return;
+    var counts = Object.create(null);
+    words.forEach(function (w) { counts[w] = (counts[w] || 0) + 1; });
+
+    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        // Skip code, pre and already-processed spans.
+        var p = node.parentNode;
+        while (p && p !== el) {
+          var tag = p.nodeName;
+          if (tag === 'CODE' || tag === 'PRE' ||
+              (p.classList && p.classList.contains('hkj-word-changed'))) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          p = p.parentNode;
+        }
+        return node.nodeValue.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+      }
+    });
+
+    var targets = [];
+    var current;
+    while ((current = walker.nextNode())) { targets.push(current); }
+
+    targets.forEach(function (node) {
+      var parts = node.nodeValue.split(/(\s+)/);
+      var changedHere = false;
+      parts.forEach(function (tok) {
+        if (tok && !/^\s+$/.test(tok)) {
+          var core = tok.replace(STRIP, '');
+          if (core && counts[core] > 0) { changedHere = true; }
+        }
+      });
+      if (!changedHere) return;
+
+      var frag = document.createDocumentFragment();
+      parts.forEach(function (tok) {
+        if (tok === '') return;
+        if (/^\s+$/.test(tok)) {
+          frag.appendChild(document.createTextNode(tok));
+          return;
+        }
+        var core = tok.replace(STRIP, '');
+        if (core && counts[core] > 0) {
+          counts[core] -= 1;
+          var span = document.createElement('span');
+          span.className = 'hkj-word-changed';
+          span.textContent = tok;
+          frag.appendChild(span);
+        } else {
+          frag.appendChild(document.createTextNode(tok));
+        }
+      });
+      node.parentNode.replaceChild(frag, node);
+    });
+  }
+
+  // --- run grouping + wrapping ---------------------------------------------
+
+  function collectEntries(content) {
+    var marks = content.querySelectorAll('.hkj-ct-mark');
+    var entries = [];
+    Array.prototype.forEach.call(marks, function (mark) {
+      entries.push({
+        mark: mark,
+        block: mark.nextElementSibling,
+        kind: mark.getAttribute('data-kind') || 'new',
+        run: mark.getAttribute('data-run') || 'solo',
+        words: decodeWords(mark)
+      });
+    });
+    return entries;
+  }
+
+  function groupRuns(entries) {
+    var runs = [];
+    var open = null;
+    entries.forEach(function (entry) {
+      if (entry.run === 'solo') {
+        runs.push([entry]);
+        open = null;
+      } else if (entry.run === 'start') {
+        open = [entry];
+        runs.push(open);
+      } else if ((entry.run === 'mid' || entry.run === 'end') && open) {
+        open.push(entry);
+        if (entry.run === 'end') open = null;
+      } else {
+        // Malformed sequence: fall back to a standalone run.
+        runs.push([entry]);
+        open = null;
+      }
+    });
+    return runs;
+  }
+
+  function wrapRun(run) {
+    var blocks = run.map(function (e) { return e.block; }).filter(Boolean);
+    if (!blocks.length) {
+      run.forEach(function (e) { if (e.mark.parentNode) e.mark.remove(); });
+      return;
+    }
+    var wrapper = document.createElement('div');
+    wrapper.className = 'hkj-new-content';
+    var since = run[0].mark.getAttribute('data-since');
+    if (since) wrapper.setAttribute('data-since', since);
+
+    blocks[0].parentNode.insertBefore(wrapper, blocks[0]);
+    // Remove markers first so they don't get pulled into the wrapper.
+    run.forEach(function (e) { if (e.mark.parentNode) e.mark.remove(); });
+    blocks.forEach(function (block) { wrapper.appendChild(block); });
+
+    // Underline changed words per modified block.
+    run.forEach(function (entry) {
+      if (entry.kind === 'modified' && entry.block) {
+        underlineWords(entry.block, entry.words);
+      }
+    });
+  }
+
+  function processContent() {
+    var content = document.getElementById('content') || document.querySelector('main');
+    if (!content) return;
+    var entries = collectEntries(content);
+    if (!entries.length) return;
+    groupRuns(entries).forEach(wrapRun);
+  }
+
+  // --- sidebar TOC decoration ----------------------------------------------
+
+  function readManifest() {
+    var el = document.getElementById('hkj-ct-manifest');
+    if (!el) return null;
+    var since = el.getAttribute('data-since') || '';
+    var changed = [];
+    var raw = el.getAttribute('data-changed');
+    if (raw) {
+      try {
+        var json = decodeURIComponent(escape(window.atob(raw)));
+        var arr = JSON.parse(json);
+        if (Array.isArray(arr)) changed = arr;
+      } catch (e) { /* leave changed empty */ }
+    }
+    return { changed: changed, since: since };
+  }
+
+  function decorateSidebar(changedPaths) {
+    if (!changedPaths || !changedPaths.length) return;
+    var sidebar = document.querySelector('#sidebar .chapter') ||
+                  document.querySelector('#sidebar') ||
+                  document.querySelector('.sidebar');
+    if (!sidebar) return;
+
+    changedPaths.forEach(function (path) {
+      // Match the sidebar link for this chapter by href suffix (hrefs are
+      // relative and depth-dependent, so endsWith is the robust match).
+      var links = sidebar.querySelectorAll('a[href]');
+      Array.prototype.forEach.call(links, function (link) {
+        var href = link.getAttribute('href').split('#')[0].split('?')[0];
+        if (!href.endsWith(path)) return;
+        link.classList.add('hkj-ct-changed');
+
+        // Flag ancestor sections so a collapsed group still signals that
+        // something inside it changed (hollow dot, styled by CSS). In mdBook a
+        // section heading and its children are *siblings*: the children live in
+        // an <ol.section> wrapped in a bare <li>, and the heading is the
+        // <li.chapter-item> immediately before that wrapper. Climb by hopping
+        // wrapper -> previous sibling (the heading) -> its enclosing <ol>.
+        var li = link.closest('li');
+        while (li) {
+          var ol = li.parentElement;                 // enclosing <ol>
+          var wrap = ol && ol.parentElement;         // bare <li> holding <ol>
+          if (!wrap || wrap.tagName !== 'LI') break;  // reached top <ol.chapter>
+          var headingLi = wrap.previousElementSibling;
+          if (!headingLi || headingLi.tagName !== 'LI') break;
+          var headingLink = headingLi.querySelector(':scope > a');
+          if (headingLink && !headingLink.classList.contains('hkj-ct-changed')) {
+            headingLink.classList.add('hkj-ct-changed-descendant');
+          }
+          li = headingLi;
+        }
+      });
+    });
+  }
+
+  // --- header toggle --------------------------------------------------------
+
+  function installToggle(sinceLabel) {
+    var container = document.querySelector('.right-buttons') ||
+                    document.querySelector('#menu-bar .menu-title');
+    if (!container || document.getElementById('hkj-ct-toggle')) return;
+
+    var button = document.createElement('button');
+    button.id = 'hkj-ct-toggle';
+    button.type = 'button';
+    button.className = 'icon-button';
+
+    var dot = document.createElement('span');
+    dot.className = 'hkj-ct-dot';
+    var label = document.createElement('span');
+    label.className = 'hkj-ct-label';
+    button.appendChild(dot);
+    button.appendChild(label);
+
+    function render() {
+      var state = readState();
+      var meta = STATE_META[state];
+      label.textContent = meta.label;
+      var title = meta.title;
+      if (sinceLabel) title += ' (since ' + sinceLabel + ')';
+      button.title = title;
+      button.setAttribute('aria-label', title);
+    }
+
+    button.addEventListener('click', function () {
+      var next = (STATES.indexOf(readState()) + 1) % STATES.length;
+      applyState(STATES[next]);
+      render();
+    });
+
+    container.appendChild(button);
+    render();
+  }
+
+  // --- init -----------------------------------------------------------------
+
+  function init() {
+    applyState(readState());
+    processContent();
+    var manifest = readManifest();
+    if (manifest) {
+      decorateSidebar(manifest.changed);
+      installToggle(manifest.since);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Description

Adds opt-in **change tracking** to `hkj-book` so readers can see what content is new or changed relative to a baseline release. Signals, all controlled by a three-state header toggle:

- a **vertical mauve line in the left margin** marking a run of new/changed blocks,
- a **faint dotted underline** on the individual words that changed within an edited block, and
- **sidebar TOC indicators** so readers can navigate straight to what changed — a solid mauve dot on each changed chapter/section, and the same solid dot propagated to ancestor sections (so a collapsed group still signals that something inside it changed).

### How it works

- **`.github/scripts/hkj_changes_preprocessor.py`** — an mdBook preprocessor (runs before `admonish`/`alerts`). For each chapter it diffs the current markdown against a baseline, segments into top-level blocks (keeping code fences and `~~~admonish` blocks atomic), classifies each changed block as `new` vs `modified`, and for modified blocks computes the exact changed words. It injects *empty* marker `<div>`s before each changed block — it never wraps markdown, so rendering is untouched. It also emits a compact per-page **manifest** of changed chapters (plus the baseline label) into every page, which drives the sidebar decoration. All diffing is done at build time and shipped to the browser as data attributes.
  - Baseline resolution: `HKJ_CHANGES_BASE` (a git ref, read via `git show <ref>:path`) or `HKJ_CHANGES_BASELINE_DIR` (a local snapshot). **No-op when neither is set**, so it is always safe to leave enabled.
- **`hkj-book/theme/change-tracking.js`** — groups markers into runs, wraps rendered blocks in a `.hkj-new-content` container (the margin line), underlines changed words on text nodes (skips `<code>`/`<pre>`), reads the manifest to decorate the sidebar TOC (solid dot on changed entries, propagated to ancestor sections), and installs the three-state header toggle (`full → lines → off`, persisted in `localStorage`).
- **`hkj-book/theme/change-tracking.css`** — margin line, faint word underline, sidebar dots, and toggle states. The accent is tuned **per theme** to the book's brand mauve (Catppuccin mauve of each flavour: latte `#8839ef`, frappé `#ca9ee6`, macchiato `#c6a0f6`, mocha `#cba6f7`), falling back to `--links`.
- **`hkj-book/book.toml`** — registers the preprocessor and the new CSS/JS.
- **`.github/workflows/deploy-mdbook-versioned.yml`** — computes the baseline for each deploy (previous tag for a tagged release, latest tag for the `latest`/snapshot build) and passes it to `mdbook build`.

### Maintainer preview tooling

- **`hkj-book/preview-changes.sh`** — `mdbook serve` with change tracking enabled against any baseline tag/commit (defaults to the latest tag). Preview locally before deploying.
- **`.github/workflows/preview-change-tracking.yml`** — `workflow_dispatch` that builds the book against a chosen (or auto-picked) baseline and uploads it as an artifact. Never touches the published site.

Relates to # (issue number)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

This change is documentation/tooling only (no Java/Gradle surface), so `./gradlew test` is not applicable. Verified the book pipeline instead:

- **Preprocessor logic (standalone):** block segmentation keeps a Java code fence and a `~~~admonish` block (each with internal blank lines) atomic; a reworded sentence yields `modified` with the exact changed word set; an added paragraph yields `new`.
- **Both baseline code paths:** directory baseline and git-ref baseline (`git show <commit>:path`) both produce markers correctly.
- **Full `mdbook build` render** against a real baseline: a modified block gets the margin line + underlines on exactly the changed words; a new block gets the margin line only; the manifest is injected on every page (verified on a page with no changes of its own).
- **Browser verification (Chromium/Playwright)** across light (latte) and dark (macchiato) themes: computed accent `rgb(136,57,239)` in latte and `rgb(198,160,246)` in macchiato; the sidebar shows a solid dot on the changed chapter (5.3.2 Lenses) and on its ancestors (5 Optics, 5.3 Fundamentals); toggle `full` shows all signals, `lines` removes the word underline, `off` hides the margin line and all sidebar dots; state persists.

No tracked chapter content was modified — the local test put the "old" text in a throwaway snapshot so the pristine page rendered as changed.

- [ ] `./gradlew test` passes locally (N/A — docs/tooling only)
- [ ] New unit tests added/updated
- [ ] Relevant examples updated/tested (if applicable)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (N/A — no Java changes)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)
- [x] I have checked that the GitHub Actions CI build passes with my changes

## Additional Comments (Optional)

Two follow-ups worth a maintainer decision, not blocking:

1. **Snapshot noise** — a `latest` build far from the last release highlights a lot. The `off` toggle covers it, but the default could instead be `lines`, or aggregate to a page-level badge when a page is heavily changed.
2. **Block→element assumption** — the runtime treats each marked block as rendering to a single top-level element (true for paragraphs, code fences, admonitions, lists, tables). Exotic constructs that split into multiple top-level elements would need an extra guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L84tZWuhLEC5qN1ThJUjcd