### PR TITLE
docs: Improve SEO and AI discoverability of the book

### DIFF
--- a/.github/scripts/generate_llms_full.py
+++ b/.github/scripts/generate_llms_full.py
@@ -1,0 +1,87 @@
+"""Generate ``llms-full.txt`` - the full-text companion to ``llms.txt``.
+
+``llms.txt`` (curated by hand) is a concise index of the documentation for AI
+crawlers. Its optional companion ``llms-full.txt`` is the *entire* documentation
+concatenated into a single Markdown file, so an assistant can ingest the whole
+library in one fetch rather than crawling 280+ pages.
+
+This script reads ``SUMMARY.md`` to preserve the authored reading order, then
+concatenates each referenced Markdown source. Pages that ``SUMMARY.md`` links
+but that do not exist in ``src`` at generation time (e.g. root files that CI
+copies in later) are skipped with a warning.
+
+Run from the repository root. Configured via environment variables:
+
+* ``MDBOOK_SRC_DIR``    - book source directory (default ``hkj-book/src``)
+* ``MDBOOK_OUTPUT_DIR`` - built book directory, where the file is written
+                          (default ``hkj-book/book``)
+"""
+
+import os
+import re
+
+# Matches Markdown links to local .md files in SUMMARY.md, e.g. [Title](foo/bar.md).
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+\.md)\)")
+
+PREAMBLE = """# Higher-Kinded-J - Full Documentation
+
+> Unifying Composable Effects and Advanced Optics for Java 25+
+
+This file is the complete Higher-Kinded-J documentation concatenated into a
+single document for AI ingestion. It is generated from the book source in
+reading order. For a concise index, see llms.txt.
+
+"""
+
+
+def ordered_sources(summary_path: str):
+    """Yield unique .md targets from SUMMARY.md in document order."""
+    seen = set()
+    with open(summary_path, encoding="utf-8") as fh:
+        for line in fh:
+            for match in LINK_RE.finditer(line):
+                target = match.group(1).strip()
+                # Ignore absolute URLs and anchors; keep repo-relative paths.
+                if target.startswith(("http://", "https://", "#")):
+                    continue
+                if target not in seen:
+                    seen.add(target)
+                    yield target
+
+
+def main() -> None:
+    src_dir = os.environ.get("MDBOOK_SRC_DIR", "hkj-book/src")
+    out_dir = os.environ.get("MDBOOK_OUTPUT_DIR", "hkj-book/book")
+    summary_path = os.path.join(src_dir, "SUMMARY.md")
+
+    if not os.path.isfile(summary_path):
+        raise SystemExit(f"Error: SUMMARY.md not found at '{summary_path}'")
+
+    parts = [PREAMBLE]
+    included = 0
+    missing = 0
+    for target in ordered_sources(summary_path):
+        path = os.path.join(src_dir, target)
+        if not os.path.isfile(path):
+            print(f"  skipping (not found): {target}")
+            missing += 1
+            continue
+        with open(path, encoding="utf-8") as fh:
+            body = fh.read().strip()
+        parts.append(f"<!-- Source: {target} -->\n\n{body}\n")
+        included += 1
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, "llms-full.txt")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(parts))
+
+    size_kb = os.path.getsize(out_path) / 1024
+    print(
+        f"llms-full.txt generated at {out_path}: "
+        f"{included} pages, {missing} skipped, {size_kb:.0f} KB."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/generate_llms_full.py
+++ b/.github/scripts/generate_llms_full.py
@@ -6,9 +6,15 @@ concatenated into a single Markdown file, so an assistant can ingest the whole
 library in one fetch rather than crawling 280+ pages.
 
 This script reads ``SUMMARY.md`` to preserve the authored reading order, then
-concatenates each referenced Markdown source. Pages that ``SUMMARY.md`` links
-but that do not exist in ``src`` at generation time (e.g. root files that CI
-copies in later) are skipped with a warning.
+concatenates each referenced Markdown source. Because the book embeds its code
+examples with mdBook ``{{#include path:anchor}}`` directives, those directives
+are resolved here too - otherwise the corpus would contain the literal
+``{{#include ...}}`` text instead of the code, dropping the most useful part of
+many pages. Only the anchor / line-range / whole-file forms mdBook supports are
+handled; an unresolved directive is replaced with an HTML comment and logged.
+
+Pages that ``SUMMARY.md`` links but that do not exist in ``src`` at generation
+time (e.g. root files that CI copies in later) are skipped with a warning.
 
 Run from the repository root. Configured via environment variables:
 
@@ -19,9 +25,13 @@ Run from the repository root. Configured via environment variables:
 
 import os
 import re
+import sys
 
 # Matches Markdown links to local .md files in SUMMARY.md, e.g. [Title](foo/bar.md).
 LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+\.md)\)")
+
+# Matches mdBook include-family directives, capturing the argument (path[:spec]).
+INCLUDE_RE = re.compile(r"\{\{#(?:include|rustdoc_include|playground)\s+([^}]+?)\s*\}\}")
 
 PREAMBLE = """# Higher-Kinded-J - Full Documentation
 
@@ -29,9 +39,87 @@ PREAMBLE = """# Higher-Kinded-J - Full Documentation
 
 This file is the complete Higher-Kinded-J documentation concatenated into a
 single document for AI ingestion. It is generated from the book source in
-reading order. For a concise index, see llms.txt.
+reading order, with code examples inlined. For a concise index, see llms.txt.
 
 """
+
+
+def warn(message: str) -> None:
+    """Emit a diagnostic to stderr so it stays separate from the output."""
+    print(message, file=sys.stderr)
+
+
+def extract_anchor(lines: list, name: str):
+    """Return the lines of the ``ANCHOR: name`` .. ``ANCHOR_END: name`` region.
+
+    Marker lines (and any nested anchor markers) are stripped, mirroring
+    mdBook's behaviour. Returns ``None`` if the anchor is not found.
+    """
+    start = re.compile(r"ANCHOR:\s*" + re.escape(name) + r"\b")
+    end = re.compile(r"ANCHOR_END:\s*" + re.escape(name) + r"\b")
+    out = []
+    inside = False
+    found = False
+    for line in lines:
+        if not inside:
+            if start.search(line):
+                inside = True
+                found = True
+            continue
+        if end.search(line):
+            break
+        # Drop any other anchor markers that fall within the region.
+        if "ANCHOR:" in line or "ANCHOR_END:" in line:
+            continue
+        out.append(line)
+    return out if found else None
+
+
+def resolve_include_arg(arg: str, base_dir: str):
+    """Resolve one include argument to a list of lines, or ``(None, error)``."""
+    parts = arg.split(":")
+    rel_path = parts[0].strip()
+    spec = [p.strip() for p in parts[1:]]
+
+    file_path = os.path.normpath(os.path.join(base_dir, rel_path))
+    if not os.path.isfile(file_path):
+        return None, f"file not found: {rel_path}"
+    with open(file_path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+
+    if not spec:  # {{#include file}}
+        return lines, None
+    if len(spec) == 1:
+        token = spec[0]
+        if token.isdigit():  # {{#include file:LINE}}
+            idx = int(token) - 1
+            return (lines[idx : idx + 1] if 0 <= idx < len(lines) else []), None
+        anchored = extract_anchor(lines, token)  # {{#include file:anchor}}
+        if anchored is None:
+            return None, f"anchor '{token}' not found in {rel_path}"
+        return anchored, None
+    if len(spec) == 2:  # {{#include file:START:END}} (either may be empty)
+        start = int(spec[0]) - 1 if spec[0] else 0
+        stop = int(spec[1]) if spec[1] else len(lines)
+        return lines[start:stop], None
+    return None, f"unsupported include spec: {arg}"
+
+
+def resolve_includes(md_text: str, md_path: str, counters: dict) -> str:
+    """Replace every include directive in ``md_text`` with the referenced code."""
+    base_dir = os.path.dirname(md_path)
+
+    def replace(match: "re.Match") -> str:
+        arg = match.group(1)
+        content, error = resolve_include_arg(arg, base_dir)
+        if error is not None:
+            warn(f"  include unresolved ({md_path}): {arg} - {error}")
+            counters["unresolved"] += 1
+            return f"<!-- include unresolved: {arg} -->"
+        counters["resolved"] += 1
+        return "\n".join(content)
+
+    return INCLUDE_RE.sub(replace, md_text)
 
 
 def ordered_sources(summary_path: str):
@@ -60,14 +148,15 @@ def main() -> None:
     parts = [PREAMBLE]
     included = 0
     missing = 0
+    counters = {"resolved": 0, "unresolved": 0}
     for target in ordered_sources(summary_path):
         path = os.path.join(src_dir, target)
         if not os.path.isfile(path):
-            print(f"  skipping (not found): {target}")
+            warn(f"  skipping (not found): {target}")
             missing += 1
             continue
         with open(path, encoding="utf-8") as fh:
-            body = fh.read().strip()
+            body = resolve_includes(fh.read(), path, counters).strip()
         parts.append(f"<!-- Source: {target} -->\n\n{body}\n")
         included += 1
 
@@ -79,7 +168,9 @@ def main() -> None:
     size_kb = os.path.getsize(out_path) / 1024
     print(
         f"llms-full.txt generated at {out_path}: "
-        f"{included} pages, {missing} skipped, {size_kb:.0f} KB."
+        f"{included} pages, {missing} skipped, "
+        f"{counters['resolved']} includes inlined "
+        f"({counters['unresolved']} unresolved), {size_kb:.0f} KB."
     )
 
 

--- a/.github/scripts/postprocess_seo.py
+++ b/.github/scripts/postprocess_seo.py
@@ -1,0 +1,131 @@
+"""Post-build SEO fix-ups for the built mdBook HTML.
+
+mdBook's ``{{ path }}`` template variable resolves to the Markdown *source*
+path (``foo.md``), so per-page ``og:url`` and ``rel="canonical"`` tags cannot
+be produced correctly in ``theme/head.hbs``. This script walks the built HTML
+and rewrites them with the real page URL instead.
+
+Two deliberate choices:
+
+* **Canonical always points at ``/latest/``.** The same book is built once and
+  copied to ``/latest/`` and to each ``/vX.Y.Z/`` path. Pointing every copy's
+  canonical at ``/latest/`` consolidates search-engine ranking onto the current
+  docs and stops old versions competing with themselves for duplicate content.
+  The ``/latest/`` deploy is therefore self-canonical.
+* **``og:url`` mirrors the canonical URL**, so social/AI unfurls resolve to the
+  same page search engines treat as authoritative.
+
+It also injects a per-page ``TechArticle`` JSON-LD block (the site-wide
+``SoftwareApplication`` identity lives in ``head.hbs``). The script is
+idempotent: re-running it neither duplicates canonical tags nor re-injects the
+article block.
+
+Run from the repository root. Configured via environment variables:
+
+* ``MDBOOK_OUTPUT_DIR`` - built book directory (default ``hkj-book/book``)
+* ``HKJ_CANONICAL_BASE`` - canonical base URL
+  (default ``https://higher-kinded-j.github.io/latest/``)
+"""
+
+import html
+import json
+import os
+import re
+
+# Built pages that must never be advertised as canonical/indexable content.
+EXCLUDED_FILES = {"404.html", "print.html", "toc.html"}
+
+OG_URL_RE = re.compile(
+    r'(<meta\s+property="og:url"\s+content=")[^"]*(">)', re.IGNORECASE
+)
+CANONICAL_RE = re.compile(r'<link\s+rel="canonical"', re.IGNORECASE)
+TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+TECHARTICLE_MARKER = "hkj-techarticle"
+HEAD_CLOSE_RE = re.compile(r"</head>", re.IGNORECASE)
+
+
+def page_url(base_url: str, book_dir: str, file_path: str) -> str:
+    """Map a built HTML file to its canonical URL under ``base_url``."""
+    rel = os.path.relpath(file_path, book_dir).replace(os.path.sep, "/")
+    return base_url + rel
+
+
+def techarticle_ldjson(url: str, title: str) -> str:
+    """Build a per-page TechArticle JSON-LD ``<script>`` for the given page."""
+    data = {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": title,
+        "url": url,
+        "mainEntityOfPage": {"@type": "WebPage", "@id": url},
+        "inLanguage": "en-GB",
+        "isPartOf": {"@id": "https://higher-kinded-j.github.io/#website"},
+        "about": {"@id": "https://higher-kinded-j.github.io/#software"},
+        "author": {"@id": "https://higher-kinded-j.github.io/#author"},
+        "publisher": {"@id": "https://higher-kinded-j.github.io/#author"},
+    }
+    # json.dumps handles all string escaping, keeping the block valid JSON.
+    return (
+        f'<script type="application/ld+json" data-hkj="{TECHARTICLE_MARKER}">'
+        + json.dumps(data, ensure_ascii=False)
+        + "</script>"
+    )
+
+
+def process_file(file_path: str, url: str) -> bool:
+    """Apply the SEO fix-ups to one file. Returns True if it was changed."""
+    with open(file_path, encoding="utf-8") as fh:
+        content = fh.read()
+    original = content
+
+    # 1. Rewrite og:url to the real page URL.
+    content = OG_URL_RE.sub(rf"\g<1>{url}\g<2>", content, count=1)
+
+    # 2 + 3. Inject canonical + TechArticle just before </head>, once.
+    additions = []
+    if not CANONICAL_RE.search(content):
+        additions.append(f'<link rel="canonical" href="{url}">')
+    if TECHARTICLE_MARKER not in content:
+        match = TITLE_RE.search(content)
+        title = html.unescape(match.group(1).strip()) if match else "Higher-Kinded-J"
+        additions.append(techarticle_ldjson(url, title))
+
+    if additions:
+        injection = "\n" + "\n".join(additions) + "\n"
+        content = HEAD_CLOSE_RE.sub(injection + "</head>", content, count=1)
+
+    if content != original:
+        with open(file_path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        return True
+    return False
+
+
+def main() -> None:
+    book_dir = os.environ.get("MDBOOK_OUTPUT_DIR", "hkj-book/book")
+    base_url = os.environ.get(
+        "HKJ_CANONICAL_BASE", "https://higher-kinded-j.github.io/latest/"
+    )
+    if not base_url.endswith("/"):
+        base_url += "/"
+
+    if not os.path.isdir(book_dir):
+        raise SystemExit(f"Error: book directory '{book_dir}' does not exist")
+
+    changed = 0
+    total = 0
+    for root, _, files in os.walk(book_dir):
+        for name in files:
+            if not name.endswith(".html") or name in EXCLUDED_FILES:
+                continue
+            total += 1
+            path = os.path.join(root, name)
+            if process_file(path, page_url(base_url, book_dir, path)):
+                changed += 1
+
+    print(f"SEO post-processing complete: {changed}/{total} HTML files updated.")
+    print(f"Canonical base: {base_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/postprocess_seo.py
+++ b/.github/scripts/postprocess_seo.py
@@ -47,6 +47,12 @@ HEAD_CLOSE_RE = re.compile(r"</head>", re.IGNORECASE)
 def page_url(base_url: str, book_dir: str, file_path: str) -> str:
     """Map a built HTML file to its canonical URL under ``base_url``."""
     rel = os.path.relpath(file_path, book_dir).replace(os.path.sep, "/")
+    # Canonicalise directory index pages to the clean directory URL
+    # (".../" rather than ".../index.html"), including the site root.
+    if rel == "index.html":
+        return base_url
+    if rel.endswith("/index.html"):
+        return base_url + rel[: -len("index.html")]
     return base_url + rel
 
 
@@ -78,13 +84,19 @@ def process_file(file_path: str, url: str) -> bool:
         content = fh.read()
     original = content
 
-    # 1. Rewrite og:url to the real page URL.
-    content = OG_URL_RE.sub(rf"\g<1>{url}\g<2>", content, count=1)
+    # HTML-escape the URL for use in attribute values. (The JSON-LD block below
+    # takes the raw URL - json.dumps handles its escaping.)
+    href = html.escape(url, quote=True)
+
+    # 1. Rewrite og:url to the real page URL. A function replacement avoids
+    #    re.sub interpreting backslashes / group refs in the URL, and needs no
+    #    manual escaping of the replacement text.
+    content = OG_URL_RE.sub(lambda m: m.group(1) + href + m.group(2), content, count=1)
 
     # 2 + 3. Inject canonical + TechArticle just before </head>, once.
     additions = []
     if not CANONICAL_RE.search(content):
-        additions.append(f'<link rel="canonical" href="{url}">')
+        additions.append(f'<link rel="canonical" href="{href}">')
     if TECHARTICLE_MARKER not in content:
         match = TITLE_RE.search(content)
         title = html.unescape(match.group(1).strip()) if match else "Higher-Kinded-J"

--- a/.github/scripts/robots.txt
+++ b/.github/scripts/robots.txt
@@ -8,4 +8,5 @@ Allow: /
 Sitemap: https://higher-kinded-j.github.io/latest/sitemap.xml
 
 # AI-friendly documentation
-# See: https://higher-kinded-j.github.io/latest/llms.txt
+# Concise index:   https://higher-kinded-j.github.io/latest/llms.txt
+# Full-text corpus: https://higher-kinded-j.github.io/llms-full.txt

--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -143,6 +143,20 @@ jobs:
           HKJ_CHANGES_SINCE_LABEL: ${{ steps.baseline.outputs.since_label }}
         run: mdbook build
 
+      - name: Post-process SEO tags (og:url + canonical + per-page JSON-LD)
+        run: python .github/scripts/postprocess_seo.py
+        env:
+          MDBOOK_OUTPUT_DIR: ./${{ env.BOOK_ROOT_DIR }}/book
+          # Every deploy (latest and each vX.Y.Z) canonicalises to /latest/ so
+          # old versions consolidate ranking onto the current docs.
+          HKJ_CANONICAL_BASE: "https://higher-kinded-j.github.io/latest/"
+
+      - name: Generate llms-full.txt (full-text corpus for AI crawlers)
+        run: python .github/scripts/generate_llms_full.py
+        env:
+          MDBOOK_SRC_DIR: ./${{ env.BOOK_ROOT_DIR }}/src
+          MDBOOK_OUTPUT_DIR: ./${{ env.BOOK_ROOT_DIR }}/book
+
       - name: Generate Sitemap
         run: python .github/scripts/generate_sitemap.py
         env:
@@ -197,6 +211,12 @@ jobs:
           if [ -f "${{ env.BOOK_ROOT_DIR }}/book/llms.txt" ]; then
             cp ${{ env.BOOK_ROOT_DIR }}/book/llms.txt gh-pages-repo/llms.txt
             echo "llms.txt copied to root"
+          fi
+
+          # Copy llms-full.txt (full-text corpus) for AI discoverability
+          if [ -f "${{ env.BOOK_ROOT_DIR }}/book/llms-full.txt" ]; then
+            cp ${{ env.BOOK_ROOT_DIR }}/book/llms-full.txt gh-pages-repo/llms-full.txt
+            echo "llms-full.txt copied to root"
           fi
 
           # Copy social preview image to root for Open Graph meta tags

--- a/hkj-book/src/llms.txt
+++ b/hkj-book/src/llms.txt
@@ -193,6 +193,7 @@ dependencies {
 - Spring Boot: https://higher-kinded-j.github.io/latest/spring/spring_boot_integration.html
 - Testing (hkj-test): https://higher-kinded-j.github.io/latest/tooling/test_assertions.html
 - Examples: https://higher-kinded-j.github.io/latest/examples/ch_intro.html
+- Full documentation (single file): https://higher-kinded-j.github.io/llms-full.txt
 
 ## Source Code
 

--- a/hkj-book/theme/head.hbs
+++ b/hkj-book/theme/head.hbs
@@ -37,7 +37,9 @@
     <meta property="og:description" content="Unifying Composable Effects and Advanced Optics for Java. The most comprehensive functional programming library with Effect Path API, Focus DSL, and code generation for Java records.">
 {{/if}}
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://higher-kinded-j.github.io/{{ path_in_book }}">
+{{! og:url is a site-wide fallback; postprocess_seo.py rewrites it (and adds
+    <link rel="canonical">) per page in CI with the real page URL. }}
+<meta property="og:url" content="https://higher-kinded-j.github.io/latest/">
 <meta property="og:image" content="https://higher-kinded-j.github.io/preview.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -50,3 +52,48 @@
 <meta name="twitter:description" content="Unifying Composable Effects and Advanced Optics for Java. Effect Path API, Focus DSL, and the most comprehensive optics implementation in the Java ecosystem.">
 <meta name="twitter:image" content="https://higher-kinded-j.github.io/preview.png">
 <meta name="twitter:image:alt" content="Higher-Kinded-J: Composable Effects and Advanced Optics for Java">
+
+{{! Site-wide structured data (schema.org / JSON-LD).
+    Identical on every page, so it lives here rather than in the per-page
+    post-build step. Describes the library's identity for search engines and
+    AI crawlers. Kept as static literals (no template variables) to guarantee
+    valid JSON regardless of page title escaping. }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://higher-kinded-j.github.io/#website",
+      "name": "Higher-Kinded-J",
+      "alternateName": "HKJ",
+      "url": "https://higher-kinded-j.github.io/latest/",
+      "description": "The most comprehensive functional programming library for Java. Composable effects via the Effect Path API and immutable data navigation via the Focus DSL and advanced optics.",
+      "inLanguage": "en-GB",
+      "publisher": { "@id": "https://higher-kinded-j.github.io/#author" }
+    },
+    {
+      "@type": ["SoftwareApplication", "SoftwareSourceCode"],
+      "@id": "https://higher-kinded-j.github.io/#software",
+      "name": "Higher-Kinded-J",
+      "alternateName": "HKJ",
+      "description": "A functional programming library for Java that simulates Higher-Kinded Types and implements advanced optics. Unifies error handling, optional values, and immutable data navigation through the Effect Path API and Focus DSL, with compile-time code generation for Java records and Spring Boot integration.",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Cross-platform (JVM)",
+      "url": "https://higher-kinded-j.github.io/latest/",
+      "codeRepository": "https://github.com/higher-kinded-j/higher-kinded-j",
+      "programmingLanguage": { "@type": "ComputerLanguage", "name": "Java" },
+      "runtimePlatform": "Java 25+",
+      "license": "https://opensource.org/licenses/MIT",
+      "author": { "@id": "https://higher-kinded-j.github.io/#author" },
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://higher-kinded-j.github.io/#author",
+      "name": "The Higher-Kinded-J Team",
+      "url": "https://github.com/higher-kinded-j/higher-kinded-j"
+    }
+  ]
+}
+</script>


### PR DESCRIPTION
## Summary

Fixes and extends the search-engine and LLM-crawler metadata for the versioned mdBook site. Builds on the existing setup (meta tags, Open Graph, `llms.txt`, sitemap, `robots.txt`) by closing four concrete gaps.

## Changes

**1. Fix `og:url` (bug).** `theme/head.hbs` used the non-existent `{{ path_in_book }}` mdBook variable, so **every page's `og:url` resolved to the site root** — verified in the built HTML. Because mdBook's `{{ path }}` only exposes the `.md` *source* path, the correct per-page URL is now written by a post-build script.

**2. Per-page `<link rel="canonical">`.** The site ships versioned docs (`/latest/`, `/vX.Y.Z/`) built from one source and copied to each path — classic duplicate-content risk. Every deploy now canonicalises to `/latest/`, consolidating ranking onto the current docs. The `/latest/` copy is self-canonical.

**3. JSON-LD structured data.** Two layers:
- Static site-wide `@graph` (`WebSite` + `SoftwareApplication`/`SoftwareSourceCode` + `Organization`) in `head.hbs` — ships on every page, including local builds.
- Per-page `TechArticle` injected by the post-build script with the real URL and title (JSON-escaped).

**4. `llms-full.txt`.** Full-text corpus companion to the curated `llms.txt`, concatenating all pages in `SUMMARY.md` order (~3.6 MB, 275 pages). Wired into CI, copied to the site root, and referenced from `robots.txt` and `llms.txt`.

## Implementation notes

- `og:url`, canonical, and per-page `TechArticle` are path-dependent, so they live in `postprocess_seo.py` (mirrors how `generate_sitemap.py` already runs post-build). The static identity lives in `head.hbs` so local builds get it too.
- Both scripts run after `mdbook build` in `deploy-mdbook-versioned.yml`, before the deploy copy.
- Social preview image (`og:image`): the existing `preview.png` (1200×630) referenced in `head.hbs` and copied to the site root by the deploy workflow is unchanged. This PR doesn't modify it, but the `og:url` fix means social/AI unfurls now pair that image with the correct per-page URL instead of always resolving to the site root.

## Verification

- Both scripts run against a fresh `mdbook build`: 281/281 HTML files updated, `llms-full.txt` generated.
- **Idempotent**: re-running yields exactly 1 canonical + 1 `TechArticle` per page.
- All JSON-LD blocks (static and rendered) parse as valid JSON.
- `mdbook build` succeeds with the theme change.

## Caveat

Canonical always points at `/latest/`. If a page exists in an old version but was removed from latest, its canonical would point to a 404 — standard for versioned docs and low-risk, but noted in case per-version self-canonicals are preferred later.


