### PR TITLE
Fix incorrect 0.4.8 documentation, and make drift impossible to merge

### DIFF
--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -299,6 +299,23 @@ Use the following admonishment types consistently:
 
 ## Code Formatting
 
+### Java code in hkj-book must be verified
+
+Hand-written Java in a book page drifts: nothing compiles it, so it rots silently and readers copy
+code that does not build. Prefer, in this order:
+
+1. **Include it from a compiled example.** Anchor the code in
+   `hkj-examples/src/main/java/org/higherkindedj/example/book/**` and `{{#include}}` it. The page then
+   renders code the build compiles *and runs*, so it cannot drift, and a runnable example also proves
+   the output comments the page asserts.
+2. **Mark the fence `<!-- verify -->`.** The gate compiles a copy of it against the real library and
+   the real annotation processor. Use this only when the snippet cannot be runnable code (a shape
+   written against abstract type variables, for instance).
+3. A plain fence, verified by nothing, is a last resort. Two ratchets fail the build if the number of
+   includes or verified snippets falls, so it cannot become the default by accident.
+
+See `hkj-examples/BOOK-SNIPPETS.md`, and run `gradle :hkj-examples:bookVerify`.
+
 ### Code Blocks
 
 Use triple backticks with language specifier:

--- a/hkj-book/src/cheatsheet.md
+++ b/hkj-book/src/cheatsheet.md
@@ -20,6 +20,7 @@
 | `EitherOrBothPath<L, A>` | Success with warnings | `Path.rightNel(v)`, `Path.bothNel(w, v)`, `Path.leftNel(e)` | `.run()` → `EitherOrBoth<L, A>` |
 | `IOPath<A>` | Deferred side effects | `Path.io(() -> ...)`, `Path.ioPure(v)` | `.unsafeRun()` → `A` |
 | `VTaskPath<A>` | Virtual threads | `Path.vtask(() -> ...)`, `Path.vtaskPure(v)` | `.unsafeRun()` → `A` |
+| `VResultPath<E, A>` | Virtual threads + typed error | `Path.vresultRight(v)`, `Path.vresultLeft(e)`, `Path.vresultDefer(() -> either)` | `.toEitherPath()` → `EitherPath<E, A>` |
 | `ReaderPath<R, A>` | Dependency injection | `Path.reader(r)`, `Path.ask()`, `Path.asks(fn)` | `.run(env)` → `A` |
 | `WriterPath<W, A>` | Logging, audit | `Path.writer(w, m)`, `Path.tell(log, m)` | `.run()` → `Writer<W, A>` |
 | `WithStatePath<S, A>` | Stateful computation | `Path.state(s)`, `Path.getState()` | `.run(initial)` → `(S, A)` |
@@ -159,6 +160,11 @@ import static org.higherkindedj.hkt.instances.Witnesses.*;
 | `TryPath<A>` | `MaybePath<A>` | `.toMaybePath()` |
 | `ValidationPath<E, A>` | `EitherPath<E, A>` | `.toEitherPath()` |
 | `ValidationPath<E, A>` | `MaybePath<A>` | `.toMaybePath()` |
+| `VResultPath<E, A>` | `EitherPath<E, A>` | `.toEitherPath()` (runs it) |
+| `VResultPath<E, A>` | `VTaskPath<A>` | `.toVTaskPath(errorToException)` |
+| `EitherOrBoth<L, R>` | `Either<L, R>` | `.toEitherDroppingWarnings()`, `.toEitherFailingOnWarnings()` |
+| `EitherOrBoth<L, R>` | `Validated<L, R>` | `.toValidated()` |
+| `EitherOrBoth<L, R>` | `Maybe<R>` | `.toMaybe()` |
 | `FocusPath<S, A>` | `MaybePath<A>` | `.toMaybePath()` |
 | `FocusPath<S, A>` | `EitherPath<E, A>` | `.toEitherPath(errorFn)` |
 | `AffinePath<S, A>` | `MaybePath<A>` | `.toMaybePath()` |

--- a/hkj-book/src/effect/conversions.md
+++ b/hkj-book/src/effect/conversions.md
@@ -48,6 +48,18 @@ The Path API supports rich conversions between all path types. Some conversions 
 │                                                                                  │
 │    TryPath ─────── toValidationPath(mapper) ────────────────→ ValidationPath     │
 │                                                                                  │
+│  ASYNC TYPED-ERROR PATHS                                                         │
+│  ───────────────────────                                                         │
+│    VResultPath ─── toEitherPath() ──────────────────────────→ EitherPath         │
+│       │            (runs the task)                                               │
+│    VResultPath ─── toVTaskPath(errorToException) ───────────→ VTaskPath          │
+│                                                                                  │
+│  INCLUSIVE-OR                                                                    │
+│  ────────────                                                                    │
+│    EitherOrBoth ── toEitherDroppingWarnings() ──────────────→ Either             │
+│       │            toEitherFailingOnWarnings()                                   │
+│    EitherOrBoth ── toValidated() / toMaybe() ───────────────→ Validated / Maybe  │
+│                                                                                  │
 │  UTILITY PATHS                                                                   │
 │  ─────────────                                                                   │
 │    IdPath ←──────── toIdPath() / toMaybePath() ─────────────→ MaybePath          │

--- a/hkj-book/src/effect/path_either_or_both.md
+++ b/hkj-book/src/effect/path_either_or_both.md
@@ -1,5 +1,10 @@
 # EitherOrBothPath
 
+~~~admonish example title="See Example Code"
+**The code on this page is [EitherOrBothPathBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java)** - the page includes it directly, so it is compiled and run by the build.
+~~~
+
+
 `EitherOrBothPath<L, A>` wraps [`EitherOrBoth<L, A>`](../monads/either_or_both_monad.md) for
 computations that succeed but may also carry **non-fatal warnings**. It is the railway companion to
 `ValidationPath`: where `ValidationPath` is success *or* accumulated errors, `EitherOrBothPath` adds a
@@ -26,15 +31,13 @@ The `rightNel` / `leftNel` / `bothNel` factories bake in `NonEmptyList.semigroup
 case needs no `Semigroup` argument and no manual single-warning wrapping:
 
 ```java
-EitherOrBothPath<NonEmptyList<String>, Config> ok      = Path.rightNel(config);
-EitherOrBothPath<NonEmptyList<String>, Config> warned  = Path.bothNel("deprecated key", config);
-EitherOrBothPath<NonEmptyList<String>, Config> failed  = Path.leftNel("config missing");
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java:create}}
 ```
 
 When you need a custom warning channel, supply the `Semigroup` explicitly:
 
 ```java
-EitherOrBothPath<String, Integer> p = Path.both("warn", 42, Semigroups.string("; "));
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java:custom_semigroup}}
 ```
 
 ---
@@ -71,15 +74,7 @@ Like `ValidationPath`, `EitherOrBothPath` offers both short-circuit and accumula
 accumulates any the next step produces:
 
 ```java
-EitherOrBothPath<NonEmptyList<String>, Integer> result =
-    Path.<String, Integer>bothNel("uses deprecated key", 8)
-        .via(value -> value < 10
-            ? Path.bothNel("value is low", value)
-            : Path.rightNel(value));
-
-result.run();        // Both([uses deprecated key, value is low], 8)
-result.warnings();   // Just([uses deprecated key, value is low])
-result.getOrElse(0); // 8
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java:via}}
 ```
 
 ### Accumulating (`zipWithAccum`)
@@ -88,12 +83,7 @@ result.getOrElse(0); // 8
 `Left` (the `Validated`-style accumulation that the monadic operations deliberately do not do):
 
 ```java
-EitherOrBothPath<NonEmptyList<String>, String> name = Path.bothNel("name was trimmed", "Ada");
-EitherOrBothPath<NonEmptyList<String>, Integer> age = Path.bothNel("age defaulted", 30);
-
-EitherOrBothPath<NonEmptyList<String>, String> reg =
-    name.zipWithAccum(age, (n, a) -> n + " (" + a + ")");
-// Both([name was trimmed, age defaulted], "Ada (30)")
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java:zip_accum}}
 ```
 
 `andAlso` / `andThen` are conveniences over `zipWithAccum` that keep one side's value while still
@@ -113,11 +103,7 @@ warning regardless. Choose by intent: sequential dependency → `via`; independe
 For N independent fields, the staged assembly on the core type extends `zipWithAccum` to open arity: warnings accumulate while the value keeps flowing, and the result wraps back into a path with `Path.eitherOrBoth` when railway composition should continue.
 
 ```java
-EitherOrBoth<NonEmptyList<String>, Config> cfg =
-    EitherOrBoth.accumulate()
-        .and(parsePortLenient(raw.port()))
-        .and(parseTimeoutLenient(raw.timeout()))
-        .apply(Config::new);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java:accumulate}}
 ```
 
 See [Accumulating Assembly](../monads/validated_assembly.md).
@@ -130,8 +116,7 @@ See [Accumulating Assembly](../monads/validated_assembly.md).
 passed through unchanged:
 
 ```java
-Path.<String, Integer>leftNel("config missing").recover(errors -> 0).run();   // Right(0)
-Path.<String, Integer>bothNel("deprecated", 42).recover(errors -> 0).run();    // Both([deprecated], 42)
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java:recover}}
 ```
 
 To transform the warning type, use `mapErrorWith(mapper, newSemigroup)` (a new `Semigroup` is needed

--- a/hkj-book/src/effect/path_types.md
+++ b/hkj-book/src/effect/path_types.md
@@ -155,6 +155,7 @@ with a `Monad` instance.
 | [`VResultPath<E, A>`](path_vresult.md) | `VTask<Either<E, A>>` | `E` (typed) | **Deferred** | Async work with a typed domain error |
 | [`VStreamPath<A>`](path_vstream.md) | `VStream<A>` | Via VTask | **Lazy pull** | Lazy streaming on virtual threads |
 | [`ValidationPath<E, A>`](path_validation.md) | `Validated<E, A>` | `E` (accumulated) | Immediate | Form validation |
+| [`EitherOrBothPath<L, A>`](path_either_or_both.md) | `EitherOrBoth<L, A>` | `L` (fatal, or non-fatal warnings alongside a value) | Immediate | Success that may carry warnings |
 | [`IdPath<A>`](path_id.md) | `Id<A>` | None (always succeeds) | Immediate | Pure values |
 | [`OptionalPath<A>`](path_optional.md) | `Optional<A>` | None (absence) | Immediate | Java stdlib bridge |
 | [`GenericPath<F, A>`](path_generic.md) | `Kind<F, A>` | Depends on monad | Depends | Custom monads |
@@ -181,6 +182,7 @@ These types handle failures with different strategies:
 - **[EitherPath](path_either.md)** - Typed errors, short-circuit on first failure
 - **[TryPath](path_try.md)** - Exception-based errors
 - **[ValidationPath](path_validation.md)** - Accumulate all errors
+- **[EitherOrBothPath](path_either_or_both.md)** - Success that can still carry non-fatal warnings
 
 ### Deferred Computation
 

--- a/hkj-book/src/effect/path_vresult.md
+++ b/hkj-book/src/effect/path_vresult.md
@@ -8,6 +8,7 @@ _Async work that can fail with a typed, domain error: the railway for the shape 
 
 Pynchon's binary is a dread; for a service call it is the goal. Every remote request settles onto exactly one of two channels: a value, or a typed, domain reason it produced none. `VTask<Either<E, A>>` (call something remote, get back either a value or a typed failure) is the single most common effect stack in real services. HKJ models both halves well separately (`VTaskPath` for async, `EitherPath` for typed errors); `VResultPath<E, A>` is their composition as a first-class path, so neither `Kind` ceremony nor a hand-rolled `EitherT` bridge ever surfaces:
 
+<!-- verify -->
 ``` java
 VResultPath<OrderError, OrderResult> process(OrderRequest request) {
     return validateShippingAddress(request.shippingAddress())    // VResultPath<OrderError, Address>
@@ -37,6 +38,7 @@ It speaks the family vocabulary exactly (`map`/`via`/`then` on the success chann
 
 ## Construction
 
+<!-- verify -->
 ``` java
 VResultPath<E, A> p1 = Path.vresultRight(value);          // pure success
 VResultPath<E, A> p2 = Path.vresultLeft(error);           // typed failure
@@ -51,9 +53,10 @@ VResultPath<E, A> p5 = Path.vresultDefer(() -> decide()); // defer the decision 
 
 The structured-concurrency surface keeps typed failures **in the value channel**: no thrown-and-recovered domain errors, no `instanceof` bridges, no side flags.
 
+<!-- verify -->
 ``` java
 // First warehouse to succeed wins; typed failures do not abort, they're collected.
-VResultPath<NonEmptyList<OrderError>, Reservation> reservation =
+VResultPath<NonEmptyList<OrderError>, Reservation> fromAnyWarehouse =
     VResultPath.firstSuccess(List.of(warehouse1, warehouse2, warehouse3))
         .withTimeout(Duration.ofSeconds(10), () -> NonEmptyList.of(OrderError.timeout()));
 
@@ -72,7 +75,7 @@ VResultPath<OrderError, OrderResult> fulfilled =
 - **`allSucceed`**: fail-fast; the first typed failure cancels the remaining tasks and becomes the result.
 - **`allSucceedAccumulating`**: run everything to completion and collect every typed failure at once.
 - **`withTimeout(duration, onTimeout)`**: a timeout becomes the designated typed error, on the railway.
-- **`bracketOutcome`**: release *always* runs and receives the `Either` outcome, so confirm-vs-compensate is decided from the result; defects inside `use` are typed through `onDefect` first, so release always observes a real outcome. This is the substrate the order example's deferred compensation Saga hangs on.
+- **`bracketOutcome`**: once the resource is acquired, release *always* runs and receives the `Either` outcome (a typed failure from `acquire` skips both `use` and `release`, since nothing was acquired), so confirm-vs-compensate is decided from the result; defects inside `use` are typed through `onDefect` first, so release always observes a real outcome. This is the substrate the order example's deferred compensation Saga hangs on.
 
 ~~~admonish note title="Why these live on VResultPath, not Scope"
 The issue sketched `Scope.firstSuccess(...)`, but `Scope` lives in `hkt.vtask`, which `hkt.effect` depends on; statics there referencing `VResultPath` would create a package cycle. The combinators sit on `VResultPath`, implemented over the same `Scope`/`ScopeJoiner` substrate (which gained an `Either`-aware `firstSuccessEither` joiner).
@@ -84,6 +87,7 @@ The issue sketched `Scope.firstSuccess(...)`, but `Scope` lives in `hkt.vtask`, 
 
 The full `with*` resilience vocabulary chains directly on the path, and every combinator is railway-aware: a typed `Left` is a *value*, not a fault.
 
+<!-- verify -->
 ``` java
 VResultPath<OrderError, Reservation> guarded =
     reserveInventory(order)
@@ -105,6 +109,7 @@ Because the path is lazy, protection wraps the *computation*: apply the combinat
 
 ## Escaping the path
 
+<!-- verify -->
 ``` java
 VTask<Either<E, A>> carrier = path.run();                 // the boundary type
 EitherPath<E, A>   decided = path.toEitherPath();         // blocking: runs the task

--- a/hkj-book/src/monads/either_or_both_monad.md
+++ b/hkj-book/src/monads/either_or_both_monad.md
@@ -1,6 +1,11 @@
 # EitherOrBoth:
 ## _Success That Can Also Carry Warnings_
 
+~~~admonish example title="See Example Code"
+**The code on this page is [EitherOrBothBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java)** - the page includes it directly, so it is compiled and run by the build.
+~~~
+
+
 ~~~admonish info title="What You'll Learn"
 - Why neither `Either` nor `Validated` can model "success with warnings", and how `EitherOrBoth` fills the gap
 - The three cases (`Left`, `Right`, `Both`) and the total accessors (`getLeft` / `getRight`) that never throw
@@ -26,9 +31,7 @@ Neither models a genuinely common outcome: a **successful value that also carrie
 `EitherOrBoth<L, R>` is the principled type. It is an *inclusive*-or: a `Left`, a `Right`, **or `Both` at once**.
 
 ```java
-EitherOrBoth<NonEmptyList<Warning>, Config> result =
-    parseConfig(raw)                          // Right(cfg), Both(warnings, cfg), or Left(fatal)
-        .flatMap(NonEmptyList.semigroup(), cfg -> validateConfig(cfg)); // warnings accumulate
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java:flatmap}}
 ```
 
 By convention it is **right-biased**: success on the right, problems on the left, so `map` / `flatMap` feel identical to the rest of the railway. A `Both` is therefore "a successful value *and* the warnings gathered while producing it".
@@ -46,21 +49,13 @@ descriptive name; the aliases are noted only so the concept is recognisable.
 `switch`-matchable:
 
 ```java
-String describe(EitherOrBoth<NonEmptyList<Warning>, Config> r) {
-  return switch (r) {
-    case EitherOrBoth.Left<NonEmptyList<Warning>, Config>(var w)        -> "failed: " + w;
-    case EitherOrBoth.Right<NonEmptyList<Warning>, Config>(var cfg)     -> "ok: " + cfg;
-    case EitherOrBoth.Both<NonEmptyList<Warning>, Config>(var w, var c) -> "ok with warnings: " + c;
-  };
-}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java:switch}}
 ```
 
 Create values with `left` / `right` / `both`:
 
 ```java
-EitherOrBoth<String, Integer> left  = EitherOrBoth.left("fatal");
-EitherOrBoth<String, Integer> right = EitherOrBoth.right(42);
-EitherOrBoth<String, Integer> both  = EitherOrBoth.both("deprecated key", 42);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java:cases}}
 ```
 
 Values are **never `null`**: the components are validated at construction, which is what keeps the
@@ -82,10 +77,7 @@ return a `Maybe`:
 `fold` collapses all three cases at once:
 
 ```java
-String s = both.fold(
-    warnings -> "failed: " + warnings,
-    value    -> "ok: " + value,
-    (w, v)   -> "ok (" + v + ") with " + w);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java:fold}}
 ```
 
 ---
@@ -106,9 +98,7 @@ forward and accumulates them.**
 </pre>
 
 ```java
-EitherOrBoth<L, R2> flatMap(
-    Semigroup<L> semigroup,
-    Function<? super R, ? extends EitherOrBoth<L, ? extends R2>> mapper);
+{{#include ../../../hkj-core/src/main/java/org/higherkindedj/hkt/eitherorboth/EitherOrBoth.java:flatmap_signature}}
 ```
 
 For `Both(l, r).flatMap(⊕, f)`:
@@ -173,12 +163,7 @@ result can be *both* a value and a set of problems.
 The staged assembly builder gives `EitherOrBoth` the same open-arity construction story as [Validated](validated_assembly.md), in tolerant form: warnings accumulate (`Both`) while the value keeps flowing, and any `Left` makes the whole assembly `Left` while still keeping every warning, in field-declaration order.
 
 ```java
-EitherOrBoth<NonEmptyList<String>, Config> cfg =
-    EitherOrBoth.accumulate()
-        .and(parsePortLenient(raw.port()))       // Both("port defaulted", 8080)
-        .and(parseTimeoutLenient(raw.timeout())) // Right(30)
-        .apply(Config::new);
-// Both(NonEmptyList[port defaulted], Config[port=8080, timeout=30])
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java:accumulate}}
 ```
 
 The combination primitive behind it is `zipWithAccum(other, semigroup, combiner)`: the `Validated`-style merge in which the right is present only if both are, and nothing short-circuits the warning collection. `EitherOrBoth.fields()` is the labelled twin over `NonEmptyList<FieldError>`, with paths that compose through nesting.

--- a/hkj-book/src/monads/nonemptylist_monad.md
+++ b/hkj-book/src/monads/nonemptylist_monad.md
@@ -1,6 +1,11 @@
 # NonEmptyList:
 ## _A List That Is Never Empty_
 
+~~~admonish example title="See Example Code"
+**The code on this page is [NonEmptyListBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java)** - the page includes it directly, so it is compiled and run by the build.
+~~~
+
+
 ~~~admonish info title="What You'll Learn"
 - Why `List<Error>` is the wrong type for an accumulating error channel, and how `NonEmptyList` fixes it
 - Total operations (`head`, `last`, `reduce`, `min`, `max`) that never throw, because there is always at least one element
@@ -18,9 +23,7 @@
 Accumulating validation is one of Higher-Kinded-J's headline stories: `Validated` and `ValidationPath` collect *all* the errors instead of stopping at the first. But the type the errors are carried in matters. The common choice, `List<Error>`, permits an impossible state:
 
 ```java
-// An "invalid" result always has at least one error, yet the type allows zero.
-ValidationPath<List<Error>, User> failure = Path.invalid(List.of(error), Semigroups.list());
-Error first = failure.run().getError().getFirst();   // partial: getFirst() throws on empty
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:partial}}
 ```
 
 Three things hurt here:
@@ -32,9 +35,7 @@ Three things hurt here:
 `NonEmptyList<A>` is a list guaranteed by its type to contain at least one element. The invalid branch proves non-emptiness at compile time, and the common case loses its boilerplate:
 
 ```java
-// NonEmptyList error channel: no Semigroup argument, no List.of wrapping.
-ValidationPath<NonEmptyList<Error>, User> failure = Path.invalidNel(error);
-Error first = failure.run().getError().head();   // total: never throws, returns Error
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:total}}
 ```
 
 This is the canonical companion to `Validated` in comparable libraries (Cats' `NonEmptyList` / `ValidatedNel`) precisely because it removes the empty-error-list footgun.
@@ -58,16 +59,13 @@ This is the canonical companion to `Validated` in comparable libraries (Cats' `N
 Java has no non-empty literal, so construction is explicit about where the guaranteed element comes from:
 
 ```java
-NonEmptyList<Integer> a = NonEmptyList.of(1, 2, 3);        // head + varargs tail
-NonEmptyList<Integer> b = NonEmptyList.of(1, List.of(2));  // head + explicit tail
-NonEmptyList<Integer> c = NonEmptyList.single(42);         // single element
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:construct}}
 ```
 
 To build one from data that *might* be empty, use the checked factories. They never throw; they return `Maybe`:
 
 ```java
-Maybe<NonEmptyList<Integer>> maybe = NonEmptyList.fromList(List.of(1, 2, 3)); // Just([1, 2, 3])
-Maybe<NonEmptyList<Integer>> none  = NonEmptyList.fromList(List.of());        // Nothing
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:from_list}}
 ```
 
 ~~~admonish note title="Immutable and null-safe"
@@ -81,13 +79,7 @@ The `tail` is defensively copied on construction, `tail()` returns an unmodifiab
 Because non-emptiness is part of the type, operations that are *partial* on an ordinary `List` are **total** here: they always return a value and never throw, with no `Optional` to unwrap:
 
 ```java
-NonEmptyList<Integer> nel = NonEmptyList.of(3, 1, 2);
-
-int head = nel.head();                          // 3   (never throws)
-int last = nel.last();                          // 2   (never throws)
-int sum  = nel.reduce((x, y) -> x + y);         // 6   (reduce without an identity)
-int min  = nel.min(Comparator.naturalOrder());  // 1
-int max  = nel.max(Comparator.naturalOrder());  // 3
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:total_ops}}
 ```
 
 It is also `Iterable`, so it works directly in for-each loops and streams, and `toJavaList()` gives an immutable `java.util.List` for interop.
@@ -99,20 +91,13 @@ It is also `Iterable`, so it works directly in for-each loops and streams, and `
 `NonEmptyList` is the natural carrier for accumulating validation. The `Path` factories bake in `NonEmptyList.semigroup()`, so the common case needs no `Semigroup` argument and no manual `List.of(error)` wrapping:
 
 ```java
-// A single-error leaf wraps its error in a singleton NonEmptyList; that is the whole idiom.
-ValidationPath<NonEmptyList<String>, String> name  = Path.invalidNel("name is blank");
-ValidationPath<NonEmptyList<String>, String> email = Path.invalidNel("email is invalid");
-
-// Accumulation just concatenates the two NonEmptyLists, non-empty by construction.
-ValidationPath<NonEmptyList<String>, String> both = name.andAlso(email);
-both.run().getError().toJavaList();   // ["name is blank", "email is invalid"]  (left-to-right)
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:accumulate}}
 ```
 
 The same conveniences exist directly on `Validated`:
 
 ```java
-Validated<NonEmptyList<String>, Integer> ok  = Validated.validNel(42);
-Validated<NonEmptyList<String>, Integer> bad = Validated.invalidNel("must be positive");
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:validated_nel}}
 ```
 
 ~~~admonish tip title="Two distinct 'combines'"
@@ -128,8 +113,7 @@ The existing `Semigroups.list()` channel keeps working unchanged; `NonEmptyList`
 Casual use never requires `Kind`: `NonEmptyList.of(a, b).map(f).flatMap(g)` is a plain fluent chain. When you need the type-class instances for generic code, reach them through the usual registry:
 
 ```java
