### PR TITLE
build: Give core modules distinct POM names and richer descriptions

### DIFF
--- a/hkj-annotations/build.gradle.kts
+++ b/hkj-annotations/build.gradle.kts
@@ -18,8 +18,8 @@ mavenPublishing {
 
     // POM details are defined once and inherited by all published submodules.
     pom {
-        name.set("Higher-Kinded-J")
-        description.set("Bringing Higher-Kinded Types to Java Functional Patterns - Annotations")
+        name.set("Higher-Kinded-J Annotations")
+        description.set("Annotations for Higher-Kinded-J code generation, including optics (@GenerateLenses, @GeneratePrisms, @GenerateTraversals, @GenerateIsos) and data mapping.")
         url.set("https://github.com/higher-kinded-j/higher-kinded-j")
 
         licenses {

--- a/hkj-annotations/build.gradle.kts
+++ b/hkj-annotations/build.gradle.kts
@@ -40,6 +40,15 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 
 }

--- a/hkj-api/build.gradle.kts
+++ b/hkj-api/build.gradle.kts
@@ -55,6 +55,15 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 
 }

--- a/hkj-api/build.gradle.kts
+++ b/hkj-api/build.gradle.kts
@@ -33,8 +33,8 @@ mavenPublishing {
 
     // POM details are defined once and inherited by all published submodules.
     pom {
-        name.set("Higher-Kinded-J")
-        description.set("Bringing Higher-Kinded Types to Java Functional Patterns - API")
+        name.set("Higher-Kinded-J API")
+        description.set("Public API for Higher-Kinded-J: core interfaces for higher-kinded types (Kind, Functor, Applicative, Monad) and optics (Lens, Prism, Traversal, Iso).")
         url.set("https://github.com/higher-kinded-j/higher-kinded-j")
 
         licenses {

--- a/hkj-bom/build.gradle.kts
+++ b/hkj-bom/build.gradle.kts
@@ -56,5 +56,14 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 }

--- a/hkj-checker/build.gradle.kts
+++ b/hkj-checker/build.gradle.kts
@@ -96,5 +96,14 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 }

--- a/hkj-core/build.gradle.kts
+++ b/hkj-core/build.gradle.kts
@@ -155,6 +155,15 @@ mavenPublishing {
       developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
       url.set("https://github.com/higher-kinded-j/higher-kinded-j")
     }
+    inceptionYear.set("2025")
+    organization {
+      name.set("The Higher-Kinded-J Team")
+      url.set("https://github.com/higher-kinded-j")
+    }
+    issueManagement {
+      system.set("GitHub")
+      url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+    }
   }
 
 }

--- a/hkj-core/build.gradle.kts
+++ b/hkj-core/build.gradle.kts
@@ -133,8 +133,8 @@ mavenPublishing {
 
   // POM details are defined once and inherited by all published submodules.
   pom {
-    name.set("Higher-Kinded-J")
-    description.set("Bringing Higher-Kinded Types to Java Functional Patterns - Core")
+    name.set("Higher-Kinded-J Core")
+    description.set("Core Higher-Kinded-J implementations: higher-kinded type simulations, monads and type classes, the Effect Path API, and optics for Java.")
     url.set("https://github.com/higher-kinded-j/higher-kinded-j")
 
     licenses {

--- a/hkj-processor-plugins/build.gradle.kts
+++ b/hkj-processor-plugins/build.gradle.kts
@@ -114,6 +114,15 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 
 }

--- a/hkj-processor-plugins/build.gradle.kts
+++ b/hkj-processor-plugins/build.gradle.kts
@@ -92,8 +92,8 @@ mavenPublishing {
 
     // POM details are defined once and inherited by all published submodules.
     pom {
-        name.set("Higher-Kinded-J")
-        description.set("Bringing Higher-Kinded Types to Java Functional Patterns - Annotation Processor Plugins")
+        name.set("Higher-Kinded-J Annotation Processor Plugins")
+        description.set("Annotation processor plugins for Higher-Kinded-J providing traversal generators for optics code generation.")
         url.set("https://github.com/higher-kinded-j/higher-kinded-j")
 
         licenses {

--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -179,6 +179,15 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 
 }

--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -157,8 +157,8 @@ mavenPublishing {
 
     // POM details are defined once and inherited by all published submodules.
     pom {
-        name.set("Higher-Kinded-J")
-        description.set("Bringing Higher-Kinded Types to Java Functional Patterns - Annotation Processor")
+        name.set("Higher-Kinded-J Annotation Processor")
+        description.set("Annotation processor for Higher-Kinded-J that generates optics and data-mapping boilerplate for Java records and sealed interfaces.")
         url.set("https://github.com/higher-kinded-j/higher-kinded-j")
 
         licenses {

--- a/hkj-spring/autoconfigure/build.gradle.kts
+++ b/hkj-spring/autoconfigure/build.gradle.kts
@@ -88,5 +88,14 @@ mavenPublishing {
       developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
       url.set("https://github.com/higher-kinded-j/higher-kinded-j")
     }
+    inceptionYear.set("2025")
+    organization {
+      name.set("The Higher-Kinded-J Team")
+      url.set("https://github.com/higher-kinded-j")
+    }
+    issueManagement {
+      system.set("GitHub")
+      url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+    }
   }
 }

--- a/hkj-spring/client-processor/build.gradle.kts
+++ b/hkj-spring/client-processor/build.gradle.kts
@@ -72,5 +72,14 @@ mavenPublishing {
       developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
       url.set("https://github.com/higher-kinded-j/higher-kinded-j")
     }
+    inceptionYear.set("2025")
+    organization {
+      name.set("The Higher-Kinded-J Team")
+      url.set("https://github.com/higher-kinded-j")
+    }
+    issueManagement {
+      system.set("GitHub")
+      url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+    }
   }
 }

--- a/hkj-spring/client/build.gradle.kts
+++ b/hkj-spring/client/build.gradle.kts
@@ -74,5 +74,14 @@ mavenPublishing {
       developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
       url.set("https://github.com/higher-kinded-j/higher-kinded-j")
     }
+    inceptionYear.set("2025")
+    organization {
+      name.set("The Higher-Kinded-J Team")
+      url.set("https://github.com/higher-kinded-j")
+    }
+    issueManagement {
+      system.set("GitHub")
+      url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+    }
   }
 }

--- a/hkj-spring/starter/build.gradle.kts
+++ b/hkj-spring/starter/build.gradle.kts
@@ -57,5 +57,14 @@ mavenPublishing {
       developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
       url.set("https://github.com/higher-kinded-j/higher-kinded-j")
     }
+    inceptionYear.set("2025")
+    organization {
+      name.set("The Higher-Kinded-J Team")
+      url.set("https://github.com/higher-kinded-j")
+    }
+    issueManagement {
+      system.set("GitHub")
+      url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+    }
   }
 }

