### PR TITLE
Default change tracking to off except on latest snapshot

### DIFF
--- a/hkj-book/theme/change-tracking.css
+++ b/hkj-book/theme/change-tracking.css
@@ -5,9 +5,9 @@
  *   - a faint underline on the individual words that changed within a block
  *
  * State is a class on <html> set by change-tracking.js:
- *   .hkj-ct-full  -> margin line + word underlines   (default)
+ *   .hkj-ct-full  -> margin line + word underlines   (default on /latest/)
  *   .hkj-ct-lines -> margin line only
- *   .hkj-ct-off   -> nothing shown
+ *   .hkj-ct-off   -> nothing shown                    (default elsewhere)
  */
 
 /* Change-tracking accent, tuned per theme to the book's mauve brand accent

--- a/hkj-book/theme/change-tracking.js
+++ b/hkj-book/theme/change-tracking.js
@@ -29,19 +29,43 @@
 
   // --- state persistence ----------------------------------------------------
 
+  // The preference is scoped per docs version (latest / vX.Y.Z / local build),
+  // so a choice made on one version never leaks across the latest<->release
+  // boundary: each version re-evaluates its own default and remembers its own
+  // toggle independently. Detection mirrors version-switcher.js.
+  function currentVersion() {
+    try {
+      var m = window.location.pathname.match(/^\/(v\d+\.\d+\.\d+|latest)(\/|$)/);
+      if (m) return m[1];
+    } catch (e) { /* window.location may be unavailable */ }
+    return 'local';
+  }
+
+  function storageKey() {
+    return STORAGE_KEY + ':' + currentVersion();
+  }
+
+  // The latest snapshot (deployed under /latest/) is where new/changed content
+  // is most relevant, so change tracking defaults to 'full' there. Released
+  // versions (/vX.Y.Z/) and everywhere else default to 'off' so historical or
+  // baseline-less docs read cleanly. A stored preference for THIS version wins.
+  function defaultState() {
+    return currentVersion() === 'latest' ? 'full' : 'off';
+  }
+
   function readState() {
     try {
-      var stored = window.localStorage.getItem(STORAGE_KEY);
+      var stored = window.localStorage.getItem(storageKey());
       if (STATES.indexOf(stored) !== -1) return stored;
     } catch (e) { /* localStorage may be unavailable */ }
-    return 'full';
+    return defaultState();
   }
 
   function applyState(state) {
     var root = document.documentElement;
     STATES.forEach(function (s) { root.classList.remove('hkj-ct-' + s); });
     root.classList.add('hkj-ct-' + state);
-    try { window.localStorage.setItem(STORAGE_KEY, state); } catch (e) { /* ignore */ }
+    try { window.localStorage.setItem(storageKey(), state); } catch (e) { /* ignore */ }
   }
 
   // --- word underlining -----------------------------------------------------


### PR DESCRIPTION
## Description

The docs book's change-tracking feature (margin lines + word underlines marking content that is new/changed vs a baseline release) previously defaulted to `full` on **every** version of the site. On released versions (`/vX.Y.Z/`) that baseline diff is rarely relevant to a reader pinned to that version, so the annotations were just noise.

This PR makes the default context-aware and scopes the reader's toggle preference per docs version:

- **Default is now conditional.** Change tracking defaults to `full` only on the **latest snapshot** (deployed under `/latest/`), where new/changed content is most useful. Released versions and any other context (e.g. local `mdbook serve` without a baseline) default to `off`.
- **Preference is scoped per version.** The toggle state was stored under a single origin-wide `localStorage` key (`hkj-ct-state`), so a choice made on one version leaked to every other version on `higher-kinded-j.github.io` — crossing the latest↔release boundary carried a stale value instead of re-evaluating that version's default. The key is now `hkj-ct-state:<version>` (`latest` / `vX.Y.Z` / `local`), matching the version detection already used by `version-switcher.js`. Each version re-evaluates its own default and remembers its own toggle independently.

Files touched:
- `hkj-book/theme/change-tracking.js` — version detection, per-version storage key, conditional default.
- `hkj-book/theme/change-tracking.css` — updated the state-legend comment to reflect the conditional default.

No behavioural change to the build-time preprocessor or the baseline resolution in the deploy workflow.

Relates to # (issue number)

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- Syntax-checked the runtime with `node --check hkj-book/theme/change-tracking.js`.
- Traced the resulting behaviour:
  - First visit to `/latest/` → `full`; first visit to `/v0.4.8/` → `off`.
  - A choice made on `/latest/` no longer leaks to a released version — each version re-evaluates its own default and persists its own state.
  - Any pre-existing origin-wide `hkj-ct-state` value is now ignored (the desired "ignore stale value" behaviour).

This change is confined to the mdBook theme (client-side JS/CSS); no Java sources are affected, so `./gradlew test` is not relevant here.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have checked that the GitHub Actions CI build passes with my changes

## Additional Comments (Optional)

`localStorage` is per-origin, so the per-version keys coexist without collision. The old `hkj-ct-state` key is left untouched (harmless orphan); it can be cleaned up separately if desired.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Change-tracking display preferences are now saved separately for each documentation version.
  * Switching between the latest and versioned documentation no longer carries over an unintended display mode.
  * Default change-tracking visibility now matches the documentation version: enabled on the latest version and disabled elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->