-Monad<NonEmptyListKind.Witness> monad = Instances.monad(nonEmptyList());
-Kind<NonEmptyListKind.Witness, Integer> lifted = monad.of(1);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java:instances}}
 ```
 
 ~~~admonish warning title="No empty, by design"

--- a/hkj-book/src/monads/validated_assembly.md
+++ b/hkj-book/src/monads/validated_assembly.md
@@ -1,6 +1,11 @@
 # Accumulating Assembly:
 ## _Building a Record from N Validated Fields_
 
+~~~admonish example title="See Example Code"
+**The code on this page is [ValidatedAssemblyBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java)** - the page includes it directly, so it is compiled and run by the build.
+~~~
+
+
 ~~~admonish info title="What You'll Learn"
 - Assembling a record from independently validated fields with `Validated.fields()` and `Validated.accumulate()`: every error reported at once, no `Semigroup` argument, no arity wall, no `Kind`
 - How `field(label, value)` attaches a path to each error, and how nesting composes paths (`address.zip`)
@@ -18,10 +23,7 @@
 [Validated](validated_monad.md) accumulates errors, and [NonEmptyList](nonemptylist_monad.md) gives the errors an honest carrier. But the everyday task (a request DTO becomes a domain aggregate; a raw config becomes a settings object) is assembling a record from N validated fields, and until now that meant choosing between:
 
 ```java
-// The HKT-generic form: capped at map5, and every call passes the Semigroup by hand.
-ValidatedMonad<List<String>> validatedMonad = Instances.validated(Semigroups.list());
-Kind<ValidatedKind.Witness<List<String>>, User> user =
-    validatedMonad.map3(nameKind, emailKind, ageKind, User::new);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:hkt_generic}}
 ```
 
 - **An arity wall.** `map2..map5` stop at five fields; `zipWithAccum` is binary and `zipWith3Accum` ternary.
@@ -37,14 +39,7 @@ The staged assembly builder removes all three at once.
 `Validated.fields()` opens a labelled assembly over `NonEmptyList<FieldError>`. Each `field(label, value)` adds one validated field; `apply(...)` completes the assembly with a constructor reference or lambda of exactly the accumulated arity:
 
 ```java
-Validated<NonEmptyList<FieldError>, User> user =
-    Validated.fields()
-        .field("name", parseName(dto.name()))     // Validated<NonEmptyList<FieldError>, Name>
-        .field("email", parseEmail(dto.email()))
-        .field("age", parseAge(dto.age()))
-        .apply(User::new);                        // (Name, Email, Age) -> User
-
-// Invalid(NonEmptyList[email: not an email address, age: not a number]) - name was fine.
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:fields}}
 ```
 
 Three guarantees, all by construction:
@@ -60,17 +55,7 @@ A leaf validator creates unlabelled errors with `FieldError.of("message")`; the 
 Because `at()` *prepends*, assembling a sub-record under an outer label prefixes all its inner paths:
 
 ```java
-Validated<NonEmptyList<FieldError>, Address> address =
-    Validated.fields()
-        .field("street", parseStreet(raw.street()))
-        .field("zip", parseZip(raw.zip()))          // fails: "zip: not a postcode"
-        .apply(Address::new);
-
-Validated<NonEmptyList<FieldError>, Customer> customer =
-    Validated.fields()
-        .field("name", parseName(raw.name()))
-        .field("address", address)                  // prefixes: "address.zip: not a postcode"
-        .apply(Customer::new);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:nesting}}
 ```
 
 This also doubles as the escape hatch for very wide records: `apply` overloads exist up to arity 16 (matching the shipped `Function3..Function16`); a record with more fields nests a sub-record per group, which usually improves the domain model anyway.
@@ -82,11 +67,7 @@ This also doubles as the escape hatch for very wide records: `apply` overloads e
 When your error type is not `FieldError`, `accumulate()` gives the same open-arity assembly for any payload `X`, carried as `NonEmptyList<X>`. Fields join with `and(value)`:
 
 ```java
-Validated<NonEmptyList<ConfigError>, Settings> settings =
-    Validated.accumulate()
-        .and(parseHost(raw.host()))
-        .and(parsePort(raw.port()))
-        .apply(Settings::new);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:accumulate}}
 ```
 
 There is still no `Semigroup` argument: the carrier is fixed to `NonEmptyList`, and accumulation is concatenation.
@@ -111,12 +92,7 @@ The same two entry points exist on each carrier, so the assembly reads identical
 The tolerant flavour is the natural fit for lenient config parsing:
 
 ```java
-EitherOrBoth<NonEmptyList<String>, Config> cfg =
-    EitherOrBoth.accumulate()
-        .and(parsePortLenient(raw.port()))       // Both("port defaulted", 8080)
-        .and(parseTimeoutLenient(raw.timeout())) // Right(30)
-        .apply(Config::new);
-// Both(NonEmptyList[port defaulted], Config[port=8080, timeout=30])
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:eob_accumulate}}
 ```
 
 Under the hood every stage transition delegates to the existing accumulation primitives: `Validated.ap` with `NonEmptyList.semigroup()`, `ValidationPath.zipWithAccum`, and `EitherOrBoth.zipWithAccum`. The builder introduces no second accumulation mechanism.
@@ -128,15 +104,9 @@ Under the hood every stage transition delegates to the existing accumulation pri
 For records you own, the annotation processor generates a per-record companion that removes the three remaining failure modes of the hand-written chain: labels come from the component names (typo-proof, rename-safe), field order cannot be wrong (named, order-enforcing stage methods), and there is no arity ceiling (the generator emits exact arity, even past 16).
 
 ```java
-@GenerateAssembly
-record User(String name, String email, int age) {}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:generated_spec}}
 
-Validated<NonEmptyList<FieldError>, User> user =
-    UserAssembly.fields()
-        .name(parseName(dto.name()))      // label "name" attached automatically
-        .email(parseEmail(dto.email()))
-        .age(parseAge(dto.age()))
-        .assemble();                       // canonical constructor baked in
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java:generated_usage}}
 ```
 
 A component whose type is itself annotated accepts its sub-companion's result directly, and the outer component name prefixes the inner paths (`address.zip`). The companion lives in the record's package, named `<Record>Assembly`; for a nested record the enclosing simple names are joined (`Outer.Inner` gives `OuterInnerAssembly`). Under the hood the companion merges through the same `Validated.ap` / `NonEmptyList.semigroup()` primitives as the builder, so the two agree on every input. Generic records are not supported; use the hand-written `fields()` builder for records you cannot annotate.
@@ -158,10 +128,7 @@ A component whose type is itself annotated accepts its sub-companion's result di
 `hkj-test` ships `assertThatFieldError` alongside `assertThatValidated`:
 
 ```java