--- a/hkj-test/build.gradle.kts
+++ b/hkj-test/build.gradle.kts
@@ -103,5 +103,14 @@ mavenPublishing {
       developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
       url.set("https://github.com/higher-kinded-j/higher-kinded-j")
     }
+    inceptionYear.set("2025")
+    organization {
+      name.set("The Higher-Kinded-J Team")
+      url.set("https://github.com/higher-kinded-j")
+    }
+    issueManagement {
+      system.set("GitHub")
+      url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+    }
   }
 }

--- a/plugins/hkj-gradle-plugin/build.gradle.kts
+++ b/plugins/hkj-gradle-plugin/build.gradle.kts
@@ -120,5 +120,14 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 }

--- a/plugins/hkj-maven-plugin/build.gradle.kts
+++ b/plugins/hkj-maven-plugin/build.gradle.kts
@@ -107,5 +107,14 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://github.com/higher-kinded-j/higher-kinded-j.git")
             url.set("https://github.com/higher-kinded-j/higher-kinded-j")
         }
+        inceptionYear.set("2025")
+        organization {
+            name.set("The Higher-Kinded-J Team")
+            url.set("https://github.com/higher-kinded-j")
+        }
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/higher-kinded-j/higher-kinded-j/issues")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Improves the Maven Central POM metadata for discoverability, in two parts:

1. **Distinct names + richer descriptions** for the five modules that shared the generic POM `<name>` **Higher-Kinded-J** and an older tagline (`Bringing Higher-Kinded Types to Java Functional Patterns - X`).
2. **Completeness fields** (`inceptionYear`, `organization`, `issueManagement`) added to **all 14** publishable modules.

Maven Central, mvnrepository.com and javadoc.io index and display these fields, so the improvements surface anywhere the artifacts are browsed.

## Part 1 — names & descriptions

Distinct `<name>` (following the existing `Higher-Kinded-J <X>` convention already used by the Spring/test/plugin modules) and an accurate, keyword-aware `<description>` for:

| Module | New name | Description gist |
|---|---|---|
| `hkj-core` | Higher-Kinded-J Core | HKT simulations, monads/type classes, Effect Path API, optics |
| `hkj-api` | Higher-Kinded-J API | Core interfaces (Kind, Functor, Monad) + optics (Lens, Prism, Traversal, Iso) |
| `hkj-annotations` | Higher-Kinded-J Annotations | Code-gen annotations for optics + data mapping |
| `hkj-processor` | Higher-Kinded-J Annotation Processor | Generates optics + mapping boilerplate for records/sealed interfaces |
| `hkj-processor-plugins` | Higher-Kinded-J Annotation Processor Plugins | Traversal generators for optics code generation |

The BOM, checker, Spring, test and plugin modules already had distinct names and accurate descriptions and are **left unchanged** in this part.

## Part 2 — completeness fields (all 14 modules)

Added to every publishable module's `pom {}` block:

- `<inceptionYear>2025</inceptionYear>`
- `<organization>` — The Higher-Kinded-J Team (`https://github.com/higher-kinded-j`)
- `<issueManagement>` — GitHub issues (`https://github.com/higher-kinded-j/higher-kinded-j/issues`)

## Scope / timing

Metadata only — no code or dependency changes. Takes effect on the **next** publish; existing released artifacts are unaffected.

## Verification

- `generatePomFileForMavenPublication` (and `generatePomFileForPluginMavenPublication` for the Gradle plugin) run for all modules.
- Generated POMs confirmed to carry the new `<name>`/`<description>` and all three completeness fields, with existing `<licenses>`, `<developers>` and `<scm>` intact.
- No Kotlin/`.kts` formatting gate in this repo (spotless targets Java only), so the build-script edits are style-safe.


