### PR TITLE
docs: Align home.md and README.md with the documentation style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ You don't need to learn an esoteric functional library to feel the benefit. Each
 | Instead of… | Today you reach for | Higher-Kinded-J gives you |
 |-------------|---------------------|---------------------------|
 | Nested `Optional`, thrown exceptions, and validation that stops at the first error | the standard library | one railway vocabulary (`map` / `via` / `recover`) across absence, typed errors, async, and **accumulating** validation |
-| `Option` / `Either` / `Try` from **Vavr** | the FP library most Java developers know | the same core types **plus** higher-kinded abstraction, a full optics suite, monad transformers, and an effect system — built natively on modern Java (records, sealed types, virtual threads), where Vavr keeps a Java 8 foundation |
+| `Option` / `Either` / `Try` from **Vavr** | the FP library most Java developers know | the same core types **plus** higher-kinded abstraction, a full optics suite, monad transformers, and an effect system, built natively on modern Java (records, sealed types, virtual threads), where Vavr keeps a Java 8 foundation |
 | **MapStruct** / ModelMapper for DTO↔domain mapping | annotation-driven mappers | `@GenerateMapping` with a total `build` **and** an accumulating `parse` that reports every bad field, law-checked at compile time |
 | **Resilience4j** annotations for retry / circuit-breaker / bulkhead | AOP-style resilience | the same policies as composable path combinators (`withRetry` / `withCircuitBreaker` / `withBulkhead`) that treat a business `Left` as a value, never as a failure to retry |
-| Hand-written `wither` / copy-constructor updates on records | manual boilerplate | generated lenses, prisms, and traversals — the most comprehensive optics available for Java |
+| Hand-written `wither` / copy-constructor updates on records | manual boilerplate | generated lenses, prisms, and traversals: the most comprehensive optics available for Java |
 
-And unlike any of those tools, effects and data navigation speak **the same language** — the Effect-Optics bridge above is something no other Java library offers.
+And unlike any of those tools, effects and data navigation speak **the same language**: the Effect-Optics bridge above is something no other Java library offers.
 
 <details>
 <summary><strong>How the optics compare to other Java optics libraries</strong></summary>
@@ -243,7 +243,7 @@ Higher-Kinded-J also offers the most advanced optics implementation in the Java 
 | `VTaskPath<A>` | Virtual thread-based concurrency with Par combinators |
 | `VStreamPath<A>` | Lazy pull-based streaming on virtual threads |
 
-Each Path provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL. The lazy carriers (`IOPath`, `VTaskPath`, `VResultPath`) additionally chain path-native resilience — `withRetry` / `withTimeout` / `withCircuitBreaker` / `withBulkhead` — that treats a business `Left` as a value, never as a failure to retry.
+Each Path provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL. The lazy carriers (`IOPath`, `VTaskPath`, `VResultPath`) additionally chain path-native resilience (`withRetry` / `withTimeout` / `withCircuitBreaker` / `withBulkhead`) that treats a business `Left` as a value, never as a failure to retry.
 
 ### Optic Path Types
 
@@ -315,7 +315,7 @@ The hkj-spring-boot-starter requires Spring Boot 4.1.0 or later with Jackson 3.x
 
 ## How to Use This Library
 
-### Gradle -- With HKJ Plugin (Recommended)
+### Gradle: With HKJ Plugin (Recommended)
 
 ```gradle
 // build.gradle.kts
@@ -347,7 +347,7 @@ repositories {
 }
 ```
 
