### PR TITLE
Prepare for v0.4.8 release

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -3,7 +3,7 @@
 This page documents the evolution of Higher-Kinded-J from its initial release through to the current version. Each release builds on the foundations established by earlier versions, progressively adding type classes, monads, optics, and the Effect Path API.
 
 ~~~admonish info title="What You'll Find"
-- Detailed release notes for recent versions (0.3.0–0.4.8) with links to documentation
+- Detailed release notes for recent versions (0.3.0–0.4.9) with links to documentation
 - Summary release notes for earlier versions (pre-0.3.0)
 - Links to GitHub release pages for full changelogs
 ~~~
@@ -11,6 +11,12 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 ---
 
 ## Recent Releases
+
+### 0.4.9-SNAPSHOT (Latest)
+
+_In development. Release notes will be added here as changes land on `main`._
+
+---
 
 ### [v0.4.8](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.8) (17 July 2026)
 

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -12,7 +12,7 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 ## Recent Releases
 
-### 0.4.8-SNAPSHOT (Latest)
+### [v0.4.8](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.8) (17 July 2026)
 
 **Async, Typed Errors, and Resilience**
 


### PR DESCRIPTION
## Summary

Release-history prep around **v0.4.8**, in two steps:

### 1. Promote v0.4.8
`0.4.8-SNAPSHOT (Latest)` → the released heading format used by every prior version:
```
### [v0.4.8](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.8) (17 July 2026)
```
The release-notes body is unchanged; the tag link resolves once `v0.4.8` is pushed.

### 2. Open the next snapshot
Add a fresh `0.4.9-SNAPSHOT (Latest)` placeholder at the top of Recent Releases for the next cycle's notes to accumulate against, and bump the intro's "What You'll Find" range to `0.3.0–0.4.9` (the range tracks the current snapshot, as it did for 0.4.8).

```
## Recent Releases

### 0.4.9-SNAPSHOT (Latest)

_In development. Release notes will be added here as changes land on `main`._

---

### [v0.4.8](…/releases/tag/v0.4.8) (17 July 2026)
```

## Notes
- The project version isn't pinned in a tracked file (supplied via the `projectVersion` Gradle property at publish time), so no other file needed a bump.
- Tagging `v0.4.8` and publishing artifacts remain manual release steps outside this docs PR.

## Verification
`mdbook build` succeeds; the v0.4.8 heading matches the v0.4.7 entry's format and the new snapshot sits at the top.