-assertThatFieldError(FieldError.of("not a postcode").at("zip").at("address"))
-    .hasPath("address.zip")
-    .hasSegments("address", "zip")
-    .hasMessageContaining("postcode");
+{{#include ../../../hkj-examples/src/test/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBookTest.java:field_error}}
 ```
 ~~~
 
@@ -178,7 +145,7 @@ assertThatFieldError(FieldError.of("not a postcode").at("zip").at("address"))
 - [NonEmptyList](nonemptylist_monad.md): the error carrier the builder is fixed to
 - [EitherOrBoth](either_or_both_monad.md): the tolerant carrier
 - [ValidationPath](../effect/path_validation.md): the railway validation API
-- [Validated Prisms](../optics/validated_prism.md): a leaf parser with a faithful render-back *is* a `ValidatedPrism`: pass `vp::parse` to `field(label, ...)`. (`fields()` accumulates *siblings*; a prism's `andThen` short-circuits *nesting*.)
+- [Validated Prisms](../optics/validated_prism.md): a leaf parser with a faithful render-back *is* a `ValidatedPrism`: pass `vp.parse(raw)` to `field(label, ...)`. (`fields()` accumulates *siblings*; a prism's `andThen` short-circuits *nesting*.)
 - [Applicative](../functional/applicative.md): the `mapN` family for `Kind`-generic code
 - [Multi-Edit and Sparse Updates](../optics/multi_edit.md): the same all-errors-at-once model for *updating* existing values
 ~~~

--- a/hkj-book/src/monads/validated_monad.md
+++ b/hkj-book/src/monads/validated_monad.md
@@ -95,7 +95,8 @@ The examples below use `Validated<List<String>, T>`, but an *invalid* result alw
 Each validator is an independent function that returns `Validated<List<String>, T>`:
 
 ```java
-ValidatedMonad<List<String>> validatedMonad = Instances.validated(Semigroups.list());
+MonadError<ValidatedKind.Witness<List<String>>, List<String>> validatedMonad =
+    Instances.validated(Semigroups.list());
 
 static Validated<List<String>, String> validateName(String name) {
     return (name == null || name.isBlank())

--- a/hkj-book/src/optics/multi_edit.md
+++ b/hkj-book/src/optics/multi_edit.md
@@ -1,5 +1,10 @@
 # Multi-Edit and Sparse Updates
 
+~~~admonish example title="See Example Code"
+**The code on this page is [MultiEditBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java)** - the page includes it directly, so it is compiled and run by the build.
+~~~
+
+
 _Apply N independent edits at different paths in one reusable operation, including the sparse, all-errors-at-once REST `PATCH` shape._
 
 ~~~admonish info title="What You'll Learn"
@@ -15,17 +20,7 @@ _Apply N independent edits at different paths in one reusable operation, includi
 An optic edits one path at a time (`FocusPath.set`, `Setter.modify`). But the everyday case is applying **several** edits at once, the classic example being a REST `PATCH` that tidies the email, trims the SKU, and bumps the quantity. By hand that means threading the value through every step, guarding each optional field with an `if`, and (if you validate at all) throwing on the first bad field:
 
 ``` java
-Order updated = order;
-if (req.email() != null) {
-    updated = updated.withEmail(req.email().toLowerCase());        // thread the result...
-}
-if (req.sku() != null) {
-    updated = updated.withSku(req.sku().trim());                   // ...through every step
-}
-if (req.qtyDelta() != null) {
-    updated = updated.withQuantity(updated.quantity() + req.qtyDelta());
-}
-// And if the email was malformed? You throw on the first bad field and never see the rest.
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java:before}}
 ```
 
 Three pains recur: one `if` per optional field, the value re-threaded by hand at every step, and validation that stops at the first error instead of collecting them all.
@@ -50,12 +45,7 @@ Each `Edit` factory pairs an optic (a `FocusPath` or a `Setter`) with a value or
 ``` java
 import static org.higherkindedj.optics.edit.Edit.*;
 
-Update<Order> normalise = Edits.combine(
-    modify(EMAIL, String::toLowerCase),
-    modify(SKU,   String::trim));
-
-Order a = normalise.apply(orderA);
-Order b = normalise.andThen(applyDiscount).apply(orderB);   // Update composes further
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java:combine}}
 ```
 
 Only pure `Edit`s fit `combine`'s signature; a fallible edit is rejected **at compile time**, so validation failures can never be silently dropped.
@@ -67,8 +57,7 @@ Only pure `Edit`s fit `combine`'s signature; a fallible edit is rejected **at co
 The `…IfPresent` factories treat `null` as *absent*: the edit contributes the identity update, so a sparse request DTO lands one-to-one with no `if` ceremony:
 
 ``` java
-setIfPresent(ORDER_NUMBER, req.orderNumber())              // null -> no-op
-modifyIfPresent(QUANTITY, req.qtyDelta(), (delta, qty) -> qty + delta)
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java:sparse}}
 ```
 
 Each request field maps to exactly one slot; an absent field simply contributes nothing to the fold:
@@ -91,16 +80,10 @@ A sparse edit cannot *clear* a field: `setIfPresent(path, null)` means "no chang
 
 ## Validated PATCH: `Edits.accumulate`
 
-`parseIfPresent` parses the incoming value first, and `.at(label)` locates any failure, exactly as `FieldError.at` composes paths. The parser you hand it has exactly the shape of a [`ValidatedPrism`](validated_prism.md)'s `parse`: define the boundary once as a prism (gaining the total render-back and the round-trip laws) and pass `email::parse` here. `accumulate` validates **every** edit independently and reports **all** bad fields at once:
+`parseIfPresent` parses the incoming value first, and a generated path locates any failure **automatically** from its own label (`.at(label)` prepends further context, exactly as `FieldError.at` composes paths). The parser you hand it has exactly the shape of a [`ValidatedPrism`](validated_prism.md)'s `parse`: define the boundary once as a prism (gaining the total render-back and the round-trip laws) and pass `Email::parse` here. `accumulate` validates **every** edit independently and reports **all** bad fields at once:
 
 ``` java
-Validated<NonEmptyList<FieldError>, Order> updated =
-    Edits.accumulate(
-            setIfPresent(ORDER_NUMBER, req.orderNumber()),
-            parseIfPresent(EMAIL, req.email(), Email::parse).at("email"),
-            modifyIfPresent(QUANTITY, req.qtyDelta(), (delta, qty) -> qty + delta))
-        .apply(order);
-// Invalid(NEL[ "email: not an address" ]) — or Valid(order') with only the present fields changed
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java:accumulate}}
 ```
 
 Errors accumulate in edit order on the `NonEmptyList` channel, exactly like the [accumulating assembly](../monads/validated_assembly.md), but as a homogeneous fold, so there is **no arity ceiling**.

--- a/hkj-book/src/optics/record_mapping.md
+++ b/hkj-book/src/optics/record_mapping.md
@@ -14,20 +14,15 @@ Every service boundary maps between a rich domain record and a flat wire DTO. Ha
 ~~~
 
 ~~~admonish example title="See Example Code"
+**The code on this page is [RecordMappingBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java)** - the page includes it directly, so it is compiled and run by the build.
+
 [GenerateMappingExample.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/optics/GenerateMappingExample.java)
 ~~~
 
 ``` java
-import org.higherkindedj.optics.annotations.GenerateMapping;
-import org.higherkindedj.optics.annotations.MappingSpec;
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:basics_spec}}
 
-@GenerateMapping
-public interface PersonMapping extends MappingSpec<Person, PersonDto> {}
-
-// Same-named, same-typed components match automatically:
-PersonDto dto   = PersonMappingImpl.INSTANCE.build(person);      // total
-Validated<NonEmptyList<FieldError>, Person> back =
-    PersonMappingImpl.INSTANCE.parse(dto);                       // accumulating, located
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:basics_usage}}
 ```
 
 The two directions have different shapes, and that asymmetry runs through the whole page:
@@ -47,15 +42,9 @@ The generated class is `<Spec>Impl` beside the spec, used through its `INSTANCE`
 Where the two sides differ in type, the boundary conversion is a [`ValidatedPrism`](validated_prism.md) supplied as a **zero-parameter `default` method named after the domain component**:
 
 ``` java
-@GenerateMapping
-public interface CustomerMapping extends MappingSpec<Customer, CustomerDto> {
-  default ValidatedPrism<String, EmailAddress> email() {   // wire first, domain second
-    return EmailCodecs.EMAIL;
-  }
-}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:leaf_spec}}
 
-CustomerMappingImpl.INSTANCE.parse(new CustomerDto("Bob", "not-an-email"));
-// Invalid(NonEmptyList[email: not an email address])
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:leaf_usage}}
 ```
 
 ~~~admonish tip title="A leaf beats an identity match"
@@ -69,11 +58,7 @@ An explicit leaf wins even when the two component types are identical, so a `Val
 A rename is an abstract method named after the *domain* component, with `to` naming the *wire* component:
 
 ``` java
-@GenerateMapping
-public interface PersonMapping extends MappingSpec<Person, PersonDto> {
-  @MapField(to = "fullName")
-  String name();          // Person.name <-> PersonDto.fullName
-}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:rename_spec}}
 ```
 
 Each wire component takes exactly one domain source; colliding renames are compile errors, not surprises.
@@ -85,20 +70,9 @@ Each wire component takes exactly one domain source; colliding renames are compi
 A wire component with **no domain counterpart** can be computed from the whole domain value. Declare a zero-parameter `default` method named after the *wire* component, returning `Getter<Domain, WireComponentType>`:
 
 ``` java
-import org.higherkindedj.optics.Getter;
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:derived_spec}}
 
-public record Profile(String first, String last) {}
-public record ProfileDto(String first, String last, String displayName) {}
-
-@GenerateMapping
-public interface ProfileMapping extends MappingSpec<Profile, ProfileDto> {
-  default Getter<Profile, String> displayName() {
-    return Getter.of(p -> p.first() + " " + p.last());
-  }
-}
-
-ProfileMappingImpl.INSTANCE.build(new Profile("Ada", "Lovelace"));
-// ProfileDto[first=Ada, last=Lovelace, displayName=Ada Lovelace]
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:derived_usage}}
 ```
 
 The two directions are asymmetric: `build` computes the derived component, `parse` throws it away.
@@ -142,14 +116,9 @@ Four shapes are rejected, each with a what/why/fix diagnostic:
 A component whose two sides are themselves mapped by **another spec in the same compilation** nests automatically, and failures compose into dotted paths:
 
 ``` java
-public record Invoice(String id, Customer customer) {}
-public record InvoiceDto(String id, CustomerDto customer) {}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:nesting_spec}}
 
-@GenerateMapping
-public interface InvoiceMapping extends MappingSpec<Invoice, InvoiceDto> {}
-
-InvoiceMappingImpl.INSTANCE.parse(new InvoiceDto("INV-2", new CustomerDto("Bob", "nope")));
-// Invalid(NonEmptyList[customer.email: not an email address])
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:nesting_usage}}
 ```
 
 Containers lift the same way:
@@ -170,9 +139,7 @@ The rendered path uses each key's `toString()`, so a key containing a dot looks 
 A `MappingSpec` over two **sealed interfaces** dispatches over the permitted subtype pairs, one spec per pair, exhaustively in both directions:
 
 ``` java
-@GenerateMapping public interface CardMapping extends MappingSpec<Card, CardDto> {}
-@GenerateMapping public interface BankMapping extends MappingSpec<Bank, BankDto> {}
-@GenerateMapping public interface PaymentMapping extends MappingSpec<Payment, PaymentDto> {}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:sealed_spec}}
 
 // generated PaymentMappingImpl.build:
 //   return switch (domain) {
@@ -197,14 +164,9 @@ The field correspondences select what the Impl can lawfully offer; nothing is fa
 | Every parse-capable mapping | **`asValidatedPrism()`**: the mapping as a leaf, so it nests and lifts |
 
 ``` java
-public record Employee(String name, String department, int age) {}
-public record EmployeeCardDto(String name, String department) {}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:projection_spec}}
 
-@GenerateMapping
-public interface EmployeeCardMapping extends MappingSpec<Employee, EmployeeCardDto> {}
-
-Lens<Employee, EmployeeCardDto> badge = EmployeeCardMappingImpl.INSTANCE.asLens();
-Employee moved = badge.set(new EmployeeCardDto("Ada", "Platform"), employee);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:projection_usage}}
 // department written back, age kept: a lawful lens, not a fake inverse
 ```
 
@@ -215,10 +177,7 @@ Employee moved = badge.set(new EmployeeCardDto("Ada", "Platform"), employee);
 ``` java
 import org.higherkindedj.optics.laws.MappingLaws;
 
-MappingLaws.assertMappingLaws(
-    CustomerMappingImpl.INSTANCE.asValidatedPrism(),
-    new CustomerDto("Ada", "ada@example.org"),    // parses
-    new CustomerDto("Bob", "not-an-email"));      // must not parse
+{{#include ../../../hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/RecordMappingBookLawsTest.java:laws}}
 ```
 
 The overloads follow the tiers:
@@ -241,22 +200,15 @@ The annotation sits on *your* spec interface, never on the mapped types, so thir
 The forward-only sibling: assemble one target from **several** sources, declared entirely by the spec method's signature, no class literals, no inverse (truthful types):
 
 ``` java
-@GenerateMerge
-public interface DashboardAssembly {
-  Dashboard assemble(User user, Account account, Settings settings);
-}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:merge_spec}}
 
-Dashboard dashboard = DashboardAssemblyImpl.INSTANCE.assemble(user, account, settings);
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:merge_usage}}
 ```
 
 Each target component fills from the one source with a same-named component: identity when the types match, through a `ValidatedPrism` leaf when they differ, or through a sibling `@GenerateMapping` spec (the `customer` below parses through `CustomerMappingImpl`, and failures locate as dotted paths):
 
 ``` java
-@GenerateMerge
-public interface ProfileCardAssembly {
-  Validated<NonEmptyList<FieldError>, ProfileCard> assemble(User user, Wrapper wrapper);
-}
-// Invalid(NonEmptyList[customer.email: not an email address])
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:nested_merge_spec}}
 ```
 
 Ambiguity (two sources carrying the component) and unfilled components are compile errors, and the return type must tell the truth: fallible fills demand the `Validated` return; an identity-only merge must declare the plain target.
@@ -268,18 +220,7 @@ Ambiguity (two sources carrying the component) and unfilled components are compi
 The third generator in the family targets the other end of the boundary: the typed domain error a fallible mapping produces. A sealed error hierarchy re-declares the same envelope (`code`, `message`, `timestamp`, `context`) on every variant, and `context` is usually an untyped `Map<String, Object>`. `@GenerateErrorEnvelope` supplies the envelope and types the context, so each variant declares only its domain-specific components plus one `ErrorEnvelope<C>` component:
 
 ``` java
-// The context is records-as-schema: nullable components, an all-absent default.
-record OrderErrorContext(@Nullable OrderId orderId, @Nullable TraceId traceId) {}
-
-@GenerateErrorEnvelope
-public sealed interface OrderError {
-  ErrorEnvelope<OrderErrorContext> envelope();          // declared once
-
-  record OutOfStock(List<ProductId> products, ErrorEnvelope<OrderErrorContext> envelope)
-      implements OrderError {}
-  record PaymentDeclined(CardRef card, ErrorEnvelope<OrderErrorContext> envelope)
-      implements OrderError {}
-}
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/OrderErrorBook.java:error_envelope}}
 ```
 
 ~~~admonish note title="Two senses of 'context'"
@@ -295,12 +236,7 @@ For `OrderError` the processor generates a companion named `OrderErrors` with th
 Add a one-line `default` so the wither reads as an instance method, and construction plus enrichment matches the shape you would hand-write:
 
 ``` java
-default OrderError editContext(UnaryOperator<OrderErrors.ContextBuilder> edit) {
-  return OrderErrors.editContext(this, edit);
-}
-
-OrderError error = OrderErrors.outOfStock(products)                 // typed factory
-    .editContext(ctx -> ctx.orderId(orderId).traceId(traceId));     // typed context, not map.put
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/OrderErrorBook.java:edit_context}}
 ```
 
 The context type is discovered **structurally** from the `ErrorEnvelope` component's type argument, never a class literal, and every variant must agree on it. Three rules apply, each a what/why/fix diagnostic:

--- a/hkj-book/src/optics/validated_prism.md
+++ b/hkj-book/src/optics/validated_prism.md
@@ -1,5 +1,10 @@
 # Validated Prisms
 
+~~~admonish example title="See Example Code"
+**The code on this page is [ValidatedPrismBook.java](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-examples/src/main/java/org/higherkindedj/example/book/optics/ValidatedPrismBook.java)** - the page includes it directly, so it is compiled and run by the build.
+~~~
+
+
 _The smart-constructor optic: a `Prism` whose match says **why not**, and all the reasons at once._
 
 ~~~admonish info title="What You'll Learn"
@@ -32,17 +37,9 @@ In code:
 ``` java
 import org.higherkindedj.optics.validated.ValidatedPrism;
 
-ValidatedPrism<String, EmailAddress> email = ValidatedPrism.of(
-    EmailAddress::parse,      // String -> Validated<NonEmptyList<FieldError>, EmailAddress>
-    EmailAddress::value);     // EmailAddress -> String   (total)
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/optics/ValidatedPrismBook.java:prism}}
 
-Validated<NonEmptyList<FieldError>, EmailAddress> parsed = email.parse("  NOPE ");
-
-EmailAddress addr = /* a valid domain value */;
-String rendered = email.build(addr);              // always succeeds
-
-ValidationPath<NonEmptyList<FieldError>, EmailAddress> railway =
-    email.parsePath("ada@corp.example");
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/optics/ValidatedPrismBook.java:usage}}
 ```
 
 ---
@@ -91,9 +88,7 @@ Only compositions that preserve the **total build** yield a `ValidatedPrism`:
 A lawful validated boundary satisfies both round trips, verified with [`ValidatedPrismLaws`](../tooling/test_assertions.md) from `hkj-test`:
 
 ``` java
-ValidatedPrismLaws.assertValidatedPrismLaws(email, "ada@corp.example", "not-an-email");
-// parse-build: parse(build(a)) == Valid(a)
-// build-parse: parse(s) == Valid(a)  =>  build(a) == s   (no lossy parse-normalise)
+{{#include ../../../hkj-examples/src/test/java/org/higherkindedj/example/book/optics/ValidatedPrismBookLawsTest.java:laws}}
 ```
 
 The second law is the subtle one. If `build` changes the value as it renders (zero-padding a code, trimming whitespace), the round trip no longer holds. Keep all normalising in `parse`, and let `build` render the value faithfully.

--- a/hkj-core/src/main/java/org/higherkindedj/hkt/eitherorboth/EitherOrBoth.java
+++ b/hkj-core/src/main/java/org/higherkindedj/hkt/eitherorboth/EitherOrBoth.java
@@ -233,8 +233,10 @@ public sealed interface EitherOrBoth<L, R> extends EitherOrBothKind<L, R>, Eithe
    * @throws NullPointerException if {@code semigroup} or {@code mapper} is null
    * @throws org.higherkindedj.hkt.exception.KindUnwrapException if {@code mapper} returns null
    */