-### Maven -- With HKJ Plugin (Recommended)
+### Maven: With HKJ Plugin (Recommended)
 
 ```xml
 <build>

--- a/hkj-book/src/home.md
+++ b/hkj-book/src/home.md
@@ -161,10 +161,10 @@ You don't need to learn an esoteric functional library to feel the benefit. Each
 | Instead of… | Today you reach for | Higher-Kinded-J gives you |
 |-------------|---------------------|---------------------------|
 | Nested `Optional`, thrown exceptions, and validation that stops at the first error | the standard library | one railway vocabulary (`map` / `via` / `recover`) across absence, typed errors, async, and **accumulating** validation |
-| `Option` / `Either` / `Try` from **Vavr** | the FP library most Java developers know | the same core types **plus** higher-kinded abstraction, a full optics suite, monad transformers, and an effect system — built natively on modern Java (records, sealed types, virtual threads), where Vavr keeps a Java 8 foundation |
+| `Option` / `Either` / `Try` from **Vavr** | the FP library most Java developers know | the same core types **plus** higher-kinded abstraction, a full optics suite, monad transformers, and an effect system, built natively on modern Java (records, sealed types, virtual threads), where Vavr keeps a Java 8 foundation |
 | **MapStruct** / ModelMapper for DTO↔domain mapping | annotation-driven mappers | `@GenerateMapping` with a total `build` **and** an accumulating `parse` that reports every bad field, law-checked at compile time |
 | **Resilience4j** annotations for retry / circuit-breaker / bulkhead | AOP-style resilience | the same policies as composable path combinators (`withRetry` / `withCircuitBreaker` / `withBulkhead`) that treat a business `Left` as a value, never as a failure to retry |
-| Hand-written `wither` / copy-constructor updates on records | manual boilerplate | generated lenses, prisms, and traversals — the most comprehensive optics available for Java |
+| Hand-written `wither` / copy-constructor updates on records | manual boilerplate | generated lenses, prisms, and traversals: the most comprehensive optics available for Java |
 
 And unlike any of those tools, effects and data navigation speak **the same language**: the [Effect-Optics bridge](#the-bridge-effects-meet-optics) above is something no other Java library offers.
 
@@ -223,7 +223,7 @@ Higher-Kinded-J also offers the most advanced optics implementation in the Java 
 | `VTaskPath<A>` | Virtual thread-based concurrency with Par combinators |
 | `VStreamPath<A>` | Lazy pull-based streaming on virtual threads |
 
-Each Path wraps its underlying effect and provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL. The lazy carriers (`IOPath`, `VTaskPath`, `VResultPath`) additionally chain **[path-native resilience](resilience/ch_intro.md)** — `withRetry` / `withTimeout` / `withCircuitBreaker` / `withBulkhead` — that treats a business `Left` as a value, never as a failure to retry.
+Each Path wraps its underlying effect and provides `map`, `via`, `run`, `recover`, and integration with the Focus DSL. The lazy carriers (`IOPath`, `VTaskPath`, `VResultPath`) additionally chain **[path-native resilience](resilience/ch_intro.md)** (`withRetry` / `withTimeout` / `withCircuitBreaker` / `withBulkhead`) that treats a business `Left` as a value, never as a failure to retry.
 
 ---
 
@@ -333,7 +333,7 @@ If you want working code immediately, start with the **[Quickstart](quickstart.m
 2. **[Core Paths](effect/effect_path_overview.md):** The railway model, the six core path types, composition, and basic ForPath comprehensions
 3. **[Optics Integration](effect/focus_integration.md):** Bridging Effect Paths with the Focus DSL
 4. **[Advanced Paths](effect/advanced_topics.md):** Free monads, effect handlers, contexts, ForPath parallelism, and resilience
-5. **[Reference](effect/capabilities.md):** Capability typeclasses, type conversions, compiler errors, and production readiness
+5. **[Reference](effect/capabilities.md):** Capability type classes, type conversions, compiler errors, and production readiness
 
 ### Monad Transformers
 For the cases where the Path API does not fit (a different outer monad, polymorphic library code, or integrating with raw `Kind` shapes).


### PR DESCRIPTION
## Summary

Brings the two landing pages (`hkj-book/src/home.md` and the root `README.md`) into line with `docs/STYLE-GUIDE.md`. I checked both against the guide's objective, mechanically-verifiable rules.

## Violations found and fixed

**Em dashes (—)** — the guide says "Do not use em dashes; use commas or semicolons instead" (and parentheses for asides). Fixed all 7 occurrences across both files, choosing the replacement by context:
- Comma where the sentence continues past an elaboration (`…an effect system, built natively on modern Java…`).
- Colon for a label-and-expansion (`…and traversals: the most comprehensive optics available for Java`; `…speak the same language: the Effect-Optics bridge…`).
- Parentheses for a mid-sentence aside (`…path-native resilience (withRetry / withTimeout / …) that treats…`).

**`--` separators (README)** — the guide says to avoid ` -- ` (renders as an en-dash) and prefer a colon for a label. Fixed the two install headings:
- `### Gradle -- With HKJ Plugin` → `### Gradle: With HKJ Plugin`
- `### Maven -- With HKJ Plugin` → `### Maven: With HKJ Plugin`

**Terminology (home.md)** — the guide says "type class" (two words), not "typeclass":
- `Capability typeclasses` → `Capability type classes`

## Checked and deliberately left alone

- **`✓` / `✗` markers** in the comparison tables — explicitly allowed by the guide as pass/fail signals (the plain-text equivalents of ✅/❌).
- **`→` flow arrows** — not emojis; used for "input → output" flow, which the guide does not restrict.
- **American spellings** — the only hits (`color=green`, `prefers-color-scheme`) are inside a shields.io badge URL and a CSS media query, i.e. code, not prose.

## Verification
Re-scanned both files: 0 em dashes, 0 ` -- ` separators, 0 `typeclass`. `mdbook build` succeeds for `home.md`.