### PR TITLE
Refresh landing pages for the 0.4.8 surface and reframe the pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ What makes Higher-Kinded-J unique is the seamless integration between **Effect P
   IOPath<Data>         ────┤
   VTaskPath<A>         ────┤
   VStreamPath<A>       ────┤
-  ValidationPath<E, A> ────┘
+  ValidationPath<E, A> ────┤
+  EitherOrBothPath<L, A>───┘
                             │       │
                             ▼       ▼
                        ┌─────────────────┐
@@ -140,6 +141,7 @@ Higher-Kinded-J provides the most comprehensive optics implementation available 
 * **External type import** via `@ImportOptics` for types you don't own (e.g., `java.time.LocalDate`)
 * **Spec interfaces** for complex external types with copy strategy annotations (`@ViaBuilder`, `@Wither`, `@ViaCopyAndSet`)
 * **Works with popular libraries**: Jackson JsonNode, JOOQ records, Immutables, Lombok, AutoValue, and Protocol Buffers
+* **[ValidatedPrism](https://higher-kinded-j.github.io/latest/optics/validated_prism.html)** for parse-don't-validate boundaries: `parse` returns a `Validated` locating every failure, `build` is total, and both round-trip laws ship in `hkj-test`
 * **Filtered traversals** for predicate-based focusing within collections
 * **Indexed optics** for position-aware transformations
 * **Focus DSL** for type-safe, fluent path navigation with seamless bridging into external libraries
@@ -155,11 +157,37 @@ For services with complex domain workflows, Higher-Kinded-J provides algebraic-e
 * **Mock-free testing** via `Id` monad interpreters; no mocking frameworks needed
 * **Program inspection** with `ProgramAnalyser` before any side effects execute
 
+### [Record Mapping and Typed-Error Codegen](https://higher-kinded-j.github.io/latest/optics/record_mapping.html)
+
+The boundary between your domain records and the wire is usually hand-written mappers or a reflective bean-mapper. Higher-Kinded-J turns it into compile-time codegen that never loses an error:
+
+* **`@GenerateMapping`** generates a total `build` **and** an accumulating `parse` returning `Validated<NonEmptyList<FieldError>, T>`; every emission tier is law-checked against `hkj-test`
+* **`@GenerateMerge`** assembles one target record from several source records, filling each component by name
+* **[Open-arity accumulating assembly](https://higher-kinded-j.github.io/latest/monads/validated_assembly.html)** (`fields()` / `accumulate()` / `@GenerateAssembly`) builds a record from N independently-validated fields, collecting every error in declaration order with no `Semigroup` ceremony
+* **`@GenerateErrorEnvelope`** gives a sealed error hierarchy a typed context record (records-as-schema, not `Map<String, Object>`) with deterministic timestamps from a `TimeSource`
+
 ---
 
 ## Why Higher-Kinded-J?
 
-Higher-Kinded-J offers the most advanced optics implementation in the Java ecosystem, combined with a unified effect system that no other library provides.
+Modern Java handed you records, sealed interfaces, and pattern matching. What it didn't hand you is a way to make them *compose*: errors that chain instead of nest, validation that collects every failure instead of stopping at the first, deep immutable updates in one line instead of nested `with…` calls, and typed errors that survive a network hop. Higher-Kinded-J is the missing layer.
+
+You don't need to learn an esoteric functional library to feel the benefit. Each capability replaces something you already reach for today:
+
+| Instead of… | Today you reach for | Higher-Kinded-J gives you |
+|-------------|---------------------|---------------------------|
+| Nested `Optional`, thrown exceptions, and validation that stops at the first error | the standard library | one railway vocabulary (`map` / `via` / `recover`) across absence, typed errors, async, and **accumulating** validation |
+| `Option` / `Either` / `Try` from **Vavr** | the FP library most Java developers know | the same core types **plus** higher-kinded abstraction, a full optics suite, monad transformers, and an effect system — built natively on modern Java (records, sealed types, virtual threads), where Vavr keeps a Java 8 foundation |
+| **MapStruct** / ModelMapper for DTO↔domain mapping | annotation-driven mappers | `@GenerateMapping` with a total `build` **and** an accumulating `parse` that reports every bad field, law-checked at compile time |
+| **Resilience4j** annotations for retry / circuit-breaker / bulkhead | AOP-style resilience | the same policies as composable path combinators (`withRetry` / `withCircuitBreaker` / `withBulkhead`) that treat a business `Left` as a value, never as a failure to retry |
+| Hand-written `wither` / copy-constructor updates on records | manual boilerplate | generated lenses, prisms, and traversals — the most comprehensive optics available for Java |
+
+And unlike any of those tools, effects and data navigation speak **the same language** — the Effect-Optics bridge above is something no other Java library offers.
+
+<details>
+<summary><strong>How the optics compare to other Java optics libraries</strong></summary>
+
+Higher-Kinded-J also offers the most advanced optics implementation in the Java ecosystem. Measured against the dedicated Java optics libraries:
 
 | Feature | Higher-Kinded-J | Functional Java | Fugue Optics | Derive4J |
 |---------|:--------------:|:---------------:|:------------:|:--------:|
@@ -185,6 +213,8 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 
 *\* Derive4J generates getters/setters but requires Functional Java for actual optic classes*
 
+</details>
+
 ---
 
 ## Path Types at a Glance
@@ -193,9 +223,11 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 |-----------|-------------|
 | `MaybePath<A>` | Absence is normal, not an error |
 | `EitherPath<E, A>` | Errors carry typed, structured information |
+| `EitherOrBothPath<L, A>` | Success that also carries non-fatal warnings (inclusive-or) |
 | `TryPath<A>` | Wrapping code that throws exceptions |
 | `ValidationPath<E, A>` | Collecting *all* errors, not just the first |
 | `IOPath<A>` | Side effects you want to defer and sequence |
+| `VResultPath<E, A>` | Async work that fails with a *typed* domain error (`VTask<Either<E, A>>`) |
 | `TrampolinePath<A>` | Stack-safe recursion |
 | `CompletableFuturePath<A>` | Async operations |
 | `ReaderPath<R, A>` | Dependency injection, configuration access |
@@ -211,7 +243,7 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 | `VTaskPath<A>` | Virtual thread-based concurrency with Par combinators |
 | `VStreamPath<A>` | Lazy pull-based streaming on virtual threads |
 
-Each Path provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL.
+Each Path provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL. The lazy carriers (`IOPath`, `VTaskPath`, `VResultPath`) additionally chain path-native resilience — `withRetry` / `withTimeout` / `withCircuitBreaker` / `withBulkhead` — that treats a business `Left` as a value, never as a failure to retry.
 
 ### Optic Path Types
 

--- a/hkj-book/src/home.md
+++ b/hkj-book/src/home.md
@@ -66,7 +66,8 @@ What makes Higher-Kinded-J unique is the seamless integration between **Effect P
   IOPath<Data>         ────┤
   VTaskPath<A>         ────┤
   VStreamPath<A>       ────┤
-  ValidationPath<E, A> ────┘
+  ValidationPath<E, A> ────┤
+  EitherOrBothPath<L, A>───┘
                             │       │
                             ▼       ▼
                        ┌─────────────────┐
@@ -123,6 +124,7 @@ Higher-Kinded-J provides the most comprehensive optics implementation available 
 * **[External type import](optics/importing_optics.md)** via `@ImportOptics` for types you don't own
 * **[Spec interfaces](optics/optics_spec_interfaces.md)** for complex external types with copy strategy annotations (`@ViaBuilder`, `@Wither`, `@ViaCopyAndSet`)
 * **[Third-party integration](optics/focus_external_bridging.md)** with Jackson, JOOQ, Immutables, Lombok, AutoValue, and Protocol Buffers
+* **[ValidatedPrism](optics/validated_prism.md)** for parse-don't-validate boundaries: `parse` returns a `Validated` locating every failure, `build` is total, and both round-trip laws ship in `hkj-test`
 * **Filtered traversals** for predicate-based focusing within collections
 * **Indexed optics** for position-aware transformations
 * **Profunctor architecture** enabling adaptation between different data shapes
@@ -139,11 +141,35 @@ For services with complex domain workflows, Higher-Kinded-J provides algebraic-e
 * **Mock-free testing** via `Id` monad interpreters
 * **[Program inspection](effect/effect_handlers.md#program-analysis)** with `ProgramAnalyser` before any side effects execute
 
+### [Record Mapping and Typed-Error Codegen](optics/record_mapping.md)
+
+The boundary between your domain records and the wire is usually hand-written mappers or a reflective bean-mapper. Higher-Kinded-J turns it into compile-time codegen that never loses an error:
+
+* **[`@GenerateMapping`](optics/record_mapping.md)** generates a total `build` **and** an accumulating `parse` returning `Validated<NonEmptyList<FieldError>, T>`; every emission tier is law-checked against `hkj-test`
+* **[`@GenerateMerge`](optics/record_mapping.md)** assembles one target record from several source records, filling each component by name
+* **[Open-arity accumulating assembly](monads/validated_assembly.md)** (`fields()` / `accumulate()` / `@GenerateAssembly`) builds a record from N independently-validated fields, collecting every error in declaration order with no `Semigroup` ceremony
+* **[`@GenerateErrorEnvelope`](optics/record_mapping.md#generating-error-envelopes-generateerrorenvelope)** gives a sealed error hierarchy a typed context record (records-as-schema, not `Map<String, Object>`) with deterministic timestamps from a `TimeSource`
+
 ---
 
 ## Why Higher-Kinded-J?
 
-Higher-Kinded-J offers the most advanced optics implementation in the Java ecosystem, combined with a unified effect system that no other library provides.
+Modern Java handed you records, sealed interfaces, and pattern matching. What it didn't hand you is a way to make them *compose*: errors that chain instead of nest, validation that collects every failure instead of stopping at the first, deep immutable updates in one line instead of nested `with…` calls, and typed errors that survive a network hop. Higher-Kinded-J is the missing layer.
+
+You don't need to learn an esoteric functional library to feel the benefit. Each capability replaces something you already reach for today:
+
+| Instead of… | Today you reach for | Higher-Kinded-J gives you |
+|-------------|---------------------|---------------------------|
+| Nested `Optional`, thrown exceptions, and validation that stops at the first error | the standard library | one railway vocabulary (`map` / `via` / `recover`) across absence, typed errors, async, and **accumulating** validation |
+| `Option` / `Either` / `Try` from **Vavr** | the FP library most Java developers know | the same core types **plus** higher-kinded abstraction, a full optics suite, monad transformers, and an effect system — built natively on modern Java (records, sealed types, virtual threads), where Vavr keeps a Java 8 foundation |
+| **MapStruct** / ModelMapper for DTO↔domain mapping | annotation-driven mappers | `@GenerateMapping` with a total `build` **and** an accumulating `parse` that reports every bad field, law-checked at compile time |
+| **Resilience4j** annotations for retry / circuit-breaker / bulkhead | AOP-style resilience | the same policies as composable path combinators (`withRetry` / `withCircuitBreaker` / `withBulkhead`) that treat a business `Left` as a value, never as a failure to retry |
+| Hand-written `wither` / copy-constructor updates on records | manual boilerplate | generated lenses, prisms, and traversals — the most comprehensive optics available for Java |
+
+And unlike any of those tools, effects and data navigation speak **the same language**: the [Effect-Optics bridge](#the-bridge-effects-meet-optics) above is something no other Java library offers.
+
+~~~admonish note title="How the optics compare to other Java optics libraries" collapsible=true
+Higher-Kinded-J also offers the most advanced optics implementation in the Java ecosystem. Measured against the dedicated Java optics libraries:
 
 | Feature | Higher-Kinded-J | Functional Java | Fugue Optics | Derive4J |
 |---------|:--------------:|:---------------:|:------------:|:--------:|
@@ -167,6 +193,7 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 | **Effect Handlers / Free Monads** | ✓ | ✗ | ✗ | ✗ |
 
 ^1^ *Derive4J generates getters/setters but requires Functional Java for actual optic classes*
+~~~
 
 ---
 
@@ -176,9 +203,11 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 |-----------|---------------------|
 | `MaybePath<A>` | Absence is normal, not an error |
 | `EitherPath<E, A>` | Errors carry typed, structured information |
+| `EitherOrBothPath<L, A>` | Success that also carries non-fatal warnings (inclusive-or) |
 | `TryPath<A>` | Wrapping code that throws exceptions |
 | `ValidationPath<E, A>` | Collecting *all* errors, not just the first |
 | `IOPath<A>` | Side effects you want to defer and sequence |
+| `VResultPath<E, A>` | Async work that fails with a *typed* domain error (`VTask<Either<E, A>>`) |
 | `TrampolinePath<A>` | Stack-safe recursion |
 | `CompletableFuturePath<A>` | Async operations |
 | `ReaderPath<R, A>` | Dependency injection, configuration access |
@@ -194,7 +223,7 @@ Higher-Kinded-J offers the most advanced optics implementation in the Java ecosy
 | `VTaskPath<A>` | Virtual thread-based concurrency with Par combinators |
 | `VStreamPath<A>` | Lazy pull-based streaming on virtual threads |
 
-Each Path wraps its underlying effect and provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL.
+Each Path wraps its underlying effect and provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL. The lazy carriers (`IOPath`, `VTaskPath`, `VResultPath`) additionally chain **[path-native resilience](resilience/ch_intro.md)** — `withRetry` / `withTimeout` / `withCircuitBreaker` / `withBulkhead` — that treats a business `Left` as a value, never as a failure to retry.
 
 ---
 


### PR DESCRIPTION
## Summary

`README.md` and `hkj-book/src/home.md` had drifted behind the 0.4.8 feature wave (they predate almost the entire release), and the **Why Higher-Kinded-J?** section led with a feature matrix against three niche/dormant optics libraries (Functional Java, Fugue, Derive4J) that the target reader has never heard of. This PR brings both pages current and reframes the pitch around the tools Java developers actually reach for.

## Currency fixes

- Added `EitherOrBothPath` to the effect-optics bridge diagram and both Path-types tables.
- Added `VResultPath` to the Path-types tables and a resilience note — **not** to the bridge diagram, because it has no `.focus()` (it reaches optics only transitively via `toEitherPath()`); the diagram's left column is `.focus()`-capable types.
- Added a **Record Mapping and Typed-Error Codegen** foundation block (`@GenerateMapping`, `@GenerateMerge`, open-arity accumulating assembly / `@GenerateAssembly`, `@GenerateErrorEnvelope`) — a whole 0.4.8 pillar that was previously invisible on the landing pages.
- Added `ValidatedPrism` to the optics bullets.
- Noted path-native resilience (`withRetry`/`withTimeout`/`withCircuitBreaker`/`withBulkhead`) on the lazy carriers.

## Why-section reframe

- Leads with the reader's problem ("modern Java gave you records/sealed/pattern-matching but no way to make them *compose*") instead of an obscure-library matrix.
- New comparison table against the **mainstream toolbelt**: the standard library, Vavr, MapStruct, Resilience4j, and hand-written withers — the choices a developer actually weighs.
- The original optics-library matrix is retained as a proof point but demoted into a collapsible (`<details>` in the README, `collapsible=true` admonish in the book).

## Accuracy notes

- The Vavr row states HKJ is built natively on modern Java (records, sealed types, virtual threads) where Vavr keeps a Java 8 foundation — verified against Vavr's roadmap (1.0.x is deliberately Java 8; the Java 17/21 bump and modern-JVM features are staged for 2.x, late 2026). An earlier draft's "actively developed against Java 25" line was dropped as inaccurate.
- All feature claims were cross-checked against the release history (itself library-verified). `mdbook build` is clean; the collapsible renders and internal anchors resolve.

Release history was checked separately and is already current for 0.4.8; no changes there.