+  // ANCHOR: flatmap_signature
   default <R2> EitherOrBoth<L, R2> flatMap(
       Semigroup<L> semigroup, Function<? super R, ? extends EitherOrBoth<L, ? extends R2>> mapper) {
+    // ANCHOR_END: flatmap_signature
     Validation.function().require(semigroup, "semigroup", FLAT_MAP);
     Validation.function().require(mapper, "mapper", FLAT_MAP);
     return switch (this) {

--- a/hkj-core/src/main/java/org/higherkindedj/optics/edit/Edits.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/edit/Edits.java
@@ -37,7 +37,7 @@ import org.higherkindedj.hkt.validated.Validated;
  * Validated<NonEmptyList<FieldError>, Order> updated =
  *     Edits.accumulate(
  *             setIfPresent(ORDER_NUMBER, req.orderNumber()),
- *             parseIfPresent(EMAIL, req.email(), Email::parse).at("email"),
+ *             parseIfPresent(EMAIL, req.email(), Email::parse),
  *             modifyIfPresent(QUANTITY, req.qtyDelta(), (delta, qty) -> qty + delta))
  *         .apply(order);
  * }</pre>

--- a/hkj-core/src/main/java/org/higherkindedj/optics/edit/FallibleEdit.java
+++ b/hkj-core/src/main/java/org/higherkindedj/optics/edit/FallibleEdit.java
@@ -18,15 +18,21 @@ import org.higherkindedj.hkt.validated.Validated;
  * accumulated writes to a source, which {@link Edits#accumulate} performs only if <em>every</em>
  * edit validated.
  *
- * <p>Failures are located: {@link #at(String)} tags this edit's errors with a field label, exactly
- * as {@link FieldError#at(String)} composes paths outward-in:
+ * <p>Failures are located automatically: a path from a {@code @GenerateFocus} companion carries its
+ * component name as a segment, so {@code parseIfPresent} already tags failures with it. {@link
+ * #at(String)} <em>prepends</em> a further segment, exactly as {@link FieldError#at(String)}
+ * composes paths outward-in - use it for extra context, or for hand-written optics that carry no
+ * label of their own:
  *
  * <pre>{@code
  * Edits.accumulate(
  *         Edit.setIfPresent(ORDER_NUMBER, req.orderNumber()),
- *         Edit.parseIfPresent(EMAIL, req.email(), Email::parse).at("email"))
+ *         Edit.parseIfPresent(EMAIL, req.email(), Email::parse))   // EMAIL is OrderFocus.email()
  *     .apply(order);
  * // Invalid(NEL[ "email: not an address" ]) — or Valid(order') with only present fields changed
+ *
+ * // .at("customer") prepends, giving "customer.email: not an address":
+ * Edit.parseIfPresent(EMAIL, req.email(), Email::parse).at("customer");
  * }</pre>
  *
  * @param <S> the type of the value being edited

--- a/hkj-examples/BOOK-SNIPPETS.md
+++ b/hkj-examples/BOOK-SNIPPETS.md
@@ -1,0 +1,140 @@
+# Book snippet verification
+
+The book's code is kept honest in two ways. **Prefer the first.**
+
+| | How | Guarantee |
+|---|---|---|
+| **1. Include** (preferred) | The page `{{#include}}`s an anchored region of a compiled example in this module | Drift is **impossible**: the page renders the code the build compiles and runs |
+| **2. Verify marker** | The page marks a fence `<!-- verify -->`; the gate compiles a copy of it | Drift is **caught**: the build fails if the code stops compiling |
+
+Use (1) whenever the snippet can be real, runnable code. It is strictly stronger, and a runnable
+example can also prove the *output* comments a page asserts, which the compile gate cannot. Fall back
+to (2) when a page needs a shape that cannot be a runnable example (an abstract signature, a
+`VResultPath<E, A>` written against type variables).
+
+The exact counts live in the two ratchets (`MINIMUM_INCLUDES`, `MINIMUM_VERIFIED_SNIPPETS`) rather
+than here, so they cannot go stale. Today the only markers left are `path_vresult`'s catalogue of
+shapes written against abstract type variables, which is the one thing an include cannot express.
+
+The book-facing examples live under `org.higherkindedj.example.book.*`, **one package per page**: the
+types must be top-level (so the processor generates the names the book teaches), and two pages that
+both want a `User` would otherwise collide.
+
+## Includes
+
+Anchor the Java, and include it from the page:
+
+```java
+// ANCHOR: leaf_spec
+@GenerateMapping
+interface CustomerMapping extends MappingSpec<Customer, CustomerDto> { ... }
+// ANCHOR_END: leaf_spec
+```
+
+    ``` java
+    {{#include ../../../hkj-examples/src/main/java/.../RecordMappingBook.java:leaf_spec}}
+    ```
+
+Two things matter:
+
+- **Declare the types top-level, not nested in a holder class.** A nested spec joins its enclosing
+  simple names, so `Shop.CustomerMapping` generates `ShopCustomerMappingImpl`. The book teaches
+  `CustomerMappingImpl`, which is only true at top level. Nesting also renders the snippet indented.
+- **mdbook does NOT fail on a missing anchor.** It renders an empty code block and says nothing. So
+  a typo silently deletes the code from the page. `BookIncludeTest` closes that hole: every include
+  must resolve to a real file, a real anchor, and a non-empty one.
+
+
+Compiles the code snippets in `hkj-book` against the real library, so the documentation cannot drift
+away from the API without failing the build.
+
+It lives in `hkj-examples` (`src/test/java/org/higherkindedj/book/`) rather than in a module of its
+own, because this module already wires everything it needs: the annotation processor, `hkj-test`,
+JUnit and AssertJ. It is also where the runnable examples the book cites already live.
+
+`hkj-book` is not a Gradle module, so nothing used to compile its code. The snippets were
+hand-maintained and they drifted: two shipped examples did not compile, one documented a method as
+taking a type it does not take, and one printed an output it does not produce. A reader copying those
+examples got a compiler error. A coding assistant reading them generated code that would not build.
+
+The gate closes that hole. It runs with `hkj-examples`' tests, as part of `gradle build`, so CI enforces it.
+
+## Marking a snippet
+
+Put `<!-- verify -->` on the line before the fence. It is an HTML comment, so it is invisible in the
+rendered book.
+
+```markdown
+<!-- verify -->
+``` java
+Validated<NonEmptyList<FieldError>, User> user =
+    Validated.fields()
+        .field("name", parseName(dto.name()))
+        .apply(User::new);
+```
+```
+
+Each marked snippet is compiled **independently**, with the real HKJ classpath and the real
+annotation processor, so a `@GenerateMapping` or `@GenerateAssembly` snippet is checked against
+genuinely generated code, not a stand-in.
+
+Snippets are compiled separately rather than a whole page at once because a page's snippets are
+illustrations, not one program: two of them may legitimately show different `User` records.
+
+## Fixtures: what a page elides
+
+A page usually omits imports and domain types so the snippet stays about the thing it is teaching.
+Supply them from `hkj-examples/src/test/resources/fixtures/<page-slug>.java`, where the slug is the page path with
+non-alphanumerics replaced by `_` (`monads/validated_assembly.md` -> `monads_validated_assembly`).
+
+A fixture may declare:
+
+- **imports**: hoisted into the snippet's compilation unit
+- **types**: `record User(...) {}`, emitted as top-level types
+- **a `Fixture` class**: the snippet's wrapper extends it, so `static` members are in scope and a
+  snippet can call `parseName(dto.name())` bare, exactly as the page writes it
+
+A type the snippet declares for itself shadows the fixture's, so a page may show its own `User`
+without colliding.
+
+The fixtures are `.java` for IDE support but are **resources, not sources**: their imports exist for
+the snippet they are spliced into, so Spotless excludes them (an "unused import" cleanup would
+silently break them; see the `targetExclude` in `build.gradle.kts`).
+
+## What a snippet may be
+
+The extractor works out what each block is, so a page can be written naturally:
+
+| The block is | It becomes |
+|---|---|
+| loose statements | the body of a method |
+| a type declaration (`record Order(...) {}`, a `@GenerateMapping` spec) | a top-level type |
+| a whole method (`VResultPath<E, A> process(...) { ... }`) | a member of the wrapper |
+| **only** body-less signatures (`EitherOrBoth<L, R2> flatMap(Semigroup<L> sg, ...);`) | an `interface`, where a body-less method is legal and still type-checked |
+
+Signature quotations are exactly the lines that drift, so they are compiled rather than skipped.
+
+A **generic** fixture (`class Fixture<E, A, B>`) lends its type parameters to the snippet, which is
+how a page can show `VResultPath<E, A>` as a *shape* without inventing a domain for it.
+
+## When a snippet cannot compile
+
+A block is left unmarked only when it cannot be a compilation unit at all, and today none are. The
+two that once were (`record_mapping`'s `@GenerateErrorEnvelope` hierarchy and its `editContext`
+interface `default` method) are now `{{#include}}`d from a real example, where they compile
+naturally.
+
+Prefer fixing a snippet over excluding it. Three blocks looked like prose at first and turned out to
+be worth rescuing: a pseudo-code placeholder (`EmailAddress addr = /* a valid domain value */;`), two
+bare expressions with no statement around them, and a merge spec whose records the page never showed.
+Making each of them real code both brought it under the gate and improved the page.
+
+The gate is opt-in so that prose *can* stay prose, not so that awkward code can hide.
+
+## The ratchet
+
+`MINIMUM_VERIFIED_SNIPPETS` is a floor on the number of marked snippets. Deleting a marker to silence
+a failure drops the count and fails the build. Raise the floor as pages are brought under the gate.
+
+If a snippet genuinely can no longer be verified, lower the floor deliberately and say why in the
+commit message. That should be rare, and it should be visible in review.

--- a/hkj-examples/build.gradle.kts
+++ b/hkj-examples/build.gradle.kts
@@ -35,10 +35,24 @@ tasks.named("javadoc") {
     enabled = false
 }
 
+// The book-snippet fixtures (src/test/resources/fixtures) are .java for IDE support, but they are
+// resources, not sources: their imports exist for the *snippet* they are spliced into, so an
+// "unused import" cleanup would silently break them.
+spotless {
+    java {
+        targetExclude("src/test/resources/fixtures/**")
+    }
+}
+
 // Default test task: runs solution tests only (tutorials are excluded)
 // Solutions must pass as they verify the tutorial exercises are correct
 tasks.named<Test>("test") {
     useJUnitPlatform()
+
+    // The book gate has its own task (`bookVerify`, below): hanging it off `test` meant every edit
+    // to an .md file invalidated `test` and re-ran the whole tutorial/solution suite.
+    exclude("org/higherkindedj/book/**")
+
     // Exclude tutorial exercises (they are incomplete by design)
     // Include solutions which must always pass
     exclude("**/tutorial/optics/**")
@@ -53,6 +67,52 @@ tasks.named<Test>("test") {
     exclude("**/tutorial/resilience/**")
     // Solutions are in tutorial/solutions/ and will run
 }
+
+// The book gate: compiles hkj-book's `<!-- verify -->` snippets against this module's classpath and
+// the REAL annotation processor, and checks that every `{{#include}}` resolves to a real anchor. A
+// page therefore cannot drift away from the API without failing the build. It lives in this module
+// rather than one of its own because this module already wires the processor, hkj-test, JUnit and
+// AssertJ. See BOOK-SNIPPETS.md.
+val bookVerify = tasks.register<Test>("bookVerify") {
+    description = "Compiles the code in hkj-book against the library, so the docs cannot drift."
+    group = "verification"
+    useJUnitPlatform()
+
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    include("org/higherkindedj/book/**")
+
+    val bookDir = rootProject.layout.projectDirectory.dir("hkj-book/src")
+    inputs.dir(bookDir).withPropertyName("bookSources").withPathSensitivity(PathSensitivity.RELATIVE)
+    systemProperty("hkj.book.dir", bookDir.asFile.absolutePath)
+
+    // The anchored example sources are inputs too. Without this, renaming an `// ANCHOR:` would not
+    // re-run the gate: the rename is a comment, so the compiled classes are byte-identical and the
+    // task stays UP-TO-DATE while the book silently loses that code block.
+    inputs
+        .files(layout.projectDirectory.dir("src/main/java/org/higherkindedj/example/book").asFileTree)
+        .withPropertyName("bookExampleSources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs
+        .files(layout.projectDirectory.dir("src/test/java/org/higherkindedj/example/book").asFileTree)
+        .withPropertyName("bookExampleTestSources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+
+    // Declared as a proper input (so a processor change re-runs the gate) and passed via an argument
+    // provider (so the configuration cache can serialise it). It must be captured as a FileCollection,
+    // not a NamedDomainObjectProvider: the cache cannot serialise the latter.
+    val processorPath: FileCollection = configurations.getByName("annotationProcessor")
+    inputs.files(processorPath)
+        .withPropertyName("bookProcessorPath")
+        .withNormalizer(ClasspathNormalizer::class)
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf("-Dhkj.book.processorPath=${processorPath.asPath}")
+        }
+    )
+}
+
+tasks.named("check") { dependsOn(bookVerify) }
 
 // Separate task for users to run tutorial exercises
 // Usage: ./gradlew :hkj-examples:tutorialTest

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/effect/EitherOrBothPathBook.java
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.effect;
+
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.effect.EitherOrBothPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.eitherorboth.EitherOrBoth;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/effect/path_either_or_both.html">EitherOrBothPath</a>
+ * page. The page {@code {{#include}}}s the anchored regions, so it cannot drift from the API.
+ */
+public final class EitherOrBothPathBook {
+
+  private EitherOrBothPathBook() {}
+
+  public static void main(String[] args) {
+    Config config = new Config(8080, 30);
+    RawConfig raw = new RawConfig("8080", "30");
+
+    // ANCHOR: create
+    EitherOrBothPath<NonEmptyList<String>, Config> ok = Path.rightNel(config);
+    EitherOrBothPath<NonEmptyList<String>, Config> warned = Path.bothNel("deprecated key", config);
+    EitherOrBothPath<NonEmptyList<String>, Config> failed = Path.leftNel("config missing");
+    // ANCHOR_END: create
+    System.out.println(ok.run() + " / " + warned.run() + " / " + failed.run());
+
+    // ANCHOR: custom_semigroup
+    EitherOrBothPath<String, Integer> p = Path.both("warn", 42, Semigroups.string("; "));
+    // ANCHOR_END: custom_semigroup
+    System.out.println(p.run());
+
+    // ANCHOR: via
+    EitherOrBothPath<NonEmptyList<String>, Integer> result =
+        Path.<String, Integer>bothNel("uses deprecated key", 8)
+            .via(value -> value < 10 ? Path.bothNel("value is low", value) : Path.rightNel(value));
+
+    result.run(); // Both([uses deprecated key, value is low], 8)
+    result.warnings(); // Just([uses deprecated key, value is low])
+    result.getOrElse(0); // 8
+    // ANCHOR_END: via
+    System.out.println(result.run() + " / " + result.warnings() + " / " + result.getOrElse(0));
+
+    // ANCHOR: zip_accum
+    EitherOrBothPath<NonEmptyList<String>, String> name = Path.bothNel("name was trimmed", "Ada");
+    EitherOrBothPath<NonEmptyList<String>, Integer> age = Path.bothNel("age defaulted", 30);
+
+    EitherOrBothPath<NonEmptyList<String>, String> reg =
+        name.zipWithAccum(age, (n, a) -> n + " (" + a + ")");
+    // Both([name was trimmed, age defaulted], "Ada (30)")
+    // ANCHOR_END: zip_accum
+    System.out.println(reg.run());
+
+    // ANCHOR: accumulate
+    EitherOrBoth<NonEmptyList<String>, Config> cfg =
+        EitherOrBoth.accumulate()
+            .and(parsePortLenient(raw.port()))
+            .and(parseTimeoutLenient(raw.timeout()))
+            .apply(Config::new);
+    // ANCHOR_END: accumulate
+    System.out.println(cfg);
+
+    // ANCHOR: recover
+    Path.<String, Integer>leftNel("config missing").recover(errors -> 0).run(); // Right(0)
+    Path.<String, Integer>bothNel("deprecated", 42)
+        .recover(errors -> 0)
+        .run(); // Both([deprecated], 42)
+    // ANCHOR_END: recover
+    System.out.println(
+        Path.<String, Integer>leftNel("config missing").recover(errors -> 0).run()
+            + " / "
+            + Path.<String, Integer>bothNel("deprecated", 42).recover(errors -> 0).run());
+  }
+
+  static EitherOrBoth<NonEmptyList<String>, Integer> parsePortLenient(String raw) {
+    return EitherOrBoth.both(NonEmptyList.single("port defaulted"), 8080);
+  }
+
+  static EitherOrBoth<NonEmptyList<String>, Integer> parseTimeoutLenient(String raw) {
+    return EitherOrBoth.right(30);
+  }
+}
+
+record Config(int port, int timeout) {}
+
+record RawConfig(String port, String timeout) {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/OrderErrorBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/OrderErrorBook.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.mapping;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.higherkindedj.hkt.error.ErrorEnvelope;
+import org.higherkindedj.optics.annotations.GenerateErrorEnvelope;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The {@code @GenerateErrorEnvelope} code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/optics/record_mapping.html">Record Mapping</a> page. The
+ * page {@code {{#include}}}s the anchored regions, so it cannot drift from the API.
+ *
+ * <p>This exists because the page's {@code editContext} example is an interface {@code default}
+ * method spliced together with call-site usage, which cannot be assembled into a compilation unit
+ * by the snippet gate. As a real example it compiles naturally, so the block is verified rather
+ * than merely asserted.
+ */
+public final class OrderErrorBook {
+
+  private OrderErrorBook() {}
+
+  public static void main(String[] args) {
+    OrderId orderId = new OrderId("ORD-1");
+    TraceId traceId = new TraceId("trace-1");
+    List<ProductId> products = List.of(new ProductId("PROD-1"));
+
+    // ANCHOR: edit_context
+    OrderError error =
+        OrderErrors.outOfStock(products) // typed factory
+            .editContext(
+                ctx -> ctx.orderId(orderId).traceId(traceId)); // typed context, not map.put
+    // ANCHOR_END: edit_context
+    System.out.println(error.envelope());
+  }
+}
+
+record OrderId(String value) {}
+
+record TraceId(String value) {}
+
+record ProductId(String value) {}
+
+record CardRef(String value) {}
+
+// ANCHOR: error_envelope
+// The context is records-as-schema: nullable components, an all-absent default.
+record OrderErrorContext(@Nullable OrderId orderId, @Nullable TraceId traceId) {}
+
+@GenerateErrorEnvelope
+sealed interface OrderError {
+  ErrorEnvelope<OrderErrorContext> envelope(); // declared once
+
+  // A one-line default so the generated wither reads as an instance method.
+  default OrderError editContext(UnaryOperator<OrderErrors.ContextBuilder> edit) {
+    return OrderErrors.editContext(this, edit);
+  }
+
+  record OutOfStock(List<ProductId> products, ErrorEnvelope<OrderErrorContext> envelope)
+      implements OrderError {}
+
+  record PaymentDeclined(CardRef card, ErrorEnvelope<OrderErrorContext> envelope)
+      implements OrderError {}
+}
+// ANCHOR_END: error_envelope

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java
@@ -1,0 +1,222 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.mapping;
+
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.Getter;
+import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.annotations.GenerateMapping;
+import org.higherkindedj.optics.annotations.GenerateMerge;
+import org.higherkindedj.optics.annotations.MapField;
+import org.higherkindedj.optics.annotations.MappingSpec;
+import org.higherkindedj.optics.validated.ValidatedPrism;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/optics/record_mapping.html">Record Mapping</a> page.
+ *
+ * <p>The book does not paraphrase this file: it {@code {{#include}}}s the anchored regions below,
+ * so the page cannot drift from the API. Change a spec here and the page changes with it; break one
+ * and the build fails before the page can lie.
+ *
+ * <p>The specs are deliberately <b>top-level</b>, not nested in this class. A nested spec joins its
+ * enclosing simple names, so {@code Shop.CustomerMapping} would generate {@code
+ * ShopCustomerMappingImpl}. Top-level, it generates {@code CustomerMappingImpl} - which is the name
+ * the page teaches.
+ */
+public final class RecordMappingBook {
+
+  private RecordMappingBook() {}
+
+  public static void main(String[] args) {
+    // ANCHOR: basics_usage
+    Person person = new Person("Ada", 36);
+
+    // Same-named, same-typed components match automatically:
+    PersonDto dto = PersonMappingImpl.INSTANCE.build(person); // total
+    Validated<NonEmptyList<FieldError>, Person> back =
+        PersonMappingImpl.INSTANCE.parse(dto); // accumulating, located
+    // ANCHOR_END: basics_usage
+    System.out.println(dto + " / " + back);
+
+    // ANCHOR: leaf_usage
+    CustomerMappingImpl.INSTANCE.parse(new CustomerDto("Bob", "not-an-email"));
+    // Invalid(NonEmptyList[email: not an email address])
+    // ANCHOR_END: leaf_usage
+    System.out.println(CustomerMappingImpl.INSTANCE.parse(new CustomerDto("Bob", "not-an-email")));
+
+    // ANCHOR: derived_usage
+    ProfileMappingImpl.INSTANCE.build(new Profile("Ada", "Lovelace"));
+    // ProfileDto[first=Ada, last=Lovelace, displayName=Ada Lovelace]
+    // ANCHOR_END: derived_usage
+    System.out.println(ProfileMappingImpl.INSTANCE.build(new Profile("Ada", "Lovelace")));
+
+    // ANCHOR: nesting_usage
+    InvoiceMappingImpl.INSTANCE.parse(new InvoiceDto("INV-2", new CustomerDto("Bob", "nope")));
+    // Invalid(NonEmptyList[customer.email: not an email address])
+    // ANCHOR_END: nesting_usage
+    System.out.println(
+        InvoiceMappingImpl.INSTANCE.parse(new InvoiceDto("INV-2", new CustomerDto("Bob", "nope"))));
+
+    // ANCHOR: projection_usage
+    Employee employee = new Employee("Ada", "Research", 36);
+    Lens<Employee, EmployeeCardDto> badge = EmployeeCardMappingImpl.INSTANCE.asLens();
+    Employee moved = badge.set(new EmployeeCardDto("Ada", "Platform"), employee);
+    // ANCHOR_END: projection_usage
+    System.out.println(moved);
+
+    // ANCHOR: merge_usage
+    Dashboard dashboard =
+        DashboardAssemblyImpl.INSTANCE.assemble(
+            new User("Ada", "ada@corp.example"),
+            new Account("GB29-XXXX", 4200),
+            new Settings(true));
+    // ANCHOR_END: merge_usage
+    System.out.println(dashboard);
+
+    System.out.println(
+        ProfileCardAssemblyImpl.INSTANCE.assemble(
+            new User("Ada", "ada@corp.example"), new Wrapper(new CustomerDto("Bob", "nope"))));
+  }
+}
+
+// ANCHOR: email_leaf
+record EmailAddress(String value) {}
+
+final class EmailCodecs {
+  static final ValidatedPrism<String, EmailAddress> EMAIL =
+      ValidatedPrism.of(
+          raw ->
+              raw.contains("@")
+                  ? Validated.validNel(new EmailAddress(raw))
+                  : Validated.invalidNel(FieldError.of("not an email address")),
+          EmailAddress::value);
+
+  private EmailCodecs() {}
+}
+
+// ANCHOR_END: email_leaf
+
+// ANCHOR: basics_spec
+record Person(String name, int age) {}
+
+record PersonDto(String name, int age) {}
+
+@GenerateMapping
+interface PersonMapping extends MappingSpec<Person, PersonDto> {}
+
+// ANCHOR_END: basics_spec
+
+// ANCHOR: leaf_spec
+record Customer(String name, EmailAddress email) {}
+
+record CustomerDto(String name, String email) {}
+
+@GenerateMapping
+interface CustomerMapping extends MappingSpec<Customer, CustomerDto> {
+  default ValidatedPrism<String, EmailAddress> email() { // wire first, domain second
+    return EmailCodecs.EMAIL;
+  }
+}
+
+// ANCHOR_END: leaf_spec
+
+// ANCHOR: rename_spec
+record PersonCardDto(String fullName, int age) {}
+
+@GenerateMapping
+interface PersonCardMapping extends MappingSpec<Person, PersonCardDto> {
+  @MapField(to = "fullName")
+  String name(); // Person.name <-> PersonCardDto.fullName
+}
+
+// ANCHOR_END: rename_spec
+
+// ANCHOR: derived_spec
+record Profile(String first, String last) {}
+
+record ProfileDto(String first, String last, String displayName) {}
+
+@GenerateMapping
+interface ProfileMapping extends MappingSpec<Profile, ProfileDto> {
+  default Getter<Profile, String> displayName() {
+    return Getter.of(p -> p.first() + " " + p.last());
+  }
+}
+
+// ANCHOR_END: derived_spec
+
+// ANCHOR: nesting_spec
+record Invoice(String id, Customer customer) {}
+
+record InvoiceDto(String id, CustomerDto customer) {}
+
+@GenerateMapping
+interface InvoiceMapping extends MappingSpec<Invoice, InvoiceDto> {}
+
+// ANCHOR_END: nesting_spec
+
+// ANCHOR: sealed_spec
+sealed interface Payment permits Card, Bank {}
+
+record Card(String pan) implements Payment {}
+
+record Bank(String iban) implements Payment {}
+
+sealed interface PaymentDto permits CardDto, BankDto {}
+
+record CardDto(String pan) implements PaymentDto {}
+
+record BankDto(String iban) implements PaymentDto {}
+
+@GenerateMapping
+interface CardMapping extends MappingSpec<Card, CardDto> {}
+
+@GenerateMapping
+interface BankMapping extends MappingSpec<Bank, BankDto> {}
+
+@GenerateMapping
+interface PaymentMapping extends MappingSpec<Payment, PaymentDto> {}
+
+// ANCHOR_END: sealed_spec
+
+// ANCHOR: projection_spec
+record Employee(String name, String department, int age) {}
+
+record EmployeeCardDto(String name, String department) {}
+
+@GenerateMapping
+interface EmployeeCardMapping extends MappingSpec<Employee, EmployeeCardDto> {}
+
+// ANCHOR_END: projection_spec
+
+// ANCHOR: merge_spec
+record User(String name, String email) {}
+
+record Account(String iban, int balance) {}
+
+record Settings(boolean darkMode) {}
+
+record Dashboard(String name, String iban, boolean darkMode) {}
+
+@GenerateMerge
+interface DashboardAssembly {
+  Dashboard assemble(User user, Account account, Settings settings);
+}
+
+// ANCHOR_END: merge_spec
+
+// ANCHOR: nested_merge_spec
+record Wrapper(CustomerDto customer) {} // the wire side
+
+record ProfileCard(String name, Customer customer) {} // the domain side
+
+@GenerateMerge
+interface ProfileCardAssembly {
+  // ProfileCard.customer fills from Wrapper.customer through CustomerMapping,
+  // so a bad email is: Invalid(NonEmptyList[customer.email: not an email address])
+  Validated<NonEmptyList<FieldError>, ProfileCard> assemble(User user, Wrapper wrapper);
+}
+// ANCHOR_END: nested_merge_spec

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBook.java
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.monads.assembly;
+
+import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
+
+import java.util.List;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.MonadError;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.eitherorboth.EitherOrBoth;
+import org.higherkindedj.hkt.instances.Instances;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.hkt.validated.ValidatedKind;
+import org.higherkindedj.optics.annotations.GenerateAssembly;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/monads/validated_assembly.html">Accumulating Assembly</a>
+ * page. The page {@code {{#include}}}s the anchored regions, so it cannot drift from the API.
+ */
+public final class ValidatedAssemblyBook {
+
+  private ValidatedAssemblyBook() {}
+
+  public static void main(String[] args) {
+    // Deliberately bad, so the accumulating result below is the one the page shows.
+    UserDto dto = new UserDto("Ada", "not-an-email", "not-a-number");
+    RawAddress raw = new RawAddress("Ada", "1 Main St", "SW1A 1AA");
+    RawSettings rawSettings = new RawSettings("localhost", "8080");
+    RawConfigIn rawConfig = new RawConfigIn("8080", "30");
+
+    Kind<ValidatedKind.Witness<List<String>>, Name> nameKind =
+        VALIDATED.widen(Validated.valid(new Name("Ada")));
+    Kind<ValidatedKind.Witness<List<String>>, Email> emailKind =
+        VALIDATED.widen(Validated.valid(new Email("ada@example.com")));
+    Kind<ValidatedKind.Witness<List<String>>, Age> ageKind =
+        VALIDATED.widen(Validated.valid(new Age(36)));
+
+    // ANCHOR: hkt_generic
+    // The HKT-generic form: capped at map5, and every call passes the Semigroup by hand.
+    MonadError<ValidatedKind.Witness<List<String>>, List<String>> validatedMonad =
+        Instances.validated(Semigroups.list());
+    Kind<ValidatedKind.Witness<List<String>>, User> user =
+        validatedMonad.map3(nameKind, emailKind, ageKind, User::new);
+    // ANCHOR_END: hkt_generic
+
+    // ANCHOR: fields
+    Validated<NonEmptyList<FieldError>, User> assembled =
+        Validated.fields()
+            .field("name", parseName(dto.name())) // Validated<NonEmptyList<FieldError>, Name>
+            .field("email", parseEmail(dto.email()))
+            .field("age", parseAge(dto.age()))
+            .apply(User::new); // (Name, Email, Age) -> User
+
+    // Invalid(NonEmptyList[email: not an email address, age: not a number]) - name was fine.
+    // ANCHOR_END: fields
+    System.out.println(assembled);
+
+    // ANCHOR: nesting
+    Validated<NonEmptyList<FieldError>, Address> address =
+        Validated.fields()
+            .field("street", parseStreet(raw.street()))
+            .field("zip", parseZip(raw.zip())) // fails: "zip: not a postcode"
+            .apply(Address::new);
+
+    Validated<NonEmptyList<FieldError>, Customer> customer =
+        Validated.fields()
+            .field("name", parseName(raw.name()))
+            .field("address", address) // prefixes: "address.zip: not a postcode"
+            .apply(Customer::new);
+    // ANCHOR_END: nesting
+    System.out.println(customer);
+
+    // ANCHOR: accumulate
+    Validated<NonEmptyList<ConfigError>, Settings> settings =
+        Validated.accumulate()
+            .and(parseHost(rawSettings.host()))
+            .and(parsePort(rawSettings.port()))
+            .apply(Settings::new);
+    // ANCHOR_END: accumulate
+    System.out.println(settings);
+
+    // ANCHOR: eob_accumulate
+    EitherOrBoth<NonEmptyList<String>, Config> cfg =
+        EitherOrBoth.accumulate()
+            .and(parsePortLenient(rawConfig.port())) // Both("port defaulted", 8080)
+            .and(parseTimeoutLenient(rawConfig.timeout())) // Right(30)
+            .apply(Config::new);
+    // Both(NonEmptyList[port defaulted], Config[port=8080, timeout=30])
+    // ANCHOR_END: eob_accumulate
+    System.out.println(cfg);
+
+    // ANCHOR: generated_usage
+    Validated<NonEmptyList<FieldError>, User> generated =
+        UserAssembly.fields()
+            .name(parseName(dto.name())) // label "name" attached automatically
+            .email(parseEmail(dto.email()))
+            .age(parseAge(dto.age()))
+            .assemble(); // canonical constructor baked in
+    // ANCHOR_END: generated_usage
+    System.out.println(generated);
+  }
+
+  static Validated<NonEmptyList<FieldError>, Name> parseName(String s) {
+    return Validated.validNel(new Name(s));
+  }
+
+  static Validated<NonEmptyList<FieldError>, Email> parseEmail(String s) {
+    return s.contains("@")
+        ? Validated.validNel(new Email(s))
+        : Validated.invalidNel(FieldError.of("not an email address"));
+  }
+
+  static Validated<NonEmptyList<FieldError>, Age> parseAge(String s) {
+    try {
+      return Validated.validNel(new Age(Integer.parseInt(s)));
+    } catch (NumberFormatException e) {
+      // Accumulate the reason; do not throw. Throwing here would defeat the whole page.
+      return Validated.invalidNel(FieldError.of("not a number"));
+    }
+  }
+
+  static Validated<NonEmptyList<FieldError>, String> parseStreet(String s) {
+    return Validated.validNel(s);
+  }
+
+  static Validated<NonEmptyList<FieldError>, String> parseZip(String s) {
+    return Validated.invalidNel(FieldError.of("not a postcode"));
+  }
+
+  static Validated<NonEmptyList<ConfigError>, String> parseHost(String s) {
+    return Validated.validNel(s);
+  }
+
+  static Validated<NonEmptyList<ConfigError>, Integer> parsePort(String s) {
+    return Validated.validNel(Integer.parseInt(s));
+  }
+
+  static EitherOrBoth<NonEmptyList<String>, Integer> parsePortLenient(String s) {
+    return EitherOrBoth.both(NonEmptyList.single("port defaulted"), 8080);
+  }
+
+  static EitherOrBoth<NonEmptyList<String>, Integer> parseTimeoutLenient(String s) {
+    return EitherOrBoth.right(30);
+  }
+}
+
+record Name(String value) {}
+
+record Email(String value) {}
+
+record Age(int value) {}
+
+// ANCHOR: generated_spec
+@GenerateAssembly
+record User(Name name, Email email, Age age) {}
+
+// ANCHOR_END: generated_spec
+
+record Address(String street, String zip) {}
+
+record Customer(Name name, Address address) {}
+
+record Settings(String host, int port) {}
+
+record Config(int port, int timeout) {}
+
+record ConfigError(String message) {}
+
+record UserDto(String name, String email, String age) {}
+
+record RawAddress(String name, String street, String zip) {}
+
+record RawSettings(String host, String port) {}
+
+record RawConfigIn(String port, String timeout) {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/eitherorboth/EitherOrBothBook.java
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.monads.eitherorboth;
+
+import org.higherkindedj.hkt.eitherorboth.EitherOrBoth;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/monads/either_or_both_monad.html">EitherOrBoth</a> page.
+ * The page {@code {{#include}}}s the anchored regions, so it cannot drift from the API.
+ *
+ * <p>One block on that page is not here: it quotes {@code flatMap}'s <em>signature</em> against
+ * abstract type variables, which is a shape rather than runnable code. That block keeps a {@code
+ * <!-- verify -->} marker instead, so it is still compiled.
+ */
+public final class EitherOrBothBook {
+
+  // ANCHOR: switch
+  static String describe(EitherOrBoth<NonEmptyList<Warning>, Config> r) {
+    return switch (r) {
+      case EitherOrBoth.Left<NonEmptyList<Warning>, Config>(var w) -> "failed: " + w;
+      case EitherOrBoth.Right<NonEmptyList<Warning>, Config>(var cfg) -> "ok: " + cfg;
+      case EitherOrBoth.Both<NonEmptyList<Warning>, Config>(var w, var c) ->
+          "ok with warnings: " + c;
+    };
+  }
+
+  // ANCHOR_END: switch
+
+  private EitherOrBothBook() {}
+
+  public static void main(String[] args) {
+    RawConfig raw = new RawConfig("8080", "30");
+
+    // ANCHOR: flatmap
+    EitherOrBoth<NonEmptyList<Warning>, Config> result =
+        parseConfig(raw) // Right(cfg), Both(warnings, cfg), or Left(fatal)
+            .flatMap(NonEmptyList.semigroup(), cfg -> validateConfig(cfg)); // warnings accumulate
+    // ANCHOR_END: flatmap
+    System.out.println(describe(result));
+
+    // ANCHOR: cases
+    EitherOrBoth<String, Integer> left = EitherOrBoth.left("fatal");
+    EitherOrBoth<String, Integer> right = EitherOrBoth.right(42);
+    EitherOrBoth<String, Integer> both = EitherOrBoth.both("deprecated key", 42);
+    // ANCHOR_END: cases
+    System.out.println(left + " " + right);
+
+    // ANCHOR: fold
+    String s =
+        both.fold(
+            warnings -> "failed: " + warnings,
+            value -> "ok: " + value,
+            (w, v) -> "ok (" + v + ") with " + w);
+    // ANCHOR_END: fold
+    System.out.println(s);
+
+    // ANCHOR: accumulate
+    EitherOrBoth<NonEmptyList<String>, Config> cfg =
+        EitherOrBoth.accumulate()
+            .and(parsePortLenient(raw.port())) // Both("port defaulted", 8080)
+            .and(parseTimeoutLenient(raw.timeout())) // Right(30)
+            .apply(Config::new);
+    // Both(NonEmptyList[port defaulted], Config[port=8080, timeout=30])
+    // ANCHOR_END: accumulate
+    System.out.println(cfg);
+  }
+
+  static EitherOrBoth<NonEmptyList<Warning>, Config> parseConfig(RawConfig raw) {
+    return EitherOrBoth.both(
+        NonEmptyList.single(new Warning("deprecated key")), new Config(8080, 30));
+  }
+
+  static EitherOrBoth<NonEmptyList<Warning>, Config> validateConfig(Config cfg) {
+    return EitherOrBoth.right(cfg);
+  }
+
+  static EitherOrBoth<NonEmptyList<String>, Integer> parsePortLenient(String raw) {
+    return EitherOrBoth.both(NonEmptyList.single("port defaulted"), 8080);
+  }
+
+  static EitherOrBoth<NonEmptyList<String>, Integer> parseTimeoutLenient(String raw) {
+    return EitherOrBoth.right(30);
+  }
+}
+
+record Warning(String message) {}
+
+record Config(int port, int timeout) {}
+
+record RawConfig(String port, String timeout) {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/monads/nonemptylist/NonEmptyListBook.java
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.monads.nonemptylist;
+
+import static org.higherkindedj.hkt.instances.Witnesses.nonEmptyList;
+
+import java.util.Comparator;
+import java.util.List;
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Monad;
+import org.higherkindedj.hkt.Semigroups;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.ValidationPath;
+import org.higherkindedj.hkt.instances.Instances;
+import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyListKind;
+import org.higherkindedj.hkt.validated.Validated;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/monads/nonemptylist_monad.html">NonEmptyList</a> page.
+ * The page {@code {{#include}}}s the anchored regions, so it cannot drift from the API.
+ */
+public final class NonEmptyListBook {
+
+  private NonEmptyListBook() {}
+
+  public static void main(String[] args) {
+    ValidationError error = new ValidationError("boom");
+
+    // ANCHOR: partial
+    // An "invalid" result always has at least one error, yet the type allows zero.
+    ValidationPath<List<ValidationError>, User> failure =
+        Path.invalid(List.of(error), Semigroups.list());
+    ValidationError first =
+        failure.run().getError().getFirst(); // partial: getFirst() throws on empty
+    // ANCHOR_END: partial
+    System.out.println(first);
+
+    // ANCHOR: total
+    // NonEmptyList error channel: no Semigroup argument, no List.of wrapping.
+    ValidationPath<NonEmptyList<ValidationError>, User> nelFailure = Path.invalidNel(error);
+    ValidationError head =
+        nelFailure.run().getError().head(); // total: never throws, returns ValidationError
+    // ANCHOR_END: total
+    System.out.println(head);
+
+    // ANCHOR: construct
+    NonEmptyList<Integer> a = NonEmptyList.of(1, 2, 3); // head + varargs tail
+    NonEmptyList<Integer> b = NonEmptyList.of(1, List.of(2)); // head + explicit tail
+    NonEmptyList<Integer> c = NonEmptyList.single(42); // single element
+    // ANCHOR_END: construct
+    System.out.println(a + " " + b + " " + c);
+
+    // ANCHOR: from_list
+    Maybe<NonEmptyList<Integer>> maybe = NonEmptyList.fromList(List.of(1, 2, 3)); // Just([1, 2, 3])
+    Maybe<NonEmptyList<Integer>> none = NonEmptyList.fromList(List.of()); // Nothing
+    // ANCHOR_END: from_list
+    System.out.println(maybe + " " + none);
+
+    totalOps();
+    accumulation();
+    validatedAndInstances();
+  }
+
+  /** Its own scope, so the page can show `first` rather than a de-collided `first3`. */
+  static void totalOps() {
+    // ANCHOR: total_ops
+    NonEmptyList<Integer> nel = NonEmptyList.of(3, 1, 2);
+
+    int first = nel.head(); // 3   (never throws)
+    int last = nel.last(); // 2   (never throws)
+    int sum = nel.reduce((x, y) -> x + y); // 6   (reduce without an identity)
+    int min = nel.min(Comparator.naturalOrder()); // 1
+    int max = nel.max(Comparator.naturalOrder()); // 3
+    // ANCHOR_END: total_ops
+    System.out.println(first + " " + last + " " + sum + " " + min + " " + max);
+  }
+
+  static void accumulation() {
+    // ANCHOR: accumulate
+    // A single-error leaf wraps its error in a singleton NonEmptyList; that is the whole idiom.
+    ValidationPath<NonEmptyList<String>, String> name = Path.invalidNel("name is blank");
+    ValidationPath<NonEmptyList<String>, String> email = Path.invalidNel("email is invalid");
+
+    // Accumulation just concatenates the two NonEmptyLists, non-empty by construction.
+    ValidationPath<NonEmptyList<String>, String> both = name.andAlso(email);
+    both.run().getError().toJavaList(); // ["name is blank", "email is invalid"]  (left-to-right)
+    // ANCHOR_END: accumulate
+    System.out.println(both.run().getError().toJavaList());
+  }
+
+  static void validatedAndInstances() {
+    // ANCHOR: validated_nel
+    Validated<NonEmptyList<String>, Integer> ok = Validated.validNel(42);
+    Validated<NonEmptyList<String>, Integer> bad = Validated.invalidNel("must be positive");
+    // ANCHOR_END: validated_nel
+    System.out.println(ok + " " + bad);
+
+    // ANCHOR: instances
+    Monad<NonEmptyListKind.Witness> monad = Instances.monad(nonEmptyList());
+    Kind<NonEmptyListKind.Witness, Integer> lifted = monad.of(1);
+    // ANCHOR_END: instances
+    System.out.println(lifted);
+  }
+}
+
+/** The page's illustrative domain error. */
+record ValidationError(String message) {}
+
+record User(String name) {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/optics/MultiEditBook.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.optics;
+
+import static org.higherkindedj.optics.edit.Edit.modify;
+import static org.higherkindedj.optics.edit.Edit.modifyIfPresent;
+import static org.higherkindedj.optics.edit.Edit.parseIfPresent;
+import static org.higherkindedj.optics.edit.Edit.setIfPresent;
+
+import org.higherkindedj.hkt.Update;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.annotations.GenerateFocus;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.edit.Edit;
+import org.higherkindedj.optics.edit.Edits;
+import org.higherkindedj.optics.focus.FocusPath;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/optics/multi_edit.html">Multi-Edit and Sparse Updates</a>
+ * page. The page {@code {{#include}}}s the anchored regions, so it cannot drift from the API.
+ *
+ * <p>The paths come from the generated {@code OrderFocus} companion, not hand-rolled optics: their
+ * labels are what let a failed parse locate itself, which is precisely what the page claims.
+ */
+public final class MultiEditBook {
+
+  // What the page calls EMAIL, SKU, QUANTITY, ORDER_NUMBER: generated, and therefore labelled.
+  static final FocusPath<Order, String> ORDER_NUMBER = OrderFocus.orderNumber();
+  static final FocusPath<Order, String> EMAIL = OrderFocus.email();
+  static final FocusPath<Order, String> SKU = OrderFocus.sku();
+  static final FocusPath<Order, Integer> QUANTITY = OrderFocus.quantity();
+
+  static final Update<Order> APPLY_DISCOUNT = o -> o;
+
+  private MultiEditBook() {}
+
+  public static void main(String[] args) {
+    Order order = new Order("ORD-1", "A@B.COM", " sku ", 1);
+    PatchRequest req = new PatchRequest("ORD-2", "not-an-address", null, 3);
+
+    // ANCHOR: before
+    Order updated = order;
+    if (req.email() != null) {
+      updated = updated.withEmail(req.email().toLowerCase()); // thread the result...
+    }
+    if (req.sku() != null) {
+      updated = updated.withSku(req.sku().trim()); // ...through every step
+    }
+    if (req.qtyDelta() != null) {
+      updated = updated.withQuantity(updated.quantity() + req.qtyDelta());
+    }
+    // And if the email was malformed? You throw on the first bad field and never see the rest.
+    // ANCHOR_END: before
+    System.out.println(updated);
+
+    // ANCHOR: combine
+    Update<Order> normalise =
+        Edits.combine(modify(EMAIL, String::toLowerCase), modify(SKU, String::trim));
+
+    Order orderA = new Order("ORD-1", "A@B.COM", " sku ", 1);
+    Order orderB = new Order("ORD-2", "C@D.COM", " sku2 ", 2);
+
+    Order a = normalise.apply(orderA);
+    Order b = normalise.andThen(APPLY_DISCOUNT).apply(orderB); // Update composes further
+    // ANCHOR_END: combine
+    System.out.println(a + " / " + b);
+
+    // ANCHOR: sparse
+    Edit<Order> number = setIfPresent(ORDER_NUMBER, req.orderNumber()); // null -> no-op
+    Edit<Order> quantity = modifyIfPresent(QUANTITY, req.qtyDelta(), (delta, qty) -> qty + delta);
+    // ANCHOR_END: sparse
+    System.out.println(Edits.combine(number, quantity).apply(order));
+
+    // ANCHOR: accumulate
+    Validated<NonEmptyList<FieldError>, Order> patched =
+        Edits.accumulate(
+                setIfPresent(ORDER_NUMBER, req.orderNumber()),
+                parseIfPresent(EMAIL, req.email(), Email::parse),
+                modifyIfPresent(QUANTITY, req.qtyDelta(), (delta, qty) -> qty + delta))
+            .apply(order);
+    // Invalid(NEL[ "email: not an address" ]), or Valid(order') with only the present fields
+    // changed
+    // ANCHOR_END: accumulate
+    System.out.println(patched);
+  }
+}
+
+@GenerateLenses
+@GenerateFocus
+record Order(String orderNumber, String email, String sku, int quantity) {
+  Order withEmail(String email) {
+    return new Order(orderNumber, email, sku, quantity);
+  }
+
+  Order withSku(String sku) {
+    return new Order(orderNumber, email, sku, quantity);
+  }
+
+  Order withQuantity(int quantity) {
+    return new Order(orderNumber, email, sku, quantity);
+  }
+}
+
+/** A sparse PATCH request: a null component means "not supplied", not "set to null". */
+record PatchRequest(
+    @Nullable String orderNumber,
+    @Nullable String email,
+    @Nullable String sku,
+    @Nullable Integer qtyDelta) {}
+
+/** The boundary parser the page hands to {@code parseIfPresent}. */
+final class Email {
+  static Validated<NonEmptyList<FieldError>, String> parse(String raw) {
+    return raw.contains("@")
+        ? Validated.validNel(raw)
+        : Validated.invalidNel(FieldError.of("not an address"));
+  }
+
+  private Email() {}
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/optics/ValidatedPrismBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/optics/ValidatedPrismBook.java
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.optics;
+
+import org.higherkindedj.hkt.effect.ValidationPath;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.validated.ValidatedPrism;
+
+/**
+ * The code shown on the book's <a
+ * href="https://higher-kinded-j.github.io/optics/validated_prism.html">Validated Prisms</a> page.
+ * The page {@code {{#include}}}s the anchored region, so it cannot drift from the API.
+ */
+public final class ValidatedPrismBook {
+
+  // ANCHOR: prism
+  static final ValidatedPrism<String, EmailAddress> EMAIL =
+      ValidatedPrism.of(
+          EmailAddress::parse, // String -> Validated<NonEmptyList<FieldError>, EmailAddress>
+          EmailAddress::value); // EmailAddress -> String   (total)
+
+  // ANCHOR_END: prism
+
+  private ValidatedPrismBook() {}
+
+  public static void main(String[] args) {
+    // ANCHOR: usage
+    Validated<NonEmptyList<FieldError>, EmailAddress> parsed = EMAIL.parse("  NOPE ");
+
+    // The only way to obtain an EmailAddress is to parse one: that is the point.
+    String rendered =
+        EMAIL
+            .parse("ada@corp.example")
+            .map(EMAIL::build) // build always succeeds
+            .orElse("");
+
+    ValidationPath<NonEmptyList<FieldError>, EmailAddress> railway =
+        EMAIL.parsePath("ada@corp.example");
+    // ANCHOR_END: usage
+    System.out.println(parsed + " / " + rendered + " / " + railway.run());
+  }
+}
+
+/** An always-valid domain value: obtainable only by parsing. */
+record EmailAddress(String value) {
+  static Validated<NonEmptyList<FieldError>, EmailAddress> parse(String raw) {
+    return raw.contains("@")
+        ? Validated.validNel(new EmailAddress(raw))
+        : Validated.invalidNel(FieldError.of("not an email"));
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/book/BookIncludeTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/book/BookIncludeTest.java
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.book;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards the book's {@code {{#include}}} directives.
+ *
+ * <p>Where a snippet has a runnable counterpart in this module, the page includes it rather than
+ * copying it, so the code on the page is the code the build compiles and runs. That is a stronger
+ * guarantee than compiling a copy - but it introduces one new way for the page to lie: <b>mdbook
+ * does not fail on a missing anchor.</b> It renders an empty code block and says nothing, so a
+ * typo, or a rename of an {@code ANCHOR} in the Java source, silently deletes the code from the
+ * page.
+ *
+ * <p>This test closes that hole: every include must resolve to a file that exists, and to an anchor
+ * that exists inside it, and the anchor must not be empty.
+ */
+@DisplayName("every book {{#include}} resolves to a real anchor")
+class BookIncludeTest {
+
+  private static final Path BOOK = Path.of(System.getProperty("hkj.book.dir"));
+
+  /**
+   * The number of includes must never fall below this. Deleting an include line, or replacing it
+   * with a stale hand-copied fence, would otherwise be invisible: the remaining includes would
+   * still all resolve, and the snippet gate no longer covers those pages.
+   */
+  private static final int MINIMUM_INCLUDES = 53;
+
+  /** Any include, in any form, so an unanchored one cannot slip past unchecked. */
+  private static final Pattern ANY_INCLUDE = Pattern.compile("\\{\\{#include\\s+([^}]+)}}");
+
+  /** {{#include <path>:<anchor>}}, the anchored form, which is the only one the book uses. */
+  private static final Pattern INCLUDE =
+      Pattern.compile("\\{\\{#include\\s+([^:}]+):([\\w-]+)\\s*}}");
+
+  /** One include: which page asked for it, and what it asked for. */
+  record Include(Path page, String rawPath, String anchor) {
+    @Override
+    public String toString() {
+      return "%s -> %s:%s".formatted(page.getFileName(), Path.of(rawPath).getFileName(), anchor);
+    }
+  }
+
+  static Stream<Include> includes() throws IOException {
+    List<Include> found = new ArrayList<>();
+    try (Stream<Path> pages = Files.walk(BOOK)) {
+      pages
+          .filter(p -> p.toString().endsWith(".md"))
+          .sorted()
+          .forEach(
+              page -> {
+                Matcher m = INCLUDE.matcher(read(page));
+                while (m.find()) {
+                  found.add(new Include(page, m.group(1).strip(), m.group(2)));
+                }
+              });
+    }
+    return found.stream();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("includes")
+  @DisplayName("include resolves")
+  void includeResolves(Include include) {
+    // mdbook resolves an include relative to the page that contains it.
+    Path target = include.page().getParent().resolve(include.rawPath()).normalize();
+
+    if (!Files.exists(target)) {
+      fail(
+          """
+
+          %s includes a file that does not exist:
+            %s
+
+          Fix the path, or restore the file. mdbook would render an empty code block and say nothing.
+          """
+              .formatted(BOOK.relativize(include.page()), target));
+    }
+
+    String source = read(target);
+
+    // The name must match EXACTLY. mdbook does, and substring matching does not: `total` is a
+    // prefix
+    // of `total_ops`, so `contains("ANCHOR: total")` happily finds `ANCHOR: total_ops`, passes, and
+    // lets the page render an empty block. That is the precise failure this test exists to catch.
+    Matcher open = anchorAt("ANCHOR", include.anchor()).matcher(source);
+    Matcher close = anchorAt("ANCHOR_END", include.anchor()).matcher(source);
+
+    if (!open.find() || !close.find()) {
+      fail(
+          """
+
+          %s includes the anchor `%s`, which does not exist in:
+            %s
+
+          mdbook does NOT fail on a missing anchor. It renders an EMPTY code block, so the page
+          would silently lose its code. Add `// ANCHOR: %s` / `// ANCHOR_END: %s` to the source, or
+          fix the name on the page.
+          """
+              .formatted(
+                  BOOK.relativize(include.page()),
+                  include.anchor(),
+                  target,
+                  include.anchor(),
+                  include.anchor()));
+    }
+
+    String body =
+        source
+            .substring(open.end(), close.start())
+            .lines()
+            .filter(line -> !line.isBlank())
+            .filter(line -> !line.strip().startsWith("// ANCHOR"))
+            .reduce("", (a, b) -> a + b + "\n");
+
+    assertThat(body.strip())
+        .as(
+            "the anchor `%s` in %s is empty, so the page would render a blank code block",
+            include.anchor(), target)
+        .isNotEmpty();
+  }
+
+  /** `ANCHOR: total` must not match `ANCHOR: total_ops`, so the name may not run on. */
+  private static Pattern anchorAt(String keyword, String anchor) {
+    return Pattern.compile(keyword + ":\\s*" + Pattern.quote(anchor) + "(?![\\w-])");
+  }
+
+  @Test
+  @DisplayName("every include is the anchored form")
+  void everyIncludeIsAnchored() throws IOException {
+    // The resolve test only understands `file:anchor`. A whole-file or line-range include would be
+    // silently unchecked, including one pointing at a file that does not exist.
+    try (Stream<Path> pages = Files.walk(BOOK)) {
+      pages
+          .filter(p -> p.toString().endsWith(".md"))
+          .forEach(
+              page -> {
+                Matcher m = ANY_INCLUDE.matcher(read(page));
+                while (m.find()) {
+                  assertThat(m.group(1))
+                      .as(
+                          "%s uses an unanchored include (%s), which this test cannot verify",
+                          BOOK.relativize(page), m.group())
+                      .contains(":");
+                }
+              });
+    }
+  }
+
+  @Test
+  @DisplayName("the include coverage does not shrink")
+  void theIncludeCoverageDoesNotShrink() throws IOException {
+    // A guard on the guard. Every include resolving is worthless if the includes were deleted: the
+    // remaining ones still pass, and the pages quietly revert to unverified hand-copied code.
+    assertThat(includes().count())
+        .as(
+            """
+            The number of {{#include}} directives dropped below the floor.
+
+            An include was deleted, or replaced with a hand-copied fence, so those pages are no \
+            longer sourced from compiled code. If a page legitimately stopped using includes, lower \
+            MINIMUM_INCLUDES deliberately and say why in the commit message.""")
+        .isGreaterThanOrEqualTo(MINIMUM_INCLUDES);
+  }
+
+  private static String read(Path file) {
+    try {
+      return Files.readString(file);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
@@ -1,0 +1,274 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.book;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The documentation gate: every snippet in hkj-book marked {@code <!-- verify -->} must compile
+ * against the real library.
+ *
+ * <p>hkj-book is not a Gradle module, so until this existed nothing compiled its code. Snippets
+ * were hand-maintained, and drifted: two shipped examples did not compile, and a third documented a
+ * method as taking a type it does not take. A reader copying those examples got a compiler error; a
+ * coding assistant reading them generated code that could not build.
+ *
+ * <p>Snippets opt in individually, so pages can be brought under the gate one at a time. {@link
+ * #theGateDoesNotShrink()} stops a marker being quietly deleted to silence a failure.
+ */
+@DisplayName("hkj-book snippets compile against the real library")
+class BookSnippetVerificationTest {
+
+  /**
+   * The number of verified snippets must never fall below this. Raise it as pages are brought under
+   * the gate; a drop means a marker was removed, which is exactly the move this gate exists to
+   * catch.
+   *
+   * <p>It went 49 -> 38 when record_mapping's eleven snippets moved to {@code {{#include}}}: the
+   * page now renders the compiled example directly, which is a stronger guarantee than compiling a
+   * copy of it, so those snippets no longer need a marker. That is the only reason this number may
+   * fall.
+   */
+  private static final int MINIMUM_VERIFIED_SNIPPETS = 5;
+
+  private static final Path BOOK = Path.of(required("hkj.book.dir"));
+  private static final String PROCESSOR_PATH = System.getProperty("hkj.book.processorPath", "");
+
+  /** Domain types a page elides for readability. Kept out of the book so the pages stay clean. */
+  private static final Path FIXTURES =
+      Path.of("src", "test", "resources", "fixtures").toAbsolutePath();
+
+  /** One row per marked snippet, so a failure names the snippet rather than the whole page. */
+  record Case(SnippetExtractor.Page page, SnippetExtractor.Snippet snippet) {
+    @Override
+    public String toString() {
+      return "%s (snippet %d, line %d)"
+          .formatted(BOOK.relativize(page.file()), snippet.index() + 1, snippet.lineNumber());
+    }
+  }
+
+  static Stream<Case> verifiedSnippets() throws IOException {
+    return verifiedPages()
+        .flatMap(page -> page.snippets().stream().map(s -> new Case(page, s)))
+        .toList()
+        .stream();
+  }
+
+  private static Stream<SnippetExtractor.Page> verifiedPages() throws IOException {
+    try (Stream<Path> pages = Files.walk(BOOK)) {
+      return pages
+          .filter(p -> p.toString().endsWith(".md"))
+          .sorted()
+          .map(BookSnippetVerificationTest::extract)
+          .filter(page -> !page.isEmpty())
+          .toList()
+          .stream();
+    }
+  }
+
+  private static SnippetExtractor.Page extract(Path page) {
+    try {
+      return SnippetExtractor.extract(page, BOOK);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("verifiedSnippets")
+  @DisplayName("snippet compiles")
+  void snippetCompiles(Case testCase) throws IOException {
+    SnippetExtractor.Page page = testCase.page();
+    String unit = SnippetExtractor.toCompilationUnit(page, testCase.snippet(), fixtureFor(page));
+
+    DiagnosticCollector<JavaFileObject> diagnostics =
+        compile(page.slug() + "_" + testCase.snippet().index(), unit);
+    List<Diagnostic<? extends JavaFileObject>> errors =
+        diagnostics.getDiagnostics().stream()
+            .filter(
+                d ->
+                    d.getKind() == Diagnostic.Kind.ERROR
+                        // The real build is -Werror on these, so a warning here is a page defect.
+                        || d.getKind() == Diagnostic.Kind.WARNING
+                        || d.getKind() == Diagnostic.Kind.MANDATORY_WARNING)
+            .filter(d -> !String.valueOf(d.getMessage(Locale.ROOT)).contains("preview"))
+            .toList();
+
+    if (!errors.isEmpty()) {
+      fail(report(testCase, unit, errors));
+    }
+  }
+
+  @Test
+  @DisplayName("the gate does not shrink")
+  void theGateDoesNotShrink() throws IOException {
+    int verified = (int) verifiedSnippets().count();
+    assertThat(verified)
+        .as(
+            """
+            The number of `<!-- verify -->` snippets dropped below the floor.
+
+            A snippet was un-marked rather than fixed, which defeats the gate. If a \
+            snippet genuinely cannot be verified any more, lower MINIMUM_VERIFIED_SNIPPETS \
+            deliberately and say why in the commit message.""")
+        .isGreaterThanOrEqualTo(MINIMUM_VERIFIED_SNIPPETS);
+  }
+
+  /** A bare NPE from a static initialiser is a miserable way to learn you skipped Gradle. */
+  private static String required(String property) {
+    String value = System.getProperty(property);
+    if (value == null) {
+      throw new IllegalStateException(
+          "System property '%s' is not set. Run this via Gradle: `gradle :hkj-examples:bookVerify`."
+              .formatted(property));
+    }
+    return value;
+  }
+
+  private static String fixtureFor(SnippetExtractor.Page page) throws IOException {
+    Path fixture = FIXTURES.resolve(page.slug() + ".java");
+    return Files.exists(fixture) ? Files.readString(fixture) : "";
+  }
+
+  private static DiagnosticCollector<JavaFileObject> compile(String slug, String source) {
+    JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+
+    try (StandardJavaFileManager files =
+        javac.getStandardFileManager(diagnostics, Locale.ROOT, StandardCharsets.UTF_8)) {
+
+      Path out = Files.createTempDirectory("book-verify-" + slug);
+      List<String> options =
+          new ArrayList<>(
+              List.of(
+                  // Follow the toolchain rather than pinning a release: when it moves to 26, a
+                  // hardcoded `--release 25 --enable-preview` becomes a confusing javac error.
+                  "--release",
+                  String.valueOf(Runtime.version().feature()),
+                  "--enable-preview",
+                  "-parameters",
+                  // Lint exactly as the real build does, so the gate cannot pass code a reader's
+                  // own `-Werror` build would reject.
+                  "-Xlint:unchecked,rawtypes",
+                  "-classpath",
+                  System.getProperty("java.class.path"),
+                  "-d",
+                  out.toString(),
+                  "-s",
+                  out.toString(),
+                  "-Xlint:-preview"));
+      if (!PROCESSOR_PATH.isBlank()) {
+        options.add("-processorpath");
+        options.add(PROCESSOR_PATH);
+      }
+
+      try {
+        javac
+            .getTask(
+                null,
+                files,
+                diagnostics,
+                options,
+                null,
+                List.of(new InMemorySource("bookverify." + slug, source)))
+            .call();
+      } finally {
+        deleteRecursively(out);
+      }
+      return diagnostics;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Each snippet compiles to its own temp directory. Left behind, they accumulate: one per verified
+   * snippet, every run. The classes are never read back, so the directory exists only for the
+   * compile and is removed the moment it is done.
+   */
+  private static void deleteRecursively(Path dir) throws IOException {
+    if (!Files.exists(dir)) {
+      return;
+    }
+    try (Stream<Path> walk = Files.walk(dir)) {
+      walk.sorted(Comparator.reverseOrder()).forEach(BookSnippetVerificationTest::deleteQuietly);
+    }
+  }
+
+  private static void deleteQuietly(Path path) {
+    try {
+      Files.delete(path);
+    } catch (IOException ignored) {
+      // A best-effort clean-up: a file we cannot delete is not worth failing the gate over.
+    }
+  }
+
+  /** A javac error tells you nothing without the line it fired on, so print the assembled unit. */
+  private static String report(
+      Case testCase, String unit, List<Diagnostic<? extends JavaFileObject>> errors) {
+
+    StringBuilder message = new StringBuilder();
+    message
+        .append("\nThe code in ")
+        .append(testCase)
+        .append(" does not compile against the library.\n")
+        .append("Fix the page (or the code it documents); do not remove the marker.\n\n");
+
+    errors.forEach(
+        e ->
+            message
+                .append("  error: ")
+                .append(e.getMessage(Locale.ROOT))
+                .append("\n    at assembled line ")
+                .append(e.getLineNumber())
+                .append('\n'));
+
+    message.append("\n--- assembled from the page's `<!-- verify -->` snippets ---\n");
+    String[] lines = unit.split("\n", -1);
+    for (int i = 0; i < lines.length; i++) {
+      message.append("%4d | %s%n".formatted(i + 1, lines[i]));
+    }
+    return message.toString();
+  }
+
+  /** javac reads sources through the file manager, so hand it the assembled unit from memory. */
+  private static final class InMemorySource extends SimpleJavaFileObject {
+    private final String code;
+
+    InMemorySource(String fullyQualifiedName, String code) {
+      super(
+          URI.create("string:///" + fullyQualifiedName.replace('.', '/') + Kind.SOURCE.extension),
+          Kind.SOURCE);
+      this.code = code;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return code;
+    }
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/book/SnippetExtractor.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/book/SnippetExtractor.java
@@ -1,0 +1,284 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.book;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Pulls the verified code snippets out of an hkj-book page and assembles them into a single Java
+ * compilation unit.
+ *
+ * <p>A snippet opts in with an HTML comment on the line before its fence:
+ *
+ * <pre>{@code
+ * <!-- verify -->
+ * ``` java
+ * Validated<NonEmptyList<FieldError>, User> user = ...;
+ * ```
+ * }</pre>
+ *
+ * <p>The comment is invisible in the rendered book. Opting in per snippet lets the gate be adopted
+ * page by page rather than all at once.
+ *
+ * <p>Each snippet is compiled <em>independently</em>, because the snippets on a page are
+ * illustrations rather than one program: two of them may legitimately show different {@code User}
+ * records. What a snippet elides for readability (the domain types, the {@code parseX} helpers)
+ * comes from an optional per-page fixture, which is kept out of the book so the page stays
+ * readable.
+ */
+final class SnippetExtractor {
+
+  /** Opt-in marker. Must sit on its own line immediately before the fence. */
+  private static final Pattern MARKER = Pattern.compile("^\\s*<!--\\s*verify\\s*-->\\s*$");
+
+  /** mdbook writes both "```java" and "``` java". */
+  private static final Pattern FENCE_OPEN = Pattern.compile("^\\s*```+\\s*java\\b.*$");
+
+  private static final Pattern FENCE_CLOSE = Pattern.compile("^\\s*```+\\s*$");
+
+  private static final Pattern IMPORT =
+      Pattern.compile("^\\s*import\\s+(static\\s+)?[\\w.*]+\\s*;\\s*$");
+
+  /**
+   * A top-level declaration: a type, or an annotation that introduces one. Anything else is treated
+   * as loose statements and wrapped in a method body.
+   */
+  private static final Pattern DECLARATION =
+      Pattern.compile(
+          "^\\s*(@(GenerateLenses|GenerateFocus|GeneratePrisms|GenerateIsos|GenerateGetters"
+              + "|GenerateSetters|GenerateFolds|GenerateMapping|GenerateMerge|GenerateAssembly"
+              + "|GenerateErrorEnvelope|EffectAlgebra|ComposeEffects)\\b"
+              + "|(public\\s+|final\\s+|abstract\\s+|sealed\\s+|non-sealed\\s+|static\\s+)*"
+              + "(class|record|interface|enum)\\s+\\w+)");
+
+  /**
+   * A method declaration, which a page writes when it is showing you a signature rather than a
+   * statement. It becomes a member of the wrapper class; wrapping it in a method body would nest a
+   * method inside a method, which is not legal Java.
+   */
+  private static final Pattern METHOD =
+      Pattern.compile(
+          "^\\s*(public\\s+|private\\s+|protected\\s+|static\\s+|final\\s+|default\\s+)*"
+              + "[\\w.$]+(<[^=;]*>)?(\\[])?\\s+\\w+\\s*\\([^;]*\\)\\s*(throws\\s+[\\w.,\\s]+)?\\{\\s*$");
+
+  /** A fixture may be generic, so a page can show `VResultPath<E, A>` without naming a domain. */
+  private static final Pattern FIXTURE_DECL =
+      Pattern.compile("\\bclass\\s+Fixture\\s*(<([^>]*)>)?");
+
+  private SnippetExtractor() {}
+
+  /** One verified snippet: its source, and where it came from (for the failure message). */
+  record Snippet(int index, int lineNumber, String body) {}
+
+  /** Every verified snippet on one page. */
+  record Page(Path file, String slug, List<Snippet> snippets) {
+    Page {
+      snippets = List.copyOf(snippets);
+    }
+
+    boolean isEmpty() {
+      return snippets.isEmpty();
+    }
+  }
+
+  static Page extract(Path page, Path bookRoot) throws IOException {
+    List<String> lines = Files.readAllLines(page);
+    List<Snippet> snippets = new ArrayList<>();
+
+    for (int i = 0; i < lines.size(); i++) {
+      if (!MARKER.matcher(lines.get(i)).matches()) {
+        continue;
+      }
+      // The fence must follow the marker, allowing for a blank line between them.
+      int fence = i + 1;
+      while (fence < lines.size() && lines.get(fence).isBlank()) {
+        fence++;
+      }
+      if (fence >= lines.size() || !FENCE_OPEN.matcher(lines.get(fence)).matches()) {
+        throw new IllegalStateException(
+            "%s:%d: `<!-- verify -->` is not followed by a ``` java fence."
+                .formatted(page.getFileName(), i + 1));
+      }
+      StringBuilder body = new StringBuilder();
+      int line = fence + 1;
+      for (; line < lines.size() && !FENCE_CLOSE.matcher(lines.get(line)).matches(); line++) {
+        body.append(lines.get(line)).append('\n');
+      }
+      snippets.add(new Snippet(snippets.size(), fence + 2, body.toString()));
+      i = line;
+    }
+    return new Page(page, slugOf(page, bookRoot), snippets);
+  }
+
+  /** "effect/path_vresult.md" -> "effect_path_vresult". A legal Java identifier, and unique. */
+  static String slugOf(Path page, Path bookRoot) {
+    String relative = bookRoot.relativize(page).toString();
+    return relative.replaceAll("\\.md$", "").replaceAll("[^A-Za-z0-9]", "_");
+  }
+
+  /**
+   * Assembles one snippet (plus its page's optional fixture) into a compilation unit.
+   *
+   * <p>Imports are hoisted. A snippet that declares a type contributes a top-level type; anything
+   * else is wrapped in a method, so loose statements type-check in a real scope.
+   *
+   * <p>A type the snippet declares itself wins over the fixture's, so a page may show its own
+   * {@code User} without colliding with the one the fixture supplies for its other snippets.
+   */
+  static String toCompilationUnit(Page page, Snippet snippet, String fixture) {
+    List<String> imports = new ArrayList<>();
+    List<String> snippetTypes = new ArrayList<>();
+    List<String> members = new ArrayList<>();
+    List<String> statements = new ArrayList<>();
+    partition(snippet.body(), imports, snippetTypes, members, statements);
+
+    List<String> fixtureTypes = new ArrayList<>();
+    if (!fixture.isBlank()) {
+      partition(fixture, imports, fixtureTypes, new ArrayList<>(), new ArrayList<>());
+    }
+    // Drop any fixture type the snippet declares for itself.
+    List<String> declared = snippetTypes.stream().map(SnippetExtractor::typeNameOf).toList();
+    List<String> types = new ArrayList<>(snippetTypes);
+    fixtureTypes.stream().filter(t -> !declared.contains(typeNameOf(t))).forEach(types::add);
+
+    // A fixture supplies the helpers a snippet calls bare (`parseName(dto.name())`). Extending it
+    // puts them in scope without the page having to spell out an import it never wrote. A generic
+    // fixture also lends its type parameters, so a page can show `VResultPath<E, A>` as a shape.
+    String fixtureParams = fixtureTypeParameters(types);
+
+    String name = page.slug() + "_" + snippet.index();
+    StringBuilder unit = new StringBuilder("package bookverify;\n\n");
+    imports.stream().distinct().sorted().forEach(i -> unit.append(i).append('\n'));
+    // Only `unused`: a snippet legitimately declares locals it never reads. `unchecked`/`rawtypes`
+    // are deliberately NOT suppressed. The real build compiles with -Xlint:unchecked,rawtypes
+    // -Werror, so suppressing them here would green-light a page showing code a reader cannot
+    // build.
+    unit.append("\n@SuppressWarnings(\"unused\")\n");
+    unit.append("final class ").append(name);
+    if (fixtureParams != null) {
+      unit.append(fixtureParams).append(" extends Fixture").append(fixtureParams);
+    }
+    unit.append(" {\n");
+    members.forEach(m -> unit.append('\n').append(m).append('\n'));
+    if (!statements.isEmpty()) {
+      unit.append("\n  void snippet() throws Exception {\n");
+      statements.forEach(unit::append);
+      unit.append("  }\n");
+    }
+    unit.append("}\n\n");
+    // Top-level types last: a file may hold many, provided none is public.
+    types.forEach(t -> unit.append(t).append('\n'));
+    return unit.toString();
+  }
+
+  /**
+   * The type-parameter list to mirror from the fixture: {@code ""} for a plain {@code Fixture},
+   * {@code "<E, A>"} for a generic one, or {@code null} when the page has no fixture at all.
+   */
+  private static String fixtureTypeParameters(List<String> types) {
+    for (String type : types) {
+      if (!"Fixture".equals(typeNameOf(type))) {
+        continue;
+      }
+      var matcher = FIXTURE_DECL.matcher(type);
+      if (matcher.find() && matcher.group(2) != null) {
+        // Strip any bounds: `<E extends Throwable>` is declared once, referenced as `<E>`.
+        String names =
+            Arrays.stream(matcher.group(2).split(","))
+                .map(p -> p.strip().split("\\s+")[0])
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+        return "<" + names + ">";
+      }
+      return "";
+    }
+    return null;
+  }
+
+  /** The declared name, so a snippet's own type can shadow the fixture's. */
+  private static String typeNameOf(String declaration) {
+    var matcher =
+        Pattern.compile("\\b(class|record|interface|enum)\\s+(\\w+)").matcher(declaration);
+    return matcher.find() ? matcher.group(2) : declaration;
+  }
+
+  /** Splits a block into imports, top-level types, class members, and loose statements. */
+  private static void partition(
+      String source,
+      List<String> imports,
+      List<String> declarations,
+      List<String> members,
+      List<String> loose) {
+    List<String> lines = List.of(source.split("\n", -1));
+    int i = 0;
+    while (i < lines.size()) {
+      String line = lines.get(i);
+      if (IMPORT.matcher(line).matches()) {
+        imports.add(line.strip());
+        i++;
+      } else if (DECLARATION.matcher(line).find()) {
+        int end = endOfDeclaration(lines, i);
+        String declaration = String.join("\n", lines.subList(i, end + 1));
+        // Several top-level types share one file, so none of them may be public. The modifier is
+        // not
+        // always at the start of a line: a page may write `@GenerateMapping public interface X {}`.
+        declarations.add(
+            declaration.replaceAll(
+                "\\bpublic\\s+(?=(final\\s+|abstract\\s+|sealed\\s+|non-sealed\\s+|static\\s+)*"
+                    + "(class|record|interface|enum)\\b)",
+                ""));
+        i = end + 1;
+      } else if (METHOD.matcher(line).matches()) {
+        // The page is showing a whole method. It becomes a member: a method cannot nest in a
+        // method.
+        int end = endOfDeclaration(lines, i);
+        members.add("  " + String.join("\n  ", lines.subList(i, end + 1)));
+        i = end + 1;
+      } else if (line.isBlank() || line.strip().startsWith("//")) {
+        i++;
+      } else {
+        loose.add("    " + line + "\n");
+        i++;
+      }
+    }
+  }
+
+  /**
+   * Walks braces to find where a declaration ends. Handles the one-line `record X(...) {}` form.
+   */
+  private static int endOfDeclaration(List<String> lines, int start) {
+    int depth = 0;
+    boolean opened = false;
+    for (int i = start; i < lines.size(); i++) {
+      String line = stripLiterals(lines.get(i));
+      for (char c : line.toCharArray()) {
+        if (c == '{') {
+          depth++;
+          opened = true;
+        } else if (c == '}') {
+          depth--;
+        }
+      }
+      if (opened && depth <= 0) {
+        return i;
+      }
+      // An abstract/interface member with no body: `Dashboard assemble(User u);`
+      if (!opened && line.strip().endsWith(";")) {
+        return i;
+      }
+    }
+    return lines.size() - 1;
+  }
+
+  /** Braces inside strings and char literals must not count towards nesting depth. */
+  private static String stripLiterals(String line) {
+    return line.replaceAll("\"(\\\\.|[^\"\\\\])*\"", "\"\"")
+        .replaceAll("'(\\\\.|[^'\\\\])'", "' '");
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/RecordMappingBookLawsTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/RecordMappingBookLawsTest.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.mapping;
+
+import org.higherkindedj.optics.laws.MappingLaws;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The law check shown on the book's Record Mapping page. The page {@code {{#include}}}s the
+ * anchored region below, so the snippet it displays is this test, and it is green.
+ *
+ * <p>{@code hkj-test} is test-scope, which is why the laws live in a test rather than beside the
+ * spec.
+ */
+@DisplayName("the book's record mappings obey the mapping laws")
+class RecordMappingBookLawsTest {
+
+  @Test
+  void customerMappingObeysTheLaws() {
+    // ANCHOR: laws
+    MappingLaws.assertMappingLaws(
+        CustomerMappingImpl.INSTANCE.asValidatedPrism(),
+        new CustomerDto("Ada", "ada@example.org"), // parses
+        new CustomerDto("Bob", "not-an-email")); // must not parse
+    // ANCHOR_END: laws
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBookTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBookTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.monads.assembly;
+
+import static org.higherkindedj.hkt.assertions.FieldErrorAssert.assertThatFieldError;
+
+import org.higherkindedj.hkt.validated.FieldError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The located-error assertion shown on the book's Accumulating Assembly page. The page {@code
+ * {{#include}}}s the anchored region, so the snippet it displays is this test, and it is green.
+ */
+@DisplayName("a located FieldError carries its path")
+class ValidatedAssemblyBookTest {
+
+  @Test
+  void locatedErrorsCarryTheirPath() {
+    // ANCHOR: field_error
+    assertThatFieldError(FieldError.of("not a postcode").at("zip").at("address"))
+        .hasPath("address.zip")
+        .hasSegments("address", "zip")
+        .hasMessageContaining("postcode");
+    // ANCHOR_END: field_error
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/optics/ValidatedPrismBookLawsTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/optics/ValidatedPrismBookLawsTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.book.optics;
+
+import org.higherkindedj.optics.laws.ValidatedPrismLaws;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The law check shown on the book's Validated Prisms page. The page {@code {{#include}}}s the
+ * anchored region, so the snippet it displays is this test, and it is green.
+ */
+@DisplayName("the book's ValidatedPrism obeys the prism laws")
+class ValidatedPrismBookLawsTest {
+
+  @Test
+  void emailPrismObeysTheLaws() {
+    // ANCHOR: laws
+    ValidatedPrismLaws.assertValidatedPrismLaws(
+        ValidatedPrismBook.EMAIL, "ada@corp.example", "not-an-email");
+    // parse-build: parse(build(a)) == Valid(a)
+    // build-parse: parse(s) == Valid(a)  =>  build(a) == s   (no lossy parse-normalise)
+    // ANCHOR_END: laws
+  }
+}

--- a/hkj-examples/src/test/resources/fixtures/effect_path_vresult.java
+++ b/hkj-examples/src/test/resources/fixtures/effect_path_vresult.java
@@ -1,0 +1,139 @@
+// Fixture for hkj-book/src/effect/path_vresult.md
+//
+// The page shows two kinds of code: a concrete order pipeline, and a catalogue of shapes written
+// against abstract type variables (`VResultPath<E, A> p1 = Path.vresultRight(value);`). The generic
+// `Fixture<E, A, B>` below lends those variables to the snippet, so the catalogue is compiled rather
+// than merely asserted.
+//
+// NOTE: the imports below look unused *here*. They are for the snippet this file is spliced into.
+// That is why spotless excludes src/test/resources (see build.gradle.kts).
+
+import java.time.Duration;
+import java.util.List;
+import org.higherkindedj.hkt.effect.EitherPath;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.VResultPath;
+import org.higherkindedj.hkt.effect.VTaskPath;
+import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.resilience.Bulkhead;
+import org.higherkindedj.hkt.resilience.CircuitBreaker;
+import org.higherkindedj.hkt.resilience.RetryPolicy;
+import org.higherkindedj.hkt.vtask.VTask;
+
+record Address(String line1) {}
+
+record Customer(String id) {}
+
+record OrderRequest(String customerId, String shippingAddress) {}
+
+record Order(String id) {}
+
+record OrderResult(String id) {}
+
+record Reservation(String id) {}
+
+sealed interface OrderError {
+  record SystemError(String why) implements OrderError {}
+
+  record Unavailable(String what) implements OrderError {}
+
+  record Busy(String what) implements OrderError {}
+
+  record Timeout() implements OrderError {}
+
+  static OrderError timeout() {
+    return new Timeout();
+  }
+
+  static OrderError unavailable(String what) {
+    return new Unavailable(what);
+  }
+
+  static OrderError busy(String what) {
+    return new Busy(what);
+  }
+}
+
+final class SystemError {
+  static OrderError fromDefect(Throwable t) {
+    return new OrderError.SystemError(t.getMessage());
+  }
+}
+
+class DomainException extends RuntimeException {
+  DomainException(Object error) {
+    super(String.valueOf(error));
+  }
+}
+
+/** Generic so the page can show `VResultPath<E, A>` as a shape rather than a domain. */
+class Fixture<E, A, B> {
+
+  A value;
+  E error;
+  Either<E, A> either;
+  VTask<Either<E, A>> vtaskOfEither;
+  VResultPath<E, A> path;
+
+  static final RetryPolicy policy = RetryPolicy.fixed(3, Duration.ofMillis(10));
+  static final CircuitBreaker breaker = CircuitBreaker.withDefaults();
+  static final Bulkhead bulkhead = Bulkhead.withMaxConcurrent(4);
+
+  static final VResultPath<OrderError, Reservation> warehouse1 = null;
+  static final VResultPath<OrderError, Reservation> warehouse2 = null;
+  static final VResultPath<OrderError, Reservation> warehouse3 = null;
+  static final Order order = new Order("o-1");
+
+  Either<E, A> decide() {
+    return either;
+  }
+
+  B onError(E e) {
+    return null;
+  }
+
+  B onValue(A a) {
+    return null;
+  }
+
+  VResultPath<OrderError, Address> validateShippingAddress(String address) {
+    return Path.vresultRight(new Address(address));
+  }
+
+  VResultPath<OrderError, Customer> lookupAndValidateCustomer(String id) {
+    return Path.vresultRight(new Customer(id));
+  }
+
+  VResultPath<OrderError, Order> buildValidatedOrder(OrderRequest request, Customer customer) {
+    return Path.vresultRight(new Order("o-1"));
+  }
+
+  VResultPath<OrderError, OrderResult> reserveThenFulfil(Order order) {
+    return Path.vresultRight(new OrderResult(order.id()));
+  }
+
+  VResultPath<OrderError, OrderResult> retryOnce(OrderError error) {
+    return Path.vresultLeft(error);
+  }
+
+  OrderError enrich(OrderError error) {
+    return error;
+  }
+
+  static VResultPath<OrderError, Reservation> reserveInventory(Order order) {
+    return Path.vresultRight(new Reservation("r-1"));
+  }
+
+  static VResultPath<OrderError, OrderResult> payThenShip(Order order, Reservation reservation) {
+    return Path.vresultRight(new OrderResult(order.id()));
+  }
+
+  static VTask<?> confirm(Reservation reservation) {
+    return VTask.succeed(reservation);
+  }
+
+  static VTask<?> releaseAndRefund(Reservation reservation) {
+    return VTask.succeed(reservation);
+  }
+}


### PR DESCRIPTION
## Why

Nothing in this repo verified documentation. `hkj-book` is not a Gradle module, no CI job compiled its snippets, and no check tied a page to the API it describes. The result was exactly what you would predict.

**Six real defects, four of which do not compile:**

| Defect | Where |
|---|---|
| A redundant `.at("email")` double-labels, so the snippet yields `email.email: …` while claiming `email: …`. The page then contradicts itself eight lines later | `multi_edit.md` **+ the shipped Javadoc of `Edits` and `FallibleEdit`** |
| `Instances.validated` returns `MonadError<…>`, not `ValidatedMonad` — **does not compile**, while the method's own Javadoc shows the correct idiom | `validated_assembly.md`, `validated_monad.md` |
| `fields().field(label, …)` takes a value, not a function, so `vp::parse` **does not compile** | `validated_assembly.md` |
| A local `reservation` collides with a lambda parameter of the same name — **does not compile** | `path_vresult.md` |
| `bracketOutcome` "release *always* runs": a typed failure from `acquire` skips it | `path_vresult.md` |
| One `PersonDto` used for two incompatible shapes (`name` vs `fullName`) | `record_mapping.md` |

The code was right in every case; the docs were wrong. `EditsTest.labelledPathAutoLocates` already asserted the correct `.at()` behaviour.

**Index drift was structural, not incidental.** Each feature PR updated a *different, non-overlapping* subset of the cross-cutting pages, so no two agreed:

- `cheatsheet.md` knew `EitherOrBothPath` (#583) but **not** `VResultPath` (#617)
- `effect/path_types.md` knew `VResultPath` but **not** `EitherOrBothPath` — the mirror image
- `effect/conversions.md` knew neither

`VResultPath`, a headline feature, was undiscoverable from the cheatsheet.

## What this does

**Fixes the defects**, then removes the conditions that produced them.

### 1. The book now renders compiled code

Seven pages `{{#include}}` anchored regions of runnable examples under `org.higherkindedj.example.book.**`, so the code a reader sees *is* the code the build compiles, the processor generates from, and `main()` runs. **53 includes.** Drift is not caught — it is impossible.

A runnable example also proves the **output comments** a page asserts, which a compile check structurally cannot. Every one now reproduces verbatim (`customer.email: …`, `address.zip: …`, the derived `displayName`, the projection's `asLens` write-back).

The types are deliberately **top-level**: a nested spec joins its enclosing names, so the existing example really generates `GenerateMappingExampleCustomerMappingImpl` while the page teaches `CustomerMappingImpl`. Including it verbatim would have made the book *less* correct.

### 2. A gate for what an include cannot express

`gradle :hkj-examples:bookVerify` compiles any fence marked `<!-- verify -->` against the real classpath **and the real annotation processor**, linting exactly as the build does (`-Xlint:unchecked,rawtypes`, warnings fatal). It lives in `hkj-examples` because that module already wires the processor, `hkj-test`, JUnit and AssertJ. **5 markers left** — `path_vresult`'s catalogue of shapes written against abstract type variables, the one thing an include cannot express.

Two ratchets (`MINIMUM_INCLUDES`, `MINIMUM_VERIFIED_SNIPPETS`) fail the build if coverage falls, so silently un-verifying a page is not an option.

