### PR TITLE
hkj-spring review fixes: security, async lifecycle, Jackson binding, dead config, docs (#642)

### DIFF
--- a/.claude/skills/hkj-spring/SKILL.md
+++ b/.claude/skills/hkj-spring/SKILL.md
@@ -732,14 +732,7 @@ hkj:
     free-path-include-exception-details: false
 
   json:
-    custom-serializers-enabled: true
-    either-format: TAGGED                   # TAGGED | SIMPLE
-    validated-format: TAGGED                # TAGGED | SIMPLE
-    maybe-format: TAGGED                    # TAGGED | SIMPLE
-
-  validation:
-    enabled: true
-    accumulate-errors: true                 # true = collect all; false = fail-fast
+    custom-serializers-enabled: true        # the only hkj.json.* key; the JSON shapes are fixed
 
   virtual-threads:
     default-timeout-ms: 30000

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -16,6 +16,18 @@ This page documents the evolution of Higher-Kinded-J from its initial release th
 
 _In development. Release notes will be added here as changes land on `main`._
 
+**hkj-spring hardening ([#642](https://github.com/higher-kinded-j/higher-kinded-j/issues/642))**
+
+A review pass over the Spring integration fixed a security fail-open in the JWT converter, several async-handler lifecycle defects, a Jackson contextual-binding bug, and a batch of dead configuration. Most changes are internal, but a few are behaviour- or source-breaking:
+
+_Breaking changes / migration:_
+
+- **SSE responses now commit after the first stream element resolves**, not immediately. This is what lets a stream that fails at its start return the configured `hkj.web.vstream-failure-status` (default 500) instead of a broken `200` stream, and it removes the hop-by-hop `Connection: keep-alive` header. Consequence: `EventSource.onopen` fires only once the first element is produced. A `VStreamPath` that may idle for a long time before its first element should emit an **early heartbeat element** so the client and any intermediary proxies see the response promptly.
+- **Removed public API on the starter's `@ConfigurationProperties` surface** (source-breaking for programmatic-config consumers): the `HkjProperties.Jackson.SerializationFormat` enum and the `either-format`/`validated-format`/`maybe-format` getters/setters; the `HkjProperties.Validation` nested class (`hkj.validation.*`); the `hkj.async.executor-*` fields; and `EffectConfig.startupValidation`/`interpreterSelection`. These keys never altered behaviour (the JSON shapes are fixed; the executor is app-defined). Also removed: `EitherAuthorizationManager.AuthorizationSuccess`. Delete any of these keys from your YAML and stop calling the getters.
+- **`hkj.security.validated-user-details` now defaults to `false`** and the bean starts empty (sample accounts moved to `ValidatedUserDetailsService.withSampleUsers()`). It is a `UserDetailsService`, so once unique it becomes the application-wide user store — enabling it without registering accounts fails every login. Enable it only when you will populate it.
+- **A JWT whose authorities claim is missing or malformed is now rejected with `BadCredentialsException` (HTTP 401)** rather than authenticating with empty authorities. If your IdP legitimately issues role-less tokens, set `hkj.security.reject-missing-authorities-claim: false` to restore lenient handling for the missing-claim case (a malformed claim is always rejected).
+- **Effect-boundary interpreter resolution now fails fast at startup** on an ambiguous match (two equally-specific eligible interpreters for one algebra) or when the only interpreter for an algebra is gated behind an inactive `@Interpreter(profile = ...)`. Both were previously silent scan-order selections.
+
 ---
 
 ### [v0.4.8](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.8) (17 July 2026)

--- a/hkj-book/src/spring/effect_boundary_integration.md
+++ b/hkj-book/src/spring/effect_boundary_integration.md
@@ -6,7 +6,7 @@
 - The progressive adoption ladder, from a single `@Bean` to full `@EnableEffectBoundary` auto-wiring
 - Writing effect algebras as Spring-managed `@Interpreter` beans with dependency injection
 - Returning `FreePath` and `IOPath` from controllers with automatic HTTP response conversion
-- Testing effect programs purely with `TestBoundary` and recording interpreters
+- Testing effect programs purely with `TestBoundary` and stub interpreters
 - How this integrates with existing hkj-spring features (actuator, Jackson, error status mapping)
 ~~~
 
@@ -29,7 +29,7 @@ The **effect handler system** (Free monads, `@EffectAlgebra`, `Interpreters.comb
 
 ## The Bridge: How Free Connects to Existing Handlers
 
-The existing hkj-spring module has 8 return value handlers for *Path types. `EffectBoundary.runIO()` returns `IOPath<A>`, which the **existing** `IOPathReturnValueHandler` already handles:
+The existing hkj-spring module has nine return value handlers for *Path types (`FreePath` makes ten). `EffectBoundary.runIO()` returns `IOPath<A>`, which the **existing** `IOPathReturnValueHandler` already handles:
 
 ```
 FreePath<F, A>  ──foldMap──▸  GenericPath<IO.Witness, A>  ──narrow──▸  IOPath<A>
@@ -51,7 +51,7 @@ Each level uses patterns Spring developers already know. No level requires the p
 |-------|---------------|----------------|-----------------|
 | **0** | `Either<E,A>`, `IOPath<A>` from controllers | N/A | None (today) |
 | **1** | `EffectBoundary` bean + `boundary.runIO()` | Any `@Bean` | None (core only) |
-| **2** | Return `FreePath<F,A>` from controller | `CompletableFuture<T>` return | Handler #9 |
+| **2** | Return `FreePath<F,A>` from controller | `CompletableFuture<T>` return | Handler #10 |
 | **3** | `@Interpreter(MyOp.class)` on interpreter classes | `@Repository`, `@Service` | Stereotype |
 | **4** | `@EnableEffectBoundary({...})` on app class | `@EnableCaching` | Auto-config |
 | **5** | `@EffectTest(effects={...})` on test class | `@WebMvcTest` | Test slice |
@@ -183,7 +183,7 @@ public class StubGatewayInterpreter
 }
 ```
 
-Run with `--spring.profiles.active=test` and the stub interpreter is used automatically.
+An interpreter with a `profile` attribute is only **eligible** when that profile is active (the registrar filters candidates with `Environment.acceptsProfiles`); one with no `profile` is always eligible. A profile-restricted interpreter is more **specific** and shadows an unrestricted one — run with `--spring.profiles.active=test` and the stub is selected for `PaymentGatewayOp` even though the profile-less `StripeGatewayInterpreter` is still eligible. Only two or more interpreters at the *same* specificity (two unrestricted beans, or two active profiled beans) fail startup with a hard error naming the ambiguous algebra.
 
 ---
 
@@ -205,12 +205,13 @@ public class PaymentApplication {
 The `@EnableEffectBoundary` registrar:
 1. Reads the effect algebra class list from the annotation
 2. Resolves each to its generated `*Kind.Witness` type
-3. Scans for `@Interpreter`-annotated beans matching each algebra
+3. Scans for `@Interpreter`-annotated beans matching each algebra, filtering by active profile
 4. Constructs the `EitherF` nesting order automatically (left-to-right = outer-to-inner)
 5. Calls `Interpreters.combine()` with the discovered interpreters
-6. Registers `EffectBoundary<ComposedWitness>` as a singleton bean
-7. Registers individual `Bound<ComposedWitness>` beans for constructor injection in services
-8. Validates at startup: missing interpreter produces a clear error naming the unimplemented algebra
+6. Registers the single `effectBoundary` bean (`EffectBoundary<ComposedWitness>`) as a singleton
+7. Validates at startup: a missing interpreter — or two equally-specific eligible interpreters for one algebra — produces a clear error naming the offending algebra
+
+The registrar honours the `hkj.effect-boundary.enabled` master switch (default `true`); when set to `false`, no boundary bean is registered.
 
 This replaces `PaymentEffectsWiring.java` (284 lines) with **one annotation**.
 
@@ -222,46 +223,51 @@ This replaces `PaymentEffectsWiring.java` (284 lines) with **one annotation**.
 
 ### Pure Service Tests
 
+A stub interpreter targets `IdKind.Witness` and records what it was asked to do. This mirrors `OrderServicePureTest` in the effect-example module:
+
 ```java
-@DisplayName("OrderService Pure Tests")
+@DisplayName("OrderService Pure Tests (No Spring Context)")
 class OrderServicePureTest {
 
-    private final RecordingOrderInterpreter orderInterp =
-        new RecordingOrderInterpreter();
-    private final RecordingInventoryInterpreter inventoryInterp =
-        new RecordingInventoryInterpreter();
-    private final RecordingNotificationInterpreter notifInterp =
-        new RecordingNotificationInterpreter();
+    /** In-memory Id-targeting interpreter for pure testing. */
+    static class StubOrderInterpreter implements Natural<OrderOpKind.Witness, IdKind.Witness> {
+        private int ordersPlaced = 0;
 
-    private final TestBoundary<OrderEffects> boundary = TestBoundary.of(
-        Interpreters.combine(orderInterp, inventoryInterp, notifInterp));
+        @Override
+        public <A> Kind<IdKind.Witness, A> apply(Kind<OrderOpKind.Witness, A> fa) {
+            OrderOp<A> op = OrderOpKindHelper.ORDER_OP.narrow(fa);
+            return switch (op) {
+                case OrderOp.PlaceOrder<A> place -> {
+                    ordersPlaced++;
+                    yield Id.of(place.k().apply(OrderResult.confirmed("ORD-TEST-0001")));
+                }
+                case OrderOp.GetStatus<A> get ->
+                    Id.of(get.k().apply(OrderStatus.CONFIRMED));
+            };
+        }
+
+        int ordersPlaced() {
+            return ordersPlaced;
+        }
+    }
+
+    private final StubOrderInterpreter interpreter = new StubOrderInterpreter();
+    private final TestBoundary<OrderOpKind.Witness> boundary = TestBoundary.of(interpreter);
+    private final OrderService service = new OrderService();
 
     @Test
-    @DisplayName("Should reserve inventory before placing order")
-    void shouldReserveInventoryBeforePlacingOrder() {
+    @DisplayName("Should place order and return confirmed result")
+    void shouldPlaceOrder() {
         OrderResult result = boundary.run(
             service.placeOrder(new OrderRequest("C001", "ITEM-42", 2)));
 
         assertThat(result.status()).isEqualTo(OrderStatus.CONFIRMED);
-        assertThat(inventoryInterp.reservations()).hasSize(1);
-        assertThat(notifInterp.sentNotifications()).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("Should not place order when inventory unavailable")
-    void shouldNotPlaceOrderWhenInventoryUnavailable() {
-        inventoryInterp.setAvailableStock("ITEM-42", 0);
-
-        OrderResult result = boundary.run(
-            service.placeOrder(new OrderRequest("C001", "ITEM-42", 2)));
-
-        assertThat(result.status()).isEqualTo(OrderStatus.REJECTED);
-        assertThat(orderInterp.placedOrders()).isEmpty();
+        assertThat(interpreter.ordersPlaced()).isEqualTo(1);
     }
 }
 ```
 
-These tests run in milliseconds. The same `OrderService` program that runs against Stripe and PostgreSQL in production runs against in-memory stubs here, with no code changes.
+These tests run in milliseconds. The same `OrderService` program that runs against real infrastructure in production runs against in-memory stubs here, with no code changes. Composing several algebras works the same way — build the boundary with `TestBoundary.of(Interpreters.combine(orderStub, inventoryStub, notifyStub))`.
 
 ### @EffectTest Test Slice
 
@@ -337,19 +343,16 @@ hkj:
     either-path-enabled: true
     maybe-path-enabled: true
 
-    # New: FreePath handler
+    # FreePath handler
     free-path-enabled: true
     free-path-failure-status: 500
     free-path-include-exception-details: false
 
   effect-boundary:
-    enabled: true                     # master switch
-    startup-validation: true          # fail-fast if interpreters missing
-    interpreter-selection:            # config-driven interpreter switching
-      payment-gateway: stripe
-      fraud-check: ml-model
-      notification: email
+    enabled: true                     # master switch consulted by the registrar (default: true)
 ```
+
+Setting `hkj.effect-boundary.enabled: false` prevents the registrar from creating the boundary bean at all. Interpreter validation is always fail-fast: a missing or ambiguous interpreter is a startup error, not a warning — there is no property to relax it. Environment-specific interpreter switching is done with the `@Interpreter(profile = ...)` attribute (see [Level 3](#level-3-interpreters-as-spring-beans)), not with configuration keys.
 
 ---
 
@@ -404,57 +407,11 @@ These appear automatically in the `/actuator/metrics` endpoint alongside existin
 
 ---
 
-## Pure Tests with TestBoundary
-
-For unit tests that verify business logic without Spring or IO, `TestBoundary` interprets programs using the Id monad. Tests execute in milliseconds and are fully deterministic:
-
-```java
-@DisplayName("OrderService Pure Tests")
-class OrderServicePureTest {
-
-    private final StubOrderInterpreter interpreter = new StubOrderInterpreter();
-    private final TestBoundary<OrderEffects> boundary = TestBoundary.of(interpreter);
-
-    @Test
-    void shouldPlaceOrder() {
-        OrderResult result = boundary.run(
-            service.placeOrder(new OrderRequest("C001", "ITEM-42", 2)));
-
-        assertThat(result.status()).isEqualTo(OrderStatus.CONFIRMED);
-        assertThat(interpreter.ordersPlaced()).isEqualTo(1);
-    }
-}
-```
-
-The stub interpreter targets `IdKind.Witness` instead of `IOKind.Witness`, returning pure `Id` values. The same `Free<F, A>` program that runs against real services in production runs against stubs here. Only the interpreter and boundary change; the program is identical.
-
-For integration tests that need Spring auto-configuration but not the web layer, use `@EffectTest(effects={...})` to auto-discover interpreters and register an `EffectBoundary` bean:
-
-```java
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@EffectTest(effects = {OrderOp.class})
-class OrderServiceSpringTest {
-
-    @Autowired EffectBoundary<OrderOpKind.Witness> boundary;
-    @Autowired OrderService service;
-
-    @Test
-    void shouldProcessOrder() {
-        OrderResult result = boundary.run(service.placeOrder(request));
-        assertThat(result.status()).isEqualTo(OrderStatus.CONFIRMED);
-    }
-}
-```
-
-`@EffectTest` discovers `@Interpreter` beans matching each listed effect algebra, combines them, and registers the boundary. No manual wiring needed. When the `effects` parameter is empty, no automatic boundary registration occurs.
-
----
-
 ~~~admonish info title="Key Takeaways"
 * **EffectBoundary bridges Free monads into existing infrastructure.** `runIO()` returns `IOPath`, which the existing handler converts to HTTP responses. No parallel universe.
 * **Adoption is progressive.** Start with a single `@Bean`, then add `@Interpreter`, then `@EnableEffectBoundary`. Each level adds value independently.
 * **Interpreters become Spring beans.** They can inject repositories, HTTP clients, and configuration. Profile-based switching replaces manual test/prod wiring.
-* **Testing is pure and fast.** `TestBoundary` with recording interpreters runs programs in milliseconds with no Spring context, no IO, and full observability into what effects were executed.
+* **Testing is pure and fast.** `TestBoundary` with stub interpreters runs programs in milliseconds with no Spring context, no IO, and full observability into what effects were executed.
 * **The same program runs everywhere.** Production interprets into IO with real services. Tests interpret into Id with stubs. Auditing wraps interpreters with logging. The program itself never changes.
 ~~~
 

--- a/hkj-book/src/spring/migrating_to_functional_errors.md
+++ b/hkj-book/src/spring/migrating_to_functional_errors.md
@@ -6,7 +6,7 @@
 - Converting exception-throwing methods to Either
 - Replacing `@ExceptionHandler` methods with automatic response conversion
 - Migrating validation logic to Validated
-- Converting async operations to EitherT
+- Converting async operations to CompletableFuturePath and VTaskPath
 - Maintaining backwards compatibility during migration
 - Common migration patterns and pitfalls to avoid
 ~~~
@@ -329,50 +329,54 @@ public record ValidationError(String field, String message) {
 @Service
 public class UserService {
 
-    public Validated<List<ValidationError>, User> validateAndCreate(UserRequest request) {
-        return Validated.validateAll(
-            validateEmail(request.email()),
-            validateFirstName(request.firstName()),
-            validateLastName(request.lastName()),
-            validateUniqueEmail(request.email())
-        ).map(tuple -> createUser(
-            tuple._1(),  // validated email
-            tuple._2(),  // validated firstName
-            tuple._3(),  // validated lastName
-            tuple._4()   // uniqueness confirmed
-        ));
+    public ValidationPath<NonEmptyList<ValidationError>, User> validateAndCreate(
+            UserRequest request) {
+        return Path.accumulate()
+            .and(validateEmail(request.email()))
+            .and(validateFirstName(request.firstName()))
+            .and(validateLastName(request.lastName()))
+            .and(validateUniqueEmail(request.email()))
+            .apply((email, firstName, lastName, uniqueEmail) ->
+                createUser(email, firstName, lastName));
     }
 
-    private Validated<ValidationError, String> validateEmail(String email) {
+    private ValidationPath<NonEmptyList<ValidationError>, String> validateEmail(String email) {
         if (email == null || !email.matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
-            return Validated.invalid(
+            return Path.invalidNel(
                 new ValidationError("email", "Invalid email format"));
         }
-        return Validated.valid(email);
+        return Path.validNel(email);
     }
 
-    private Validated<ValidationError, String> validateFirstName(String name) {
+    private ValidationPath<NonEmptyList<ValidationError>, String> validateFirstName(String name) {
         if (name == null || name.trim().length() < 2) {
-            return Validated.invalid(
+            return Path.invalidNel(
                 new ValidationError("firstName", "First name must be at least 2 characters"));
         }
-        return Validated.valid(name);
+        return Path.validNel(name);
     }
 
-    private Validated<ValidationError, String> validateLastName(String name) {
+    private ValidationPath<NonEmptyList<ValidationError>, String> validateLastName(String name) {
         if (name == null || name.trim().length() < 2) {
-            return Validated.invalid(
+            return Path.invalidNel(
                 new ValidationError("lastName", "Last name must be at least 2 characters"));
         }
-        return Validated.valid(name);
+        return Path.validNel(name);
     }
 
-    private Validated<ValidationError, String> validateUniqueEmail(String email) {
+    private ValidationPath<NonEmptyList<ValidationError>, String> validateUniqueEmail(String email) {
+        // accumulate() runs every validator independently, so this one must not query the
+        // repository for a syntactically invalid email: existsByEmail(null) could throw and turn a
+        // bad request into a 500. validateEmail already reports the format error, so skip the
+        // uniqueness check for malformed input.
+        if (email == null || !email.matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+            return Path.validNel(email);
+        }
         if (userRepository.existsByEmail(email)) {
-            return Validated.invalid(
+            return Path.invalidNel(
                 new ValidationError("email", "Email already exists"));
         }
-        return Validated.valid(email);
+        return Path.validNel(email);
     }
 }
 
@@ -381,16 +385,20 @@ public class UserService {
 public class UserController {
 
     @PostMapping
-    public Validated<List<ValidationError>, User> createUser(@RequestBody UserRequest request) {
+    public ValidationPath<NonEmptyList<ValidationError>, User> createUser(
+            @RequestBody UserRequest request) {
         return userService.validateAndCreate(request);
     }
 
     // No @ExceptionHandler needed!
     // Framework converts:
-    // - Valid(user) → 200 OK with user JSON
-    // - Invalid(errors) → 400 Bad Request with ALL validation errors
+    // - Valid(user) → 200 OK with user JSON (unwrapped)
+    // - Invalid(errors) → 400 Bad Request with ALL validation errors:
+    //   {"valid": false, "errors": [...], "errorCount": n}
 }
 ```
+
+`Path.accumulate()` opens an open-arity accumulating assembly: each `.and(...)` adds an independently validated field, and `.apply(...)` builds the result only when every field is valid — otherwise **all** errors are collected, in declaration order. Raw `Validated<List<ValidationError>, User>` works as a return type too (the same handler accepts it); the example module's `UserService.validateAndCreate` shows that style using `ValidatedMonad.instance(Semigroups.list())` with `Applicative.map3`.
 
 **Why it helps:**
 - ✅ Returns **all** validation errors at once
@@ -400,38 +408,39 @@ public class UserController {
 
 ### Migration Steps
 
-**Step 1:** Extract validation logic into individual `Validated` functions
+**Step 1:** Extract validation logic into individual single-field validators
 
 ```java
-private Validated<ValidationError, String> validateEmail(String email) {
-    // validation logic
+private ValidationPath<NonEmptyList<ValidationError>, String> validateEmail(String email) {
+    // validation logic: Path.validNel(email) or Path.invalidNel(error)
 }
 ```
 
-**Step 2:** Compose validations with `Validated.validateAll()`
+**Step 2:** Compose validations with `Path.accumulate()`
 
 ```java
-public Validated<List<ValidationError>, User> validateAndCreate(UserRequest request) {
-    return Validated.validateAll(
-        validateEmail(request.email()),
-        validateName(request.name())
-        // ... more validations
-    ).map(tuple -> createUser(...));
+public ValidationPath<NonEmptyList<ValidationError>, User> validateAndCreate(UserRequest request) {
+    return Path.accumulate()
+        .and(validateEmail(request.email()))
+        .and(validateName(request.name()))
+        // ... more fields
+        .apply((email, name) -> createUser(email, name));
 }
 ```
 
-**Step 3:** Return `Validated` from controller
+**Step 3:** Return the `ValidationPath` from the controller
 
 ```java
 @PostMapping
-public Validated<List<ValidationError>, User> createUser(@RequestBody UserRequest request) {
+public ValidationPath<NonEmptyList<ValidationError>, User> createUser(
+        @RequestBody UserRequest request) {
     return userService.validateAndCreate(request);
 }
 ```
 
 ---
 
-## Pattern 4: Async Exceptions to EitherT
+## Pattern 4: Async Exceptions to CompletableFuturePath
 
 ### Before: CompletableFuture with Exception Handling
 
@@ -488,94 +497,101 @@ public class OrderController {
 - Error handling scattered across `.handle()` and `.exceptionally()`
 - Type safety lost
 
-### After: EitherT for Async + Typed Errors
+### After: CompletableFuturePath Composition
+
+`CompletableFuturePath` wraps the future in the Effect Path API, so the chain reads linearly with `via` (async bind) and `map`, and the return-value handler takes care of Spring's async request processing:
 
 ```java
 @Service
 public class AsyncOrderService {
 
-    public EitherT<CompletableFutureKind.Witness, OrderError, Order>
-    processOrderAsync(OrderRequest request) {
-
+    public CompletableFuturePath<Order> processOrderAsync(OrderRequest request) {
         return asyncUserService.findByIdAsync(request.userId())
-            .flatMap(user -> asyncInventoryService.checkStockAsync(request.items()))
-            .flatMap(stock -> {
+            .via(user -> asyncInventoryService.checkStockAsync(request.items()))
+            .via(stock -> {
                 if (!stock.isAvailable()) {
-                    return EitherT.leftT(
-                        CompletableFutureKindHelper.FUTURE,
-                        new OutOfStockError(stock.unavailableItems())
-                    );
+                    return Path.future(CompletableFuture.failedFuture(
+                        new OutOfStockException(stock.unavailableItems())));
                 }
-                return EitherT.rightT(CompletableFutureKindHelper.FUTURE, stock);
+                return asyncPaymentService.processPaymentAsync(request.payment());
             })
-            .flatMap(stock -> asyncPaymentService.processPaymentAsync(request.payment()))
             .map(payment -> createOrder(request, payment));
 
-        // Clean, composable, type-safe
-        // Short-circuits on first error
+        // Linear composition — the failure short-circuits the chain
     }
 }
 
 @RestController
 public class OrderController {
 
-    @GetMapping("/{id}/async")
-    public EitherT<CompletableFutureKind.Witness, OrderError, Order>
-    getOrder(@PathVariable String id) {
-
-        return asyncOrderService.getOrderAsync(id);
-        // Framework handles async → sync HTTP response conversion automatically
+    @PostMapping("/orders")
+    public CompletableFuturePath<Order> createOrder(@RequestBody OrderRequest request) {
+        return asyncOrderService.processOrderAsync(request);
+        // Framework handles async → HTTP response conversion via DeferredResult
     }
 }
 ```
 
 **Improvements:**
-- ✅ Type-safe error handling in async context
-- ✅ Clean composition with `flatMap`
-- ✅ Automatic short-circuiting on errors
-- ✅ Framework handles async processing
+- ✅ Clean, linear composition with `via`/`map` — no `.handle()` / `.exceptionally()` pyramid
+- ✅ Automatic short-circuiting on failure
+- ✅ Framework handles async processing (non-blocking request thread)
+
+~~~admonish warning title="Failure mapping is coarse-grained"
+`CompletableFuturePath` (and `VTaskPath`) carry failures as **exceptions**, not typed `Left` values. A failed future maps to the configured `hkj.web.async-failure-status` (default 500) — the per-error-class `ErrorStatusCodeStrategy` mapping does not apply, because by the time the handler sees the failure it is a `Throwable`. If an endpoint needs `Left(UserNotFoundError)` → 404 semantics, keep the typed `Either` at the boundary (a synchronous `Either` return, possibly computed off-thread inside the service) rather than folding the error into an exception. This mirrors `AsyncUserService` in the example module, where `UserNotFoundException` deliberately surfaces as the configured async failure status.
+~~~
 
 ### Migration Steps
 
-**Step 1:** Convert async methods to return `EitherT`
+**Step 1:** Convert async methods to return `CompletableFuturePath` with `Path.future`
 
 ```java
-public EitherT<CompletableFutureKind.Witness, DomainError, User>
-findByIdAsync(String id) {
+public CompletableFuturePath<User> findByIdAsync(String id) {
+    CompletableFuture<User> future = CompletableFuture.supplyAsync(
+        () -> repository.findById(id)
+                  .orElseThrow(() -> new UserNotFoundException(id)),
+        asyncExecutor);
 
-    CompletableFuture<Either<DomainError, User>> future =
-        CompletableFuture.supplyAsync(() -> {
-            return repository.findById(id)
-                .map(Either::<DomainError, User>right)
-                .orElseGet(() -> Either.left(new UserNotFoundError(id)));
-        });
-
-    return EitherT.fromKind(CompletableFutureKindHelper.FUTURE.widen(future));
+    return Path.future(future);
 }
 ```
 
-**Step 2:** Compose operations with `flatMap`
+**Step 2:** Compose operations with `via` and `map`
 
 ```java
-public EitherT<CompletableFutureKind.Witness, OrderError, Order>
-processOrderAsync(OrderRequest request) {
-
-    return asyncUserService.findByIdAsync(request.userId())
-        .flatMap(user -> asyncInventoryService.checkStockAsync(request.items()))
-        .flatMap(stock -> asyncPaymentService.processPaymentAsync(request.payment()))
+public CompletableFuturePath<Order> processOrderAsync(OrderRequest request) {
+    return findByIdAsync(request.userId())
+        .via(user -> checkStockAsync(request.items()))
+        .via(stock -> processPaymentAsync(request.payment()))
         .map(payment -> createOrder(request, payment));
 }
 ```
 
-**Step 3:** Return `EitherT` from controller
+**Step 3:** Return `CompletableFuturePath` from the controller
 
 ```java
 @GetMapping("/{id}/async")
-public EitherT<CompletableFutureKind.Witness, OrderError, Order>
-getOrder(@PathVariable String id) {
+public CompletableFuturePath<Order> getOrder(@PathVariable String id) {
     return asyncOrderService.getOrderAsync(id);
 }
 ```
+
+### Alternative: VTaskPath on Virtual Threads
+
+If you are on virtual threads, `VTaskPath` gives the same handler integration with no executor bean at all — the computation is deferred and runs on a virtual thread when the handler invokes it:
+
+```java
+public VTaskPath<User> findById(String id) {
+    return Path.vtask(() -> {
+            // Blocking calls are cheap on a virtual thread
+            return repository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+        })
+        .timeout(Duration.ofSeconds(5));
+}
+```
+
+The same failure-mapping caveat applies: a thrown exception maps to `hkj.web.vtask-failure-status` (default 500). See [VTaskPath](spring_boot_integration.md#vtaskpath-virtual-thread-async) for structured-concurrency fan-out with `Scope`.
 
 ---
 
@@ -783,13 +799,13 @@ public Either<ValidationError, User> validateUser(UserRequest request) {
     // Stops at first error!
 }
 
-// ✅ GOOD: Use Validated to accumulate all errors
-public Validated<List<ValidationError>, User> validateUser(UserRequest request) {
-    return Validated.validateAll(
-        validateEmail(request.email()),
-        validateName(request.name()),
-        validateAge(request.age())
-    ).map(tuple -> createUser(...));
+// ✅ GOOD: Accumulate all errors with Path.accumulate()
+public ValidationPath<NonEmptyList<ValidationError>, User> validateUser(UserRequest request) {
+    return Path.accumulate()
+        .and(validateEmail(request.email()))
+        .and(validateName(request.name()))
+        .and(validateAge(request.age()))
+        .apply((email, name, age) -> createUser(email, name, age));
     // Returns ALL errors!
 }
 ```
@@ -801,7 +817,7 @@ public Validated<List<ValidationError>, User> validateUser(UserRequest request) 
 When migrating an endpoint:
 
 - [ ] Define domain error types as sealed interface
-- [ ] Convert service methods to return Either/Validated/EitherT
+- [ ] Convert service methods to return Either/Validated/CompletableFuturePath/VTaskPath
 - [ ] Update controller methods to return functional types
 - [ ] Remove corresponding `@ExceptionHandler` methods
 - [ ] Update unit tests (no more exception mocking!)
@@ -877,7 +893,7 @@ The migration is straightforward and the benefits are immediate. Start with one 
 - [Spring Boot Integration](./spring_boot_integration.md) - Complete integration guide
 - [Either Monad](../monads/either_monad.md) - Either usage patterns
 - [Validated Monad](../monads/validated_monad.md) - Validation patterns
-- [EitherT Transformer](../transformers/eithert_transformer.md) - Async composition
+- [Effect Path API](../effect/path_types.md) - CompletableFuturePath, VTaskPath, and friends
 ~~~
 
 ---

--- a/hkj-book/src/spring/spring_boot_integration.md
+++ b/hkj-book/src/spring/spring_boot_integration.md
@@ -2,7 +2,7 @@
 ## _Bringing Type-Safe Error Handling to Your REST APIs_
 
 ~~~admonish info title="What You'll Learn"
-- How to use Either, Validated, Maybe, Try, IO, CompletableFuture, VTask, VStream, and Free as Spring controller return types (via their Path wrappers)
+- How to use Either, Validated, Maybe, Try, IO, CompletableFuture, VTask, VStream, EitherOrBoth, and Free as Spring controller return types (via their Path wrappers)
 - Zero-configuration setup with the hkj-spring-boot-starter
 - Virtual thread integration with VTaskPath (async) and VStreamPath (SSE streaming)
 - Automatic JSON serialisation with customisable formats
@@ -146,6 +146,7 @@ That's it! The starter auto-configures everything:
 - CompletableFuturePath support for async operations
 - VTaskPath support for virtual thread async via DeferredResult
 - VStreamPath support for SSE streaming on virtual threads
+- EitherOrBothPath support for success-with-warnings responses (warnings in the `X-Hkj-Warnings` header)
 - FreePath support for Free-monad programs interpreted through `EffectBoundary`
 - `@ResponseStatus` honoured on handler methods to override the default success status
 - JSON serialisation for functional types
@@ -230,8 +231,10 @@ public class UserController {
 ```
 
 **Response Mapping:**
-- `Right(user)` → HTTP 200 with JSON: `{"id": "1", "email": "alice@example.com", ...}`
-- `Left(UserNotFoundError)` → HTTP 404 with JSON: `{"success": false, "error": {"type": "UserNotFoundError", ...}}`
+- `Right(user)` → HTTP 200 with the value unwrapped as JSON: `{"id": "1", "email": "alice@example.com", ...}`
+- `Left(UserNotFoundError)` → HTTP 404 with the error wrapped in an envelope: `{"success": false, "error": {"userId": "999", ...}}`
+
+The error object inside the envelope is the error record serialised as-is — there is no automatic `type` discriminator. If your clients need one, add it to the error type with Jackson's `@JsonTypeInfo(use = Id.NAME, ...)` on the sealed interface.
 
 #### Error Type to HTTP Status Mapping {#error-type-http-status-mapping}
 
@@ -307,43 +310,65 @@ public Validated<List<ValidationError>, User> createUser(@RequestBody UserReques
 ```
 
 **Response Mapping:**
-- `Valid(user)` → HTTP 200 with JSON: `{"id": "1", "email": "alice@example.com", ...}`
-- `Invalid(errors)` → HTTP 400 with JSON: `{"success": false, "errors": [{"field": "email", "message": "Invalid format"}, ...]}`
+- `Valid(user)` → HTTP 200 with the value unwrapped as JSON: `{"id": "1", "email": "alice@example.com", ...}`
+- `Invalid(errors)` → HTTP 400 with JSON: `{"valid": false, "errors": [{"field": "email", "message": "Invalid format"}, ...], "errorCount": 2}`
 
 #### Validation Example
+
+Individual field checks each return a `Validated`; the applicative for `Validated` (with a list semigroup for the error channel) combines them so that **every** failing check is reported:
 
 ```java
 @Service
 public class UserService {
 
     public Validated<List<ValidationError>, User> validateAndCreate(UserRequest request) {
-        return Validated.validateAll(
-            validateEmail(request.email()),
-            validateName(request.firstName()),
-            validateName(request.lastName())
-        ).map(tuple -> new User(
-            UUID.randomUUID().toString(),
-            tuple._1(),  // email
-            tuple._2(),  // firstName
-            tuple._3()   // lastName
-        ));
+        Applicative<ValidatedKind.Witness<List<ValidationError>>> applicative =
+            ValidatedMonad.instance(Semigroups.list());
+
+        var result = applicative.map3(
+            VALIDATED.widen(validateEmail(request.email())),
+            VALIDATED.widen(validateName("firstName", request.firstName())),
+            VALIDATED.widen(validateName("lastName", request.lastName())),
+            (email, firstName, lastName) ->
+                new User(UUID.randomUUID().toString(), email, firstName, lastName));
+
+        return VALIDATED.narrow(result);
     }
 
-    private Validated<ValidationError, String> validateEmail(String email) {
+    private Validated<List<ValidationError>, String> validateEmail(String email) {
         if (email == null || !email.contains("@")) {
-            return Validated.invalid(new ValidationError("email", "Invalid email format"));
+            return Validated.invalid(List.of(new ValidationError("email", "Invalid email format")));
         }
         return Validated.valid(email);
     }
 
-    private Validated<ValidationError, String> validateName(String name) {
+    private Validated<List<ValidationError>, String> validateName(String field, String name) {
         if (name == null || name.trim().isEmpty()) {
-            return Validated.invalid(new ValidationError("name", "Name cannot be empty"));
+            return Validated.invalid(List.of(new ValidationError(field, "Name cannot be empty")));
         }
         return Validated.valid(name);
     }
 }
 ```
+
+This mirrors `UserService.validateAndCreate` in the example module. (`VALIDATED` is the `ValidatedKindHelper.VALIDATED` widening/narrowing helper.)
+
+~~~admonish tip title="Prefer the Path builders for new code"
+The `ValidationPath` accumulating builders avoid the widen/narrow ceremony entirely — controllers can return `ValidationPath` directly and the same handler applies. Each field validator returns `ValidationPath<NonEmptyList<ValidationError>, String>` (built with `Path.validNel` / `Path.invalidNel`):
+
+```java
+public ValidationPath<NonEmptyList<ValidationError>, User> validateAndCreate(UserRequest request) {
+    return Path.accumulate()
+        .and(validateEmail(request.email()))
+        .and(validateName("firstName", request.firstName()))
+        .and(validateName("lastName", request.lastName()))
+        .apply((email, firstName, lastName) ->
+            new User(UUID.randomUUID().toString(), email, firstName, lastName));
+}
+```
+
+See the [Effect Path API](../effect/path_types.md) for `Path.accumulate()` and its labelled sibling `Path.fields()`.
+~~~
 
 **Key Difference from Either:**
 - `Either` short-circuits on first error (fail-fast)
@@ -432,7 +457,7 @@ public VTaskPath<EnrichedUser> getEnrichedUser(@PathVariable String id) {
     VTask<Profile> profileTask = VTask.of(() -> fetchProfile(id));
     VTask<OrderSummary> ordersTask = VTask.of(() -> fetchOrders(id));
 
-    return Path.vtask(
+    return Path.vtaskPath(
         Scope.<Object>allSucceed()
             .fork(userTask)
             .fork(profileTask)
@@ -491,6 +516,44 @@ public VStreamPath<TickEvent> streamTicks(@RequestParam(defaultValue = "10") int
 
 ---
 
+### 6. EitherOrBoth: Success with Warnings {#eitherorboth-success-with-warnings}
+
+`EitherOrBoth<W, A>` is the inclusive-or: a computation that fails with warnings (`Left`), succeeds cleanly (`Right`), or **succeeds while also carrying non-fatal warnings** (`Both`). Controllers can return either the raw `EitherOrBoth` or its Path wrapper `EitherOrBothPath` — both are handled by `EitherOrBothPathReturnValueHandler`.
+
+#### Basic Usage
+
+```java
+@PostMapping("/imports")
+public EitherOrBothPath<NonEmptyList<ImportWarning>, ImportSummary> importBatch(
+        @RequestBody ImportRequest request) {
+    return importService.importBatch(request);
+}
+```
+
+**Response Mapping (three branches, not two):**
+
+| Result | Status | Body | Extra |
+|--------|--------|------|-------|
+| `Right(value)` | success status (200, or `@ResponseStatus` on the handler) | the value, unwrapped | — |
+| `Both(warnings, value)` | the **same** success status | the value, unwrapped | warnings JSON-encoded into the `X-Hkj-Warnings` response header |
+| `Left(warnings)` | resolved by `ErrorStatusCodeStrategy` (same as `EitherPath`) | `{"success": false, "error": <warnings>}` | `HttpHeaderCarrier` headers applied if implemented |
+
+The `Both` branch is the point: warnings are never silently dropped, but the success body stays the bare value, so clients that ignore the header see exactly the same response as a clean success. Clients that care read `X-Hkj-Warnings` and parse the JSON array.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Hkj-Warnings: [{"row":17,"message":"duplicate SKU skipped"}]
+
+{"imported": 240, "skipped": 1}
+```
+
+Disable the handler with `hkj.web.either-or-both-path-enabled: false` (default: `true`).
+
+See [EitherOrBoth](../monads/either_or_both_monad.md) for the type itself, including `zipWithAccum` for combining independent checks whilst accumulating warnings.
+
+---
+
 ## HTTP Status Codes {#http-status-codes}
 
 Every Effect Path return-value handler resolves the success and error status codes independently, so the same controller method can map typed successes and typed failures to different HTTP responses.
@@ -527,7 +590,7 @@ public class OrderController {
 }
 ```
 
-All nine Effect Path handlers honour `@ResponseStatus` consistently.
+All ten Effect Path handlers honour `@ResponseStatus` consistently.
 
 ### Error Status Mapping
 
@@ -586,7 +649,7 @@ public record MfaThrottledError(int retryAfterSeconds)
 }
 ```
 
-The headers are applied by the `EitherPath`, `TryPath`, `ValidationPath`, `IOPath`, `CompletableFuturePath`, `VTaskPath`, and `FreePath` return-value handlers before the JSON body is written. Internally the headers are added (not set), so multi-valued headers such as `WWW-Authenticate`, `Set-Cookie`, and `Link` accumulate as separate header lines, matching the HTTP grammar; upstream headers set by filters or interceptors are also preserved. For collection-typed payloads (such as `ValidationPath` `Invalid` values), every element that implements `HttpHeaderCarrier` contributes; values accumulate. For single-valued headers like `Retry-After`, the carrier should ensure the value appears at most once across all payload elements.
+The headers are applied by the `EitherPath`, `EitherOrBothPath`, `TryPath`, `ValidationPath`, `IOPath`, `CompletableFuturePath`, `VTaskPath`, and `FreePath` return-value handlers before the JSON body is written. Internally the headers are added (not set), so multi-valued headers such as `WWW-Authenticate`, `Set-Cookie`, and `Link` accumulate as separate header lines, matching the HTTP grammar; upstream headers set by filters or interceptors are also preserved. For collection-typed payloads (such as `ValidationPath` `Invalid` values), every element that implements `HttpHeaderCarrier` contributes; values accumulate. For single-valued headers like `Retry-After`, the carrier should ensure the value appears at most once across all payload elements.
 
 `VStreamPath` does not honour `HttpHeaderCarrier`, because the response status and headers are committed before the first SSE event. Set required headers via a servlet filter or controller advice before the stream begins.
 
@@ -604,56 +667,50 @@ The example module contains a [`ErrorStatusFixtureController`](https://github.co
 
 ## JSON Serialisation {#json-serialisation}
 
-The starter provides flexible JSON serialisation for functional types.
+Two different mechanisms produce JSON for functional types, and it matters which one applies:
 
-### Configuration
+### Top-level return values (the handlers)
 
-Configure serialisation format in `application.yml`:
+When a controller returns a functional type directly, the return-value handler shapes the response:
+
+- **Success values are unwrapped.** `Right(user)`, `Valid(user)`, a completed `CompletableFuturePath<User>`, etc. all produce the bare value as the body: `{"id": "1", "email": "alice@example.com"}` — no envelope.
+- **Either errors** produce `{"success": false, "error": <error record serialised as-is>}`.
+- **Validated errors** produce `{"valid": false, "errors": [...], "errorCount": n}`.
+- **EitherOrBoth `Both`** produces the unwrapped value plus the `X-Hkj-Warnings` header (see [above](#eitherorboth-success-with-warnings)).
+
+### Nested values (the Jackson module)
+
+When an `Either`, `Validated`, `EitherOrBoth`, or `NonEmptyList` appears **inside** a DTO (for example a batch result containing `List<Either<DomainError, User>>`), the `HkjJacksonModule` serialises it with a tagged shape:
+
+```json
+// Nested Either.right(user)
+{"isRight": true, "right": {"id": "1", "email": "alice@example.com"}}
+
+// Nested Either.left(error)
+{"isRight": false, "left": {"userId": "999"}}
+
+// Nested Validated
+{"valid": true, "value": ...}
+{"valid": false, "errors": [...]}
+
+// Nested EitherOrBoth
+{"kind": "right", "right": ...}
+{"kind": "both", "left": [...warnings...], "right": ...}
+```
+
+These shapes are fixed — there is no format-toggle property. The only Jackson-related switch is:
 
 ```yaml
 hkj:
   json:
-    custom-serializers-enabled: true  # Enable custom serialisers (default: true)
-    either-format: TAGGED             # TAGGED or SIMPLE
-    validated-format: TAGGED          # TAGGED or SIMPLE
-    maybe-format: TAGGED              # TAGGED or SIMPLE
+    custom-serializers-enabled: true  # Register HkjJacksonModule (default: true)
 ```
 
-~~~admonish note title="Property prefix vs. actuator key"
-The configuration prefix is `hkj.json.*`. The actuator endpoint at `/actuator/hkj` reports the same values under the `"jackson"` key for backward compatibility with earlier releases.
+~~~admonish warning title="No Maybe or Try Jackson support"
+The Jackson module covers `Either`, `Validated`, `EitherOrBoth`, and `NonEmptyList`. `Maybe` and `Try` have **no** nested-serialisation support — return them at the top level (where the handlers apply) or convert them to a supported type before embedding them in a DTO.
 ~~~
 
-### Serialisation Formats
-
-#### TAGGED (Default)
-
-Wraps the value with metadata indicating success/failure:
-
-```json
-// Right(user)
-{
-  "success": true,
-  "value": {
-    "id": "1",
-    "email": "alice@example.com"
-  }
-}
-
-// Left(error)
-{
-  "success": false,
-  "error": {
-    "type": "UserNotFoundError",
-    "userId": "999"
-  }
-}
-```
-
-#### SIMPLE
-
-Compact form without the discriminator metadata, suitable for clients that already infer success and failure from the HTTP status code.
-
-For complete serialisation details, including the exact field names produced for each format, see [hkj-spring/JACKSON_SERIALIZATION.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/JACKSON_SERIALIZATION.md).
+For complete serialisation details, see [hkj-spring/JACKSON_SERIALIZATION.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/JACKSON_SERIALIZATION.md).
 
 ---
 
@@ -665,13 +722,14 @@ For complete serialisation details, including the exact field names produced for
 hkj:
   web:
     either-path-enabled: true               # Enable EitherPath handler (default: true)
-    validated-path-enabled: true            # Enable ValidationPath handler (default: true)
+    validation-path-enabled: true           # Enable ValidationPath handler (default: true)
     maybe-path-enabled: true                # Enable MaybePath handler (default: true)
     try-path-enabled: true                  # Enable TryPath handler (default: true)
     io-path-enabled: true                   # Enable IOPath handler (default: true)
     completable-future-path-enabled: true   # Enable CompletableFuturePath handler (default: true)
     vtask-path-enabled: true                # Enable VTaskPath handler (default: true)
     vstream-path-enabled: true              # Enable VStreamPath handler (default: true)
+    either-or-both-path-enabled: true       # Enable EitherOrBothPath handler (default: true)
     free-path-enabled: true                 # Enable FreePath handler (default: true)
     either:
       default-error-status: 400             # Default HTTP status for unmapped Left errors
@@ -681,16 +739,27 @@ The canonical key for the EitherPath default error status is `hkj.web.either.def
 
 ### Async Executor Configuration
 
-For CompletableFuturePath operations, configure the async thread pool:
+The starter does **not** create or configure a thread pool for `CompletableFuturePath` operations — your application defines its own executor bean and passes it to `CompletableFuture.supplyAsync(...)` in the service layer. The example module's `AsyncConfig` shows the pattern:
 
-```yaml
-hkj:
-  async:
-    core-pool-size: 10                 # Minimum threads
-    max-pool-size: 20                  # Maximum threads
-    queue-capacity: 100                # Queue size before rejection
-    thread-name-prefix: "hkj-async-"   # Thread naming pattern
+```java
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "hkjAsyncExecutor")
+    public Executor hkjAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("hkj-async-");
+        executor.initialize();
+        return executor;
+    }
+}
 ```
+
+Naming the bean `hkjAsyncExecutor` also lights up the optional async-executor health indicator (see [Monitoring](#monitoring-with-spring-boot-actuator)). The one async property the starter does read is `hkj.async.default-timeout-ms` (default: 30000), the response timeout for `CompletableFuturePath` requests.
 
 ### Virtual Thread Configuration
 
@@ -855,53 +924,46 @@ The hkj-spring-boot-starter provides optional Spring Security integration with f
 hkj:
   security:
     enabled: true                       # Enable functional security (default: false)
-    validated-user-details: true        # Use Validated for user loading
     either-authentication: true         # Use Either for authentication
     either-authorization: true          # Use Either for authorisation
+    # Opt-in (default: false). Only enable when you will register accounts: once it is the sole
+    # UserDetailsService bean, Spring Security adopts it as the application-wide user store — and it
+    # starts EMPTY, so enabling it without adding users fails every form/basic login.
+    # validated-user-details: true
 ```
 
 ### Functional User Details Service
 
-Use `Validated` to accumulate authentication errors:
+`ValidatedUserDetailsService` validates the username with `Validated`, accumulating **all** format errors (too short *and* illegal characters, not just the first) before looking the user up. It starts **empty** — register accounts explicitly:
 
 ```java
-@Service
-public class CustomUserDetailsService implements ValidatedUserDetailsService {
-
-    @Override
-    public Validated<List<SecurityError>, UserDetails> loadUserByUsername(String username) {
-        return Validated.validateAll(
-            validateUsername(username),
-            validateAccountStatus(username),
-            validateCredentials(username)
-        ).map(tuple -> new User(
-            tuple._1(),  // username
-            tuple._2(),  // password
-            tuple._3()   // authorities
-        ));
-
-        // Returns ALL validation errors at once
-        // e.g., "Username too short" + "Account locked"
-    }
+@Bean
+public UserDetailsService userDetailsService(PasswordEncoder encoder) {
+    var service = new ValidatedUserDetailsService();
+    service.addUser(User.builder()
+        .username("alice")
+        .password(encoder.encode(secret))
+        .roles("USER")
+        .build());
+    return service;
 }
 ```
 
+~~~admonish warning title="Sample users are opt-in, demos only"
+`ValidatedUserDetailsService.withSampleUsers()` returns an instance pre-populated with well-known accounts (`admin`/`admin123`, `user`/`user123`, `disabled`/`disabled123`) using plaintext `{noop}` passwords. It exists for demos and tests — never use it in production. The no-argument constructor registers **no** users.
+~~~
+
 ### Functional Authentication
 
-Use `Either` for JWT authentication with typed errors:
+`EitherAuthenticationConverter` converts JWTs to `Authentication` using `Either` internally. A **malformed** authorities claim (wrong type, or a collection with a non-string element) always folds the `Left` into a thrown `BadCredentialsException`, so such a token is **rejected** (HTTP 401) — it never produces an authenticated token. A **missing** claim is rejected the same way only while `hkj.security.reject-missing-authorities-claim` stays `true` (the default); set it to `false` to allow legitimately role-less tokens (e.g. client-credentials) to authenticate with empty authorities:
 
 ```java
-@Component
-public class JwtAuthenticationConverter {
-
-    public Either<AuthenticationError, Authentication> convert(Jwt jwt) {
-        return extractUsername(jwt)
-            .flatMap(this::validateToken)
-            .flatMap(this::extractAuthorities)
-            .map(authorities -> new JwtAuthenticationToken(jwt, authorities));
-
-        // Short-circuits on first error
-    }
+@Bean
+public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.oauth2ResourceServer(oauth2 -> oauth2
+        .jwt(jwt -> jwt
+            .jwtAuthenticationConverter(new EitherAuthenticationConverter())));
+    return http.build();
 }
 ```
 
@@ -918,18 +980,19 @@ Track functional programming patterns in production with built-in Actuator integ
 ```yaml
 hkj:
   actuator:
-    metrics:
-      enabled: true                     # Enable metrics tracking
-    health:
-      async-executor:
-        enabled: true                   # Monitor CompletableFuturePath thread pool
+    metrics-enabled: true               # Enable metrics tracking (default: true)
 
 management:
+  health:
+    hkj-async:
+      enabled: true                     # Async executor health indicator (default: true)
   endpoints:
     web:
       exposure:
         include: health,info,metrics,hkj
 ```
+
+The `hkj-async` health indicator only registers when your application defines an `Executor` bean named `hkjAsyncExecutor` (see [Async Executor Configuration](#async-executor-configuration)) — without that bean there is nothing to monitor. Any `Executor` is accepted: a `ThreadPoolTaskExecutor` reports full pool statistics, while other types (e.g. a virtual-thread executor) report `UP` with a `type` detail (or `DOWN` if shut down).
 
 ### Available Metrics
 
@@ -937,10 +1000,10 @@ The starter automatically tracks:
 
 - **EitherPath metrics:** Success/error counts and rates
 - **ValidationPath metrics:** Valid/invalid counts and error distributions
-- **CompletableFuturePath metrics:** Async operation durations and success rates
 - **VTaskPath metrics:** Virtual thread execution durations and success rates
 - **VStreamPath metrics:** Stream completion counts and element distribution
-- **Thread pool health:** Active threads, queue size, saturation
+- **EffectBoundary metrics:** Free-program execution counts and durations (via `ObservableEffectBoundary`)
+- **Thread pool health:** Active threads, queue size, saturation (requires a `hkjAsyncExecutor` bean)
 
 ### Custom HKJ Endpoint
 
@@ -950,42 +1013,63 @@ Access functional programming metrics via the custom actuator endpoint:
 curl http://localhost:8080/actuator/hkj
 ```
 
-Response:
+Response (metric keys are `either`, `validated`, `eitherT`, `vtask`, and `vstream`):
 ```json
 {
   "configuration": {
     "web": {
       "eitherPathEnabled": true,
-      "validatedPathEnabled": true,
-      "completableFuturePathEnabled": true
+      "maybePathEnabled": true,
+      "tryPathEnabled": true,
+      "validationPathEnabled": true,
+      "ioPathEnabled": true,
+      "completableFuturePathEnabled": true,
+      "vtaskPathEnabled": true,
+      "vstreamPathEnabled": true,
+      "eitherOrBothPathEnabled": true,
+      "freePathEnabled": true,
+      "defaultErrorStatus": 400
     },
     "jackson": {
-      "eitherFormat": "TAGGED",
-      "validatedFormat": "TAGGED"
+      "customSerializersEnabled": true
     }
   },
   "metrics": {
-    "eitherPath": {
+    "either": {
       "successCount": 1547,
       "errorCount": 123,
       "totalCount": 1670,
       "successRate": 0.926
     },
-    "validationPath": {
+    "validated": {
       "validCount": 892,
       "invalidCount": 45,
       "totalCount": 937,
       "validRate": 0.952
     },
-    "completableFuturePath": {
+    "eitherT": {
       "successCount": 234,
       "errorCount": 12,
       "totalCount": 246,
       "successRate": 0.951
+    },
+    "vtask": {
+      "successCount": 340,
+      "errorCount": 15,
+      "totalCount": 355,
+      "successRate": 0.958
+    },
+    "vstream": {
+      "successCount": 120,
+      "errorCount": 5,
+      "totalCount": 125,
+      "successRate": 0.960
     }
   }
 }
 ```
+
+(The `eitherT` key and its `hkj.either_t.*` Micrometer meters are a legacy async-metrics surface retained for dashboard compatibility; the actively recorded handler metrics are `either`, `validated`, `vtask`, and `vstream`.)
 
 ### Prometheus Integration
 
@@ -993,24 +1077,25 @@ Export metrics to Prometheus for monitoring and alerting:
 
 ```yaml
 management:
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 ```
 
-Example Prometheus queries:
+The Micrometer meter names are `hkj.either.invocations`, `hkj.validated.invocations`, `hkj.either_t.invocations`, `hkj.either_t.async.duration`, `hkj.vtask.invocations`, `hkj.vtask.duration`, and `hkj.vstream.invocations` (Prometheus renders the dots as underscores):
+
 ```promql
 # EitherPath error rate
-rate(hkj_either_path_invocations_total{result="error"}[5m])
+rate(hkj_either_invocations_total{result="error"}[5m])
 
-# CompletableFuturePath p95 latency
+# VTaskPath p95 latency
 histogram_quantile(0.95,
-  rate(hkj_completable_future_path_async_duration_seconds_bucket[5m]))
+  rate(hkj_vtask_duration_seconds_bucket[5m]))
 
 # ValidationPath success rate
-sum(rate(hkj_validation_path_invocations_total{result="valid"}[5m]))
-  / sum(rate(hkj_validation_path_invocations_total[5m]))
+sum(rate(hkj_validated_invocations_total{result="valid"}[5m]))
+  / sum(rate(hkj_validated_invocations_total[5m]))
 ```
 
 For complete Actuator integration details, see [hkj-spring/ACTUATOR.md](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-spring/ACTUATOR.md).
@@ -1035,9 +1120,9 @@ class UserControllerTest {
     void shouldReturn200ForExistingUser() throws Exception {
         mockMvc.perform(get("/api/users/1"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.value.id").value("1"))
-            .andExpect(jsonPath("$.value.email").value("alice@example.com"));
+            // Success bodies are unwrapped — no envelope fields
+            .andExpect(jsonPath("$.id").value("1"))
+            .andExpect(jsonPath("$.email").value("alice@example.com"));
     }
 
     @Test
@@ -1045,7 +1130,8 @@ class UserControllerTest {
         mockMvc.perform(get("/api/users/999"))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.success").value(false))
-            .andExpect(jsonPath("$.error.type").value("UserNotFoundError"));
+            // The error record is embedded as-is — assert on its own fields
+            .andExpect(jsonPath("$.error.userId").value("999"));
     }
 }
 ```
@@ -1067,9 +1153,9 @@ void shouldAccumulateValidationErrors() throws Exception {
             .contentType(MediaType.APPLICATION_JSON)
             .content(invalidRequest))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.valid").value(false))
         .andExpect(jsonPath("$.errors").isArray())
-        .andExpect(jsonPath("$.errors.length()").value(3));  // All errors returned
+        .andExpect(jsonPath("$.errorCount").value(3));  // All errors returned
 }
 ```
 
@@ -1107,11 +1193,11 @@ class UserControllerWebMvcSliceTest {
     @Test
     void shouldReturn200ForExistingUser() throws Exception {
         when(userService.findById("1"))
-            .thenReturn(Either.right(new User("1", "alice@example.com")));
+            .thenReturn(Either.right(new User("1", "alice@example.com", "Alice", "Smith")));
 
         mockMvc.perform(get("/api/users/1"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.value.id").value("1"));
+            .andExpect(jsonPath("$.id").value("1"));
     }
 
     @Test
@@ -1125,7 +1211,7 @@ class UserControllerWebMvcSliceTest {
 }
 ```
 
-The three imports activate EitherPath/ValidationPath/Maybe/Try/IO/CompletableFuture/VTask/VStream/Free return-value handling, Jackson modules for functional types, and the error-status mapper; everything a controller slice needs. For integration-style tests covering the full stack, prefer `@SpringBootTest @AutoConfigureMockMvc` as shown above.
+The three imports activate EitherPath/ValidationPath/Maybe/Try/IO/CompletableFuture/VTask/VStream/EitherOrBoth/Free return-value handling, Jackson modules for functional types, and the error-status mapper; everything a controller slice needs. For integration-style tests covering the full stack, prefer `@SpringBootTest @AutoConfigureMockMvc` as shown above.
 
 ### Unit Testing Services
 
@@ -1207,7 +1293,7 @@ public class HkjWebMvcAutoConfiguration implements WebMvcConfigurer {
 ```
 
 Auto-configuration activates when:
-- `higher-kinded-j-core` is on the classpath
+- `hkj-core` is on the classpath
 - Spring Web MVC is present
 - Application is a servlet web app
 
@@ -1215,22 +1301,23 @@ Auto-configuration activates when:
 
 Each functional type has a dedicated handler:
 
-1. **EitherPathReturnValueHandler:** Converts `EitherPath<L, R>` to HTTP responses
-2. **ValidationPathReturnValueHandler:** Converts `ValidationPath<E, A>` to HTTP responses
+1. **EitherPathReturnValueHandler:** Converts `EitherPath<L, R>` (and raw `Either`) to HTTP responses
+2. **ValidationPathReturnValueHandler:** Converts `ValidationPath<E, A>` (and raw `Validated`) to HTTP responses
 3. **MaybePathReturnValueHandler:** Converts `MaybePath<A>`, mapping `Just` to `200` and `Nothing` to `404`
 4. **TryPathReturnValueHandler:** Converts `TryPath<A>`, mapping `Success` to `200` and `Failure` to an error response
 5. **IOPathReturnValueHandler:** Executes `IOPath<A>` and writes the captured result
 6. **CompletableFuturePathReturnValueHandler:** Unwraps `CompletableFuturePath<A>` for async processing
 7. **VTaskPathReturnValueHandler:** Executes `VTaskPath<A>` on virtual threads via `DeferredResult`
 8. **VStreamPathReturnValueHandler:** Streams `VStreamPath<A>` as SSE events on virtual threads
-9. **FreePathReturnValueHandler:** Interprets `FreePath<F, A>` via the registered `EffectBoundary` bean
+9. **EitherOrBothPathReturnValueHandler:** Converts `EitherOrBothPath<W, A>` (and raw `EitherOrBoth`), surfacing `Both` warnings in the `X-Hkj-Warnings` header
+10. **FreePathReturnValueHandler:** Interprets `FreePath<F, A>` via the registered `EffectBoundary` bean
 
 Supporting collaborators:
 
 - **`SuccessStatusResolver`:** Reads `@ResponseStatus` on the handler method (with controller-class fallback and meta-annotation support) so each handler can override its default success status.
 - **`ErrorStatusCodeStrategy`:** Functional interface invoked once per error response. The default `DefaultErrorStatusCodeStrategy` consults `hkj.web.error-status-mappings` first, then falls back to `ErrorStatusCodeMapper`'s tokenised heuristics, then to `hkj.web.either.default-error-status`. Replace the bean to inject custom logic (for example, status that depends on an error's field values).
 - **`ErrorStatusCodeMapper`:** Token-aware heuristic resolver used by the default strategy. Exposed as a static helper so custom strategies can delegate to the same logic.
-- **`HttpHeaderCarrier`:** Mix-in interface that lets `Left`-side error payloads add response headers (`Retry-After`, `WWW-Authenticate`, and similar) to the outgoing response. Honoured by every error-bearing handler except `VStreamPath`.
+- **`HttpHeaderCarrier`:** Mix-in interface that lets `Left`-side error payloads add response headers (`Retry-After`, `WWW-Authenticate`, and similar) to the outgoing response. Honoured by every error-bearing handler except `VStreamPath` and `MaybePath` (which has no error payload).
 
 Handlers are registered automatically and integrated seamlessly with Spring's request processing lifecycle.
 

--- a/hkj-spring/ACTUATOR.md
+++ b/hkj-spring/ACTUATOR.md
@@ -21,7 +21,7 @@ This guide covers the Spring Boot Actuator integration for higher-kinded-j, prov
 
 The higher-kinded-j Actuator integration provides:
 
-- **Metrics tracking** for Either, Validated, CompletableFuturePath, VTask, and VStream operations
+- **Metrics tracking** for Either, Validated, VTask, VStream, and EffectBoundary operations
 - **Custom actuator endpoint** exposing HKJ configuration and metrics
 - **Health indicator** for async executor monitoring
 - **Micrometer integration** for metrics export to monitoring systems
@@ -29,7 +29,7 @@ The higher-kinded-j Actuator integration provides:
 ### Benefits
 
 - Monitor functional error handling in production
-- Track success/failure rates for Either, CompletableFuturePath, VTask, and VStream
+- Track success/failure rates for Either, Validated, VTask, and VStream
 - Validate thread pool health for async operations
 - Track virtual thread performance and streaming element counts
 - Export metrics to Prometheus, Graphite, or other systems
@@ -61,19 +61,23 @@ The Actuator integration is included in `hkj-spring-boot-starter`:
 # application.yml
 hkj:
   actuator:
-    metrics:
-      enabled: true          # Enable HKJ metrics (default: true)
-    health:
-      async-executor:
-        enabled: true        # Enable async health indicator (default: true)
+    metrics-enabled: true    # Enable HKJ metrics (default: true)
 
 # Expose actuator endpoints
 management:
+  health:
+    hkj-async:
+      enabled: true          # Async executor health indicator (default: true)
   endpoints:
     web:
       exposure:
         include: health,info,metrics,hkj
 ```
+
+> The `hkj-async` health indicator only registers when the application defines an `Executor` bean
+> named `hkjAsyncExecutor` — the starter does not create one. Any `Executor` is accepted: a
+> `ThreadPoolTaskExecutor` reports full pool statistics, while other types (e.g. a virtual-thread
+> executor) report `UP` with a `type` detail (or `DOWN` if the executor is shut down).
 
 ### 3. Access Metrics
 
@@ -97,10 +101,10 @@ The `HkjMetricsService` tracks metrics for all functional constructs using Micro
 | `hkj.either.errors` | Counter | Either errors (tagged: error_type) |
 | `hkj.validated.invocations` | Counter | Validated invocations (tagged: valid/invalid) |
 | `hkj.validated.error_count` | Summary | Number of errors in Invalid cases |
-| `hkj.async.invocations` | Counter | CompletableFuturePath invocations (tagged: success/error) |
-| `hkj.async.errors` | Counter | CompletableFuturePath errors (tagged: error_type) |
-| `hkj.async.duration` | Timer | CompletableFuturePath async operation duration |
-| `hkj.async.exceptions` | Counter | CompletableFuturePath exceptions (tagged: exception_type) |
+| `hkj.either_t.invocations` | Counter | Legacy async invocations (tagged: success/error) — registered for dashboard compatibility, not recorded by the current handlers |
+| `hkj.either_t.errors` | Counter | Legacy async errors (tagged: error_type) |
+| `hkj.either_t.async.duration` | Timer | Legacy async operation duration |
+| `hkj.either_t.exceptions` | Counter | Legacy async exceptions (tagged: exception_type) |
 | `hkj.vtask.invocations` | Counter | VTask invocations (tagged: success/error) |
 | `hkj.vtask.errors` | Counter | VTask errors (tagged: error_type) |
 | `hkj.vtask.duration` | Timer | VTask virtual thread operation duration |
@@ -161,10 +165,7 @@ GET /actuator/hkj
       "defaultErrorStatus": 400
     },
     "jackson": {
-      "customSerializersEnabled": true,
-      "eitherFormat": "TAGGED",
-      "validatedFormat": "TAGGED",
-      "maybeFormat": "TAGGED"
+      "customSerializersEnabled": true
     }
   },
   "metrics": {
@@ -180,11 +181,11 @@ GET /actuator/hkj
       "totalCount": 250,
       "validRate": 0.800
     },
-    "async": {
-      "successCount": 75,
-      "errorCount": 10,
-      "totalCount": 85,
-      "successRate": 0.882
+    "eitherT": {
+      "successCount": 0,
+      "errorCount": 0,
+      "totalCount": 0,
+      "successRate": 0.0
     },
     "vtask": {
       "successCount": 340,
@@ -272,30 +273,19 @@ hkj:
     completable-future-path-enabled: true
     default-error-status: 400
 
-  # Jackson serialization
-  jackson:
+  # Jackson serialisation (property prefix is hkj.json)
+  json:
     custom-serializers-enabled: true
-    either-format: TAGGED
-    validated-format: TAGGED
-    maybe-format: TAGGED
-
-  # Async executor for CompletableFuturePath
-  async:
-    executor-core-pool-size: 10
-    executor-max-pool-size: 20
-    executor-queue-capacity: 100
-    executor-thread-name-prefix: "hkj-async-"
 
   # Actuator integration
   actuator:
-    metrics:
-      enabled: true
-    health:
-      async-executor:
-        enabled: true
+    metrics-enabled: true
 
 # Spring Boot Actuator
 management:
+  health:
+    hkj-async:
+      enabled: true   # Requires a user-defined "hkjAsyncExecutor" bean
   endpoints:
     web:
       exposure:
@@ -308,6 +298,8 @@ management:
       enabled: true
 ```
 
+The `CompletableFuturePath` thread pool itself is not configured by the starter — the application defines its own `Executor` bean (see the example module's `AsyncConfig`) and names it `hkjAsyncExecutor` if the health indicator should monitor it.
+
 ### Conditional Configuration
 
 Disable metrics if not needed:
@@ -315,18 +307,16 @@ Disable metrics if not needed:
 ```yaml
 hkj:
   actuator:
-    metrics:
-      enabled: false  # Metrics service will not be created
+    metrics-enabled: false  # Metrics service will not be created
 ```
 
 Disable async health checks:
 
 ```yaml
-hkj:
-  actuator:
-    health:
-      async-executor:
-        enabled: false  # Health indicator will not be registered
+management:
+  health:
+    hkj-async:
+      enabled: false  # Health indicator will not be registered
 ```
 
 ## Metrics Details
@@ -375,29 +365,9 @@ rate(hkj_validated_error_count_sum[5m])
 rate(hkj_validated_error_count_count[5m])
 ```
 
-### CompletableFuturePath Metrics
+### Legacy Async (EitherT) Metrics
 
-Track async operations with success rates, durations, and exception handling.
-
-**Use Cases:**
-- Monitor async API performance
-- Track async error rates
-- Identify slow async operations
-- Monitor exception patterns
-
-**Example Queries:**
-
-```promql
-# Prometheus query for CompletableFuturePath latency (p95)
-histogram_quantile(0.95,
-  rate(hkj_async_duration_seconds_bucket[5m]))
-
-# CompletableFuturePath error rate
-rate(hkj_async_invocations_total{result="error"}[5m])
-
-# Exception types distribution
-sum by (exception_type) (hkj_async_exceptions_total)
-```
+The `hkj.either_t.*` meters (`invocations`, `errors`, `async.duration`, `exceptions`) are registered for dashboard compatibility with earlier releases, and their counts are exposed under the `eitherT` key of `/actuator/hkj`. The current `CompletableFuturePath` handler does not record into them — for live async metrics use the VTask meters below, or record into `HkjMetricsService` manually from your own code.
 
 ### VTask Metrics
 
@@ -487,13 +457,17 @@ The async health indicator monitors thread pool saturation and queue fullness.
 
 **Indicates:** Queue is full, new async operations will be rejected.
 
-**Action:** Increase pool size or queue capacity:
+**Action:** Increase the pool size or queue capacity on your `hkjAsyncExecutor` bean:
 
-```yaml
-hkj:
-  async:
-    max-pool-size: 40      # Increase max threads
-    queue-capacity: 200    # Increase queue size
+```java
+@Bean(name = "hkjAsyncExecutor")
+public Executor hkjAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setMaxPoolSize(40);       // Increase max threads
+    executor.setQueueCapacity(200);    // Increase queue size
+    executor.initialize();
+    return executor;
+}
 ```
 
 ### Custom Health Checks
@@ -547,9 +521,9 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus,hkj
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 ```
 
@@ -570,9 +544,9 @@ scrape_configs:
 # Either error rate over time
 rate(hkj_either_invocations_total{result="error"}[5m])
 
-# EitherT p95 latency
+# VTask p95 latency
 histogram_quantile(0.95,
-  rate(hkj_either_t_async_duration_seconds_bucket[5m]))
+  rate(hkj_vtask_duration_seconds_bucket[5m]))
 
 # Validated success rate
 sum(rate(hkj_validated_invocations_total{result="valid"}[5m]))
@@ -596,18 +570,18 @@ Example Grafana queries for HKJ metrics:
       ]
     },
     {
-      "title": "EitherT Async Duration (p95)",
+      "title": "VTask Duration (p95)",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, rate(hkj_either_t_async_duration_seconds_bucket[5m]))"
+          "expr": "histogram_quantile(0.95, rate(hkj_vtask_duration_seconds_bucket[5m]))"
         }
       ]
     },
     {
-      "title": "Thread Pool Utilization",
+      "title": "VStream Elements per Stream (avg)",
       "targets": [
         {
-          "expr": "hkj_async_active_count / hkj_async_pool_size"
+          "expr": "rate(hkj_vstream_elements_sum[5m]) / rate(hkj_vstream_elements_count[5m])"
         }
       ]
     }
@@ -635,22 +609,14 @@ groups:
           summary: "High Either error rate"
           description: "Either error rate is {{ $value }} (>50%)"
 
-      # Alert when async queue is getting full
-      - alert: AsyncQueueNearFull
-        expr: hkj_async_queue_remaining_capacity < 10
-        for: 2m
-        annotations:
-          summary: "Async queue near capacity"
-          description: "Only {{ $value }} slots remaining"
-
-      # Alert when EitherT operations are slow
-      - alert: SlowEitherTOperations
+      # Alert when VTask operations are slow
+      - alert: SlowVTaskOperations
         expr: |
           histogram_quantile(0.95,
-            rate(hkj_either_t_async_duration_seconds_bucket[5m])) > 5
+            rate(hkj_vtask_duration_seconds_bucket[5m])) > 5
         for: 5m
         annotations:
-          summary: "Slow EitherT operations"
+          summary: "Slow VTask operations"
           description: "p95 latency is {{ $value }}s (>5s)"
 ```
 
@@ -666,29 +632,22 @@ Metrics collection has minimal overhead:
 
 ### Tuning Thread Pool
 
-Monitor these indicators to tune the async executor:
+The async pool is your own `hkjAsyncExecutor` bean, so tuning happens in code:
 
-```yaml
-# Conservative (low traffic)
-hkj:
-  async:
-    core-pool-size: 5
-    max-pool-size: 10
-    queue-capacity: 50
-
-# Moderate (medium traffic)
-hkj:
-  async:
-    core-pool-size: 10
-    max-pool-size: 20
-    queue-capacity: 100
-
-# Aggressive (high traffic)
-hkj:
-  async:
-    core-pool-size: 20
-    max-pool-size: 50
-    queue-capacity: 500
+```java
+@Bean(name = "hkjAsyncExecutor")
+public Executor hkjAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    // Conservative (low traffic):  core 5,  max 10, queue 50
+    // Moderate (medium traffic):   core 10, max 20, queue 100
+    // Aggressive (high traffic):   core 20, max 50, queue 500
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(20);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("hkj-async-");
+    executor.initialize();
+    return executor;
+}
 ```
 
 **Monitoring Guidelines:**
@@ -839,8 +798,7 @@ class HkjEndpointIntegrationTest {
    ```yaml
    hkj:
      actuator:
-       metrics:
-         enabled: true
+       metrics-enabled: true
    ```
 
 2. Verify HkjMetricsService bean exists:
@@ -866,11 +824,15 @@ class HkjEndpointIntegrationTest {
 **Problem:** `hkjAsync` always shows DOWN status
 
 **Solutions:**
-1. Check executor is initialized:
+1. Check the indicator is enabled and the executor bean exists — the indicator only registers
+   when the application defines an `Executor` bean named `hkjAsyncExecutor` (a
+   `ThreadPoolTaskExecutor` exposes full pool statistics; other executor types report `UP` with a
+   `type` detail):
    ```yaml
-   hkj:
-     async:
-       core-pool-size: 10  # Must be > 0
+   management:
+     health:
+       hkj-async:
+         enabled: true
    ```
 
 2. Verify executor bean:
@@ -906,7 +868,7 @@ class HkjEndpointIntegrationTest {
 
 The higher-kinded-j Actuator integration provides:
 
-- **Comprehensive metrics** for Either, Validated, CompletableFuturePath, VTask, and VStream
+- **Comprehensive metrics** for Either, Validated, VTask, VStream, and EffectBoundary
 - **Health monitoring** for async thread pools
 - **Custom endpoint** for configuration and metrics snapshots
 - **Micrometer integration** for export to monitoring systems

--- a/hkj-spring/CONFIGURATION.md
+++ b/hkj-spring/CONFIGURATION.md
@@ -6,10 +6,10 @@ This document provides a complete reference for all configuration properties ava
 
 1. [Quick Start](#quick-start)
 2. [Web/MVC Configuration](#webmvc-configuration)
-3. [Validation Configuration](#validation-configuration)
-4. [JSON Serialization Configuration](#json-serialization-configuration)
-5. [Async Configuration](#async-configuration)
-6. [Virtual Thread Configuration](#virtual-thread-configuration)
+3. [JSON Serialization Configuration](#json-serialization-configuration)
+4. [Async Configuration](#async-configuration)
+5. [Virtual Thread Configuration](#virtual-thread-configuration)
+6. [Effect Boundary Configuration](#effect-boundary-configuration)
 7. [Client HTTP Configuration](#client-http-configuration)
 8. [Complete Example](#complete-example)
 9. [Disabling Features](#disabling-features)
@@ -31,8 +31,8 @@ All configuration is optional. The integration works out-of-the-box with sensibl
 hkj:
   web:
     default-error-status: 500
-  json:
-    either-format: SIMPLE
+    error-status-mappings:
+      ConflictError: 409
 ```
 
 ## Web/MVC Configuration
@@ -158,6 +158,38 @@ hkj:
   web:
     vstream-path-enabled: false  # Disable VStreamPath handler
 ```
+
+### `hkj.web.either-or-both-path-enabled`
+
+Enable or disable the `EitherOrBothPathReturnValueHandler`.
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Effect:** When enabled, controllers can return `EitherOrBothPath<W, A>` (or raw `EitherOrBoth<W, A>`) — the inclusive-or type whose `Both` case models "success with non-fatal warnings"
+
+**Response contract:**
+
+| Result | Status | Body | Header |
+|--------|--------|------|--------|
+| `Right(value)` | success status (200 or `@ResponseStatus`) | value, unwrapped | — |
+| `Both(warnings, value)` | same success status | value, unwrapped | warnings JSON-encoded into `X-Hkj-Warnings` |
+| `Left(warnings)` | resolved by `ErrorStatusCodeStrategy` (as for `EitherPath`) | `{"success": false, "error": <warnings>}` | `HttpHeaderCarrier` headers if implemented |
+
+Warnings on the `Both` branch are never silently dropped, but the success body stays the bare value: clients that ignore the `X-Hkj-Warnings` header see a normal success response; clients that care parse the header's JSON.
+
+**Example:**
+```yaml
+hkj:
+  web:
+    either-or-both-path-enabled: false  # Disable EitherOrBothPath handler
+```
+
+### `hkj.web.free-path-enabled`
+
+Enable or disable the `FreePathReturnValueHandler` (Free-monad programs interpreted through the `EffectBoundary` bean). See [EFFECT_BOUNDARY.md](EFFECT_BOUNDARY.md) for the companion keys `free-path-failure-status` and `free-path-include-exception-details`.
+
+- **Type:** `boolean`
+- **Default:** `true`
 
 ### `hkj.web.either.default-error-status` (alias: `hkj.web.default-error-status`)
 
@@ -391,70 +423,18 @@ For anything beyond table lookup — for example, a status that depends on a rec
 (`MfaThrottledError.retryAfter() ≥ 60 → 503`) — register a custom
 [`ErrorStatusCodeStrategy` bean](#error-status-code-strategy-bean).
 
-## Validation Configuration
-
-Configure validation behaviour for `Validated` types.
-
-### `hkj.validation.enabled`
-
-Enable or disable validation support.
-
-- **Type:** `boolean`
-- **Default:** `true`
-- **Effect:** Global toggle for Validated functionality
-- **Note:** Currently informational; all validation features are always available
-
-**Example:**
-```yaml
-hkj:
-  validation:
-    enabled: false
-```
-
-### `hkj.validation.accumulate-errors`
-
-Accumulate all validation errors vs. fail-fast on first error.
-
-- **Type:** `boolean`
-- **Default:** `true`
-- **Effect:** When true, `Validated` accumulates all errors; when false, stops at first error (behaves like Either)
-- **Note:** Currently informational; error accumulation is controlled by using `Validated` vs `Either`
-
-**Example:**
-```yaml
-hkj:
-  validation:
-    accumulate-errors: false  # Fail-fast behaviour
-```
-
-### `hkj.validation.max-errors`
-
-Maximum number of errors to accumulate.
-
-- **Type:** `int`
-- **Default:** `0` (unlimited)
-- **Effect:** Limits error accumulation to prevent unbounded error lists
-- **Note:** Currently informational; will be implemented in future versions
-
-**Example:**
-```yaml
-hkj:
-  validation:
-    max-errors: 10  # Stop after 10 errors
-```
-
 ## JSON Serialization Configuration
 
 Configure Jackson serialization for higher-kinded-j types.
 
 ### `hkj.json.custom-serializers-enabled`
 
-Enable or disable custom Jackson serializers for Either and Validated.
+Enable or disable the custom Jackson serializers for `Either`, `Validated`, `EitherOrBoth`, and `NonEmptyList`.
 
 - **Type:** `boolean`
 - **Default:** `true`
 - **Effect:** Controls registration of `HkjJacksonModule`
-- **When disabled:** Either and Validated will use default Jackson serialization (may fail)
+- **When disabled:** Nested HKJ types will use default Jackson serialization (may fail)
 
 **Example:**
 ```yaml
@@ -463,152 +443,36 @@ hkj:
     custom-serializers-enabled: false  # Use default serialization
 ```
 
-### `hkj.json.either-format`
+The JSON shapes produced by the module are **fixed** — there are no format-toggle properties. Nested values serialise as:
 
-JSON output format for Either types (when serialized by Jackson).
-
-- **Type:** `SerializationFormat` enum
-- **Default:** `TAGGED`
-- **Valid values:**
-  - `TAGGED`: `{"isRight": true/false, "right/left": value}`
-  - `SIMPLE`: `{"value": ...}` or `{"error": ...}`
-- **Effect:** Changes JSON structure for nested Either values
-- **Note:** Does NOT affect top-level Either return values (those use return value handler)
-
-**Example:**
-```yaml
-hkj:
-  json:
-    either-format: SIMPLE  # Simpler JSON structure
-```
-
-**Output comparison:**
-
-**TAGGED format (default):**
 ```json
-{
-  "results": [
-    {"isRight": true, "right": {"id": "1", "name": "Alice"}},
-    {"isRight": false, "left": "Not found"}
-  ]
-}
+// Either
+{"isRight": true, "right": <value>}
+{"isRight": false, "left": <error>}
+
+// Validated
+{"valid": true, "value": <value>}
+{"valid": false, "errors": <errors>}
+
+// EitherOrBoth
+{"kind": "right", "right": <value>}
+{"kind": "both", "left": <warnings>, "right": <value>}
+{"kind": "left", "left": <warnings>}
 ```
 
-**SIMPLE format:**
-```json
-{
-  "results": [
-    {"value": {"id": "1", "name": "Alice"}},
-    {"error": "Not found"}
-  ]
-}
-```
-
-### `hkj.json.validated-format`
-
-JSON output format for Validated types (when serialized by Jackson).
-
-- **Type:** `SerializationFormat` enum
-- **Default:** `TAGGED`
-- **Valid values:**
-  - `TAGGED`: `{"valid": true/false, "value/errors": ...}`
-  - `SIMPLE`: `{"value": ...}` or `{"errors": ...}`
-
-**Example:**
-```yaml
-hkj:
-  json:
-    validated-format: SIMPLE
-```
-
-### `hkj.json.maybe-format`
-
-JSON output format for Maybe types (when serialized by Jackson).
-
-- **Type:** `SerializationFormat` enum
-- **Default:** `TAGGED`
-- **Valid values:**
-  - `TAGGED`: `{"present": true/false, "value": ...}`
-  - `SIMPLE`: `{"value": ...}` or null
-
-**Example:**
-```yaml
-hkj:
-  json:
-    maybe-format: SIMPLE
-```
+`Maybe` and `Try` have no Jackson support: return them at the top level (where the return-value handlers apply) rather than nesting them inside DTOs. Top-level controller return values are shaped by the handlers, not by these serializers — see [JACKSON_SERIALIZATION.md](JACKSON_SERIALIZATION.md).
 
 ## Async Configuration
 
-Configure async execution for CompletableFuturePath operations.
-
-### `hkj.async.executor-core-pool-size`
-
-Core thread pool size for async operations.
-
-- **Type:** `int`
-- **Default:** `10`
-- **Effect:** Minimum number of threads in the pool
-
-**Example:**
-```yaml
-hkj:
-  async:
-    executor-core-pool-size: 20
-```
-
-### `hkj.async.executor-max-pool-size`
-
-Maximum thread pool size for async operations.
-
-- **Type:** `int`
-- **Default:** `20`
-- **Effect:** Maximum number of threads in the pool
-
-**Example:**
-```yaml
-hkj:
-  async:
-    executor-max-pool-size: 50
-```
-
-### `hkj.async.executor-queue-capacity`
-
-Queue capacity for async executor.
-
-- **Type:** `int`
-- **Default:** `100`
-- **Effect:** Number of tasks to queue when all threads are busy
-
-**Example:**
-```yaml
-hkj:
-  async:
-    executor-queue-capacity: 500
-```
-
-### `hkj.async.executor-thread-name-prefix`
-
-Thread name prefix for async executor threads.
-
-- **Type:** `String`
-- **Default:** `"hkj-async-"`
-- **Effect:** Makes threads identifiable in logs and profilers
-
-**Example:**
-```yaml
-hkj:
-  async:
-    executor-thread-name-prefix: "my-app-async-"
-```
+`CompletableFuturePath` services supply their own executor — the starter does not create a thread pool. Define an `Executor` bean in your application (the example module's `AsyncConfig` uses a `ThreadPoolTaskExecutor` named `hkjAsyncExecutor`) and pass it to `CompletableFuture.supplyAsync(...)`. Naming the bean `hkjAsyncExecutor` also enables the optional `hkj-async` health indicator (see [ACTUATOR.md](ACTUATOR.md)).
 
 ### `hkj.async.default-timeout-ms`
 
-Default timeout for async operations in milliseconds.
+Default timeout for `CompletableFuturePath` responses in milliseconds.
 
 - **Type:** `long`
 - **Default:** `30000` (30 seconds)
-- **Effect:** Maximum time to wait for async operations
+- **Effect:** Maximum time to wait for the future to complete before the `DeferredResult` times out (HTTP 504)
 
 **Example:**
 ```yaml
@@ -650,6 +514,18 @@ hkj:
   virtual-threads:
     stream-timeout-ms: 120000  # 2 minutes
 ```
+
+## Effect Boundary Configuration
+
+### `hkj.effect-boundary.enabled`
+
+Master switch for `@EnableEffectBoundary` auto-configuration.
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Effect:** When `false`, the registrar does not create the `effectBoundary` bean
+
+Interpreter validation is always fail-fast (a missing or ambiguous interpreter is a startup error), and environment-specific interpreter switching uses the `@Interpreter(profile = ...)` attribute — neither is configurable via properties. See [EFFECT_BOUNDARY.md](EFFECT_BOUNDARY.md) for the full guide.
 
 ## Client HTTP Configuration
 
@@ -735,17 +611,21 @@ hkj:
     completable-future-path-enabled: true
     vtask-path-enabled: true
     vstream-path-enabled: true
+    either-or-both-path-enabled: true
+    free-path-enabled: true
     default-error-status: 400
     maybe-nothing-status: 404
     try-failure-status: 500
     validation-invalid-status: 400
     vtask-failure-status: 500
     vstream-failure-status: 500
+    free-path-failure-status: 500
     try-include-exception-details: false
     io-include-exception-details: false
     async-include-exception-details: false
     vtask-include-exception-details: false
     vstream-include-exception-details: false
+    free-path-include-exception-details: false
     error-status-mappings:
       UserNotFoundError: 404
       ValidationError: 400
@@ -754,27 +634,18 @@ hkj:
       ServerError: 500
       ConflictError: 409
 
-  validation:
-    enabled: true
-    accumulate-errors: true
-    max-errors: 0  # unlimited
-
   json:
     custom-serializers-enabled: true
-    either-format: TAGGED
-    validated-format: TAGGED
-    maybe-format: TAGGED
 
   async:
-    executor-core-pool-size: 10
-    executor-max-pool-size: 20
-    executor-queue-capacity: 100
-    executor-thread-name-prefix: "hkj-async-"
     default-timeout-ms: 30000
 
   virtual-threads:
     default-timeout-ms: 30000
     stream-timeout-ms: 60000
+
+  effect-boundary:
+    enabled: true
 ```
 
 ## Disabling Features
@@ -853,6 +724,8 @@ hkj:
     completable-future-path-enabled: false
     vtask-path-enabled: false
     vstream-path-enabled: false
+    either-or-both-path-enabled: false
+    free-path-enabled: false
   json:
     custom-serializers-enabled: false
 ```
@@ -874,8 +747,6 @@ hkj:
     async-include-exception-details: true
     vtask-include-exception-details: true
     vstream-include-exception-details: true
-  json:
-    either-format: TAGGED  # More verbose for debugging
 ```
 
 ### Production
@@ -894,8 +765,6 @@ hkj:
       UserNotFoundError: 404
       ValidationError: 400
       AuthorizationError: 403
-  json:
-    either-format: SIMPLE  # Cleaner API responses
 ```
 
 ### Testing
@@ -906,8 +775,6 @@ hkj:
     default-error-status: 400
     try-include-exception-details: true  # Helps debug test failures
   async:
-    executor-core-pool-size: 2  # Smaller pool for tests
-    executor-max-pool-size: 5
     default-timeout-ms: 5000  # Shorter timeout
 ```
 
@@ -925,6 +792,8 @@ hkj.web.io-path-enabled=true
 hkj.web.completable-future-path-enabled=true
 hkj.web.vtask-path-enabled=true
 hkj.web.vstream-path-enabled=true
+hkj.web.either-or-both-path-enabled=true
+hkj.web.free-path-enabled=true
 hkj.web.default-error-status=400
 hkj.web.maybe-nothing-status=404
 hkj.web.try-failure-status=500
@@ -937,23 +806,14 @@ hkj.web.vstream-include-exception-details=false
 hkj.web.error-status-mappings.UserNotFoundError=404
 hkj.web.error-status-mappings.ValidationError=400
 
-# Validation configuration
-hkj.validation.enabled=true
-hkj.validation.accumulate-errors=true
-hkj.validation.max-errors=0
-
 # JSON configuration
 hkj.json.custom-serializers-enabled=true
-hkj.json.either-format=TAGGED
-hkj.json.validated-format=TAGGED
-hkj.json.maybe-format=TAGGED
 
 # Async configuration
-hkj.async.executor-core-pool-size=10
-hkj.async.executor-max-pool-size=20
-hkj.async.executor-queue-capacity=100
-hkj.async.executor-thread-name-prefix=hkj-async-
 hkj.async.default-timeout-ms=30000
+
+# Effect boundary configuration
+hkj.effect-boundary.enabled=true
 
 # Virtual thread configuration
 hkj.virtual-threads.default-timeout-ms=30000
@@ -981,9 +841,6 @@ public class HkjConfig {
         // Configure web
         properties.getWeb().setDefaultErrorStatus(500);
         properties.getWeb().getErrorStatusMappings().put("MyCustomError", 418);
-
-        // Configure JSON
-        properties.getJson().setEitherFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
 
         return properties;
     }
@@ -1028,7 +885,7 @@ public record MfaThrottledError(int retryAfterSeconds) implements DomainError, H
 }
 ```
 
-The headers are applied by `EitherPath`, `TryPath`, `ValidationPath`, `IOPath`,
+The headers are applied by `EitherPath`, `EitherOrBothPath`, `TryPath`, `ValidationPath`, `IOPath`,
 `CompletableFuturePath`, `VTaskPath`, and `FreePath` handlers before the JSON body is written.
 Internally the headers are added (not set), so multi-valued headers such as
 `WWW-Authenticate`, `Set-Cookie`, and `Link` accumulate as separate header lines on the

--- a/hkj-spring/EFFECT_BOUNDARY.md
+++ b/hkj-spring/EFFECT_BOUNDARY.md
@@ -99,17 +99,9 @@ public class PaymentController {
 ### `hkj.effect-boundary.enabled`
 
 - **Type:** `boolean` | **Default:** `true`
-- **Effect:** Master switch for EffectBoundary auto-configuration
+- **Effect:** Master switch consulted by the `@EnableEffectBoundary` registrar. When `false`, the `effectBoundary` bean is not registered.
 
-### `hkj.effect-boundary.startup-validation`
-
-- **Type:** `boolean` | **Default:** `true`
-- **Effect:** Fail fast at startup if any declared effect algebra has no matching `@Interpreter` bean
-
-### `hkj.effect-boundary.interpreter-selection`
-
-- **Type:** `Map<String, String>` | **Default:** empty
-- **Effect:** Configuration-driven interpreter selection by qualifier (keys are hyphenated algebra names, values are bean qualifiers)
+Interpreter validation is always fail-fast: a declared effect algebra with no matching `@Interpreter` bean — or with more than one eligible bean in the same specificity tier after profile filtering — is a startup error. A profile-restricted interpreter is more specific and shadows an unrestricted one, so a `profile = "test"` stub automatically replaces the production interpreter when the test profile is active. There is no property to relax this, and interpreter switching is done with `@Interpreter(profile = ...)`, not configuration keys.
 
 ### `hkj.web.free-path-enabled`
 
@@ -200,12 +192,11 @@ Replaces manual wiring with a single declaration. The `value` attribute lists th
 
 1. Reads the effect algebra class list from the annotation
 2. Resolves each to its generated `*Kind.Witness` type
-3. Scans for `@Interpreter`-annotated beans matching each algebra
+3. Scans for `@Interpreter`-annotated beans matching each algebra, filtering by active profile
 4. Constructs the `EitherF` nesting order automatically (left-to-right = outer-to-inner)
 5. Calls `Interpreters.combine()` with the discovered interpreters
-6. Registers `EffectBoundary<ComposedWitness>` as a singleton bean
-7. Registers individual `Bound<ComposedWitness>` beans for constructor injection in services
-8. Validates at startup: missing interpreter produces a clear error naming the unimplemented algebra
+6. Registers the single `effectBoundary` bean (`EffectBoundary<ComposedWitness>`) as a singleton
+7. Validates at startup: a missing interpreter — or two equally-specific eligible interpreters for one algebra — produces a clear error naming the offending algebra
 
 ### Multiple Boundary Beans
 
@@ -230,7 +221,7 @@ Inject with `@Qualifier("payments") EffectBoundary<PaymentEffects> boundary` in 
 Marks a class as a Spring-managed interpreter for a specific effect algebra. Because `@Interpreter` includes `@Component`, interpreters are full Spring beans and constructor injection works naturally.
 
 - **`value()`** -- The effect algebra class this interpreter handles. The registrar uses this to match interpreters to algebras declared in `@EnableEffectBoundary`.
-- **`profile()`** -- Optional Spring profile. When set, the interpreter is only active in that profile, enabling environment-based switching.
+- **`profile()`** -- Optional Spring profile expression. When set, the interpreter is only **eligible** while that profile is active (the registrar filters candidates with `Environment.acceptsProfiles`); when empty, it is always eligible. An eligible profile-restricted interpreter **shadows** an unrestricted one, so an active `profile = "test"` stub wins over the production interpreter without further configuration. Two or more eligible interpreters at the same specificity (both unrestricted, or both profile-restricted and active) fail startup with an error naming the ambiguous algebra.
 
 ### Profile-Based Switching
 
@@ -278,26 +269,42 @@ The handler is registered via `HkjWebMvcAutoConfiguration` using `org.springfram
 
 `TestBoundary<F extends WitnessArity<TypeArity.Unary>>` interprets programs using the Id monad (`IdKind.Witness`): pure, synchronous, deterministic. No IO, no Spring context. The same service program that runs against real infrastructure in production runs against in-memory stubs here.
 
+A stub interpreter targets `IdKind.Witness` and records what it was asked to do (see `OrderServicePureTest` in the effect-example module for the full listing):
+
 ```java
 class OrderServicePureTest {
-    private final RecordingOrderInterpreter orderInterp = new RecordingOrderInterpreter();
-    private final RecordingInventoryInterpreter inventoryInterp = new RecordingInventoryInterpreter();
-    private final TestBoundary<OrderEffects> boundary = TestBoundary.of(
-        Interpreters.combine(orderInterp, inventoryInterp));
 
-    @Test void shouldReserveInventory() {
-        OrderResult result = boundary.run(service.placeOrder(new OrderRequest("C001", "ITEM-42", 2)));
-        assertThat(result.status()).isEqualTo(OrderStatus.CONFIRMED);
-        assertThat(inventoryInterp.reservations()).hasSize(1);
+    static class StubOrderInterpreter implements Natural<OrderOpKind.Witness, IdKind.Witness> {
+        private int ordersPlaced = 0;
+
+        @Override
+        public <A> Kind<IdKind.Witness, A> apply(Kind<OrderOpKind.Witness, A> fa) {
+            OrderOp<A> op = OrderOpKindHelper.ORDER_OP.narrow(fa);
+            return switch (op) {
+                case OrderOp.PlaceOrder<A> place -> {
+                    ordersPlaced++;
+                    yield Id.of(place.k().apply(OrderResult.confirmed("ORD-TEST-0001")));
+                }
+                case OrderOp.GetStatus<A> get -> Id.of(get.k().apply(OrderStatus.CONFIRMED));
+            };
+        }
+
+        int ordersPlaced() { return ordersPlaced; }
     }
 
-    @Test void shouldRejectWhenUnavailable() {
-        inventoryInterp.setAvailableStock("ITEM-42", 0);
+    private final StubOrderInterpreter interpreter = new StubOrderInterpreter();
+    private final TestBoundary<OrderOpKind.Witness> boundary = TestBoundary.of(interpreter);
+    private final OrderService service = new OrderService();
+
+    @Test void shouldPlaceOrder() {
         OrderResult result = boundary.run(service.placeOrder(new OrderRequest("C001", "ITEM-42", 2)));
-        assertThat(result.status()).isEqualTo(OrderStatus.REJECTED);
+        assertThat(result.status()).isEqualTo(OrderStatus.CONFIRMED);
+        assertThat(interpreter.ordersPlaced()).isEqualTo(1);
     }
 }
 ```
+
+Composing several algebras works the same way: `TestBoundary.of(Interpreters.combine(orderStub, inventoryStub))`.
 
 ### @EffectTest Test Slice
 
@@ -338,12 +345,7 @@ hkj:
     free-path-include-exception-details: false
 
   effect-boundary:
-    enabled: true
-    startup-validation: true
-    interpreter-selection:
-      payment-gateway: stripe
-      fraud-check: ml-model
-      notification: email
+    enabled: true   # master switch (default: true)
 ```
 
 ## Comparison
@@ -418,7 +420,7 @@ The `ObservableEffectBoundary` provides the same API as `EffectBoundary` (`run()
 
 **Solution:** Ensure the interpreter class is within the component scan base packages. If it is in a separate module, add `@ComponentScan(basePackages = {...})` to include the relevant packages.
 
-> **Important**: With `hkj.effect-boundary.startup-validation` set to `true` (the default), a missing interpreter causes the application to fail at startup with a descriptive error. This is the recommended behaviour for production deployments.
+> **Important**: Startup validation is always on: a missing (or ambiguous) interpreter causes the application to fail at startup with a descriptive error. This fail-fast behaviour is deliberate and not configurable.
 
 ## Related Documentation
 

--- a/hkj-spring/HTTP_CLIENT.md
+++ b/hkj-spring/HTTP_CLIENT.md
@@ -109,7 +109,9 @@ without codegen.
 A failed response (`RestClientResponseException`) is turned into your declared error type by a
 `ResponseErrorDecoder<E>`. Rather than wiring one decoder bean per error type, the generated client
 autowires a single `ResponseErrorDecoderFactory` and builds a per-method decoder for whatever error
-type that method declares:
+type that method declares. Each per-method decoder is created **once**, in the generated client's
+constructor, and reused for every call — a custom `ResponseErrorDecoderFactory` therefore sees only
+construction-time state, not per-call state:
 
 ```java
 @FunctionalInterface

--- a/hkj-spring/JACKSON_SERIALIZATION.md
+++ b/hkj-spring/JACKSON_SERIALIZATION.md
@@ -7,8 +7,10 @@ This document explains how higher-kinded-j types (Either, Validated) are seriali
 The `hkj-spring-autoconfigure` module provides custom Jackson serializers and deserializers for:
 - `Either<L, R>` - Sum type for error handling
 - `Validated<E, A>` - Validation with error accumulation
+- `EitherOrBoth<W, A>` - Inclusive-or (success that may carry warnings)
+- `NonEmptyList<A>` - Non-empty list (serialised as a plain JSON array)
 
-These serializers are **automatically registered** when using Spring Boot auto-configuration.
+These serializers are **automatically registered** when using Spring Boot auto-configuration. The shapes below are fixed — there are no format-toggle properties. `Maybe` and `Try` have **no** Jackson support: return them at the top level (where the return-value handlers apply) rather than nesting them in DTOs.
 
 ## JSON Format
 
@@ -65,6 +67,18 @@ Validated<List<String>, User> success = Validated.valid(new User("1", "alice@exa
 Validated<List<String>, User> errors = Validated.invalid(List.of("Invalid email", "Name required"));
 // JSON: {"valid": false, "errors": ["Invalid email", "Name required"]}
 ```
+
+### EitherOrBoth Serialization
+
+`EitherOrBoth` has three cases, so it uses a `kind` discriminator:
+
+```json
+{"kind": "left",  "left":  <warnings>}
+{"kind": "right", "right": <value>}
+{"kind": "both",  "left":  <warnings>, "right": <value>}
+```
+
+This applies to **nested** `EitherOrBoth` values. A top-level `EitherOrBoth` / `EitherOrBothPath` controller return value is shaped by `EitherOrBothPathReturnValueHandler` instead: the success body is the bare value, `Both` warnings travel JSON-encoded in the `X-Hkj-Warnings` response header, and a `Left` produces the `{"success": false, "error": ...}` envelope (see [CONFIGURATION.md](CONFIGURATION.md#hkjwebeither-or-both-path-enabled)).
 
 ## When Jackson Serializers Are Used
 
@@ -385,14 +399,14 @@ class BatchControllerTest {
 
 **Problem:** Either/Validated not serializing with custom format
 
-**Solution:** Verify HkjJacksonModule is registered. You can add a debug endpoint to check module registration:
+**Solution:** Verify HkjJacksonModule is registered by probing real serialisation behaviour (Jackson 3.x does not expose registered module IDs directly). The example module's `/api/users/debug/jackson-modules` endpoint serialises a sample `Either` with the injected `JsonMapper` and reports whether the tagged shape came back:
+
 ```java
-@GetMapping("/debug/jackson")
-public Map<String, Object> getJacksonInfo(ObjectMapper objectMapper) {
-    return Map.of(
-        "hkjModulePresent", true,  // Set based on your verification logic
-        "registeredModules", List.of("HkjJacksonModule")
-    );
+@GetMapping("/debug/jackson-modules")
+public Map<String, Object> getJacksonInfo() {
+    String probe = jsonMapper.writeValueAsString(Either.<String, String>right("probe"));
+    boolean hkjModulePresent = probe.contains("\"isRight\"");
+    return Map.of("hkjModulePresent", hkjModulePresent, "eitherProbe", probe);
 }
 ```
 

--- a/hkj-spring/README.md
+++ b/hkj-spring/README.md
@@ -57,7 +57,7 @@ That's it! The starter auto-configures everything.
 
 ## Features
 
-### Effect Path API Support (8 Handler Types)
+### Effect Path API Support (10 Handler Types)
 
 | Path Type | Success | Failure | Use Case |
 |-----------|---------|---------|----------|
@@ -65,10 +65,12 @@ That's it! The starter auto-configures everything.
 | `MaybePath<A>` | HTTP 200 | HTTP 404 | Optional values |
 | `TryPath<A>` | HTTP 200 | HTTP 500 | Exception handling |
 | `ValidationPath<E, A>` | HTTP 200 | HTTP 400 (with all errors) | Input validation |
+| `EitherOrBothPath<W, A>` | HTTP 200 (+ `X-Hkj-Warnings` on `Both`) | HTTP 4xx/5xx (based on error type) | Success with warnings |
 | `IOPath<A>` | HTTP 200 | HTTP 500 | Deferred side effects |
 | `CompletableFuturePath<A>` | HTTP 200 | HTTP 500 | Async operations |
 | `VTaskPath<A>` | HTTP 200 (via DeferredResult) | HTTP 500 | Virtual thread async |
-| `VStreamPath<A>` | SSE stream | SSE error event | Virtual thread streaming |
+| `VStreamPath<A>` | SSE stream | Failure status before first element, else SSE error event | Virtual thread streaming |
+| `FreePath<F, A>` | HTTP 200 | HTTP 500 | Effect boundary interpretation |
 
 ### Automatic Path → HTTP Response Conversion
 
@@ -97,6 +99,7 @@ hkj:
   web:
     # Enable/disable individual handlers
     either-path-enabled: true
+    either-or-both-path-enabled: true
     maybe-path-enabled: true
     try-path-enabled: true
     validation-path-enabled: true
@@ -104,6 +107,7 @@ hkj:
     completable-future-path-enabled: true
     vtask-path-enabled: true
     vstream-path-enabled: true
+    free-path-enabled: true
 
     # Customize status codes
     default-error-status: 400

--- a/hkj-spring/SECURITY.md
+++ b/hkj-spring/SECURITY.md
@@ -31,9 +31,11 @@ The hkj-spring security integration brings functional programming patterns to Sp
 hkj:
   security:
     enabled: true
-    validated-user-details: true
     either-authentication: true
     either-authorization: true
+    # Opt-in: only enable when you will register accounts — once unique, this bean
+    # becomes the application-wide UserDetailsService and it starts EMPTY.
+    # validated-user-details: true
 ```
 
 ### 2. Configure Spring Security
@@ -72,17 +74,41 @@ Accumulates validation errors instead of fail-fast exceptions.
 
 #### Features
 
-- Username format validation
-- Account status validation (enabled, locked, expired)
-- Credentials expiration checking
-- **ALL errors reported at once**
+- Username format validation, with **ALL errors reported at once**
+- In-memory user store, populated explicitly via `addUser(...)`
+- `validateAccountStatus(...)` helper for an accumulated view of enabled/locked/expired checks (status *enforcement* stays with the authentication provider, per the `UserDetailsService` contract)
+
+> **Warning — the service starts empty; sample users are opt-in.**
+> `new ValidatedUserDetailsService()` registers **no** users; authentication fails for every
+> username until you call `addUser(...)`. The `withSampleUsers()` factory pre-populates
+> well-known demo accounts (`admin`/`admin123`, `user`/`user123`, `disabled`/`disabled123`)
+> with plaintext `{noop}` passwords — use it for demos and tests only, **never in
+> production**.
 
 #### Example
 
 ```java
 @Bean
-public UserDetailsService userDetailsService() {
-    return new ValidatedUserDetailsService();
+public UserDetailsService userDetailsService(
+        PasswordEncoder encoder,
+        @Value("${app.security.alice-password}") String alicePassword) {
+    var service = new ValidatedUserDetailsService();
+    service.addUser(User.builder()
+        .username("alice")
+        .password(encoder.encode(alicePassword))  // never hard-code — source from config/secrets
+        .roles("USER")
+        .build());
+    return service;
+}
+```
+
+For a throwaway demo or test context only:
+
+```java
+@Bean
+@Profile("demo")
+public UserDetailsService demoUserDetailsService() {
+    return ValidatedUserDetailsService.withSampleUsers();  // NEVER in production
 }
 ```
 
@@ -120,10 +146,9 @@ Converts JWT tokens to Authentication using Either for functional error handling
 
 #### Features
 
-- Extracts authorities from JWT claims
-- Handles missing/invalid claims gracefully
+- Extracts authorities from JWT claims using `Either` internally
 - Configurable claim name and authority prefix
-- Returns empty authorities on error (no exceptions)
+- **Rejects on failure (by default):** a *malformed* authorities claim always folds the `Left` into a thrown `BadCredentialsException` (HTTP 401); a *missing* claim does the same while `reject-missing-authorities-claim` stays `true` (the default), so a bad token yields no authenticated principal. Set that flag to `false` to let legitimately role-less tokens (e.g. client-credentials) authenticate with empty authorities — malformed claims stay rejected regardless
 
 #### Example
 
@@ -156,7 +181,18 @@ hkj:
   security:
     jwt-authorities-claim: "roles"      # JWT claim containing roles
     jwt-authority-prefix: "ROLE_"        # Prefix added to each role
+    reject-missing-authorities-claim: true  # default: true
 ```
+
+A token whose authorities claim is **missing** or **malformed** is rejected with
+`BadCredentialsException` (surfaced as HTTP 401) — the converter never authenticates a token whose
+authorities it could not read. If your IdP legitimately issues role-less tokens (e.g.
+client-credentials), set `reject-missing-authorities-claim: false` to let a token with **no**
+authorities claim authenticate with an empty authority set. A **malformed** (wrong-type) claim is
+always rejected regardless of this flag.
+
+> A present-but-empty list (`"roles": []`) always authenticates with empty authorities — it is a
+> valid claim, not a missing one.
 
 ---
 
@@ -190,21 +226,28 @@ public SecurityFilterChain filterChain(
 #### Authorization Flow
 
 ```java
-Either<AuthorizationError, AuthorizationSuccess> result =
-    checkAuthentication(auth)           // Is user authenticated?
-        .flatMap(this::checkAuthorities)     // Has required roles?
-        .flatMap(auth -> checkRequestPath(auth, context));  // Path allowed?
-
+// Rules are chained with flatMap: the first Left denies access
+Either<AuthorizationError, Authentication> result = checkAuthentication(auth);
+for (AuthorizationRule rule : rules) {
+    result = result.flatMap(a -> rule.check(a, context));
+}
 // Short-circuits on first error (Either flatMap semantics)
+```
+
+Build your own policy with the rule factories, evaluated in order:
+
+```java
+var authManager = new EitherAuthorizationManager(List.of(
+    EitherAuthorizationManager.requireAuthority("ROLE_ADMIN"),
+    EitherAuthorizationManager.denyPathPrefix("/api/admin/dangerous")));
 ```
 
 #### Built-in Rules
 
-The default `EitherAuthorizationManager` requires:
-1. Authentication present
-2. Authentication authenticated
-3. `ROLE_ADMIN` authority
-4. Blocks `/api/admin/dangerous` paths
+The no-arg `EitherAuthorizationManager` keeps the historical default policy as three explicit rules:
+1. Authentication present and authenticated (always checked first)
+2. `requireAuthority("ROLE_ADMIN")`
+3. `denyPathPrefix("/api/admin/dangerous")` (matched against the decoded, normalised path)
 
 ---
 
@@ -218,13 +261,15 @@ hkj:
     # Enable/disable security integration
     enabled: false  # default: false (opt-in)
 
-    # ValidatedUserDetailsService
-    validated-user-details: true  # default: true
+    # ValidatedUserDetailsService (opt-in: starts empty and, once unique, becomes the
+    # application-wide UserDetailsService)
+    validated-user-details: false  # default: false
 
     # EitherAuthenticationConverter (JWT)
     either-authentication: true  # default: true
     jwt-authorities-claim: "roles"  # default: "roles"
     jwt-authority-prefix: "ROLE_"   # default: "ROLE_"
+    reject-missing-authorities-claim: true  # default: true (false = lenient, role-less tokens ok)
 
     # EitherAuthorizationManager
     either-authorization: true  # default: true
@@ -383,6 +428,21 @@ void shouldConvertJwtWithRoles() {
 
     assertThat(token.getAuthorities()).extracting("authority")
         .containsExactlyInAnyOrder("ROLE_USER", "ROLE_ADMIN");
+}
+
+@Test
+void shouldRejectJwtWithMissingRolesClaim() {
+    EitherAuthenticationConverter converter = new EitherAuthenticationConverter();
+
+    Jwt jwt = Jwt.withTokenValue("token")
+        .header("alg", "none")
+        .subject("user123")
+        .claim("other", "value")   // no "roles" claim
+        .build();
+
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(BadCredentialsException.class)
+        .hasMessageContaining("Missing authorities claim");
 }
 ```
 

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/actuator/HkjAsyncHealthIndicator.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/actuator/HkjAsyncHealthIndicator.java
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.spring.actuator;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -49,14 +52,19 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  */
 public class HkjAsyncHealthIndicator implements HealthIndicator {
 
-  private final ThreadPoolTaskExecutor executor;
+  private final @Nullable Executor executor;
 
   /**
    * Creates a new HkjAsyncHealthIndicator.
    *
+   * <p>Accepts any {@link Executor}: full pool statistics are reported for a {@link
+   * ThreadPoolTaskExecutor}, while any other executor type (e.g. a virtual-thread-per-task
+   * executor) reports {@code UP} with a {@code type} detail rather than failing — the named {@code
+   * hkjAsyncExecutor} bean is not required to be a {@code ThreadPoolTaskExecutor}.
+   *
    * @param executor the async executor to monitor (may be null if not configured)
    */
-  public HkjAsyncHealthIndicator(ThreadPoolTaskExecutor executor) {
+  public HkjAsyncHealthIndicator(@Nullable Executor executor) {
     this.executor = executor;
   }
 
@@ -66,8 +74,26 @@ public class HkjAsyncHealthIndicator implements HealthIndicator {
       return Health.outOfService().withDetail("reason", "Async executor not configured").build();
     }
 
+    if (!(executor instanceof ThreadPoolTaskExecutor poolExecutor)) {
+      // Pool statistics are only available for ThreadPoolTaskExecutor. A shutdown ExecutorService
+      // (including a closed virtual-thread executor) can still be reported as unhealthy, since
+      // submissions would be rejected — check that before the type-only UP.
+      if (executor instanceof ExecutorService executorService && executorService.isShutdown()) {
+        return Health.down()
+            .withDetail("type", executor.getClass().getSimpleName())
+            .withDetail("reason", "Executor is shutdown")
+            .build();
+      }
+      // Otherwise report UP with the type so a live virtual-thread (or other) executor does not
+      // read as unhealthy or fail startup.
+      return Health.up()
+          .withDetail("type", executor.getClass().getSimpleName())
+          .withDetail("detail", "pool statistics unavailable for this executor type")
+          .build();
+    }
+
     try {
-      var threadPoolExecutor = executor.getThreadPoolExecutor();
+      var threadPoolExecutor = poolExecutor.getThreadPoolExecutor();
 
       if (threadPoolExecutor == null || threadPoolExecutor.isShutdown()) {
         return Health.down().withDetail("reason", "Thread pool is shutdown").build();
@@ -78,7 +104,7 @@ public class HkjAsyncHealthIndicator implements HealthIndicator {
       int corePoolSize = threadPoolExecutor.getCorePoolSize();
       int maxPoolSize = threadPoolExecutor.getMaximumPoolSize();
       int queueSize = threadPoolExecutor.getQueue().size();
-      int queueCapacity = executor.getQueueCapacity();
+      int queueCapacity = poolExecutor.getQueueCapacity();
       int queueRemainingCapacity = threadPoolExecutor.getQueue().remainingCapacity();
 
       // Health check: queue should not be full

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/actuator/HkjMetricsEndpoint.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/actuator/HkjMetricsEndpoint.java
@@ -29,15 +29,13 @@ import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
  * {
  *   "configuration": {
  *     "web": {
- *       "eitherResponseEnabled": true,
- *       "validatedResponseEnabled": true,
- *       "asyncEitherTEnabled": true,
+ *       "eitherPathEnabled": true,
+ *       "validationPathEnabled": true,
+ *       "vtaskPathEnabled": true,
  *       "defaultErrorStatus": 400
  *     },
  *     "jackson": {
- *       "customSerializersEnabled": true,
- *       "eitherFormat": "TAGGED",
- *       "validatedFormat": "TAGGED"
+ *       "customSerializersEnabled": true
  *     }
  *   },
  *   "metrics": {
@@ -121,6 +119,8 @@ public class HkjMetricsEndpoint {
     web.put("completableFuturePathEnabled", properties.getWeb().isCompletableFuturePathEnabled());
     web.put("vtaskPathEnabled", properties.getWeb().isVtaskPathEnabled());
     web.put("vstreamPathEnabled", properties.getWeb().isVstreamPathEnabled());
+    web.put("eitherOrBothPathEnabled", properties.getWeb().isEitherOrBothPathEnabled());
+    web.put("freePathEnabled", properties.getWeb().isFreePathEnabled());
     web.put("defaultErrorStatus", properties.getWeb().getDefaultErrorStatus());
     return web;
   }
@@ -128,9 +128,6 @@ public class HkjMetricsEndpoint {
   private Map<String, Object> getJacksonConfig() {
     Map<String, Object> jackson = new LinkedHashMap<>();
     jackson.put("customSerializersEnabled", properties.getJson().isCustomSerializersEnabled());
-    jackson.put("eitherFormat", properties.getJson().getEitherFormat().name());
-    jackson.put("validatedFormat", properties.getJson().getValidatedFormat().name());
-    jackson.put("maybeFormat", properties.getJson().getMaybeFormat().name());
     return jackson;
   }
 

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjActuatorAutoConfiguration.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjActuatorAutoConfiguration.java
@@ -3,10 +3,13 @@
 package org.higherkindedj.spring.autoconfigure;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.Executor;
 import org.higherkindedj.spring.actuator.HkjAsyncHealthIndicator;
 import org.higherkindedj.spring.actuator.HkjMetricsEndpoint;
 import org.higherkindedj.spring.actuator.HkjMetricsService;
 import org.higherkindedj.spring.actuator.HkjVirtualThreadHealthIndicator;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -15,7 +18,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
  * Auto-configuration for higher-kinded-j Spring Boot Actuator integration.
@@ -78,25 +80,30 @@ public class HkjActuatorAutoConfiguration {
    * <p>Enabled by default. Disable with: {@code management.endpoint.hkj.enabled=false}
    *
    * @param properties the HKJ configuration properties
-   * @param metricsService the metrics service (optional)
+   * @param metricsService provider of the metrics service (empty when {@code
+   *     hkj.actuator.metrics-enabled=false}; the endpoint then reports configuration only)
    * @return the custom endpoint
    */
   @Bean
   @ConditionalOnAvailableEndpoint
   public HkjMetricsEndpoint hkjMetricsEndpoint(
-      HkjProperties properties, HkjMetricsService metricsService) {
-    return new HkjMetricsEndpoint(properties, metricsService);
+      HkjProperties properties, ObjectProvider<HkjMetricsService> metricsService) {
+    return new HkjMetricsEndpoint(properties, metricsService.getIfAvailable());
   }
 
   /**
    * Creates the async executor health indicator.
    *
-   * <p>Monitors the thread pool used by EitherT async operations.
+   * <p>Monitors the application-defined {@code hkjAsyncExecutor} bean. It is injected as the widest
+   * {@link Executor} type — the qualifier binds it to that specific bean, and {@link
+   * HkjAsyncHealthIndicator} reports full pool statistics for a {@code ThreadPoolTaskExecutor} or a
+   * type-only {@code UP} for any other executor (e.g. a virtual-thread executor). Injecting the
+   * concrete pool type would instead fail context startup when the named bean is not one.
    *
-   * <p>Enabled by default when async executor is configured. Disable with: {@code
+   * <p>Enabled by default when the executor bean is defined. Disable with: {@code
    * management.health.hkj-async.enabled=false}
    *
-   * @param executor the async executor bean (optional, may not be present)
+   * @param executor the {@code hkjAsyncExecutor} bean
    * @return the health indicator
    */
   @Bean(name = "hkjAsyncHealthIndicator")
@@ -105,7 +112,8 @@ public class HkjActuatorAutoConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   @ConditionalOnBean(name = "hkjAsyncExecutor")
-  public HkjAsyncHealthIndicator hkjAsyncHealthIndicator(ThreadPoolTaskExecutor executor) {
+  public HkjAsyncHealthIndicator hkjAsyncHealthIndicator(
+      @Qualifier("hkjAsyncExecutor") Executor executor) {
     return new HkjAsyncHealthIndicator(executor);
   }
 

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjProperties.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjProperties.java
@@ -26,18 +26,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     default-error-status: 400
  *     maybe-nothing-status: 404
  *     try-include-exception-details: false
- *   validation:
- *     accumulate-errors: true
  *   json:
  *     custom-serializers-enabled: true
- *     either-format: TAGGED
  * </pre>
  */
 @ConfigurationProperties(prefix = "hkj")
 public class HkjProperties {
 
   private Web web = new Web();
-  private Validation validation = new Validation();
   private Jackson json = new Jackson();
   private Async async = new Async();
   private Actuator actuator = new Actuator();
@@ -64,24 +60,6 @@ public class HkjProperties {
    */
   public void setWeb(Web web) {
     this.web = web;
-  }
-
-  /**
-   * Returns the validation configuration.
-   *
-   * @return the validation configuration
-   */
-  public Validation getValidation() {
-    return validation;
-  }
-
-  /**
-   * Sets the validation configuration.
-   *
-   * @param validation the validation configuration
-   */
-  public void setValidation(Validation validation) {
-    this.validation = validation;
   }
 
   /**
@@ -852,117 +830,10 @@ public class HkjProperties {
     }
   }
 
-  /** Validation configuration properties. */
-  public static class Validation {
-    /** Enable Validated-based validation support. Default: true */
-    private boolean enabled = true;
-
-    /**
-     * Accumulate all validation errors (true) or fail-fast on first error (false). Default: true
-     */
-    private boolean accumulateErrors = true;
-
-    /** Maximum number of errors to accumulate (0 = unlimited). Default: 0 (unlimited) */
-    private int maxErrors = 0;
-
-    /** Creates a new Validation configuration with default values. */
-    public Validation() {}
-
-    /**
-     * Returns whether validation is enabled.
-     *
-     * @return whether validation is enabled
-     */
-    public boolean isEnabled() {
-      return enabled;
-    }
-
-    /**
-     * Sets whether validation is enabled.
-     *
-     * @param enabled whether validation is enabled
-     */
-    public void setEnabled(boolean enabled) {
-      this.enabled = enabled;
-    }
-
-    /**
-     * Returns whether errors are accumulated.
-     *
-     * @return whether errors are accumulated
-     */
-    public boolean isAccumulateErrors() {
-      return accumulateErrors;
-    }
-
-    /**
-     * Sets whether errors are accumulated.
-     *
-     * @param accumulateErrors whether errors are accumulated
-     */
-    public void setAccumulateErrors(boolean accumulateErrors) {
-      this.accumulateErrors = accumulateErrors;
-    }
-
-    /**
-     * Returns the maximum number of errors to accumulate.
-     *
-     * @return the maximum number of errors to accumulate
-     */
-    public int getMaxErrors() {
-      return maxErrors;
-    }
-
-    /**
-     * Sets the maximum number of errors to accumulate.
-     *
-     * @param maxErrors the maximum number of errors to accumulate
-     */
-    public void setMaxErrors(int maxErrors) {
-      this.maxErrors = maxErrors;
-    }
-  }
-
   /** Jackson JSON serialization configuration properties. */
   public static class Jackson {
     /** Enable custom Jackson serializers for Either, Validated types. Default: true */
     private boolean customSerializersEnabled = true;
-
-    /**
-     * Format for Either JSON output.
-     *
-     * <ul>
-     *   <li>TAGGED: {"isRight": true/false, "right/left": ...} (default)
-     *   <li>SIMPLE: {"value": ...} or {"error": ...}
-     * </ul>
-     *
-     * Default: TAGGED
-     */
-    private SerializationFormat eitherFormat = SerializationFormat.TAGGED;
-
-    /**
-     * Format for Validated JSON output.
-     *
-     * <ul>
-     *   <li>TAGGED: {"valid": true/false, "value/errors": ...} (default)
-     *   <li>SIMPLE: {"value": ...} or {"errors": ...}
-     * </ul>
-     *
-     * Default: TAGGED
-     */
-    private SerializationFormat validatedFormat = SerializationFormat.TAGGED;
-
-    /**
-     * Format for Maybe JSON output.
-     *
-     * <ul>
-     *   <li>TAGGED: {"present": true/false, "value": ...} (default)
-     *   <li>SIMPLE: {"value": ...} or null
-     * </ul>
-     *
-     * Default: TAGGED
-     */
-    private SerializationFormat maybeFormat = SerializationFormat.TAGGED;
 
     /** Creates a new Jackson configuration with default values. */
     public Jackson() {}
@@ -984,162 +855,18 @@ public class HkjProperties {
     public void setCustomSerializersEnabled(boolean customSerializersEnabled) {
       this.customSerializersEnabled = customSerializersEnabled;
     }
-
-    /**
-     * Returns the Either serialization format.
-     *
-     * @return the Either serialization format
-     */
-    public SerializationFormat getEitherFormat() {
-      return eitherFormat;
-    }
-
-    /**
-     * Sets the Either serialization format.
-     *
-     * @param eitherFormat the Either serialization format
-     */
-    public void setEitherFormat(SerializationFormat eitherFormat) {
-      this.eitherFormat = eitherFormat;
-    }
-
-    /**
-     * Returns the Validated serialization format.
-     *
-     * @return the Validated serialization format
-     */
-    public SerializationFormat getValidatedFormat() {
-      return validatedFormat;
-    }
-
-    /**
-     * Sets the Validated serialization format.
-     *
-     * @param validatedFormat the Validated serialization format
-     */
-    public void setValidatedFormat(SerializationFormat validatedFormat) {
-      this.validatedFormat = validatedFormat;
-    }
-
-    /**
-     * Returns the Maybe serialization format.
-     *
-     * @return the Maybe serialization format
-     */
-    public SerializationFormat getMaybeFormat() {
-      return maybeFormat;
-    }
-
-    /**
-     * Sets the Maybe serialization format.
-     *
-     * @param maybeFormat the Maybe serialization format
-     */
-    public void setMaybeFormat(SerializationFormat maybeFormat) {
-      this.maybeFormat = maybeFormat;
-    }
-
-    /** JSON serialization format for HKJ types. */
-    public enum SerializationFormat {
-      /** Simple format: minimal wrapping, direct value or error */
-      SIMPLE,
-
-      /** Tagged format: includes discriminator tags and both branches */
-      TAGGED
-    }
   }
 
-  /** Async configuration properties (for future EitherT support). */
+  /**
+   * Async configuration properties for the {@code CompletableFuturePath} handler. The starter does
+   * not create an executor; applications define their own bean when they need one.
+   */
   public static class Async {
-    /** Core thread pool size for async IO execution. Default: 10 */
-    private int executorCorePoolSize = 10;
-
-    /** Maximum thread pool size for async IO execution. Default: 20 */
-    private int executorMaxPoolSize = 20;
-
-    /** Queue capacity for async IO executor. Default: 100 */
-    private int executorQueueCapacity = 100;
-
-    /** Thread name prefix for async IO executor. Default: "hkj-async-" */
-    private String executorThreadNamePrefix = "hkj-async-";
-
     /** Default timeout for async operations (milliseconds). Default: 30000 (30 seconds) */
     private long defaultTimeoutMs = 30000;
 
     /** Creates a new Async configuration with default values. */
     public Async() {}
-
-    /**
-     * Returns the executor core pool size.
-     *
-     * @return the executor core pool size
-     */
-    public int getExecutorCorePoolSize() {
-      return executorCorePoolSize;
-    }
-
-    /**
-     * Sets the executor core pool size.
-     *
-     * @param executorCorePoolSize the executor core pool size
-     */
-    public void setExecutorCorePoolSize(int executorCorePoolSize) {
-      this.executorCorePoolSize = executorCorePoolSize;
-    }
-
-    /**
-     * Returns the executor maximum pool size.
-     *
-     * @return the executor maximum pool size
-     */
-    public int getExecutorMaxPoolSize() {
-      return executorMaxPoolSize;
-    }
-
-    /**
-     * Sets the executor maximum pool size.
-     *
-     * @param executorMaxPoolSize the executor maximum pool size
-     */
-    public void setExecutorMaxPoolSize(int executorMaxPoolSize) {
-      this.executorMaxPoolSize = executorMaxPoolSize;
-    }
-
-    /**
-     * Returns the executor queue capacity.
-     *
-     * @return the executor queue capacity
-     */
-    public int getExecutorQueueCapacity() {
-      return executorQueueCapacity;
-    }
-
-    /**
-     * Sets the executor queue capacity.
-     *
-     * @param executorQueueCapacity the executor queue capacity
-     */
-    public void setExecutorQueueCapacity(int executorQueueCapacity) {
-      this.executorQueueCapacity = executorQueueCapacity;
-    }
-
-    /**
-     * Returns the executor thread name prefix.
-     *
-     * @return the executor thread name prefix
-     */
-    public String getExecutorThreadNamePrefix() {
-      return executorThreadNamePrefix;
-    }
-
-    /**
-     * Sets the executor thread name prefix.
-     *
-     * @param executorThreadNamePrefix the executor thread name prefix
-     */
-    public void setExecutorThreadNamePrefix(String executorThreadNamePrefix) {
-      this.executorThreadNamePrefix = executorThreadNamePrefix;
-    }
 
     /**
      * Returns the default timeout in milliseconds.
@@ -1192,8 +919,12 @@ public class HkjProperties {
     /** Enable HKJ Spring Security integration. Default: false (opt-in) */
     private boolean enabled = false;
 
-    /** Enable ValidatedUserDetailsService for error accumulation. Default: true */
-    private boolean validatedUserDetails = true;
+    /**
+     * Enable the ValidatedUserDetailsService bean. Opt-in (default: false): the bean implements
+     * UserDetailsService, so once unique it becomes the application-wide user store — it must only
+     * exist when the application intends to populate and use it.
+     */
+    private boolean validatedUserDetails = false;
 
     /** Enable EitherAuthenticationConverter for JWT processing. Default: true */
     private boolean eitherAuthentication = true;
@@ -1206,6 +937,13 @@ public class HkjProperties {
 
     /** Prefix to add to JWT authorities (e.g., "ROLE_"). Default: "ROLE_" */
     private String jwtAuthorityPrefix = "ROLE_";
+
+    /**
+     * Reject a JWT whose authorities claim is absent. Default: true (safe). Set false to let a
+     * legitimately role-less token (e.g. client-credentials) authenticate with no authorities; a
+     * malformed (wrong-type) claim is always rejected regardless.
+     */
+    private boolean rejectMissingAuthoritiesClaim = true;
 
     /** Creates a new Security configuration with default values. */
     public Security() {}
@@ -1317,14 +1055,33 @@ public class HkjProperties {
     public void setJwtAuthorityPrefix(String jwtAuthorityPrefix) {
       this.jwtAuthorityPrefix = jwtAuthorityPrefix;
     }
+
+    /**
+     * Returns whether a missing authorities claim is rejected.
+     *
+     * @return whether a missing authorities claim is rejected
+     */
+    public boolean isRejectMissingAuthoritiesClaim() {
+      return rejectMissingAuthoritiesClaim;
+    }
+
+    /**
+     * Sets whether a missing authorities claim is rejected.
+     *
+     * @param rejectMissingAuthoritiesClaim whether a missing authorities claim is rejected
+     */
+    public void setRejectMissingAuthoritiesClaim(boolean rejectMissingAuthoritiesClaim) {
+      this.rejectMissingAuthoritiesClaim = rejectMissingAuthoritiesClaim;
+    }
   }
 
   /**
    * Virtual thread configuration properties for VTask and VStream integration.
    *
    * <p>These properties control the behaviour of virtual-thread-based handlers. Unlike the {@link
-   * Async} configuration which manages a fixed thread pool, virtual threads require no pool sizing
-   * — they scale automatically with the JVM.
+   * Async} configuration, which only tunes timeouts (the starter creates no executor — the
+   * application supplies its own), virtual threads require no pool sizing at all: they scale
+   * automatically with the JVM.
    *
    * <p>Example configuration:
    *
@@ -1416,31 +1173,15 @@ public class HkjProperties {
    * hkj:
    *   effect-boundary:
    *     enabled: true
-   *     startup-validation: true
-   *     interpreter-selection:
-   *       payment-gateway: stripe
-   *       fraud-check: ml-model
    * </pre>
+   *
+   * <p>Missing-interpreter validation is always fail-fast; profile-restricted interpreters are
+   * selected via {@code @Interpreter(profile = "...")}.
    */
   public static class EffectConfig {
 
     /** Enable EffectBoundary auto-configuration. Default: true */
     private boolean enabled = true;
-
-    /** Fail fast at startup if any declared effect has no matching interpreter. Default: true */
-    private boolean startupValidation = true;
-
-    /**
-     * Configuration-driven interpreter selection by qualifier.
-     *
-     * <p>Maps effect algebra names (kebab-case) to interpreter qualifier names. When set, the
-     * registrar selects the interpreter matching the configured qualifier instead of using
-     * auto-discovery.
-     *
-     * <p>Example: {@code payment-gateway: stripe} selects the interpreter annotated with
-     * {@code @Interpreter(value = PaymentGatewayOp.class, qualifier = "stripe")}.
-     */
-    private Map<String, String> interpreterSelection = new HashMap<>();
 
     /** Creates a new EffectConfig with default values. */
     public EffectConfig() {}
@@ -1461,42 +1202,6 @@ public class HkjProperties {
      */
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
-    }
-
-    /**
-     * Returns whether startup validation is enabled.
-     *
-     * @return whether startup validation is enabled
-     */
-    public boolean isStartupValidation() {
-      return startupValidation;
-    }
-
-    /**
-     * Sets whether startup validation is enabled.
-     *
-     * @param startupValidation whether startup validation is enabled
-     */
-    public void setStartupValidation(boolean startupValidation) {
-      this.startupValidation = startupValidation;
-    }
-
-    /**
-     * Returns the interpreter selection map.
-     *
-     * @return the interpreter selection map
-     */
-    public Map<String, String> getInterpreterSelection() {
-      return interpreterSelection;
-    }
-
-    /**
-     * Sets the interpreter selection map.
-     *
-     * @param interpreterSelection the interpreter selection map
-     */
-    public void setInterpreterSelection(Map<String, String> interpreterSelection) {
-      this.interpreterSelection = interpreterSelection;
     }
   }
 }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjSecurityAutoConfiguration.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjSecurityAutoConfiguration.java
@@ -21,9 +21,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
  * <p>Provides functional error handling in Spring Security contexts using Either and Validated:
  *
  * <ul>
- *   <li>{@link ValidatedUserDetailsService} - User authentication with error accumulation
- *   <li>{@link EitherAuthenticationConverter} - JWT conversion with Either error handling
- *   <li>{@link EitherAuthorizationManager} - Authorization decisions using Either
+ *   <li>{@link ValidatedUserDetailsService} - User authentication with error accumulation (starts
+ *       empty; register accounts explicitly)
+ *   <li>{@link EitherAuthenticationConverter} - JWT conversion with Either error handling (rejects
+ *       the token when authority extraction fails)
+ *   <li>{@link EitherAuthorizationManager} - Authorization decisions using composable Either-based
+ *       rules
  * </ul>
  *
  * <p>Enable via configuration property:
@@ -97,49 +100,30 @@ public class HkjSecurityAutoConfiguration {
   }
 
   /**
-   * Provides a ValidatedUserDetailsService bean if none exists.
+   * Provides a ValidatedUserDetailsService bean when explicitly enabled.
    *
-   * <p>This service uses Validated for comprehensive user validation with error accumulation.
+   * <p>This service uses Validated for username validation with error accumulation. The bean starts
+   * <strong>empty</strong> — register accounts via {@link ValidatedUserDetailsService#addUser}.
    *
-   * <p>Configure via:
+   * <p><strong>Opt-in, and application-wide once enabled:</strong> {@code
+   * ValidatedUserDetailsService} implements {@link UserDetailsService}, so when it is the only bean
+   * of that type Spring Security adopts it as the global user store (and Boot's generated default
+   * user backs off). Enabling this without registering accounts means every form/basic login fails.
+   * It is therefore disabled by default; enable it only when you intend to populate and use it:
    *
    * <pre>
    * hkj:
    *   security:
-   *     validated-user-details: true  # default: true
+   *     validated-user-details: true  # default: false (opt-in)
    * </pre>
    *
    * @return validated user details service
    */
   @Bean
   @ConditionalOnMissingBean(ValidatedUserDetailsService.class)
-  @ConditionalOnProperty(
-      prefix = "hkj.security",
-      name = "validated-user-details",
-      havingValue = "true",
-      matchIfMissing = true)
+  @ConditionalOnProperty(prefix = "hkj.security", name = "validated-user-details")
   public ValidatedUserDetailsService validatedUserDetailsService() {
     return new ValidatedUserDetailsService();
-  }
-
-  /**
-   * Provides a UserDetailsService bean that delegates to ValidatedUserDetailsService.
-   *
-   * <p>This allows Spring Security to use the Validated-based user details service without
-   * requiring changes to existing security configurations.
-   *
-   * @param validatedService the validated user details service
-   * @return user details service
-   */
-  @Bean
-  @ConditionalOnMissingBean(UserDetailsService.class)
-  @ConditionalOnProperty(
-      prefix = "hkj.security",
-      name = "validated-user-details",
-      havingValue = "true",
-      matchIfMissing = true)
-  public UserDetailsService userDetailsService(ValidatedUserDetailsService validatedService) {
-    return validatedService;
   }
 
   /**
@@ -169,16 +153,11 @@ public class HkjSecurityAutoConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   public EitherAuthenticationConverter eitherAuthenticationConverter() {
-    String authoritiesClaim =
-        properties.getSecurity() != null
-            ? properties.getSecurity().getJwtAuthoritiesClaim()
-            : "roles";
-    String authorityPrefix =
-        properties.getSecurity() != null
-            ? properties.getSecurity().getJwtAuthorityPrefix()
-            : "ROLE_";
-
-    return new EitherAuthenticationConverter(authoritiesClaim, authorityPrefix);
+    HkjProperties.Security security = properties.getSecurity();
+    return new EitherAuthenticationConverter(
+        security.getJwtAuthoritiesClaim(),
+        security.getJwtAuthorityPrefix(),
+        security.isRejectMissingAuthoritiesClaim());
   }
 
   /**

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfiguration.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/HkjWebMvcAutoConfiguration.java
@@ -3,6 +3,7 @@
 package org.higherkindedj.spring.autoconfigure;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.spring.actuator.HkjMetricsService;
@@ -19,6 +20,9 @@ import org.higherkindedj.spring.web.returnvalue.VStreamPathReturnValueHandler;
 import org.higherkindedj.spring.web.returnvalue.VTaskPathReturnValueHandler;
 import org.higherkindedj.spring.web.returnvalue.ValidationPathReturnValueHandler;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -70,8 +74,37 @@ import tools.jackson.databind.json.JsonMapper;
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class HkjWebMvcAutoConfiguration {
 
+  private static final Logger log = LoggerFactory.getLogger(HkjWebMvcAutoConfiguration.class);
+
   /** Creates a new HkjWebMvcAutoConfiguration. */
   public HkjWebMvcAutoConfiguration() {}
+
+  /**
+   * Detects a silent conflict: Spring Boot consumes {@link WebMvcRegistrations} via {@code
+   * getIfUnique()}, so if the application defines its own bean alongside {@code
+   * hkjWebMvcRegistrations}, <em>both</em> are ignored without any error and every HKJ Path
+   * return-value handler vanishes (controllers returning Path types would then be serialised as raw
+   * objects). This check makes that failure mode loud.
+   *
+   * @param applicationContext the application context
+   * @return a callback that logs a warning when more than one registrations bean exists
+   */
+  @Bean
+  public SmartInitializingSingleton hkjWebMvcRegistrationsConflictCheck(
+      ApplicationContext applicationContext) {
+    return () -> {
+      String[] names = applicationContext.getBeanNamesForType(WebMvcRegistrations.class);
+      if (names.length > 1) {
+        log.warn(
+            "Multiple WebMvcRegistrations beans found: {}. Spring Boot resolves"
+                + " WebMvcRegistrations with getIfUnique(), so ALL of them are silently ignored —"
+                + " including the HKJ Path return-value handlers. Controllers returning Path types"
+                + " will be serialised as raw objects. Merge your customisation into a single"
+                + " WebMvcRegistrations bean, or exclude HkjWebMvcAutoConfiguration.",
+            Arrays.toString(names));
+      }
+    };
+  }
 
   /**
    * Default {@link ErrorStatusCodeStrategy} that combines the {@code hkj.web.error-status-mappings}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/EffectBoundaryAutoConfiguration.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/EffectBoundaryAutoConfiguration.java
@@ -21,8 +21,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
  * </ul>
  *
  * <p>The actual {@link EffectBoundary} bean registration is handled by {@link
- * EffectBoundaryRegistrar}, which is imported via {@link EnableEffectBoundary}. This
- * auto-configuration class serves as the conditional gate and integration point.
+ * EffectBoundaryRegistrar}, which is imported via {@link EnableEffectBoundary} on the application
+ * class and consults {@code hkj.effect-boundary.enabled} itself (registrar imports are not gated by
+ * this class's conditions). This auto-configuration class is an integration point for future
+ * boundary-adjacent beans.
  *
  * @see EnableEffectBoundary
  * @see EffectBoundaryRegistrar

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/EffectBoundaryRegistrar.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/EffectBoundaryRegistrar.java
@@ -2,25 +2,23 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.spring.autoconfigure.effect;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.higherkindedj.hkt.Natural;
 import org.higherkindedj.hkt.effect.boundary.EffectBoundary;
 import org.higherkindedj.hkt.eitherf.Interpreters;
-import org.higherkindedj.hkt.io.IOKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 
 /**
@@ -30,17 +28,34 @@ import org.springframework.core.type.AnnotationMetadata;
  * <p>This registrar is imported by {@link EnableEffectBoundary} and performs its work at bean
  * definition registration time. The actual interpreter discovery and combination happens during
  * bean creation (lazy), so that all {@code @Interpreter} beans are available in the context.
+ * Discovery honours {@link Interpreter#profile()} and fails fast on ambiguous matches — see {@link
+ * InterpreterResolution}.
+ *
+ * <p>The whole mechanism can be switched off with {@code hkj.effect-boundary.enabled=false}.
  *
  * @see EnableEffectBoundary
  * @see Interpreter
  */
-public class EffectBoundaryRegistrar implements ImportBeanDefinitionRegistrar {
+public class EffectBoundaryRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
 
   private static final Logger log = LoggerFactory.getLogger(EffectBoundaryRegistrar.class);
+
+  private Environment environment;
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+  }
 
   @Override
   public void registerBeanDefinitions(
       AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+
+    if (environment != null
+        && !environment.getProperty("hkj.effect-boundary.enabled", Boolean.class, true)) {
+      log.info("EffectBoundary: disabled via hkj.effect-boundary.enabled=false");
+      return;
+    }
 
     Map<String, Object> attrs =
         importingClassMetadata.getAnnotationAttributes(EnableEffectBoundary.class.getName());
@@ -52,6 +67,11 @@ public class EffectBoundaryRegistrar implements ImportBeanDefinitionRegistrar {
     Class<?>[] effectAlgebras = (Class<?>[]) attrs.get("value");
     if (effectAlgebras == null || effectAlgebras.length == 0) {
       log.warn("@EnableEffectBoundary has no effect algebras declared");
+      return;
+    }
+
+    if (registry.containsBeanDefinition("effectBoundary")) {
+      log.debug("EffectBoundary: effectBoundary bean already registered, skipping");
       return;
     }
 
@@ -92,76 +112,10 @@ public class EffectBoundaryRegistrar implements ImportBeanDefinitionRegistrar {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public EffectBoundary<?> getObject() {
-      // Discover interpreter beans for each effect algebra
-      Map<String, Object> interpreterBeans =
-          applicationContext.getBeansWithAnnotation(Interpreter.class);
-
-      List<Natural<?, IOKind.Witness>> interpreters = new ArrayList<>();
-      List<String> missing = new ArrayList<>();
-
-      for (Class<?> algebra : effectAlgebras) {
-        boolean found = false;
-        for (Map.Entry<String, Object> entry : interpreterBeans.entrySet()) {
-          Object bean = entry.getValue();
-          Interpreter annotation =
-              AnnotationUtils.findAnnotation(bean.getClass(), Interpreter.class);
-          if (annotation != null && annotation.value().equals(algebra)) {
-            if (bean instanceof Natural<?, ?> nat) {
-              interpreters.add((Natural) nat);
-              found = true;
-              log.info(
-                  "EffectBoundary: found interpreter '{}' for {}",
-                  entry.getKey(),
-                  algebra.getSimpleName());
-              break;
-            }
-          }
-        }
-        if (!found) {
-          missing.add(algebra.getSimpleName());
-        }
-      }
-
-      if (!missing.isEmpty()) {
-        throw new BeanCreationException(
-            "effectBoundary",
-            "No interpreter found for effect algebra(s): "
-                + missing
-                + ". Declare beans annotated with @Interpreter for each algebra. "
-                + "Available interpreters: "
-                + interpreterBeans.keySet());
-      }
-
-      // Combine interpreters
-      Natural combined = combineInterpreters(interpreters);
+      Natural combined =
+          InterpreterResolution.resolveAndCombine(
+              applicationContext, effectAlgebras, "EffectBoundary");
       return EffectBoundary.of(combined);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private Natural combineInterpreters(List<Natural<?, IOKind.Witness>> interpreters) {
-      if (interpreters.size() == 1) {
-        return interpreters.getFirst();
-      } else if (interpreters.size() == 2) {
-        return Interpreters.combine((Natural) interpreters.get(0), (Natural) interpreters.get(1));
-      } else if (interpreters.size() == 3) {
-        return Interpreters.combine(
-            (Natural) interpreters.get(0),
-            (Natural) interpreters.get(1),
-            (Natural) interpreters.get(2));
-      } else if (interpreters.size() == 4) {
-        return Interpreters.combine(
-            (Natural) interpreters.get(0),
-            (Natural) interpreters.get(1),
-            (Natural) interpreters.get(2),
-            (Natural) interpreters.get(3));
-      } else {
-        throw new BeanCreationException(
-            "effectBoundary",
-            "Interpreters.combine() supports up to 4 effect algebras. "
-                + "Found "
-                + interpreters.size()
-                + ". Group related effects into sub-compositions.");
-      }
     }
 
     @Override

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/Interpreter.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/Interpreter.java
@@ -35,8 +35,8 @@ import org.springframework.stereotype.Component;
  *
  * <h2>Profile-Based Switching</h2>
  *
- * <p>Use the {@link #profile()} attribute to activate interpreters only under specific Spring
- * profiles:
+ * <p>Use the {@link #profile()} attribute to make an interpreter eligible only under a specific
+ * Spring profile (any profile expression accepted by {@code Environment.acceptsProfiles}):
  *
  * <pre>{@code
  * @Interpreter(value = PaymentGatewayOp.class, profile = "test")
@@ -44,7 +44,13 @@ import org.springframework.stereotype.Component;
  *     extends PaymentGatewayOpInterpreter<IOKind.Witness> { ... }
  * }</pre>
  *
+ * <p>Note: the bean itself is still created in every profile (the annotation is not
+ * {@code @Profile}); the profile restricts which interpreter the boundary <em>selects</em>. If more
+ * than one interpreter is eligible for the same algebra, boundary creation fails fast with the
+ * ambiguous candidates listed — selection never depends on classpath scan order.
+ *
  * @see EnableEffectBoundary
+ * @see InterpreterResolution
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -59,10 +65,10 @@ public @interface Interpreter {
   Class<?> value();
 
   /**
-   * Optional Spring profile under which this interpreter is active. When empty (default), the
-   * interpreter is active in all profiles.
+   * Optional Spring profile expression under which this interpreter is eligible for selection. When
+   * empty (default), the interpreter is eligible in all profiles.
    *
-   * @return the Spring profile name, or empty for all profiles
+   * @return the Spring profile expression, or empty for all profiles
    */
   String profile() default "";
 }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/InterpreterResolution.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/effect/InterpreterResolution.java
@@ -1,0 +1,155 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.autoconfigure.effect;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.higherkindedj.hkt.Natural;
+import org.higherkindedj.hkt.eitherf.Interpreters;
+import org.higherkindedj.hkt.io.IOKind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+
+/**
+ * Shared interpreter discovery for {@link EffectBoundaryRegistrar} and the test-slice registrar.
+ *
+ * <p>Resolution rules, per effect algebra:
+ *
+ * <ul>
+ *   <li>Only beans annotated {@link Interpreter @Interpreter} whose {@code value()} matches the
+ *       algebra are considered.
+ *   <li>An interpreter with a non-empty {@link Interpreter#profile()} is eligible only when that
+ *       profile expression is active in the {@link Environment}.
+ *   <li>An eligible profile-restricted interpreter wins over an unrestricted one — so a {@code
+ *       profile = "test"} stub automatically replaces the production interpreter when the test
+ *       profile is active.
+ *   <li>Within the same specificity tier, exactly one interpreter must remain: none at all →
+ *       startup failure listing the available beans; more than one → startup failure listing the
+ *       ambiguous candidates (previously the first bean in scan order silently won, which made
+ *       interpreter selection dependent on classpath order).
+ * </ul>
+ */
+public final class InterpreterResolution {
+
+  private static final Logger log = LoggerFactory.getLogger(InterpreterResolution.class);
+
+  private InterpreterResolution() {}
+
+  /**
+   * Discovers one interpreter per algebra and combines them with {@link Interpreters#combine}.
+   *
+   * @param applicationContext the context to discover {@code @Interpreter} beans in
+   * @param algebras the effect algebras, in composition order
+   * @param origin a short label ("EffectBoundary" / "EffectTest") for log and error messages
+   * @return the combined natural transformation
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static Natural resolveAndCombine(
+      ApplicationContext applicationContext, Class<?>[] algebras, String origin) {
+    Map<String, Object> interpreterBeans =
+        applicationContext.getBeansWithAnnotation(Interpreter.class);
+    Environment environment = applicationContext.getEnvironment();
+
+    List<Natural<?, IOKind.Witness>> interpreters = new ArrayList<>();
+    List<String> missing = new ArrayList<>();
+
+    for (Class<?> algebra : algebras) {
+      // Profile-restricted candidates are more specific and shadow unrestricted ones
+      List<String> profiledNames = new ArrayList<>();
+      List<String> unrestrictedNames = new ArrayList<>();
+      Natural<?, ?> profiledCandidate = null;
+      Natural<?, ?> unrestrictedCandidate = null;
+
+      for (Map.Entry<String, Object> entry : interpreterBeans.entrySet()) {
+        Object bean = entry.getValue();
+        Interpreter annotation = AnnotationUtils.findAnnotation(bean.getClass(), Interpreter.class);
+        if (annotation == null
+            || !annotation.value().equals(algebra)
+            || !(bean instanceof Natural<?, ?> nat)
+            || !profileActive(environment, annotation.profile())) {
+          continue;
+        }
+        if (annotation.profile().isEmpty()) {
+          unrestrictedNames.add(entry.getKey());
+          unrestrictedCandidate = nat;
+        } else {
+          profiledNames.add(entry.getKey());
+          profiledCandidate = nat;
+        }
+      }
+
+      List<String> tierNames = profiledNames.isEmpty() ? unrestrictedNames : profiledNames;
+      Natural<?, ?> selected = profiledNames.isEmpty() ? unrestrictedCandidate : profiledCandidate;
+
+      switch (tierNames.size()) {
+        case 0 -> missing.add(algebra.getSimpleName());
+        case 1 -> {
+          interpreters.add((Natural) selected);
+          log.info(
+              "{}: found interpreter '{}' for {}",
+              origin,
+              tierNames.getFirst(),
+              algebra.getSimpleName());
+        }
+        default ->
+            throw new BeanCreationException(
+                "effectBoundary",
+                origin
+                    + ": ambiguous interpreters for "
+                    + algebra.getSimpleName()
+                    + ": "
+                    + tierNames
+                    + ". Keep exactly one eligible @Interpreter bean per algebra — restrict"
+                    + " alternatives to a profile via @Interpreter(profile = \"...\").");
+      }
+    }
+
+    if (!missing.isEmpty()) {
+      throw new BeanCreationException(
+          "effectBoundary",
+          origin
+              + ": no interpreter found for effect algebra(s): "
+              + missing
+              + ". Declare beans annotated with @Interpreter for each algebra (and check any"
+              + " profile restrictions). Available interpreters: "
+              + interpreterBeans.keySet());
+    }
+
+    return combine(interpreters);
+  }
+
+  private static boolean profileActive(Environment environment, String profile) {
+    return profile.isEmpty() || environment.acceptsProfiles(Profiles.of(profile));
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static Natural combine(List<Natural<?, IOKind.Witness>> interpreters) {
+    return switch (interpreters.size()) {
+      case 1 -> interpreters.getFirst();
+      case 2 -> Interpreters.combine((Natural) interpreters.get(0), (Natural) interpreters.get(1));
+      case 3 ->
+          Interpreters.combine(
+              (Natural) interpreters.get(0),
+              (Natural) interpreters.get(1),
+              (Natural) interpreters.get(2));
+      case 4 ->
+          Interpreters.combine(
+              (Natural) interpreters.get(0),
+              (Natural) interpreters.get(1),
+              (Natural) interpreters.get(2),
+              (Natural) interpreters.get(3));
+      default ->
+          throw new BeanCreationException(
+              "effectBoundary",
+              "Interpreters.combine() supports up to 4 effect algebras. Found "
+                  + interpreters.size()
+                  + ". Group related effects into sub-compositions.");
+    };
+  }
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/test/EffectTestRegistrar.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/autoconfigure/test/EffectTestRegistrar.java
@@ -2,18 +2,15 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.spring.autoconfigure.test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.higherkindedj.hkt.Natural;
 import org.higherkindedj.hkt.effect.boundary.EffectBoundary;
-import org.higherkindedj.hkt.eitherf.Interpreters;
-import org.higherkindedj.hkt.io.IOKind;
 import org.higherkindedj.spring.autoconfigure.effect.Interpreter;
+import org.higherkindedj.spring.autoconfigure.effect.InterpreterResolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -21,7 +18,6 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.type.AnnotationMetadata;
 
 /**
@@ -31,7 +27,8 @@ import org.springframework.core.type.AnnotationMetadata;
  * <p>This registrar is imported by {@link EffectTest} and only activates when the {@code effects}
  * parameter is non-empty. It mirrors the production {@link
  * org.higherkindedj.spring.autoconfigure.effect.EffectBoundaryRegistrar} but is designed for test
- * contexts where the web layer may not be present.
+ * contexts where the web layer may not be present. Discovery is shared with the production path via
+ * {@link InterpreterResolution}, so profile filtering and ambiguity detection behave identically.
  *
  * @see EffectTest
  */
@@ -94,73 +91,9 @@ public class EffectTestRegistrar implements ImportBeanDefinitionRegistrar {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public EffectBoundary<?> getObject() {
-      Map<String, Object> interpreterBeans =
-          applicationContext.getBeansWithAnnotation(Interpreter.class);
-
-      List<Natural<?, IOKind.Witness>> interpreters = new ArrayList<>();
-      List<String> missing = new ArrayList<>();
-
-      for (Class<?> algebra : effects) {
-        boolean found = false;
-        for (Map.Entry<String, Object> entry : interpreterBeans.entrySet()) {
-          Object bean = entry.getValue();
-          Interpreter annotation =
-              AnnotationUtils.findAnnotation(bean.getClass(), Interpreter.class);
-          if (annotation != null && annotation.value().equals(algebra)) {
-            if (bean instanceof Natural<?, ?> nat) {
-              interpreters.add((Natural) nat);
-              found = true;
-              log.info(
-                  "EffectTest: found interpreter '{}' for {}",
-                  entry.getKey(),
-                  algebra.getSimpleName());
-              break;
-            }
-          }
-        }
-        if (!found) {
-          missing.add(algebra.getSimpleName());
-        }
-      }
-
-      if (!missing.isEmpty()) {
-        throw new BeanCreationException(
-            "effectBoundary",
-            "EffectTest: no interpreter found for effect algebra(s): "
-                + missing
-                + ". Declare @Interpreter beans or use @SpringBootTest with a configuration "
-                + "that provides them. Available: "
-                + interpreterBeans.keySet());
-      }
-
-      Natural combined = combineInterpreters(interpreters);
+      Natural combined =
+          InterpreterResolution.resolveAndCombine(applicationContext, effects, "EffectTest");
       return EffectBoundary.of(combined);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private Natural combineInterpreters(List<Natural<?, IOKind.Witness>> interpreters) {
-      return switch (interpreters.size()) {
-        case 1 -> interpreters.getFirst();
-        case 2 ->
-            Interpreters.combine((Natural) interpreters.get(0), (Natural) interpreters.get(1));
-        case 3 ->
-            Interpreters.combine(
-                (Natural) interpreters.get(0),
-                (Natural) interpreters.get(1),
-                (Natural) interpreters.get(2));
-        case 4 ->
-            Interpreters.combine(
-                (Natural) interpreters.get(0),
-                (Natural) interpreters.get(1),
-                (Natural) interpreters.get(2),
-                (Natural) interpreters.get(3));
-        default ->
-            throw new BeanCreationException(
-                "effectBoundary",
-                "Interpreters.combine() supports up to 4 effect algebras. Found "
-                    + interpreters.size()
-                    + ".");
-      };
     }
 
     @Override

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/EitherDeserializer.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/EitherDeserializer.java
@@ -63,8 +63,8 @@ public class EitherDeserializer extends StdDeserializer<Either<?, ?>> {
 
   @Override
   public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
-    JavaType type = (property != null) ? property.getType() : ctxt.getContextualType();
-    if (type != null && type.hasRawClass(Either.class) && type.containedTypeCount() == 2) {
+    JavaType type = HkjTypeResolution.resolveTargetType(ctxt, property, Either.class);
+    if (type != null && type.containedTypeCount() == 2) {
       return new EitherDeserializer(type.containedType(0), type.containedType(1));
     }
     return this;
@@ -75,22 +75,24 @@ public class EitherDeserializer extends StdDeserializer<Either<?, ?>> {
       throws JacksonException {
     JsonNode node = p.readValueAsTree();
 
-    if (!node.has("isRight")) {
-      throw ctxt.weirdStringException("", Either.class, "Either JSON must have 'isRight' field");
+    JsonNode flag = node.get("isRight");
+    if (flag == null || !flag.isBoolean()) {
+      return ctxt.reportInputMismatch(
+          Either.class, "Either JSON must have a boolean 'isRight' field");
     }
 
-    boolean isRight = node.get("isRight").asBoolean();
+    boolean isRight = flag.asBoolean();
 
     if (isRight) {
       if (!node.has("right")) {
-        throw ctxt.weirdStringException(
-            "", Either.class, "Either with isRight=true must have 'right' field");
+        return ctxt.reportInputMismatch(
+            Either.class, "Either with isRight=true must have 'right' field");
       }
       return Either.right(readAs(ctxt, node.get("right"), rightType));
     } else {
       if (!node.has("left")) {
-        throw ctxt.weirdStringException(
-            "", Either.class, "Either with isRight=false must have 'left' field");
+        return ctxt.reportInputMismatch(
+            Either.class, "Either with isRight=false must have 'left' field");
       }
       return Either.left(readAs(ctxt, node.get("left"), leftType));
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/EitherOrBothDeserializer.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/EitherOrBothDeserializer.java
@@ -54,8 +54,8 @@ public class EitherOrBothDeserializer extends StdDeserializer<EitherOrBoth<?, ?>
 
   @Override
   public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
-    JavaType type = (property != null) ? property.getType() : ctxt.getContextualType();
-    if (type != null && type.hasRawClass(EitherOrBoth.class) && type.containedTypeCount() == 2) {
+    JavaType type = HkjTypeResolution.resolveTargetType(ctxt, property, EitherOrBoth.class);
+    if (type != null && type.containedTypeCount() == 2) {
       return new EitherOrBothDeserializer(type.containedType(0), type.containedType(1));
     }
     return this;
@@ -67,8 +67,8 @@ public class EitherOrBothDeserializer extends StdDeserializer<EitherOrBoth<?, ?>
     JsonNode node = p.readValueAsTree();
 
     if (!node.has("kind")) {
-      throw ctxt.weirdStringException(
-          "", EitherOrBoth.class, "EitherOrBoth JSON must have a 'kind' field");
+      return ctxt.reportInputMismatch(
+          EitherOrBoth.class, "EitherOrBoth JSON must have a 'kind' field");
     }
 
     String kind = node.get("kind").asString();
@@ -88,12 +88,19 @@ public class EitherOrBothDeserializer extends StdDeserializer<EitherOrBoth<?, ?>
   private static Object readField(
       DeserializationContext ctxt, JsonNode node, String field, JavaType type) {
     if (!node.has(field)) {
-      throw ctxt.weirdStringException(
-          "", EitherOrBoth.class, "EitherOrBoth is missing required '" + field + "' field");
+      return ctxt.reportInputMismatch(
+          EitherOrBoth.class, "EitherOrBoth is missing required '" + field + "' field");
     }
     JsonNode child = node.get(field);
-    return (type != null)
-        ? ctxt.readTreeAsValue(child, type)
-        : ctxt.readTreeAsValue(child, Object.class);
+    Object value =
+        (type != null)
+            ? ctxt.readTreeAsValue(child, type)
+            : ctxt.readTreeAsValue(child, Object.class);
+    if (value == null) {
+      // EitherOrBoth branch factories reject null; report cleanly instead of escaping as an NPE
+      return ctxt.reportInputMismatch(
+          EitherOrBoth.class, "EitherOrBoth '" + field + "' must not be null");
+    }
+    return value;
   }
 }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/HkjTypeResolution.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/HkjTypeResolution.java
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.json;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+
+/** Shared contextual-type resolution for the HKJ deserialisers. */
+final class HkjTypeResolution {
+
+  private HkjTypeResolution() {}
+
+  /**
+   * Resolves the declared generic type for {@code rawClass} at the current binding site.
+   *
+   * <p>The <strong>contextual fallback</strong> is what makes nested binding work: for a collection
+   * or map <em>element</em> (the property is the {@code List<Either<E, A>>} field, whose raw class
+   * never matches) and for root-level {@code TypeReference} reads (no property at all), Jackson
+   * pushes the element/root type as {@code ctxt.getContextualType()}. Without it those sites bind
+   * to {@code Object} — the classic cause of {@code Right(LinkedHashMap)} instead of {@code
+   * Right(User)}.
+   *
+   * <p>The property type is checked first only as a stable, precise source when it is present and
+   * already matches; in practice it agrees with the contextual type (Jackson pushes the property
+   * type as contextual before contextualising), so the ordering is not load-bearing — the fallback
+   * is. Both are kept for clarity.
+   *
+   * @param ctxt the deserialisation context
+   * @param property the bean property, if any
+   * @param rawClass the HKJ type being deserialised
+   * @return the matching parameterised type, or {@code null} when unresolvable (raw read)
+   */
+  static @Nullable JavaType resolveTargetType(
+      DeserializationContext ctxt, @Nullable BeanProperty property, Class<?> rawClass) {
+    if (property != null && property.getType().hasRawClass(rawClass)) {
+      return property.getType();
+    }
+    JavaType contextual = ctxt.getContextualType();
+    if (contextual != null && contextual.hasRawClass(rawClass)) {
+      return contextual;
+    }
+    return null;
+  }
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/NonEmptyListDeserializer.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/NonEmptyListDeserializer.java
@@ -50,8 +50,8 @@ public class NonEmptyListDeserializer extends StdDeserializer<NonEmptyList<?>> {
 
   @Override
   public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
-    JavaType type = (property != null) ? property.getType() : ctxt.getContextualType();
-    if (type != null && type.hasRawClass(NonEmptyList.class) && type.containedTypeCount() == 1) {
+    JavaType type = HkjTypeResolution.resolveTargetType(ctxt, property, NonEmptyList.class);
+    if (type != null && type.containedTypeCount() == 1) {
       JavaType elem = type.containedType(0);
       if (elem != null && !elem.hasRawClass(Object.class)) {
         return new NonEmptyListDeserializer(elem);
@@ -66,11 +66,11 @@ public class NonEmptyListDeserializer extends StdDeserializer<NonEmptyList<?>> {
     JsonNode node = p.readValueAsTree();
 
     if (!node.isArray()) {
-      throw ctxt.weirdStringException("", NonEmptyList.class, "NonEmptyList JSON must be an array");
+      return ctxt.reportInputMismatch(NonEmptyList.class, "NonEmptyList JSON must be an array");
     }
     if (node.isEmpty()) {
-      throw ctxt.weirdStringException(
-          "", NonEmptyList.class, "NonEmptyList JSON array must not be empty");
+      return ctxt.reportInputMismatch(
+          NonEmptyList.class, "NonEmptyList JSON array must not be empty");
     }
 
     List<Object> elements = new ArrayList<>();
@@ -80,8 +80,8 @@ public class NonEmptyListDeserializer extends StdDeserializer<NonEmptyList<?>> {
               ? ctxt.readTreeAsValue(element, elementType)
               : ctxt.readTreeAsValue(element, Object.class);
       if (value == null) {
-        throw ctxt.weirdStringException(
-            "", NonEmptyList.class, "NonEmptyList JSON array must not contain null elements");
+        return ctxt.reportInputMismatch(
+            NonEmptyList.class, "NonEmptyList JSON array must not contain null elements");
       }
       elements.add(value);
     }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/ValidatedDeserializer.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/json/ValidatedDeserializer.java
@@ -63,8 +63,8 @@ public class ValidatedDeserializer extends StdDeserializer<Validated<?, ?>> {
 
   @Override
   public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
-    JavaType type = (property != null) ? property.getType() : ctxt.getContextualType();
-    if (type != null && type.hasRawClass(Validated.class) && type.containedTypeCount() == 2) {
+    JavaType type = HkjTypeResolution.resolveTargetType(ctxt, property, Validated.class);
+    if (type != null && type.containedTypeCount() == 2) {
       return new ValidatedDeserializer(type.containedType(0), type.containedType(1));
     }
     return this;
@@ -75,25 +75,35 @@ public class ValidatedDeserializer extends StdDeserializer<Validated<?, ?>> {
       throws JacksonException {
     JsonNode node = p.readValueAsTree();
 
-    if (!node.has("valid")) {
-      throw ctxt.weirdStringException(
-          "", Validated.class, "Validated JSON must have 'valid' field");
+    JsonNode flag = node.get("valid");
+    if (flag == null || !flag.isBoolean()) {
+      return ctxt.reportInputMismatch(
+          Validated.class, "Validated JSON must have a boolean 'valid' field");
     }
 
-    boolean isValid = node.get("valid").asBoolean();
+    boolean isValid = flag.asBoolean();
 
     if (isValid) {
       if (!node.has("value")) {
-        throw ctxt.weirdStringException(
-            "", Validated.class, "Validated with valid=true must have 'value' field");
+        return ctxt.reportInputMismatch(
+            Validated.class, "Validated with valid=true must have 'value' field");
       }
-      return Validated.valid(readAs(ctxt, node.get("value"), valueType));
+      Object value = readAs(ctxt, node.get("value"), valueType);
+      if (value == null) {
+        // Validated.valid rejects null; report cleanly instead of escaping as an NPE
+        return ctxt.reportInputMismatch(Validated.class, "Validated 'value' must not be null");
+      }
+      return Validated.valid(value);
     } else {
       if (!node.has("errors")) {
-        throw ctxt.weirdStringException(
-            "", Validated.class, "Validated with valid=false must have 'errors' field");
+        return ctxt.reportInputMismatch(
+            Validated.class, "Validated with valid=false must have 'errors' field");
       }
-      return Validated.invalid(readAs(ctxt, node.get("errors"), errorType));
+      Object errors = readAs(ctxt, node.get("errors"), errorType);
+      if (errors == null) {
+        return ctxt.reportInputMismatch(Validated.class, "Validated 'errors' must not be null");
+      }
+      return Validated.invalid(errors);
     }
   }
 

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/security/EitherAuthenticationConverter.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/security/EitherAuthenticationConverter.java
@@ -3,12 +3,11 @@
 package org.higherkindedj.spring.security;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.higherkindedj.hkt.either.Either;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -22,8 +21,15 @@ import org.springframework.security.oauth2.jwt.Jwt;
  * <ul>
  *   <li>Parse JWT claims with Either (success/failure)
  *   <li>Extract authorities with validation
- *   <li>Convert errors to AuthenticationToken or propagate
+ *   <li>Reject the token with a {@link BadCredentialsException} when extraction fails
  * </ul>
+ *
+ * <p>A malformed authorities claim (wrong type, or a collection containing a non-string element)
+ * never produces an authenticated token: the {@code Left} branch is folded into a thrown {@link
+ * BadCredentialsException}, which Spring Security surfaces as an authentication failure (HTTP 401).
+ * A <em>missing</em> claim is rejected the same way only in the strict/default mode ({@code
+ * rejectMissingClaim = true}); in lenient mode a token that simply lacks the claim authenticates
+ * with no authorities.
  *
  * <p>Example usage in SecurityConfig:
  *
@@ -41,6 +47,7 @@ public class EitherAuthenticationConverter implements Converter<Jwt, AbstractAut
 
   private final String authoritiesClaimName;
   private final String authorityPrefix;
+  private final boolean rejectMissingClaim;
 
   /**
    * Creates a new EitherAuthenticationConverter with default settings.
@@ -50,10 +57,21 @@ public class EitherAuthenticationConverter implements Converter<Jwt, AbstractAut
    * <ul>
    *   <li>authoritiesClaimName: "roles"
    *   <li>authorityPrefix: "ROLE_"
+   *   <li>rejectMissingClaim: true (a token without the claim is rejected)
    * </ul>
    */
   public EitherAuthenticationConverter() {
-    this("roles", "ROLE_");
+    this("roles", "ROLE_", true);
+  }
+
+  /**
+   * Creates a new EitherAuthenticationConverter that rejects a missing authorities claim.
+   *
+   * @param authoritiesClaimName the JWT claim name containing authorities
+   * @param authorityPrefix the prefix to add to each authority
+   */
+  public EitherAuthenticationConverter(String authoritiesClaimName, String authorityPrefix) {
+    this(authoritiesClaimName, authorityPrefix, true);
   }
 
   /**
@@ -61,25 +79,31 @@ public class EitherAuthenticationConverter implements Converter<Jwt, AbstractAut
    *
    * @param authoritiesClaimName the JWT claim name containing authorities
    * @param authorityPrefix the prefix to add to each authority
+   * @param rejectMissingClaim when {@code true} (the safe default) a token that lacks the
+   *     authorities claim is rejected with {@link BadCredentialsException}; when {@code false} such
+   *     a token authenticates with no authorities (lenient — for IdPs that legitimately issue
+   *     role-less tokens, e.g. client-credentials). A malformed (wrong-type) claim is always
+   *     rejected regardless of this flag.
    */
-  public EitherAuthenticationConverter(String authoritiesClaimName, String authorityPrefix) {
+  public EitherAuthenticationConverter(
+      String authoritiesClaimName, String authorityPrefix, boolean rejectMissingClaim) {
     this.authoritiesClaimName = authoritiesClaimName;
     this.authorityPrefix = authorityPrefix;
+    this.rejectMissingClaim = rejectMissingClaim;
   }
 
   @Override
   public AbstractAuthenticationToken convert(Jwt jwt) {
-    // Use Either for functional error handling
     Either<AuthConversionError, AbstractAuthenticationToken> result =
         extractAuthorities(jwt).map(authorities -> createAuthenticationToken(jwt, authorities));
 
-    // Fold Either to handle both success and error cases
     return result.fold(
         error -> {
-          // On error, create unauthenticated token
-          // In production, you might throw an exception or return null
-          return new UsernamePasswordAuthenticationToken(
-              jwt.getSubject(), null, Collections.emptyList());
+          if (error.missingClaim() && !rejectMissingClaim) {
+            // Lenient: a legitimately role-less token authenticates with no authorities.
+            return createAuthenticationToken(jwt, List.of());
+          }
+          throw new BadCredentialsException("JWT authority conversion failed: " + error.message());
         },
         token -> token);
   }
@@ -96,26 +120,36 @@ public class EitherAuthenticationConverter implements Converter<Jwt, AbstractAut
 
       if (claim == null) {
         return Either.left(
-            new AuthConversionError("Missing authorities claim: " + authoritiesClaimName));
+            new AuthConversionError("Missing authorities claim: " + authoritiesClaimName, true));
       }
 
       if (claim instanceof Collection<?> claimCollection) {
+        // A collection containing any non-string element is a malformed claim, not a role-less
+        // token: reject the whole claim rather than silently dropping the bad elements (which would
+        // let e.g. ["ADMIN", 123] authenticate with ROLE_ADMIN). Malformed claims are rejected
+        // regardless of the lenient rejectMissingClaim flag.
+        if (claimCollection.stream().anyMatch(item -> !(item instanceof String))) {
+          return Either.left(
+              new AuthConversionError(
+                  "Invalid authorities claim element type: " + authoritiesClaimName, false));
+        }
+
         List<GrantedAuthority> authorities =
             claimCollection.stream()
-                .filter(item -> item instanceof String)
-                .map(item -> (String) item)
-                .map(role -> new SimpleGrantedAuthority(authorityPrefix + role))
-                .collect(Collectors.toList());
+                .map(String.class::cast)
+                .map(role -> (GrantedAuthority) new SimpleGrantedAuthority(authorityPrefix + role))
+                .toList();
 
         return Either.right(authorities);
       }
 
       return Either.left(
-          new AuthConversionError("Invalid authorities claim type: " + claim.getClass().getName()));
+          new AuthConversionError(
+              "Invalid authorities claim type: " + claim.getClass().getName(), false));
 
     } catch (Exception e) {
       return Either.left(
-          new AuthConversionError("Error extracting authorities: " + e.getMessage()));
+          new AuthConversionError("Error extracting authorities: " + e.getMessage(), false));
     }
   }
 
@@ -136,6 +170,8 @@ public class EitherAuthenticationConverter implements Converter<Jwt, AbstractAut
    * Error type for authentication conversion failures.
    *
    * @param message the error message describing the conversion failure
+   * @param missingClaim {@code true} when the failure is a simply-absent authorities claim (a token
+   *     that may legitimately carry no roles), {@code false} for a malformed claim
    */
-  public record AuthConversionError(String message) {}
+  public record AuthConversionError(String message, boolean missingClaim) {}
 }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/security/EitherAuthorizationManager.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/security/EitherAuthorizationManager.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.spring.security;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.higherkindedj.hkt.either.Either;
 import org.jspecify.annotations.Nullable;
@@ -10,25 +12,30 @@ import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * Authorization manager using Either for functional authorization decisions.
  *
- * <p>Demonstrates functional approach to Spring Security authorization:
+ * <p>Authorization policy is supplied as an ordered list of {@link AuthorizationRule}s, each
+ * returning {@code Either<AuthorizationError, Authentication>}. Rules are chained with {@code
+ * flatMap}: the first {@code Left} denies access; if every rule passes, access is granted. An
+ * authentication-present check always runs before the supplied rules.
  *
- * <ul>
- *   <li>Check authorization rules with Either
- *   <li>Left: Authorization error (access denied)
- *   <li>Right: Authorization success (access granted)
- *   <li>Compose multiple authorization rules with flatMap
- * </ul>
+ * <p>The no-arg constructor keeps the historical default policy — {@link #requireAuthority
+ * requireAuthority("ROLE_ADMIN")} plus {@link #denyPathPrefix
+ * denyPathPrefix("/api/admin/dangerous")} — as two explicit, named rules. Construct with your own
+ * rules for real applications.
  *
  * <p>Example usage:
  *
  * <pre>{@code
  * @Bean
  * public SecurityFilterChain filterChain(HttpSecurity http) {
- *     var authManager = new EitherAuthorizationManager();
+ *     var authManager = new EitherAuthorizationManager(List.of(
+ *         EitherAuthorizationManager.requireAuthority("ROLE_ADMIN"),
+ *         EitherAuthorizationManager.denyPathPrefix("/api/admin/dangerous")));
  *
  *     http.authorizeHttpRequests(authz -> authz
  *         .requestMatchers("/api/admin/**").access(authManager)
@@ -50,8 +57,114 @@ import org.springframework.security.web.access.intercept.RequestAuthorizationCon
 public class EitherAuthorizationManager
     implements AuthorizationManager<RequestAuthorizationContext> {
 
-  /** Creates a new EitherAuthorizationManager with default settings. */
-  public EitherAuthorizationManager() {}
+  /**
+   * A single authorization rule: passes the authentication through on success, or denies with an
+   * {@link AuthorizationError}.
+   */
+  @FunctionalInterface
+  public interface AuthorizationRule {
+
+    /**
+     * Checks this rule against the authenticated request.
+     *
+     * @param authentication the (already authenticated) authentication
+     * @param context the request context
+     * @return {@code Right(authentication)} to allow the chain to continue, or {@code Left(error)}
+     *     to deny
+     */
+    Either<AuthorizationError, Authentication> check(
+        Authentication authentication, RequestAuthorizationContext context);
+  }
+
+  private final List<AuthorizationRule> rules;
+
+  /**
+   * Creates a manager with the historical default policy: require {@code ROLE_ADMIN} and deny paths
+   * under {@code /api/admin/dangerous}.
+   *
+   * <p>Prefer {@link #EitherAuthorizationManager(List)} with your own rules in real applications.
+   */
+  public EitherAuthorizationManager() {
+    this(List.of(requireAuthority("ROLE_ADMIN"), denyPathPrefix("/api/admin/dangerous")));
+  }
+
+  /**
+   * Creates a manager with the given ordered rules. All rules must pass for access to be granted.
+   *
+   * @param rules the authorization rules, evaluated in order
+   */
+  public EitherAuthorizationManager(List<AuthorizationRule> rules) {
+    this.rules = List.copyOf(rules);
+  }
+
+  /**
+   * Rule requiring the given granted authority.
+   *
+   * @param authority the required authority (e.g. {@code "ROLE_ADMIN"})
+   * @return the rule
+   */
+  public static AuthorizationRule requireAuthority(String authority) {
+    Objects.requireNonNull(authority, "authority");
+    return (authentication, context) ->
+        // Compare from the (non-null) required authority side: GrantedAuthority.getAuthority()
+        // may return null, which would NPE if it were the receiver.
+        authentication.getAuthorities().stream()
+                .anyMatch(granted -> authority.equals(granted.getAuthority()))
+            ? Either.right(authentication)
+            : Either.left(new AuthorizationError("Missing required authority: " + authority));
+  }
+
+  /**
+   * Rule denying the given path and any request under it.
+   *
+   * <p>Matching delegates to Spring Security's {@link PathPatternRequestMatcher}, which works on
+   * the decoded, normalised request path — a raw {@code getRequestURI().startsWith(...)} check
+   * would be bypassable with percent-encoding (e.g. {@code /api/%64angerous}).
+   *
+   * <p>The prefix is normalised: it must be non-blank, start with {@code /}, and contain no {@link
+   * PathPatternRequestMatcher} metacharacter ({@code * ? { }} — those would parse as pattern
+   * syntax, not a literal prefix, so e.g. {@code "/api/{segment}"} could deny more than intended);
+   * every trailing {@code /} is stripped. Normalising trailing slashes is a security requirement,
+   * not cosmetics — a raw {@code "/api/admin/"} or {@code "/api/admin//"} would otherwise build the
+   * descendants matcher as {@code "/api/admin//**"}, whose empty segment matches no real descendant
+   * and silently fails open. The root prefix {@code "/"} is special-cased to a {@code "/**"}
+   * descendants pattern for the same reason.
+   *
+   * @param pathPrefix the denied path prefix (a literal segment prefix, e.g. {@code "/api/admin"})
+   * @return the rule
+   * @throws IllegalArgumentException if the prefix is blank, lacks a leading {@code /}, or contains
+   *     a PathPattern metacharacter ({@code * ? { }})
+   */
+  public static AuthorizationRule denyPathPrefix(String pathPrefix) {
+    if (pathPrefix == null || pathPrefix.isBlank()) {
+      throw new IllegalArgumentException("pathPrefix must not be blank");
+    }
+    if (!pathPrefix.startsWith("/")) {
+      throw new IllegalArgumentException("pathPrefix must start with '/': " + pathPrefix);
+    }
+    if (pathPrefix.chars().anyMatch(c -> c == '*' || c == '?' || c == '{' || c == '}')) {
+      throw new IllegalArgumentException(
+          "pathPrefix must be a literal prefix without PathPattern metacharacters (* ? { }): "
+              + pathPrefix);
+    }
+    // Strip *every* trailing slash, not just one: "/api/admin//" would otherwise normalise to
+    // "/api/admin/" and rebuild the fail-open "/api/admin//**" descendants matcher.
+    String stripped = pathPrefix;
+    while (stripped.length() > 1 && stripped.endsWith("/")) {
+      stripped = stripped.substring(0, stripped.length() - 1);
+    }
+    // Effectively final for the returned rule lambda below.
+    String normalised = stripped;
+    // For the root "/", the descendants pattern is "/**" (not "//**", which matches nothing).
+    String descendantsPattern = normalised.equals("/") ? "/**" : normalised + "/**";
+    RequestMatcher exact = PathPatternRequestMatcher.withDefaults().matcher(normalised);
+    RequestMatcher descendants =
+        PathPatternRequestMatcher.withDefaults().matcher(descendantsPattern);
+    return (authentication, context) ->
+        exact.matches(context.getRequest()) || descendants.matches(context.getRequest())
+            ? Either.left(new AuthorizationError("Access denied to path: " + normalised))
+            : Either.right(authentication);
+  }
 
   /**
    * Authorizes access using Either for functional decision making.
@@ -65,14 +178,12 @@ public class EitherAuthorizationManager
       Supplier<? extends @Nullable Authentication> authentication,
       RequestAuthorizationContext context) {
 
-    Either<AuthorizationError, AuthorizationSuccess> result =
-        checkAuthentication(authentication.get())
-            .flatMap(auth -> checkAuthorities(auth))
-            .flatMap(auth -> checkRequestPath(auth, context));
+    Either<AuthorizationError, Authentication> result = checkAuthentication(authentication.get());
+    for (AuthorizationRule rule : rules) {
+      result = result.flatMap(auth -> rule.check(auth, context));
+    }
 
-    // Fold Either to AuthorizationDecision
-    return result.fold(
-        error -> new AuthorizationDecision(false), success -> new AuthorizationDecision(true));
+    return result.fold(_ -> new AuthorizationDecision(false), _ -> new AuthorizationDecision(true));
   }
 
   /**
@@ -82,7 +193,7 @@ public class EitherAuthorizationManager
    * @return Either containing authentication or error
    */
   private Either<AuthorizationError, Authentication> checkAuthentication(
-      Authentication authentication) {
+      @Nullable Authentication authentication) {
     if (authentication == null) {
       return Either.left(new AuthorizationError("No authentication present"));
     }
@@ -95,56 +206,9 @@ public class EitherAuthorizationManager
   }
 
   /**
-   * Checks if authentication has required authorities.
-   *
-   * @param authentication the authentication
-   * @return Either containing authentication or error
-   */
-  private Either<AuthorizationError, Authentication> checkAuthorities(
-      Authentication authentication) {
-    boolean hasAdminRole =
-        authentication.getAuthorities().stream()
-            .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
-
-    if (!hasAdminRole) {
-      return Either.left(new AuthorizationError("Missing required ADMIN role"));
-    }
-
-    return Either.right(authentication);
-  }
-
-  /**
-   * Checks if request path is allowed.
-   *
-   * @param authentication the authentication
-   * @param context the request context
-   * @return Either containing success or error
-   */
-  private Either<AuthorizationError, AuthorizationSuccess> checkRequestPath(
-      Authentication authentication, RequestAuthorizationContext context) {
-
-    String path = context.getRequest().getRequestURI();
-
-    // Example: block certain paths even for admins
-    if (path != null && path.startsWith("/api/admin/dangerous")) {
-      return Either.left(new AuthorizationError("Dangerous path access denied"));
-    }
-
-    return Either.right(new AuthorizationSuccess(authentication.getName(), path));
-  }
-
-  /**
    * Error type for authorization failures.
    *
    * @param reason the reason authorization was denied
    */
   public record AuthorizationError(String reason) {}
-
-  /**
-   * Success type for authorization.
-   *
-   * @param principal the authorized principal name
-   * @param allowedPath the path that was authorized
-   */
-  public record AuthorizationSuccess(String principal, String allowedPath) {}
 }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/security/ValidatedUserDetailsService.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/security/ValidatedUserDetailsService.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.higherkindedj.hkt.Semigroup;
 import org.higherkindedj.hkt.validated.Validated;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,110 +13,87 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
- * UserDetailsService using Validated for comprehensive user validation.
+ * UserDetailsService using Validated for comprehensive username validation.
  *
  * <p>Demonstrates error accumulation with Validated in Spring Security:
  *
  * <ul>
- *   <li>Validate username format
- *   <li>Validate account status (enabled, non-locked, etc.)
- *   <li>Accumulate ALL validation errors
+ *   <li>Validate username format, accumulating ALL format errors
+ *   <li>Load the user from the in-memory store
  *   <li>Return detailed error information
  * </ul>
+ *
+ * <p>The service starts <strong>empty</strong>: register users explicitly via {@link
+ * #addUser(UserDetails)}. For demos and tests, {@link #withSampleUsers()} creates an instance
+ * pre-populated with well-known sample accounts — never use that factory in production.
+ *
+ * <p>Account-status checks (disabled, locked, expired) are deliberately <em>not</em> performed
+ * here: per the {@link UserDetailsService} contract they belong to the authentication provider,
+ * which raises the specific {@code DisabledException}/{@code LockedException} variants. Use {@link
+ * #validateAccountStatus(UserDetails)} if you need an accumulated functional view of those checks.
  *
  * <p>Example usage:
  *
  * <pre>{@code
  * @Bean
- * public UserDetailsService userDetailsService() {
- *     return new ValidatedUserDetailsService();
- * }
- *
- * @Bean
- * public AuthenticationManager authManager(HttpSecurity http) {
- *     return http.getSharedObject(AuthenticationManagerBuilder.class)
- *         .userDetailsService(userDetailsService())
- *         .passwordEncoder(passwordEncoder())
- *         .and()
- *         .build();
+ * public UserDetailsService userDetailsService(PasswordEncoder encoder) {
+ *     var service = new ValidatedUserDetailsService();
+ *     service.addUser(User.builder()
+ *         .username("alice")
+ *         .password(encoder.encode(secret))
+ *         .roles("USER")
+ *         .build());
+ *     return service;
  * }
  * }</pre>
- *
- * <p>Benefits of Validated for user details:
- *
- * <ul>
- *   <li>Complete error reporting (not just first error)
- *   <li>Better UX - users see all validation issues
- *   <li>Type-safe validation
- *   <li>Composable validation rules
- * </ul>
  */
 public class ValidatedUserDetailsService implements UserDetailsService {
 
   private final Map<String, UserDetails> users = new ConcurrentHashMap<>();
 
-  // Semigroup for combining error lists
-  private static final Semigroup<List<UserValidationError>> ERROR_SEMIGROUP =
-      (a, b) -> {
-        List<UserValidationError> combined = new ArrayList<>(a);
-        combined.addAll(b);
-        return combined;
-      };
+  /** Creates a new, empty ValidatedUserDetailsService. Register users via {@link #addUser}. */
+  public ValidatedUserDetailsService() {}
 
-  /** Creates a new ValidatedUserDetailsService with sample users. */
-  public ValidatedUserDetailsService() {
-    // Add sample users for testing
-    users.put(
-        "admin",
+  /**
+   * Creates a service pre-populated with sample users for demos and tests.
+   *
+   * <p><strong>Never use in production:</strong> the accounts ({@code admin}, {@code user}, {@code
+   * disabled}) have well-known plaintext ({@code {noop}}) passwords.
+   *
+   * @return a service containing the sample accounts
+   */
+  public static ValidatedUserDetailsService withSampleUsers() {
+    var service = new ValidatedUserDetailsService();
+    service.addUser(
         User.builder().username("admin").password("{noop}admin123").roles("ADMIN", "USER").build());
-
-    users.put(
-        "user", User.builder().username("user").password("{noop}user123").roles("USER").build());
-
-    // Disabled user for testing
-    users.put(
-        "disabled",
+    service.addUser(
+        User.builder().username("user").password("{noop}user123").roles("USER").build());
+    service.addUser(
         User.builder()
             .username("disabled")
             .password("{noop}disabled123")
             .roles("USER")
             .disabled(true)
             .build());
+    return service;
   }
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    // Validate username and load user
-    Validated<List<UserValidationError>, UserDetails> validated = validateAndLoadUser(username);
+    Validated<List<UserValidationError>, UserDetails> validated =
+        validateUsername(username).flatMap(this::loadUser);
 
-    // Fold Validated to UserDetails or throw exception
     return validated.fold(
         errors -> {
-          // Collect all error messages
           String errorMessages =
-              errors.stream()
-                  .map(UserValidationError::message)
-                  .reduce((a, b) -> a + "; " + b)
-                  .orElse("Unknown error");
-
+              String.join("; ", errors.stream().map(UserValidationError::message).toList());
           throw new UsernameNotFoundException(errorMessages);
         },
         userDetails -> userDetails);
   }
 
   /**
-   * Validates username and loads user details.
-   *
-   * @param username the username to validate and load
-   * @return Validated containing user details or validation errors
-   */
-  private Validated<List<UserValidationError>, UserDetails> validateAndLoadUser(String username) {
-    // Start with username validation
-    return validateUsername(username).flatMap(this::loadUser).flatMap(this::validateUserAccount);
-  }
-
-  /**
-   * Validates username format.
+   * Validates username format, accumulating all format errors.
    *
    * @param username the username
    * @return Validated containing username or errors
@@ -143,11 +119,11 @@ public class ValidatedUserDetailsService implements UserDetailsService {
               "Username can only contain letters, numbers, underscores, and hyphens"));
     }
 
-    return errors.isEmpty() ? Validated.valid(username) : Validated.invalid(errors);
+    return errors.isEmpty() ? Validated.valid(username) : Validated.invalid(List.copyOf(errors));
   }
 
   /**
-   * Loads user from repository.
+   * Loads user from the in-memory store.
    *
    * @param username the username
    * @return Validated containing user details or error
@@ -163,12 +139,16 @@ public class ValidatedUserDetailsService implements UserDetailsService {
   }
 
   /**
-   * Validates user account status.
+   * Validates account status (enabled, non-locked, non-expired), accumulating all failures.
+   *
+   * <p>Not consulted by {@link #loadUserByUsername}: status enforcement is the authentication
+   * provider's responsibility. This is a functional convenience for callers that want the
+   * accumulated view.
    *
    * @param userDetails the user details
-   * @return Validated containing user details or errors
+   * @return Validated containing user details or all status errors
    */
-  private Validated<List<UserValidationError>, UserDetails> validateUserAccount(
+  public Validated<List<UserValidationError>, UserDetails> validateAccountStatus(
       UserDetails userDetails) {
     List<UserValidationError> errors = new ArrayList<>();
 
@@ -188,7 +168,7 @@ public class ValidatedUserDetailsService implements UserDetailsService {
       errors.add(new UserValidationError("Credentials have expired"));
     }
 
-    return errors.isEmpty() ? Validated.valid(userDetails) : Validated.invalid(errors);
+    return errors.isEmpty() ? Validated.valid(userDetails) : Validated.invalid(List.copyOf(errors));
   }
 
   /**

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandler.java
@@ -4,13 +4,14 @@ package org.higherkindedj.spring.web.returnvalue;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.higherkindedj.hkt.effect.CompletableFuturePath;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.context.request.async.WebAsyncUtils;
@@ -60,7 +61,6 @@ public class CompletableFuturePathReturnValueHandler
   private static final Logger log =
       LoggerFactory.getLogger(CompletableFuturePathReturnValueHandler.class);
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int failureStatus;
   private final boolean includeExceptionDetails;
@@ -79,7 +79,6 @@ public class CompletableFuturePathReturnValueHandler
       int failureStatus,
       boolean includeExceptionDetails,
       long timeoutMillis) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.failureStatus = failureStatus;
     this.includeExceptionDetails = includeExceptionDetails;
@@ -119,36 +118,56 @@ public class CompletableFuturePathReturnValueHandler
     DeferredResult<Void> deferredResult =
         timeoutMillis > 0 ? new DeferredResult<>(timeoutMillis) : new DeferredResult<>();
 
-    // Handle timeout
+    // Exactly one of the timeout callback and the completion callback may write the response:
+    // after a timeout the container completes (and may recycle) the request, so a late
+    // completion must not touch the response object.
+    AtomicBoolean responseWritten = new AtomicBoolean(false);
+
+    CompletableFuture<?> future = path.run();
+
     deferredResult.onTimeout(
         () -> {
+          // If completion already won the write race it owns the response and will settle the
+          // request — do NOT cancel or setResult here, or we could complete/recycle the response
+          // out from under the completion callback's in-flight write.
+          if (!responseWritten.compareAndSet(false, true)) {
+            return;
+          }
           try {
             writeTimeoutResponse(response);
           } catch (Exception e) {
             log.error("Failed to write timeout response", e);
           }
+          // cancel() settles the future so the (now no-op) completion callback fires; note the
+          // underlying work is NOT interrupted and may still run to completion in the background
+          // (see CompletableFuture.cancel semantics).
+          future.cancel(true);
+          // Settle the DeferredResult so Spring does not dispatch an AsyncRequestTimeoutException
+          // onto the committed response.
+          deferredResult.setResult(null);
         });
 
     int successStatus =
         SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
 
-    // Execute the CompletableFuture asynchronously
-    path.run()
-        .whenComplete(
-            (result, throwable) -> {
-              try {
-                if (throwable != null) {
-                  log.error("CompletableFuturePath failed", throwable);
-                  writeFailureResponse(throwable, response);
-                } else {
-                  writeSuccessResponse(result, response, successStatus);
-                }
-                deferredResult.setResult(null);
-              } catch (Exception e) {
-                log.error("Failed to write async response", e);
-                deferredResult.setErrorResult(e);
-              }
-            });
+    future.whenComplete(
+        (result, throwable) -> {
+          if (!responseWritten.compareAndSet(false, true)) {
+            return;
+          }
+          try {
+            if (throwable != null) {
+              log.error("CompletableFuturePath failed", throwable);
+              writeFailureResponse(throwable, response);
+            } else {
+              writeSuccessResponse(result, response, successStatus);
+            }
+            deferredResult.setResult(null);
+          } catch (Exception e) {
+            log.error("Failed to write async response", e);
+            deferredResult.setErrorResult(e);
+          }
+        });
 
     // Start async processing
     WebAsyncUtils.getAsyncManager(webRequest)
@@ -168,10 +187,9 @@ public class CompletableFuturePathReturnValueHandler
   private void writeFailureResponse(Throwable throwable, HttpServletResponse response) {
     try {
       response.setStatus(failureStatus);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
-      // Unwrap CompletionException if present
-      Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+      Throwable cause = JsonResponses.unwrapAsyncException(throwable);
 
       ErrorResponseHeaders.applyTo(cause, response);
 
@@ -206,7 +224,7 @@ public class CompletableFuturePathReturnValueHandler
   private void writeTimeoutResponse(HttpServletResponse response) {
     try {
       response.setStatus(HttpStatus.GATEWAY_TIMEOUT.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
       Map<String, Object> body = Map.of("success", false, "error", "Request timed out");
       objectWriter.writeValue(response.getWriter(), body);
@@ -225,8 +243,8 @@ public class CompletableFuturePathReturnValueHandler
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherOrBothPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherOrBothPathReturnValueHandler.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.eitherorboth.EitherOrBoth;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -46,7 +45,6 @@ public class EitherOrBothPathReturnValueHandler implements HandlerMethodReturnVa
   /** Response header carrying the JSON-encoded warnings of a {@code Both} result. */
   public static final String WARNINGS_HEADER = "X-Hkj-Warnings";
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int defaultErrorStatus;
   private final ErrorStatusCodeStrategy errorStatusCodeStrategy;
@@ -72,7 +70,6 @@ public class EitherOrBothPathReturnValueHandler implements HandlerMethodReturnVa
       JsonMapper jsonMapper,
       int defaultErrorStatus,
       ErrorStatusCodeStrategy errorStatusCodeStrategy) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.defaultErrorStatus = defaultErrorStatus;
     this.errorStatusCodeStrategy = errorStatusCodeStrategy;
@@ -134,12 +131,16 @@ public class EitherOrBothPathReturnValueHandler implements HandlerMethodReturnVa
 
   private void writeErrorResponse(Object warnings, HttpServletResponse response) {
     try {
-      int statusCode = errorStatusCodeStrategy.statusCodeFor(warnings, defaultErrorStatus);
+      // A one-shot Iterable Left would be exhausted by status resolution / header application and
+      // reach the body writer empty; materialise it once (single values and re-traversable
+      // payloads pass through unchanged).
+      Object materialised = JsonResponses.materialiseErrors(warnings);
+      int statusCode = errorStatusCodeStrategy.statusCodeFor(materialised, defaultErrorStatus);
       response.setStatus(statusCode);
-      ErrorResponseHeaders.applyTo(warnings, response);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      ErrorResponseHeaders.applyTo(materialised, response);
+      JsonResponses.setJsonContentType(response);
 
-      Map<String, Object> errorBody = Map.of("success", false, "error", warnings);
+      Map<String, Object> errorBody = Map.of("success", false, "error", materialised);
       objectWriter.writeValue(response.getWriter(), errorBody);
     } catch (Exception e) {
       throw new RuntimeException("Failed to write error response", e);
@@ -149,8 +150,8 @@ public class EitherOrBothPathReturnValueHandler implements HandlerMethodReturnVa
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {
@@ -164,8 +165,8 @@ public class EitherOrBothPathReturnValueHandler implements HandlerMethodReturnVa
       response.setStatus(status);
       // Warnings are surfaced as a header so the success body stays the bare value.
       response.setHeader(WARNINGS_HEADER, objectWriter.writeValueAsString(warnings));
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/EitherPathReturnValueHandler.java
@@ -9,7 +9,6 @@ import org.higherkindedj.hkt.either.Either;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -56,7 +55,6 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHandler {
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int defaultErrorStatus;
   private final ErrorStatusCodeStrategy errorStatusCodeStrategy;
@@ -84,7 +82,6 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
       JsonMapper jsonMapper,
       int defaultErrorStatus,
       ErrorStatusCodeStrategy errorStatusCodeStrategy) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.defaultErrorStatus = defaultErrorStatus;
     this.errorStatusCodeStrategy = errorStatusCodeStrategy;
@@ -154,12 +151,16 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
    */
   private void writeErrorResponse(Object error, HttpServletResponse response) {
     try {
-      int statusCode = errorStatusCodeStrategy.statusCodeFor(error, defaultErrorStatus);
+      // A one-shot Iterable Left would be exhausted by status resolution / header application and
+      // reach the body writer empty; materialise it once (single errors and re-traversable
+      // payloads pass through unchanged).
+      Object materialised = JsonResponses.materialiseErrors(error);
+      int statusCode = errorStatusCodeStrategy.statusCodeFor(materialised, defaultErrorStatus);
       response.setStatus(statusCode);
-      ErrorResponseHeaders.applyTo(error, response);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      ErrorResponseHeaders.applyTo(materialised, response);
+      JsonResponses.setJsonContentType(response);
 
-      Map<String, Object> errorBody = Map.of("success", false, "error", error);
+      Map<String, Object> errorBody = Map.of("success", false, "error", materialised);
       objectWriter.writeValue(response.getWriter(), errorBody);
     } catch (Exception e) {
       throw new RuntimeException("Failed to write error response", e);
@@ -176,8 +177,8 @@ public class EitherPathReturnValueHandler implements HandlerMethodReturnValueHan
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeaders.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeaders.java
@@ -16,9 +16,9 @@ import org.jspecify.annotations.Nullable;
  *
  * <ul>
  *   <li>If {@code error} itself implements {@link HttpHeaderCarrier}, its headers are applied.
- *   <li>Else if {@code error} is a {@link Collection} or array, every element that implements
- *       {@link HttpHeaderCarrier} contributes its headers; values accumulate rather than
- *       overwriting one another.
+ *   <li>Else if {@code error} is an {@link Iterable} (including {@code NonEmptyList} and every
+ *       {@link Collection}) or array, every element that implements {@link HttpHeaderCarrier}
+ *       contributes its headers; values accumulate rather than overwriting one another.
  *   <li>Otherwise nothing is written.
  * </ul>
  *
@@ -52,8 +52,9 @@ final class ErrorResponseHeaders {
       copy(carrier.headers(), response);
       return;
     }
-    if (error instanceof Collection<?> collection) {
-      for (Object element : collection) {
+    // Iterable also covers NonEmptyList, which is Iterable but not a Collection
+    if (error instanceof Iterable<?> iterable) {
+      for (Object element : iterable) {
         if (element instanceof HttpHeaderCarrier carrier) {
           copy(carrier.headers(), response);
         }

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/FreePathReturnValueHandler.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -48,7 +47,6 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
 
   private static final Logger log = LoggerFactory.getLogger(FreePathReturnValueHandler.class);
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int failureStatus;
   private final boolean includeExceptionDetails;
@@ -68,7 +66,6 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
       int failureStatus,
       boolean includeExceptionDetails,
       ApplicationContext applicationContext) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.failureStatus = failureStatus;
     this.includeExceptionDetails = includeExceptionDetails;
@@ -132,7 +129,7 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
     try {
       response.setStatus(failureStatus);
       ErrorResponseHeaders.applyTo(throwable, response);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
       Map<String, Object> errorBody;
       if (includeExceptionDetails) {
@@ -159,8 +156,8 @@ public class FreePathReturnValueHandler implements HandlerMethodReturnValueHandl
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/IOPathReturnValueHandler.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -57,7 +56,6 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
 
   private static final Logger log = LoggerFactory.getLogger(IOPathReturnValueHandler.class);
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int failureStatus;
   private final boolean includeExceptionDetails;
@@ -71,7 +69,6 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
    */
   public IOPathReturnValueHandler(
       JsonMapper jsonMapper, int failureStatus, boolean includeExceptionDetails) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.failureStatus = failureStatus;
     this.includeExceptionDetails = includeExceptionDetails;
@@ -124,7 +121,7 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
     try {
       response.setStatus(failureStatus);
       ErrorResponseHeaders.applyTo(throwable, response);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
       Map<String, Object> errorBody;
       if (includeExceptionDetails) {
@@ -158,8 +155,8 @@ public class IOPathReturnValueHandler implements HandlerMethodReturnValueHandler
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/JsonResponses.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/JsonResponses.java
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/** Shared response-writing helpers for the Path return value handlers. */
+final class JsonResponses {
+
+  private JsonResponses() {}
+
+  /**
+   * Sets the JSON content type with an explicit UTF-8 charset. The servlet default response
+   * encoding is ISO-8859-1, which would corrupt non-Latin body text.
+   *
+   * @param response the HTTP response
+   */
+  static void setJsonContentType(HttpServletResponse response) {
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+  }
+
+  /**
+   * Whether the given status forbids a response body per HTTP semantics: {@code 204 No Content},
+   * {@code 205 Reset Content}, and {@code 304 Not Modified}. Successful response writers must skip
+   * serialisation for these.
+   *
+   * @param status the HTTP status code
+   * @return {@code true} when the status must not carry a body
+   */
+  static boolean isBodilessStatus(int status) {
+    return status == HttpStatus.NO_CONTENT.value()
+        || status == HttpStatus.RESET_CONTENT.value()
+        || status == HttpStatus.NOT_MODIFIED.value();
+  }
+
+  /**
+   * Unwraps only the async wrapper exceptions ({@link CompletionException}, {@link
+   * ExecutionException}); a domain exception's own cause chain is preserved.
+   *
+   * @param throwable the raw failure from an async computation
+   * @return the wrapped cause, or the throwable itself
+   */
+  static Throwable unwrapAsyncException(Throwable throwable) {
+    return (throwable instanceof CompletionException || throwable instanceof ExecutionException)
+            && throwable.getCause() != null
+        ? throwable.getCause()
+        : throwable;
+  }
+
+  /**
+   * Materialises a one-shot {@link Iterable} error payload into a list so it can be traversed more
+   * than once (status resolution, headers, then the JSON body). Re-traversable payloads — {@link
+   * Collection}, {@link NonEmptyList}, and arrays — are returned unchanged so their serialised
+   * shape is preserved. A one-shot iterable would otherwise be exhausted by the first pass and
+   * reach the body writer empty.
+   *
+   * @param errors the error payload (any type)
+   * @return a re-traversable equivalent of {@code errors}
+   */
+  static Object materialiseErrors(Object errors) {
+    if (errors instanceof Collection<?>
+        || errors instanceof NonEmptyList<?>
+        || !(errors instanceof Iterable<?> iterable)) {
+      return errors;
+    }
+    List<Object> list = new ArrayList<>();
+    iterable.forEach(list::add);
+    return list;
+  }
+}

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/MaybePathReturnValueHandler.java
@@ -8,7 +8,6 @@ import org.higherkindedj.hkt.effect.MaybePath;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -45,7 +44,6 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class MaybePathReturnValueHandler implements HandlerMethodReturnValueHandler {
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int nothingStatus;
 
@@ -56,7 +54,6 @@ public class MaybePathReturnValueHandler implements HandlerMethodReturnValueHand
    * @param nothingStatus the HTTP status code for Nothing values (default 404)
    */
   public MaybePathReturnValueHandler(JsonMapper jsonMapper, int nothingStatus) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.nothingStatus = nothingStatus;
   }
@@ -99,7 +96,11 @@ public class MaybePathReturnValueHandler implements HandlerMethodReturnValueHand
   private void writeNothingResponse(HttpServletResponse response) {
     try {
       response.setStatus(nothingStatus);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      // 204/304 responses must not carry a body
+      if (JsonResponses.isBodilessStatus(nothingStatus)) {
+        return;
+      }
+      JsonResponses.setJsonContentType(response);
 
       Map<String, Object> body = Map.of("success", false, "error", "Resource not found");
       objectWriter.writeValue(response.getWriter(), body);
@@ -118,8 +119,8 @@ public class MaybePathReturnValueHandler implements HandlerMethodReturnValueHand
   private void writeJustResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/TryPathReturnValueHandler.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -50,7 +49,6 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
 
   private static final Logger log = LoggerFactory.getLogger(TryPathReturnValueHandler.class);
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int failureStatus;
   private final boolean includeExceptionDetails;
@@ -64,7 +62,6 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
    */
   public TryPathReturnValueHandler(
       JsonMapper jsonMapper, int failureStatus, boolean includeExceptionDetails) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.failureStatus = failureStatus;
     this.includeExceptionDetails = includeExceptionDetails;
@@ -116,7 +113,7 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
     try {
       response.setStatus(failureStatus);
       ErrorResponseHeaders.applyTo(throwable, response);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
       Map<String, Object> errorBody;
       if (includeExceptionDetails) {
@@ -150,8 +147,8 @@ public class TryPathReturnValueHandler implements HandlerMethodReturnValueHandle
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VStreamPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VStreamPathReturnValueHandler.java
@@ -5,10 +5,10 @@ package org.higherkindedj.spring.web.returnvalue;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.higherkindedj.hkt.effect.VStreamPath;
 import org.higherkindedj.hkt.vstream.VStream;
-import org.higherkindedj.hkt.vtask.VTask;
 import org.higherkindedj.spring.actuator.HkjMetricsService;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -48,8 +48,12 @@ import tools.jackson.databind.json.JsonMapper;
  * <ul>
  *   <li>Each emitted element → SSE {@code data:} event with JSON payload
  *   <li>Stream completion → Final SSE {@code event: complete} and connection close
- *   <li>Stream error → SSE {@code event: error} with error details
- *   <li>Timeout → HTTP 504 Gateway Timeout
+ *   <li>Error on the first pull → configured failure status (default 500) with a JSON error body;
+ *       the response commits (and SSE headers flush) once the first step resolves, so streams that
+ *       may idle before their first step should emit an early heartbeat element
+ *   <li>Error mid-stream → SSE {@code event: error} with error details
+ *   <li>Timeout → HTTP 504 Gateway Timeout (before streaming) or stream abort (mid-stream)
+ *   <li>Client disconnect → pull loop stops; upstream production ceases
  * </ul>
  *
  * <p>Example usage:
@@ -77,7 +81,6 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
 
   private static final Logger log = LoggerFactory.getLogger(VStreamPathReturnValueHandler.class);
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int failureStatus;
   private final boolean includeExceptionDetails;
@@ -99,7 +102,6 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
       boolean includeExceptionDetails,
       long timeoutMillis,
       @Nullable HkjMetricsService metricsService) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.failureStatus = failureStatus;
     this.includeExceptionDetails = includeExceptionDetails;
@@ -140,22 +142,38 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
     DeferredResult<Void> deferredResult =
         timeoutMillis > 0 ? new DeferredResult<>(timeoutMillis) : new DeferredResult<>();
 
-    // Handle timeout
+    // Signals the pull loop to stop (timeout or request completion, incl. client disconnect).
+    AtomicBoolean aborted = new AtomicBoolean(false);
+    // First claimant may write the initial response bytes; the loser must not touch it.
+    AtomicBoolean responseOwned = new AtomicBoolean(false);
+
     deferredResult.onTimeout(
         () -> {
-          try {
-            response.setStatus(HttpStatus.GATEWAY_TIMEOUT.value());
-            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            Map<String, Object> body =
-                Map.of("success", false, "error", "VStream request timed out");
-            objectWriter.writeValue(response.getWriter(), body);
-          } catch (Exception e) {
-            log.error("Failed to write timeout response", e);
+          aborted.set(true);
+          if (responseOwned.compareAndSet(false, true)) {
+            try {
+              response.setStatus(HttpStatus.GATEWAY_TIMEOUT.value());
+              JsonResponses.setJsonContentType(response);
+              Map<String, Object> body =
+                  Map.of("success", false, "error", "VStream request timed out");
+              objectWriter.writeValue(response.getWriter(), body);
+            } catch (Exception e) {
+              log.error("Failed to write timeout response", e);
+            }
           }
+          // Settle the DeferredResult so Spring does not dispatch an
+          // AsyncRequestTimeoutException onto the committed response.
+          deferredResult.setResult(null);
         });
+    deferredResult.onCompletion(() -> aborted.set(true));
 
     int successStatus =
         SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
+
+    // Enter async mode BEFORE spawning the producer, so the container is async by the time the
+    // producer can touch or commit the response (avoids a commit-before-startAsync race).
+    WebAsyncUtils.getAsyncManager(webRequest)
+        .startDeferredResultProcessing(deferredResult, mavContainer);
 
     // Execute the VStream on a virtual thread, pulling elements and writing SSE events
     Thread.ofVirtual()
@@ -163,11 +181,27 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
         .start(
             () -> {
               AtomicLong elementCount = new AtomicLong(0);
+              boolean owned = false;
+              boolean committed = false;
               try {
-                response.setStatus(successStatus);
-
-                // 204 No Content must not have a body — skip SSE headers and stream execution
-                if (successStatus == HttpStatus.NO_CONTENT.value()) {
+                // A bodiless status (204/205/304) has no body and needs no stream execution —
+                // short-circuit before running or pulling the stream, so such an endpoint never
+                // blocks, fails, or times out on a (possibly long) first pull.
+                if (JsonResponses.isBodilessStatus(successStatus)) {
+                  if (!responseOwned.compareAndSet(false, true)) {
+                    return; // a timeout already owns and has settled the response
+                  }
+                  owned = true;
+                  if (aborted.get()) {
+                    // Request completed/disconnected before we claimed the response.
+                    if (metricsService != null) {
+                      metricsService.recordVStreamError("StreamAborted");
+                      metricsService.recordVStreamElements(0);
+                    }
+                    deferredResult.setResult(null);
+                    return;
+                  }
+                  response.setStatus(successStatus);
                   if (metricsService != null) {
                     metricsService.recordVStreamSuccess();
                     metricsService.recordVStreamElements(0);
@@ -176,26 +210,61 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
                   return;
                 }
 
+                VStream<?> stream = streamPath.run();
+
+                // The first step is pulled BEFORE claiming the response or setting any status: a
+                // timeout during this (possibly long) first pull is then owned by onTimeout, which
+                // writes the 504 — not left as a broken 200-empty stream. A stream that fails on
+                // this first pull still gets the configured failure status (below). Once the first
+                // step resolves the headers flush promptly so EventSource.onopen fires and proxies
+                // see the response; streams that may idle before their first step should emit an
+                // early heartbeat element.
+                VStream.Step<?> firstStep = stream.pull().run();
+
+                // Claim the response; if a timeout already owns it, it has settled the request.
+                if (!responseOwned.compareAndSet(false, true)) {
+                  return;
+                }
+                owned = true;
+                if (aborted.get()) {
+                  // Request completed/disconnected between the first pull and our claim.
+                  if (metricsService != null) {
+                    metricsService.recordVStreamError("StreamAborted");
+                    metricsService.recordVStreamElements(0);
+                  }
+                  deferredResult.setResult(null);
+                  return;
+                }
+
+                response.setStatus(successStatus);
                 response.setContentType(MediaType.TEXT_EVENT_STREAM_VALUE);
                 response.setCharacterEncoding("UTF-8");
                 response.setHeader("Cache-Control", "no-cache");
-                response.setHeader("Connection", "keep-alive");
-                response.flushBuffer();
-
                 PrintWriter writer = response.getWriter();
-                VStream<?> stream = streamPath.run();
+                response.flushBuffer();
+                committed = true;
 
-                pullAndWrite(stream, writer, elementCount);
+                boolean completed = pullAndWrite(firstStep, writer, elementCount, aborted);
 
-                // Send completion event
-                writer.write("event: complete\ndata: {\"done\":true}\n\n");
-                writer.flush();
-
-                if (metricsService != null) {
-                  metricsService.recordVStreamSuccess();
+                if (completed) {
+                  writer.write("event: complete\ndata: {\"done\":true}\n\n");
+                  writer.flush();
+                  if (metricsService != null) {
+                    metricsService.recordVStreamSuccess();
+                    metricsService.recordVStreamElements(elementCount.get());
+                  }
+                } else if (metricsService != null) {
+                  metricsService.recordVStreamError("StreamAborted");
                   metricsService.recordVStreamElements(elementCount.get());
                 }
 
+                deferredResult.setResult(null);
+              } catch (ClientDisconnectedException e) {
+                log.debug("SSE client disconnected after {} elements", elementCount.get());
+                if (metricsService != null) {
+                  metricsService.recordVStreamError("ClientDisconnected");
+                  metricsService.recordVStreamElements(elementCount.get());
+                }
                 deferredResult.setResult(null);
               } catch (Exception e) {
                 log.error("VStreamPath streaming failed", e);
@@ -204,43 +273,112 @@ public class VStreamPathReturnValueHandler implements AsyncHandlerMethodReturnVa
                   metricsService.recordVStreamElements(elementCount.get());
                 }
                 try {
-                  writeErrorEvent(response, e);
+                  if (committed) {
+                    // Mid-stream failure on an already-open SSE stream → error event.
+                    writeErrorEvent(response, e);
+                    deferredResult.setResult(null);
+                  } else if (owned || responseOwned.compareAndSet(false, true)) {
+                    // First-pull failure on an uncommitted response we own → failure status.
+                    // Settle normally so Spring's async error dispatch does not reset the body.
+                    writeFailureResponse(response, e);
+                    deferredResult.setResult(null);
+                  } else {
+                    // A timeout owns the uncommitted response; leave its 504 in place.
+                    deferredResult.setResult(null);
+                  }
                 } catch (Exception writeError) {
-                  log.error("Failed to write error event", writeError);
+                  log.error("Failed to write error response", writeError);
+                  deferredResult.setErrorResult(e);
                 }
-                deferredResult.setErrorResult(e);
               }
             });
-
-    // Start async processing
-    WebAsyncUtils.getAsyncManager(webRequest)
-        .startDeferredResultProcessing(deferredResult, mavContainer);
   }
 
-  @SuppressWarnings("preview")
-  private void pullAndWrite(VStream<?> stream, PrintWriter writer, AtomicLong elementCount) {
-    VStream<?> current = stream;
+  /**
+   * Processes the given step and keeps pulling, writing each element as an SSE event.
+   *
+   * @return {@code true} when the stream ran to completion, {@code false} when it was aborted by
+   *     timeout or request completion
+   * @throws ClientDisconnectedException when the client has gone away (detected via {@link
+   *     PrintWriter#checkError()})
+   */
+  private boolean pullAndWrite(
+      VStream.Step<?> firstStep,
+      PrintWriter writer,
+      AtomicLong elementCount,
+      AtomicBoolean aborted) {
+    VStream.Step<?> step = firstStep;
     while (true) {
-      VTask<? extends VStream.Step<?>> pullTask = current.pull();
-      VStream.Step<?> step = pullTask.run();
-
+      // Re-checked after every (potentially long-blocking) pull as well as before it: once a
+      // timeout has settled the DeferredResult, the container may recycle the response, and a
+      // late write could land on an unrelated request.
+      if (aborted.get()) {
+        return false;
+      }
+      VStream<?> next;
       switch (step) {
         case VStream.Step.Emit<?> emit -> {
+          String json;
           try {
-            String json = objectWriter.writeValueAsString(emit.value());
-            writer.write("data: " + json + "\n\n");
-            writer.flush();
-            elementCount.incrementAndGet();
+            json = objectWriter.writeValueAsString(emit.value());
           } catch (Exception e) {
             throw new RuntimeException("Failed to serialize stream element", e);
           }
-          current = emit.tail();
+          writer.write("data: " + json + "\n\n");
+          // PrintWriter swallows IOExceptions; checkError() (which also flushes) is the only
+          // disconnect signal. Without it an infinite stream would keep a virtual thread
+          // pulling forever.
+          if (writer.checkError()) {
+            throw new ClientDisconnectedException();
+          }
+          elementCount.incrementAndGet();
+          next = emit.tail();
         }
-        case VStream.Step.Skip<?> skip -> current = skip.tail();
+        case VStream.Step.Skip<?> skip -> next = skip.tail();
         case VStream.Step.Done<?> done -> {
-          return;
+          return true;
         }
       }
+      if (aborted.get()) {
+        return false;
+      }
+      step = next.pull().run();
+    }
+  }
+
+  /**
+   * Writes the configured failure status with a JSON error body. Only valid while the response is
+   * uncommitted (i.e. the stream failed before its first element).
+   */
+  private void writeFailureResponse(HttpServletResponse response, Exception e) throws Exception {
+    response.reset();
+    response.setStatus(failureStatus);
+    // Preserve any headers the failure carries (e.g. Retry-After, WWW-Authenticate), matching the
+    // other pre-commit failure writers.
+    ErrorResponseHeaders.applyTo(e, response);
+    JsonResponses.setJsonContentType(response);
+    Map<String, Object> errorBody;
+    if (includeExceptionDetails) {
+      errorBody =
+          Map.of(
+              "success",
+              false,
+              "error",
+              Map.of(
+                  "type",
+                  e.getClass().getSimpleName(),
+                  "message",
+                  e.getMessage() != null ? e.getMessage() : "No message"));
+    } else {
+      errorBody = Map.of("success", false, "error", "Stream processing failed");
+    }
+    objectWriter.writeValue(response.getWriter(), errorBody);
+  }
+
+  /** Raised internally when {@link PrintWriter#checkError()} reports a broken connection. */
+  private static final class ClientDisconnectedException extends RuntimeException {
+    ClientDisconnectedException() {
+      super("SSE client disconnected", null, false, false);
     }
   }
 

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/VTaskPathReturnValueHandler.java
@@ -4,6 +4,8 @@ package org.higherkindedj.spring.web.returnvalue;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.higherkindedj.hkt.effect.VTaskPath;
 import org.higherkindedj.spring.actuator.HkjMetricsService;
 import org.jspecify.annotations.Nullable;
@@ -11,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.context.request.async.WebAsyncUtils;
@@ -75,7 +76,6 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
 
   private static final Logger log = LoggerFactory.getLogger(VTaskPathReturnValueHandler.class);
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int failureStatus;
   private final boolean includeExceptionDetails;
@@ -97,7 +97,6 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
       boolean includeExceptionDetails,
       long timeoutMillis,
       @Nullable HkjMetricsService metricsService) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.failureStatus = failureStatus;
     this.includeExceptionDetails = includeExceptionDetails;
@@ -138,61 +137,91 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
     DeferredResult<Void> deferredResult =
         timeoutMillis > 0 ? new DeferredResult<>(timeoutMillis) : new DeferredResult<>();
 
-    // Handle timeout
+    // Exactly one of the timeout callback and the completion callback may write the response:
+    // after a timeout the container completes (and may recycle) the request, so a late
+    // completion must not touch the response object.
+    AtomicBoolean responseWritten = new AtomicBoolean(false);
+
+    long startNanos = System.nanoTime();
+    CompletableFuture<?> future = vtaskPath.runAsync();
+
     deferredResult.onTimeout(
         () -> {
+          // If completion already won the write race it owns the response and will settle the
+          // request — do NOT cancel or setResult here, or we could complete/recycle the response
+          // out from under the completion callback's in-flight write. The winner of the CAS is the
+          // one request handler that records metrics, so a timeout is filed exactly once and as a
+          // timeout — not as the CancellationException that cancel() completes the future with.
+          if (!responseWritten.compareAndSet(false, true)) {
+            return;
+          }
           try {
             writeTimeoutResponse(response);
           } catch (Exception e) {
             log.error("Failed to write timeout response", e);
           }
+          if (metricsService != null) {
+            metricsService.recordVTaskError("timeout");
+            metricsService.recordVTaskDuration((System.nanoTime() - startNanos) / 1_000_000);
+          }
+          // cancel() settles the future so the (now no-op) completion callback fires; note the
+          // underlying work is NOT interrupted and may still run to completion in the background
+          // (see VTask.runAsync / CompletableFuture.cancel semantics).
+          future.cancel(true);
+          // Settle the DeferredResult so Spring does not dispatch an
+          // AsyncRequestTimeoutException onto the committed response.
+          deferredResult.setResult(null);
         });
 
     int successStatus =
         SuccessStatusResolver.resolveSuccessStatus(returnType, HttpStatus.OK.value());
 
-    // Execute the VTask asynchronously on a virtual thread
-    long startTime = System.currentTimeMillis();
-    vtaskPath
-        .runAsync()
-        .whenComplete(
-            (result, throwable) -> {
-              long durationMillis = System.currentTimeMillis() - startTime;
-              try {
-                if (throwable != null) {
-                  log.error("VTaskPath failed", throwable);
-                  Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
-                  if (metricsService != null) {
-                    metricsService.recordVTaskError(cause.getClass().getSimpleName());
-                    metricsService.recordVTaskDuration(durationMillis);
-                  }
-                  writeFailureResponse(throwable, response);
-                } else {
-                  if (metricsService != null) {
-                    metricsService.recordVTaskSuccess();
-                    metricsService.recordVTaskDuration(durationMillis);
-                  }
-                  writeSuccessResponse(result, response, successStatus);
-                }
-                deferredResult.setResult(null);
-              } catch (Exception e) {
-                log.error("Failed to write async response", e);
-                deferredResult.setErrorResult(e);
-              }
-            });
-
-    // Start async processing
+    // Enter async mode BEFORE installing the completion callback: whenComplete runs synchronously
+    // when the future is already complete, so an already-settled fast task must not write and
+    // settle the response before startDeferredResultProcessing (the commit-before-startAsync race
+    // the VStream handler also avoids).
     WebAsyncUtils.getAsyncManager(webRequest)
         .startDeferredResultProcessing(deferredResult, mavContainer);
+
+    future.whenComplete(
+        (result, throwable) -> {
+          // Only the writer that wins the response race records the outcome, so each request
+          // contributes exactly one correctly-attributed metric. A timeout that already won is
+          // recorded by onTimeout above; this callback then no-ops.
+          if (!responseWritten.compareAndSet(false, true)) {
+            return;
+          }
+          long durationMillis = (System.nanoTime() - startNanos) / 1_000_000;
+          if (metricsService != null) {
+            if (throwable != null) {
+              Throwable cause = JsonResponses.unwrapAsyncException(throwable);
+              metricsService.recordVTaskError(cause.getClass().getSimpleName());
+            } else {
+              metricsService.recordVTaskSuccess();
+            }
+            metricsService.recordVTaskDuration(durationMillis);
+          }
+          try {
+            if (throwable != null) {
+              log.error("VTaskPath failed", throwable);
+              writeFailureResponse(throwable, response);
+            } else {
+              writeSuccessResponse(result, response, successStatus);
+            }
+            deferredResult.setResult(null);
+          } catch (Exception e) {
+            log.error("Failed to write async response", e);
+            deferredResult.setErrorResult(e);
+          }
+        });
   }
 
   private void writeFailureResponse(Throwable throwable, HttpServletResponse response) {
     try {
       response.setStatus(failureStatus);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
-      // Unwrap CompletionException if present
-      Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+      Throwable cause = JsonResponses.unwrapAsyncException(throwable);
 
       ErrorResponseHeaders.applyTo(cause, response);
 
@@ -222,7 +251,7 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
   private void writeTimeoutResponse(HttpServletResponse response) {
     try {
       response.setStatus(HttpStatus.GATEWAY_TIMEOUT.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      JsonResponses.setJsonContentType(response);
 
       Map<String, Object> body = Map.of("success", false, "error", "VTask request timed out");
       objectWriter.writeValue(response.getWriter(), body);
@@ -234,8 +263,8 @@ public class VTaskPathReturnValueHandler implements AsyncHandlerMethodReturnValu
   private void writeSuccessResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {

--- a/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandler.java
+++ b/hkj-spring/autoconfigure/src/main/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandler.java
@@ -6,11 +6,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.Map;
 import org.higherkindedj.hkt.effect.ValidationPath;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.Validated;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
@@ -74,7 +74,6 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class ValidationPathReturnValueHandler implements HandlerMethodReturnValueHandler {
 
-  private final JsonMapper jsonMapper;
   private final ObjectWriter objectWriter;
   private final int invalidStatus;
 
@@ -85,7 +84,6 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
    * @param invalidStatus the HTTP status code for invalid results (default 400)
    */
   public ValidationPathReturnValueHandler(JsonMapper jsonMapper, int invalidStatus) {
-    this.jsonMapper = jsonMapper;
     this.objectWriter = jsonMapper.writer();
     this.invalidStatus = invalidStatus;
   }
@@ -155,12 +153,18 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
    */
   private void writeInvalidResponse(Object errors, HttpServletResponse response) {
     try {
+      // A one-shot Iterable (neither Collection nor NonEmptyList) would be exhausted by the first
+      // of applyTo/countErrors/Jackson, dropping errors from the later passes. Materialise it once;
+      // Collection, NonEmptyList and array payloads are already re-traversable and pass through
+      // unchanged so their JSON shape is preserved.
+      Object materialised = JsonResponses.materialiseErrors(errors);
       response.setStatus(invalidStatus);
-      ErrorResponseHeaders.applyTo(errors, response);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      ErrorResponseHeaders.applyTo(materialised, response);
+      JsonResponses.setJsonContentType(response);
 
-      int errorCount = countErrors(errors);
-      Map<String, Object> body = Map.of("valid", false, "errors", errors, "errorCount", errorCount);
+      int errorCount = countErrors(materialised);
+      Map<String, Object> body =
+          Map.of("valid", false, "errors", materialised, "errorCount", errorCount);
 
       objectWriter.writeValue(response.getWriter(), body);
     } catch (Exception e) {
@@ -178,8 +182,8 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
   private void writeValidResponse(Object value, HttpServletResponse response, int status) {
     try {
       response.setStatus(status);
-      if (status != HttpStatus.NO_CONTENT.value()) {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      if (!JsonResponses.isBodilessStatus(status)) {
+        JsonResponses.setJsonContentType(response);
         objectWriter.writeValue(response.getWriter(), value);
       }
     } catch (Exception e) {
@@ -190,16 +194,24 @@ public class ValidationPathReturnValueHandler implements HandlerMethodReturnValu
   /**
    * Counts the number of errors for the error count field.
    *
-   * @param errors the errors object (may be a collection or single error)
+   * @param errors the errors object (may be a collection, another iterable such as {@code
+   *     NonEmptyList}, an array, or a single error)
    * @return the count of errors
    */
   private int countErrors(Object errors) {
-    if (errors instanceof Collection<?> collection) {
-      return collection.size();
-    } else if (errors instanceof Object[] array) {
-      return array.length;
-    } else {
-      return 1;
-    }
+    return switch (errors) {
+      case Collection<?> collection -> collection.size();
+      // NonEmptyList (the idiomatic accumulation type) is Iterable but not a Collection
+      case NonEmptyList<?> nel -> nel.size();
+      case Iterable<?> iterable -> {
+        int count = 0;
+        for (var _ : iterable) {
+          count++;
+        }
+        yield count;
+      }
+      case Object[] array -> array.length;
+      default -> 1;
+    };
   }
 }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/actuator/HkjAsyncHealthIndicatorTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/actuator/HkjAsyncHealthIndicatorTest.java
@@ -45,6 +45,47 @@ class HkjAsyncHealthIndicatorTest {
   }
 
   @Nested
+  @DisplayName("Non-ThreadPoolTaskExecutor Tests")
+  class NonPoolExecutorTests {
+
+    @Test
+    @DisplayName("Reports UP with the executor type when it is not a ThreadPoolTaskExecutor")
+    void reportsUpForVirtualThreadExecutor() {
+      // A virtual-thread executor exposes no pool stats; the indicator must not fail or read DOWN.
+      var executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor();
+
+      HkjAsyncHealthIndicator indicator = new HkjAsyncHealthIndicator(executor);
+
+      try {
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsKey("type");
+        assertThat(health.getDetails()).doesNotContainKey("queueCapacity");
+      } finally {
+        executor.close();
+      }
+    }
+
+    @Test
+    @DisplayName("Reports DOWN when a virtual-thread executor is shut down")
+    void reportsDownForClosedVirtualThreadExecutor() {
+      // A closed ExecutorService (including a virtual-thread executor) rejects submissions, so it
+      // must not read UP just because it is not a ThreadPoolTaskExecutor.
+      var executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor();
+      executor.shutdown();
+
+      HkjAsyncHealthIndicator indicator = new HkjAsyncHealthIndicator(executor);
+
+      Health health = indicator.health();
+
+      assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+      assertThat(health.getDetails()).containsEntry("reason", "Executor is shutdown");
+      assertThat(health.getDetails()).containsKey("type");
+    }
+  }
+
+  @Nested
   @DisplayName("Shutdown Executor Tests")
   class ShutdownExecutorTests {
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/actuator/HkjMetricsEndpointTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/actuator/HkjMetricsEndpointTest.java
@@ -55,6 +55,8 @@ class HkjMetricsEndpointTest {
       assertThat(web.get("validationPathEnabled")).isEqualTo(true);
       assertThat(web.get("ioPathEnabled")).isEqualTo(true);
       assertThat(web.get("completableFuturePathEnabled")).isEqualTo(true);
+      assertThat(web.get("eitherOrBothPathEnabled")).isEqualTo(true);
+      assertThat(web.get("freePathEnabled")).isEqualTo(true);
       assertThat(web.get("defaultErrorStatus")).isEqualTo(400);
     }
 
@@ -67,6 +69,8 @@ class HkjMetricsEndpointTest {
       properties.getWeb().setValidationPathEnabled(false);
       properties.getWeb().setIoPathEnabled(false);
       properties.getWeb().setCompletableFuturePathEnabled(false);
+      properties.getWeb().setEitherOrBothPathEnabled(false);
+      properties.getWeb().setFreePathEnabled(false);
       properties.getWeb().setDefaultErrorStatus(500);
 
       Map<String, Object> result = endpoint.hkjMetrics();
@@ -79,6 +83,8 @@ class HkjMetricsEndpointTest {
       assertThat(web.get("validationPathEnabled")).isEqualTo(false);
       assertThat(web.get("ioPathEnabled")).isEqualTo(false);
       assertThat(web.get("completableFuturePathEnabled")).isEqualTo(false);
+      assertThat(web.get("eitherOrBothPathEnabled")).isEqualTo(false);
+      assertThat(web.get("freePathEnabled")).isEqualTo(false);
       assertThat(web.get("defaultErrorStatus")).isEqualTo(500);
     }
 
@@ -92,27 +98,18 @@ class HkjMetricsEndpointTest {
 
       Map<String, Object> jackson = section(config, "jackson");
       assertThat(jackson.get("customSerializersEnabled")).isEqualTo(true);
-      assertThat(jackson.get("eitherFormat")).isEqualTo("TAGGED");
-      assertThat(jackson.get("validatedFormat")).isEqualTo("TAGGED");
-      assertThat(jackson.get("maybeFormat")).isEqualTo("TAGGED");
     }
 
     @Test
     @DisplayName("Should include jackson configuration with custom values")
     void shouldIncludeJacksonConfigurationWithCustomValues() {
       properties.getJson().setCustomSerializersEnabled(false);
-      properties.getJson().setEitherFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
-      properties.getJson().setValidatedFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
-      properties.getJson().setMaybeFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
 
       Map<String, Object> result = endpoint.hkjMetrics();
       Map<String, Object> config = section(result, "configuration");
       Map<String, Object> jackson = section(config, "jackson");
 
       assertThat(jackson.get("customSerializersEnabled")).isEqualTo(false);
-      assertThat(jackson.get("eitherFormat")).isEqualTo("SIMPLE");
-      assertThat(jackson.get("validatedFormat")).isEqualTo("SIMPLE");
-      assertThat(jackson.get("maybeFormat")).isEqualTo("SIMPLE");
     }
 
     @Test
@@ -534,7 +531,7 @@ class HkjMetricsEndpointTest {
     void shouldReflectCurrentConfigurationState() {
       // Modify configuration
       properties.getWeb().setDefaultErrorStatus(422);
-      properties.getJson().setEitherFormat(HkjProperties.Jackson.SerializationFormat.SIMPLE);
+      properties.getJson().setCustomSerializersEnabled(false);
 
       Map<String, Object> result = endpoint.hkjMetrics();
       Map<String, Object> config = section(result, "configuration");
@@ -543,7 +540,7 @@ class HkjMetricsEndpointTest {
       assertThat(web.get("defaultErrorStatus")).isEqualTo(422);
 
       Map<String, Object> jackson = section(config, "jackson");
-      assertThat(jackson.get("eitherFormat")).isEqualTo("SIMPLE");
+      assertThat(jackson.get("customSerializersEnabled")).isEqualTo(false);
     }
 
     @Test

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjAutoConfigurationTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/HkjAutoConfigurationTest.java
@@ -47,22 +47,14 @@ class HkjAutoConfigurationTest {
             assertThat(properties.getWeb().isValidationPathEnabled()).isTrue();
             assertThat(properties.getWeb().getDefaultErrorStatus()).isEqualTo(400);
 
-            // Verify validation defaults
-            assertThat(properties.getValidation().isEnabled()).isTrue();
-            assertThat(properties.getValidation().isAccumulateErrors()).isTrue();
-            assertThat(properties.getValidation().getMaxErrors()).isEqualTo(0);
-
             // Verify JSON defaults
             assertThat(properties.getJson().isCustomSerializersEnabled()).isTrue();
-            assertThat(properties.getJson().getEitherFormat())
-                .isEqualTo(HkjProperties.Jackson.SerializationFormat.TAGGED);
 
             // Verify async defaults
-            assertThat(properties.getAsync().getExecutorCorePoolSize()).isEqualTo(10);
-            assertThat(properties.getAsync().getExecutorMaxPoolSize()).isEqualTo(20);
-            assertThat(properties.getAsync().getExecutorQueueCapacity()).isEqualTo(100);
-            assertThat(properties.getAsync().getExecutorThreadNamePrefix()).isEqualTo("hkj-async-");
             assertThat(properties.getAsync().getDefaultTimeoutMs()).isEqualTo(30000);
+
+            // Verify effect-boundary defaults
+            assertThat(properties.getEffectBoundary().isEnabled()).isTrue();
           });
     }
 
@@ -93,33 +85,12 @@ class HkjAutoConfigurationTest {
     @DisplayName("Should load custom JSON properties")
     void shouldLoadCustomJsonProperties() {
       contextRunner
-          .withPropertyValues(
-              "hkj.json.custom-serializers-enabled=false", "hkj.json.either-format=SIMPLE")
+          .withPropertyValues("hkj.json.custom-serializers-enabled=false")
           .run(
               context -> {
                 HkjProperties properties = context.getBean(HkjProperties.class);
 
                 assertThat(properties.getJson().isCustomSerializersEnabled()).isFalse();
-                assertThat(properties.getJson().getEitherFormat())
-                    .isEqualTo(HkjProperties.Jackson.SerializationFormat.SIMPLE);
-              });
-    }
-
-    @Test
-    @DisplayName("Should load custom validation properties")
-    void shouldLoadCustomValidationProperties() {
-      contextRunner
-          .withPropertyValues(
-              "hkj.validation.enabled=false",
-              "hkj.validation.accumulate-errors=false",
-              "hkj.validation.max-errors=10")
-          .run(
-              context -> {
-                HkjProperties properties = context.getBean(HkjProperties.class);
-
-                assertThat(properties.getValidation().isEnabled()).isFalse();
-                assertThat(properties.getValidation().isAccumulateErrors()).isFalse();
-                assertThat(properties.getValidation().getMaxErrors()).isEqualTo(10);
               });
     }
 
@@ -127,22 +98,25 @@ class HkjAutoConfigurationTest {
     @DisplayName("Should load custom async properties")
     void shouldLoadCustomAsyncProperties() {
       contextRunner
-          .withPropertyValues(
-              "hkj.async.executor-core-pool-size=20",
-              "hkj.async.executor-max-pool-size=50",
-              "hkj.async.executor-queue-capacity=500",
-              "hkj.async.executor-thread-name-prefix=custom-async-",
-              "hkj.async.default-timeout-ms=60000")
+          .withPropertyValues("hkj.async.default-timeout-ms=60000")
           .run(
               context -> {
                 HkjProperties properties = context.getBean(HkjProperties.class);
 
-                assertThat(properties.getAsync().getExecutorCorePoolSize()).isEqualTo(20);
-                assertThat(properties.getAsync().getExecutorMaxPoolSize()).isEqualTo(50);
-                assertThat(properties.getAsync().getExecutorQueueCapacity()).isEqualTo(500);
-                assertThat(properties.getAsync().getExecutorThreadNamePrefix())
-                    .isEqualTo("custom-async-");
                 assertThat(properties.getAsync().getDefaultTimeoutMs()).isEqualTo(60000);
+              });
+    }
+
+    @Test
+    @DisplayName("Should load custom effect-boundary properties")
+    void shouldLoadCustomEffectBoundaryProperties() {
+      contextRunner
+          .withPropertyValues("hkj.effect-boundary.enabled=false")
+          .run(
+              context -> {
+                HkjProperties properties = context.getBean(HkjProperties.class);
+
+                assertThat(properties.getEffectBoundary().isEnabled()).isFalse();
               });
     }
   }
@@ -201,20 +175,10 @@ class HkjAutoConfigurationTest {
               "hkj.web.error-status-mappings.ValidationError=400",
               "hkj.web.error-status-mappings.AuthorizationError=403",
 
-              // Validation
-              "hkj.validation.enabled=true",
-              "hkj.validation.accumulate-errors=true",
-              "hkj.validation.max-errors=0",
-
               // JSON
               "hkj.json.custom-serializers-enabled=true",
-              "hkj.json.either-format=TAGGED",
 
               // Async
-              "hkj.async.executor-core-pool-size=10",
-              "hkj.async.executor-max-pool-size=20",
-              "hkj.async.executor-queue-capacity=100",
-              "hkj.async.executor-thread-name-prefix=hkj-async-",
               "hkj.async.default-timeout-ms=30000")
           .run(
               context -> {
@@ -228,19 +192,8 @@ class HkjAutoConfigurationTest {
                     .hasSize(3)
                     .containsEntry("UserNotFoundError", 404);
 
-                assertThat(properties.getValidation().isEnabled()).isTrue();
-                assertThat(properties.getValidation().isAccumulateErrors()).isTrue();
-                assertThat(properties.getValidation().getMaxErrors()).isEqualTo(0);
-
                 assertThat(properties.getJson().isCustomSerializersEnabled()).isTrue();
-                assertThat(properties.getJson().getEitherFormat())
-                    .isEqualTo(HkjProperties.Jackson.SerializationFormat.TAGGED);
 
-                assertThat(properties.getAsync().getExecutorCorePoolSize()).isEqualTo(10);
-                assertThat(properties.getAsync().getExecutorMaxPoolSize()).isEqualTo(20);
-                assertThat(properties.getAsync().getExecutorQueueCapacity()).isEqualTo(100);
-                assertThat(properties.getAsync().getExecutorThreadNamePrefix())
-                    .isEqualTo("hkj-async-");
                 assertThat(properties.getAsync().getDefaultTimeoutMs()).isEqualTo(30000);
               });
     }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/effect/InterpreterResolutionTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/autoconfigure/effect/InterpreterResolutionTest.java
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.autoconfigure.effect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.Natural;
+import org.higherkindedj.hkt.io.IOKind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Tests for {@link InterpreterResolution}: profile eligibility, profile specificity, ambiguity
+ * detection, and missing-interpreter failure.
+ */
+@DisplayName("InterpreterResolution Tests")
+class InterpreterResolutionTest {
+
+  interface OrderAlgebra {}
+
+  /** Trivial pass-through transformation so the beans satisfy the Natural requirement. */
+  static class PassThrough implements Natural<IOKind.Witness, IOKind.Witness> {
+    @Override
+    public <A> Kind<IOKind.Witness, A> apply(Kind<IOKind.Witness, A> fa) {
+      return fa;
+    }
+  }
+
+  @Interpreter(OrderAlgebra.class)
+  static class ProductionOrderInterpreter extends PassThrough {}
+
+  @Interpreter(value = OrderAlgebra.class, profile = "test")
+  static class StubOrderInterpreter extends PassThrough {}
+
+  @Interpreter(OrderAlgebra.class)
+  static class RivalOrderInterpreter extends PassThrough {}
+
+  private static AnnotationConfigApplicationContext contextWith(
+      String[] activeProfiles, Class<?>... beans) {
+    var context = new AnnotationConfigApplicationContext();
+    context.getEnvironment().setActiveProfiles(activeProfiles);
+    context.register(beans);
+    context.refresh();
+    return context;
+  }
+
+  @Test
+  @DisplayName("Selects the unrestricted interpreter when no profile is active")
+  void selectsUnrestrictedInterpreterByDefault() {
+    try (var context =
+        contextWith(new String[0], ProductionOrderInterpreter.class, StubOrderInterpreter.class)) {
+      Natural<?, ?> combined =
+          InterpreterResolution.resolveAndCombine(
+              context, new Class<?>[] {OrderAlgebra.class}, "Test");
+
+      assertThat(combined).isInstanceOf(ProductionOrderInterpreter.class);
+    }
+  }
+
+  @Test
+  @DisplayName("A profile-restricted stub shadows the production interpreter when active")
+  void profiledStubShadowsProductionInterpreter() {
+    try (var context =
+        contextWith(
+            new String[] {"test"}, ProductionOrderInterpreter.class, StubOrderInterpreter.class)) {
+      Natural<?, ?> combined =
+          InterpreterResolution.resolveAndCombine(
+              context, new Class<?>[] {OrderAlgebra.class}, "Test");
+
+      assertThat(combined).isInstanceOf(StubOrderInterpreter.class);
+    }
+  }
+
+  @Test
+  @DisplayName("Two unrestricted interpreters for one algebra fail fast as ambiguous")
+  void ambiguousUnrestrictedInterpretersFailFast() {
+    try (var context =
+        contextWith(new String[0], ProductionOrderInterpreter.class, RivalOrderInterpreter.class)) {
+      assertThatExceptionOfType(BeanCreationException.class)
+          .isThrownBy(
+              () ->
+                  InterpreterResolution.resolveAndCombine(
+                      context, new Class<?>[] {OrderAlgebra.class}, "Test"))
+          .withMessageContaining("ambiguous interpreters for OrderAlgebra");
+    }
+  }
+
+  @Test
+  @DisplayName("A missing interpreter fails fast listing the algebra")
+  void missingInterpreterFailsFast() {
+    try (var context = contextWith(new String[0], StubOrderInterpreter.class)) {
+      // The stub's profile is inactive, so no interpreter is eligible
+      assertThatExceptionOfType(BeanCreationException.class)
+          .isThrownBy(
+              () ->
+                  InterpreterResolution.resolveAndCombine(
+                      context, new Class<?>[] {OrderAlgebra.class}, "Test"))
+          .withMessageContaining("no interpreter found")
+          .withMessageContaining("OrderAlgebra");
+    }
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/json/ContextualDeserializationTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/json/ContextualDeserializationTest.java
@@ -3,8 +3,12 @@
 package org.higherkindedj.spring.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.List;
+import java.util.Map;
 import org.higherkindedj.hkt.either.Either;
+import org.higherkindedj.hkt.eitherorboth.EitherOrBoth;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.Validated;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.json.JsonMapper;
 
 /**
@@ -19,7 +24,7 @@ import tools.jackson.databind.json.JsonMapper;
  * TypeReference} (or field type), so nested custom types round-trip to the real type rather than a
  * {@code LinkedHashMap}.
  */
-@DisplayName("Contextual deserialization of HKJ types")
+@DisplayName("Contextual deserialisation of HKJ types")
 class ContextualDeserializationTest {
 
   record Point(int x, int y) {}
@@ -29,6 +34,97 @@ class ContextualDeserializationTest {
   @BeforeEach
   void setUp() {
     mapper = JsonMapper.builder().addModule(new HkjJacksonModule()).build();
+  }
+
+  @Nested
+  @DisplayName("HKJ types nested inside collections and maps")
+  class NestedInCollections {
+
+    record ListHolder(List<Either<String, Point>> items) {}
+
+    record MapHolder(Map<String, Either<String, Point>> byKey) {}
+
+    @Test
+    @DisplayName("binds Either elements of a List bean field to the real branch types")
+    void bindsEitherInsideListField() {
+      ListHolder original =
+          new ListHolder(List.of(Either.right(new Point(1, 2)), Either.left("bad")));
+      String json = mapper.writeValueAsString(original);
+
+      ListHolder back = mapper.readValue(json, ListHolder.class);
+
+      // Regression: element contextualisation used to fall back to Object binding,
+      // producing Right(LinkedHashMap) and a ClassCastException on first typed access
+      assertThat(back.items().getFirst().getRight()).isEqualTo(new Point(1, 2));
+      assertThat(back.items().getLast().getLeft()).isEqualTo("bad");
+    }
+
+    @Test
+    @DisplayName("binds Either values of a Map bean field to the real branch types")
+    void bindsEitherInsideMapField() {
+      MapHolder original = new MapHolder(Map.of("a", Either.right(new Point(3, 4))));
+      String json = mapper.writeValueAsString(original);
+
+      MapHolder back = mapper.readValue(json, MapHolder.class);
+
+      assertThat(back.byKey().get("a").getRight()).isEqualTo(new Point(3, 4));
+    }
+
+    @Test
+    @DisplayName("binds Either elements of a root-level List read via TypeReference")
+    void bindsEitherInsideRootList() {
+      String json = "[{\"isRight\":true,\"right\":{\"x\":1,\"y\":2}}]";
+
+      List<Either<String, Point>> back =
+          mapper.readValue(json, new TypeReference<List<Either<String, Point>>>() {});
+
+      assertThat(back.getFirst().getRight()).isEqualTo(new Point(1, 2));
+    }
+
+    record Wrapper(Either<Integer, Point> inner) {}
+
+    @Test
+    @DisplayName("binds an Either field inside a bean that is itself inside an Either")
+    void bindsEitherFieldNestedInsideOuterEither() {
+      // The inner Either field resolves to its own branch types, not the outer Either's
+      Either<String, Wrapper> original = Either.right(new Wrapper(Either.right(new Point(7, 8))));
+      String json = mapper.writeValueAsString(original);
+
+      Either<String, Wrapper> back =
+          mapper.readValue(json, new TypeReference<Either<String, Wrapper>>() {});
+
+      assertThat(back.getRight().inner().getRight()).isEqualTo(new Point(7, 8));
+    }
+  }
+
+  @Nested
+  @DisplayName("Null branch values")
+  class NullBranchValues {
+
+    @Test
+    @DisplayName("Validated with null value reports a clean mapping error, not an NPE")
+    void validatedNullValueIsCleanError() {
+      assertThatExceptionOfType(DatabindException.class)
+          .isThrownBy(() -> mapper.readValue("{\"valid\":true,\"value\":null}", Validated.class))
+          .withMessageContaining("must not be null");
+    }
+
+    @Test
+    @DisplayName("EitherOrBoth with null left reports a clean mapping error, not an NPE")
+    void eitherOrBothNullLeftIsCleanError() {
+      assertThatExceptionOfType(DatabindException.class)
+          .isThrownBy(
+              () -> mapper.readValue("{\"kind\":\"left\",\"left\":null}", EitherOrBoth.class))
+          .withMessageContaining("must not be null");
+    }
+
+    @Test
+    @DisplayName("Either discriminator must be a boolean")
+    void eitherNonBooleanDiscriminatorRejected() {
+      assertThatExceptionOfType(DatabindException.class)
+          .isThrownBy(() -> mapper.readValue("{\"isRight\":null,\"left\":\"boom\"}", Either.class))
+          .withMessageContaining("boolean 'isRight'");
+    }
   }
 
   @Nested

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/security/EitherAuthenticationConverterTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/security/EitherAuthenticationConverterTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 @DisplayName("EitherAuthenticationConverter Tests")
@@ -36,6 +37,7 @@ class EitherAuthenticationConverterTest {
       AbstractAuthenticationToken token = converter.convert(jwt);
 
       assertThat(token).isNotNull();
+      assertThat(token.isAuthenticated()).isTrue();
       assertThat(token.getName()).isEqualTo("user123");
       assertThat(token.getAuthorities()).hasSize(2);
       assertThat(token.getAuthorities())
@@ -75,8 +77,8 @@ class EitherAuthenticationConverterTest {
   class ConvertErrorTests {
 
     @Test
-    @DisplayName("Should handle JWT with missing roles claim")
-    void shouldHandleJwtWithMissingRolesClaim() {
+    @DisplayName("Should reject JWT with missing roles claim")
+    void shouldRejectJwtWithMissingRolesClaim() {
       Jwt jwt =
           Jwt.withTokenValue("token")
               .header("alg", "none")
@@ -86,17 +88,15 @@ class EitherAuthenticationConverterTest {
               // No roles claim
               .build();
 
-      AbstractAuthenticationToken token = converter.convert(jwt);
-
-      // On error, returns token with empty authorities
-      assertThat(token).isNotNull();
-      assertThat(token.getName()).isEqualTo("user123");
-      assertThat(token.getAuthorities()).isEmpty();
+      // A conversion failure must never yield an authenticated token
+      assertThatExceptionOfType(BadCredentialsException.class)
+          .isThrownBy(() -> converter.convert(jwt))
+          .withMessageContaining("Missing authorities claim: roles");
     }
 
     @Test
-    @DisplayName("Should handle JWT with invalid roles type")
-    void shouldHandleJwtWithInvalidRolesType() {
+    @DisplayName("Should reject JWT with invalid roles type")
+    void shouldRejectJwtWithInvalidRolesType() {
       Jwt jwt =
           Jwt.withTokenValue("token")
               .header("alg", "none")
@@ -106,11 +106,48 @@ class EitherAuthenticationConverterTest {
               .claim("roles", "ADMIN") // String instead of Collection
               .build();
 
-      AbstractAuthenticationToken token = converter.convert(jwt);
+      assertThatExceptionOfType(BadCredentialsException.class)
+          .isThrownBy(() -> converter.convert(jwt))
+          .withMessageContaining("Invalid authorities claim type");
+    }
 
-      // On error, returns token with empty authorities
+    @Test
+    @DisplayName("Lenient mode authenticates a token with no roles claim, with empty authorities")
+    void lenientModeAuthenticatesMissingClaim() {
+      var lenient = new EitherAuthenticationConverter("roles", "ROLE_", false);
+      Jwt jwt =
+          Jwt.withTokenValue("token")
+              .header("alg", "none")
+              .subject("client-credentials")
+              .issuedAt(Instant.now())
+              .expiresAt(Instant.now().plusSeconds(3600))
+              // No roles claim
+              .build();
+
+      AbstractAuthenticationToken token = lenient.convert(jwt);
+
       assertThat(token).isNotNull();
+      assertThat(token.isAuthenticated()).isTrue();
+      assertThat(token.getName()).isEqualTo("client-credentials");
       assertThat(token.getAuthorities()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Lenient mode still rejects a malformed (wrong-type) roles claim")
+    void lenientModeStillRejectsMalformedClaim() {
+      var lenient = new EitherAuthenticationConverter("roles", "ROLE_", false);
+      Jwt jwt =
+          Jwt.withTokenValue("token")
+              .header("alg", "none")
+              .subject("user123")
+              .issuedAt(Instant.now())
+              .expiresAt(Instant.now().plusSeconds(3600))
+              .claim("roles", "ADMIN") // String instead of Collection
+              .build();
+
+      assertThatExceptionOfType(BadCredentialsException.class)
+          .isThrownBy(() -> lenient.convert(jwt))
+          .withMessageContaining("Invalid authorities claim type");
     }
 
     @Test
@@ -125,8 +162,8 @@ class EitherAuthenticationConverterTest {
     }
 
     @Test
-    @DisplayName("Should filter out non-string roles")
-    void shouldFilterOutNonStringRoles() {
+    @DisplayName("Should reject a roles claim containing non-string elements")
+    void shouldRejectNonStringRoles() {
       Jwt jwt =
           Jwt.withTokenValue("token")
               .header("alg", "none")
@@ -137,13 +174,29 @@ class EitherAuthenticationConverterTest {
                   "roles", Arrays.asList("USER", 123, "ADMIN", null)) // Mixed types including null
               .build();
 
-      AbstractAuthenticationToken token = converter.convert(jwt);
+      // A collection with any non-string element is malformed, not role-less: reject it rather
+      // than silently authenticating with the string subset (which would grant ROLE_ADMIN here).
+      assertThatExceptionOfType(BadCredentialsException.class)
+          .isThrownBy(() -> converter.convert(jwt))
+          .withMessageContaining("Invalid authorities claim element type");
+    }
 
-      assertThat(token).isNotNull();
-      assertThat(token.getAuthorities()).hasSize(2);
-      assertThat(token.getAuthorities())
-          .extracting("authority")
-          .containsExactlyInAnyOrder("ROLE_USER", "ROLE_ADMIN");
+    @Test
+    @DisplayName("Lenient mode still rejects a roles claim containing non-string elements")
+    void lenientModeStillRejectsNonStringRoles() {
+      var lenient = new EitherAuthenticationConverter("roles", "ROLE_", false);
+      Jwt jwt =
+          Jwt.withTokenValue("token")
+              .header("alg", "none")
+              .subject("user123")
+              .issuedAt(Instant.now())
+              .expiresAt(Instant.now().plusSeconds(3600))
+              .claim("roles", Arrays.asList("USER", 123))
+              .build();
+
+      assertThatExceptionOfType(BadCredentialsException.class)
+          .isThrownBy(() -> lenient.convert(jwt))
+          .withMessageContaining("Invalid authorities claim element type");
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/security/EitherAuthorizationManagerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/security/EitherAuthorizationManagerTest.java
@@ -5,7 +5,6 @@ package org.higherkindedj.spring.security;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -26,9 +26,9 @@ import org.springframework.security.web.access.intercept.RequestAuthorizationCon
 @DisplayName("EitherAuthorizationManager Tests")
 class EitherAuthorizationManagerTest {
 
-  @Mock private HttpServletRequest request;
-
   @Mock private Authentication authentication;
+
+  private MockHttpServletRequest request;
 
   private EitherAuthorizationManager manager;
   private RequestAuthorizationContext context;
@@ -36,6 +36,7 @@ class EitherAuthorizationManagerTest {
   @BeforeEach
   void setUp() {
     manager = new EitherAuthorizationManager();
+    request = new MockHttpServletRequest();
     context = new RequestAuthorizationContext(request);
   }
 
@@ -47,9 +48,8 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should grant access for admin with valid path")
     void shouldGrantAccessForAdminWithValidPath() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_ADMIN", "ROLE_USER")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/users");
+      request.setRequestURI("/api/admin/users");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -64,11 +64,10 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should grant access for admin with multiple roles")
     void shouldGrantAccessForAdminWithMultipleRoles() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("superadmin");
       doReturn(createAuthorities("ROLE_ADMIN", "ROLE_USER", "ROLE_MODERATOR"))
           .when(authentication)
           .getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/settings");
+      request.setRequestURI("/api/admin/settings");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -126,9 +125,8 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should deny access to dangerous path even for admin")
     void shouldDenyAccessToDangerousPathEvenForAdmin() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      // getName() not needed - test fails at path check, never creates success object
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/dangerous/action");
+      request.setRequestURI("/api/admin/dangerous/action");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -161,7 +159,6 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should allow safe admin paths")
     void shouldAllowSafeAdminPaths() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
 
       String[] safePaths = {
@@ -169,7 +166,7 @@ class EitherAuthorizationManagerTest {
       };
 
       for (String path : safePaths) {
-        when(request.getRequestURI()).thenReturn(path);
+        request.setRequestURI(path);
         Supplier<Authentication> authSupplier = () -> authentication;
 
         AuthorizationDecision decision =
@@ -183,7 +180,6 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should block all dangerous paths")
     void shouldBlockAllDangerousPaths() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      // getName() not needed - test fails at path check, never creates success object
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
 
       String[] dangerousPaths = {
@@ -193,7 +189,7 @@ class EitherAuthorizationManagerTest {
       };
 
       for (String path : dangerousPaths) {
-        when(request.getRequestURI()).thenReturn(path);
+        request.setRequestURI(path);
         Supplier<Authentication> authSupplier = () -> authentication;
 
         AuthorizationDecision decision =
@@ -201,6 +197,84 @@ class EitherAuthorizationManagerTest {
 
         assertThat(decision.isGranted()).as("Should deny access to path: " + path).isFalse();
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("denyPathPrefix Normalisation Tests")
+  class DenyPathPrefixNormalisationTests {
+
+    @Test
+    @DisplayName("A trailing-slash prefix still denies descendants (no fail-open)")
+    void trailingSlashPrefixStillDeniesDescendants() {
+      // Regression: "/api/admin/" would build a "/api/admin//**" descendants matcher whose empty
+      // segment matches nothing, silently allowing /api/admin/secret.
+      var custom =
+          new EitherAuthorizationManager(
+              List.of(
+                  EitherAuthorizationManager.requireAuthority("ROLE_ADMIN"),
+                  EitherAuthorizationManager.denyPathPrefix("/api/admin/")));
+      when(authentication.isAuthenticated()).thenReturn(true);
+      doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
+      request.setRequestURI("/api/admin/secret");
+
+      AuthorizationDecision decision =
+          (AuthorizationDecision) custom.authorize(() -> authentication, context);
+
+      assertThat(decision.isGranted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("A repeated trailing slash still denies descendants (no fail-open)")
+    void repeatedTrailingSlashStillDeniesDescendants() {
+      // Regression: "/api/admin//" would strip only one slash → "/api/admin/" → "/api/admin//**",
+      // whose empty segment matches nothing, silently allowing /api/admin/secret.
+      var custom =
+          new EitherAuthorizationManager(
+              List.of(
+                  EitherAuthorizationManager.requireAuthority("ROLE_ADMIN"),
+                  EitherAuthorizationManager.denyPathPrefix("/api/admin//")));
+      when(authentication.isAuthenticated()).thenReturn(true);
+      doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
+      request.setRequestURI("/api/admin/secret");
+
+      AuthorizationDecision decision =
+          (AuthorizationDecision) custom.authorize(() -> authentication, context);
+
+      assertThat(decision.isGranted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Root prefix \"/\" denies descendants, not just the root path (no fail-open)")
+    void rootPrefixDeniesDescendants() {
+      // Regression: "/" would build a "//**" descendants matcher whose empty segment matches
+      // nothing, denying only "/" itself while allowing every real path below it.
+      var custom =
+          new EitherAuthorizationManager(List.of(EitherAuthorizationManager.denyPathPrefix("/")));
+      when(authentication.isAuthenticated()).thenReturn(true);
+      request.setRequestURI("/api/users");
+
+      AuthorizationDecision decision =
+          (AuthorizationDecision) custom.authorize(() -> authentication, context);
+
+      assertThat(decision.isGranted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Rejects a blank, non-slash, or PathPattern-metacharacter prefix at construction")
+    void rejectsMalformedPrefixes() {
+      assertThatIllegalArgumentException()
+          .isThrownBy(() -> EitherAuthorizationManager.denyPathPrefix("  "));
+      assertThatIllegalArgumentException()
+          .isThrownBy(() -> EitherAuthorizationManager.denyPathPrefix("api/admin"));
+      // Every PathPattern metacharacter must be rejected: *, ?, and { } capture syntax would make
+      // the "literal prefix" match more than intended (e.g. "/api/{segment}").
+      assertThatIllegalArgumentException()
+          .isThrownBy(() -> EitherAuthorizationManager.denyPathPrefix("/api/admin/**"));
+      assertThatIllegalArgumentException()
+          .isThrownBy(() -> EitherAuthorizationManager.denyPathPrefix("/api/admin?x"));
+      assertThatIllegalArgumentException()
+          .isThrownBy(() -> EitherAuthorizationManager.denyPathPrefix("/api/{segment}"));
     }
   }
 
@@ -236,9 +310,8 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should accept ROLE_ADMIN with any case")
     void shouldAcceptRoleAdminWithCorrectCase() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/users");
+      request.setRequestURI("/api/admin/users");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -252,11 +325,10 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should work with ADMIN role among other roles")
     void shouldWorkWithAdminRoleAmongOtherRoles() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_USER", "ROLE_MODERATOR", "ROLE_ADMIN", "ROLE_AUDITOR"))
           .when(authentication)
           .getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/users");
+      request.setRequestURI("/api/admin/users");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -272,26 +344,27 @@ class EitherAuthorizationManagerTest {
   class EdgeCasesTests {
 
     @Test
-    @DisplayName("Should handle null request URI")
-    void shouldHandleNullRequestURI() {
+    @DisplayName("Should deny a percent-encoded dangerous path")
+    void shouldDenyPercentEncodedDangerousPath() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn(null);
+      // A raw startsWith check on getRequestURI() would be bypassed by this encoding
+      request.setRequestURI("/api/admin/%64angerous/action");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
-      // Should not throw exception
-      assertThatCode(() -> manager.authorize(authSupplier, context)).doesNotThrowAnyException();
+      AuthorizationDecision decision =
+          (AuthorizationDecision) manager.authorize(authSupplier, context);
+
+      assertThat(decision.isGranted()).isFalse();
     }
 
     @Test
     @DisplayName("Should handle empty request URI")
     void shouldHandleEmptyRequestURI() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn("");
+      request.setRequestURI("");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -305,9 +378,8 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should handle null authentication name")
     void shouldHandleNullAuthenticationName() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn(null);
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/users");
+      request.setRequestURI("/api/admin/users");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -342,9 +414,8 @@ class EitherAuthorizationManagerTest {
     @DisplayName("Should evaluate all checks for success case")
     void shouldEvaluateAllChecksForSuccessCase() {
       when(authentication.isAuthenticated()).thenReturn(true);
-      when(authentication.getName()).thenReturn("admin");
       doReturn(createAuthorities("ROLE_ADMIN")).when(authentication).getAuthorities();
-      when(request.getRequestURI()).thenReturn("/api/admin/users");
+      request.setRequestURI("/api/admin/users");
 
       Supplier<Authentication> authSupplier = () -> authentication;
 
@@ -356,7 +427,6 @@ class EitherAuthorizationManagerTest {
       // All checks should have been called
       verify(authentication).isAuthenticated();
       verify(authentication).getAuthorities();
-      verify(request).getRequestURI();
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/security/ValidatedUserDetailsServiceTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/security/ValidatedUserDetailsServiceTest.java
@@ -19,7 +19,7 @@ class ValidatedUserDetailsServiceTest {
 
   @BeforeEach
   void setUp() {
-    service = new ValidatedUserDetailsService();
+    service = ValidatedUserDetailsService.withSampleUsers();
   }
 
   @Nested
@@ -106,11 +106,12 @@ class ValidatedUserDetailsServiceTest {
     }
 
     @Test
-    @DisplayName("Should throw exception for disabled user")
-    void shouldThrowExceptionForDisabledUser() {
-      assertThatThrownBy(() -> service.loadUserByUsername("disabled"))
-          .isInstanceOf(UsernameNotFoundException.class)
-          .hasMessageContaining("Account is disabled");
+    @DisplayName("Should load disabled user with its status flags intact")
+    void shouldLoadDisabledUserWithStatusFlags() {
+      // Status enforcement belongs to the authentication provider, not loadUserByUsername
+      UserDetails disabled = service.loadUserByUsername("disabled");
+
+      assertThat(disabled.isEnabled()).isFalse();
     }
 
     @Test
@@ -225,8 +226,17 @@ class ValidatedUserDetailsServiceTest {
   }
 
   @Nested
-  @DisplayName("Account Status Validation Tests")
-  class AccountStatusValidationTests {
+  @DisplayName("validateAccountStatus Tests")
+  class ValidateAccountStatusTests {
+
+    @Test
+    @DisplayName("Should pass a fully active account")
+    void shouldPassActiveAccount() {
+      UserDetails active =
+          User.builder().username("active").password("{noop}password").roles("USER").build();
+
+      assertThat(service.validateAccountStatus(active).isValid()).isTrue();
+    }
 
     @Test
     @DisplayName("Should reject locked account")
@@ -239,47 +249,12 @@ class ValidatedUserDetailsServiceTest {
               .accountLocked(true)
               .build();
 
-      service.addUser(lockedUser);
+      var result = service.validateAccountStatus(lockedUser);
 
-      assertThatThrownBy(() -> service.loadUserByUsername("locked"))
-          .isInstanceOf(UsernameNotFoundException.class)
-          .hasMessageContaining("Account is locked");
-    }
-
-    @Test
-    @DisplayName("Should reject expired account")
-    void shouldRejectExpiredAccount() {
-      UserDetails expiredUser =
-          User.builder()
-              .username("expired")
-              .password("{noop}password")
-              .roles("USER")
-              .accountExpired(true)
-              .build();
-
-      service.addUser(expiredUser);
-
-      assertThatThrownBy(() -> service.loadUserByUsername("expired"))
-          .isInstanceOf(UsernameNotFoundException.class)
-          .hasMessageContaining("Account has expired");
-    }
-
-    @Test
-    @DisplayName("Should reject user with expired credentials")
-    void shouldRejectExpiredCredentials() {
-      UserDetails credentialsExpiredUser =
-          User.builder()
-              .username("credexpired")
-              .password("{noop}password")
-              .roles("USER")
-              .credentialsExpired(true)
-              .build();
-
-      service.addUser(credentialsExpiredUser);
-
-      assertThatThrownBy(() -> service.loadUserByUsername("credexpired"))
-          .isInstanceOf(UsernameNotFoundException.class)
-          .hasMessageContaining("Credentials have expired");
+      assertThat(result.isInvalid()).isTrue();
+      assertThat(result.getError())
+          .extracting(ValidatedUserDetailsService.UserValidationError::message)
+          .containsExactly("Account is locked");
     }
 
     @Test
@@ -295,43 +270,38 @@ class ValidatedUserDetailsServiceTest {
               .accountExpired(true)
               .build();
 
-      service.addUser(multipleIssuesUser);
+      var result = service.validateAccountStatus(multipleIssuesUser);
 
-      assertThatThrownBy(() -> service.loadUserByUsername("issues"))
-          .isInstanceOf(UsernameNotFoundException.class)
-          .hasMessageMatching(".*disabled.*locked.*expired.*");
+      assertThat(result.isInvalid()).isTrue();
+      assertThat(result.getError())
+          .extracting(ValidatedUserDetailsService.UserValidationError::message)
+          .containsExactly("Account is disabled", "Account is locked", "Account has expired");
     }
   }
 
   @Nested
-  @DisplayName("Pre-populated Users Tests")
-  class PrePopulatedUsersTests {
+  @DisplayName("Sample Users Factory Tests")
+  class SampleUsersFactoryTests {
 
     @Test
-    @DisplayName("Should have admin user pre-populated")
-    void shouldHaveAdminUserPrePopulated() {
+    @DisplayName("Default constructor starts with no users")
+    void defaultConstructorStartsEmpty() {
+      var empty = new ValidatedUserDetailsService();
+
+      assertThatThrownBy(() -> empty.loadUserByUsername("admin"))
+          .isInstanceOf(UsernameNotFoundException.class)
+          .hasMessageContaining("User not found");
+    }
+
+    @Test
+    @DisplayName("withSampleUsers pre-populates the demo accounts")
+    void withSampleUsersPrePopulatesDemoAccounts() {
       UserDetails admin = service.loadUserByUsername("admin");
 
-      assertThat(admin).isNotNull();
       assertThat(admin.getUsername()).isEqualTo("admin");
       assertThat(admin.getAuthorities()).hasSizeGreaterThan(1);
-    }
-
-    @Test
-    @DisplayName("Should have regular user pre-populated")
-    void shouldHaveRegularUserPrePopulated() {
-      UserDetails user = service.loadUserByUsername("user");
-
-      assertThat(user).isNotNull();
-      assertThat(user.getUsername()).isEqualTo("user");
-    }
-
-    @Test
-    @DisplayName("Should have disabled user pre-populated")
-    void shouldHaveDisabledUserPrePopulated() {
-      // This should throw because user is disabled
-      assertThatThrownBy(() -> service.loadUserByUsername("disabled"))
-          .isInstanceOf(UsernameNotFoundException.class);
+      assertThat(service.loadUserByUsername("user").getUsername()).isEqualTo("user");
+      assertThat(service.loadUserByUsername("disabled").isEnabled()).isFalse();
     }
   }
 }

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/CompletableFuturePathReturnValueHandlerTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.*;
 
+import jakarta.servlet.AsyncEvent;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -143,7 +144,7 @@ class CompletableFuturePathReturnValueHandlerTest {
               () -> {
                 assertThat(mockResponse.getStatus()).isEqualTo(HttpStatus.OK.value());
                 assertThat(mockResponse.getContentType())
-                    .isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+                    .startsWith(MediaType.APPLICATION_JSON_VALUE);
                 String json = mockResponse.getContentAsString();
                 assertThat(json).contains("\"id\":\"1\"");
                 assertThat(json).contains("\"email\":\"alice@example.com\"");
@@ -188,7 +189,7 @@ class CompletableFuturePathReturnValueHandlerTest {
                 assertThat(mockResponse.getStatus())
                     .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
                 assertThat(mockResponse.getContentType())
-                    .isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+                    .startsWith(MediaType.APPLICATION_JSON_VALUE);
                 String json = mockResponse.getContentAsString();
                 assertThat(json).contains("\"success\":false");
                 assertThat(json).contains("\"error\":\"An error occurred during async execution\"");
@@ -327,6 +328,48 @@ class CompletableFuturePathReturnValueHandlerTest {
           .atMost(Duration.ofSeconds(2))
           .pollInterval(Duration.ofMillis(10))
           .untilAsserted(() -> assertThat(mockResponse.getHeader("Retry-After")).isNull());
+    }
+  }
+
+  @Nested
+  @DisplayName("handleReturnValue - Timeout Tests")
+  class TimeoutTests {
+
+    @Test
+    @DisplayName("Timeout writes 504, cancels the future, and late completion is ignored")
+    void timeoutWrites504AndLateCompletionIsIgnored() throws Exception {
+      CompletableFuture<TestUser> source = new CompletableFuture<>();
+      CompletableFuturePath<TestUser> path = Path.future(source);
+
+      StandardServletAsyncWebRequest asyncWebRequest =
+          new StandardServletAsyncWebRequest(mockRequest, mockResponse);
+      WebAsyncUtils.getAsyncManager(webRequest).setAsyncWebRequest(asyncWebRequest);
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      // Simulate the container's async timeout event
+      asyncWebRequest.onTimeout(new AsyncEvent(mockRequest.getAsyncContext()));
+
+      assertThat(mockResponse.getStatus()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT.value());
+      assertThat(mockResponse.getContentAsString()).contains("timed out");
+
+      // The timeout must cancel the wrapped future so the underlying work stops being awaited;
+      // without cancel(true) the source would still be completable below.
+      assertThat(source.isCancelled()).isTrue();
+
+      // Late completion of the source must not overwrite the timeout response: a cancelled future
+      // rejects the completion (returns false), and without the single-writer guard the completion
+      // callback would otherwise stamp a 500 failure body here.
+      assertThat(source.complete(new TestUser("1", "late@example.com"))).isFalse();
+      await()
+          .atMost(Duration.ofSeconds(2))
+          .pollInterval(Duration.ofMillis(10))
+          .untilAsserted(
+              () -> {
+                assertThat(mockResponse.getStatus()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT.value());
+                assertThat(mockResponse.getContentAsString()).contains("timed out");
+                assertThat(mockResponse.getContentAsString()).doesNotContain("late@example.com");
+              });
     }
   }
 

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeadersTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ErrorResponseHeadersTest.java
@@ -14,6 +14,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -106,6 +107,16 @@ class ErrorResponseHeadersTest {
     verify(response).addHeader("Keep-Me", "x");
     verify(response, never()).addHeader(null, "value");
     verify(response, never()).addHeader("Skip-Me", null);
+  }
+
+  @Test
+  @DisplayName("Applies headers from each carrier element of a NonEmptyList payload")
+  void nonEmptyListPayloadAppliesAll() {
+    // NonEmptyList is Iterable but not a Collection — the idiomatic accumulation type
+    ErrorResponseHeaders.applyTo(
+        NonEmptyList.of(new ThrottledError(30), new AuthChallenge("Basic")), response);
+    verify(response).addHeader("Retry-After", "30");
+    verify(response).addHeader("WWW-Authenticate", "Basic");
   }
 
   @Test

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/VStreamPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/VStreamPathReturnValueHandlerTest.java
@@ -1,0 +1,181 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.web.returnvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.higherkindedj.hkt.effect.Path;
+import org.higherkindedj.hkt.effect.VStreamPath;
+import org.higherkindedj.hkt.vstream.VStream;
+import org.higherkindedj.spring.actuator.HkjMetricsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.async.StandardServletAsyncWebRequest;
+import org.springframework.web.context.request.async.WebAsyncManager;
+import org.springframework.web.context.request.async.WebAsyncUtils;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Behavioural tests for {@link VStreamPathReturnValueHandler}: SSE streaming, pre-commit failure
+ * status, and client-disconnect detection.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VStreamPathReturnValueHandler Tests")
+class VStreamPathReturnValueHandlerTest {
+
+  @Mock private MethodParameter returnType;
+  @Mock private HkjMetricsService metricsService;
+
+  private VStreamPathReturnValueHandler handler;
+  private MockHttpServletRequest mockRequest;
+  private MockHttpServletResponse mockResponse;
+  private ServletWebRequest webRequest;
+  private ModelAndViewContainer mavContainer;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new VStreamPathReturnValueHandler(
+            JsonMapper.builder().build(),
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            true,
+            30000,
+            metricsService);
+
+    mockRequest = new MockHttpServletRequest();
+    mockRequest.setAsyncSupported(true);
+    mockResponse = new MockHttpServletResponse();
+    webRequest = new ServletWebRequest(mockRequest, mockResponse);
+    mavContainer = new ModelAndViewContainer();
+
+    WebAsyncManager asyncManager = WebAsyncUtils.getAsyncManager(webRequest);
+    asyncManager.setAsyncWebRequest(new StandardServletAsyncWebRequest(mockRequest, mockResponse));
+  }
+
+  @Nested
+  @DisplayName("Streaming Tests")
+  class StreamingTests {
+
+    @Test
+    @DisplayName("Finite stream writes SSE events and a completion frame")
+    void finiteStreamWritesSseEvents() throws Exception {
+      VStreamPath<Integer> path = Path.vstreamOf(1, 2, 3);
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      await()
+          .atMost(Duration.ofSeconds(2))
+          .pollInterval(Duration.ofMillis(10))
+          .untilAsserted(
+              () -> {
+                assertThat(mockResponse.getStatus()).isEqualTo(HttpStatus.OK.value());
+                assertThat(mockResponse.getContentType()).startsWith("text/event-stream");
+                assertThat(mockResponse.getContentAsString())
+                    .contains("data: 1\n\n", "data: 2\n\n", "data: 3\n\n")
+                    .contains("event: complete");
+              });
+      verify(metricsService, timeout(2000)).recordVStreamSuccess();
+      verify(metricsService).recordVStreamElements(3);
+    }
+
+    @Test
+    @DisplayName("Failure before the first element yields the configured failure status")
+    void preCommitFailureYieldsFailureStatus() throws Exception {
+      VStreamPath<Integer> path =
+          Path.vstream(
+              VStream.<Integer>generate(
+                  () -> {
+                    throw new IllegalStateException("boom at start");
+                  }));
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      await()
+          .atMost(Duration.ofSeconds(2))
+          .pollInterval(Duration.ofMillis(10))
+          .untilAsserted(
+              () -> {
+                assertThat(mockResponse.getStatus())
+                    .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                assertThat(mockResponse.getContentType()).startsWith("application/json");
+                assertThat(mockResponse.getContentAsString()).contains("boom at start");
+                assertThat(mockResponse.getContentAsString()).doesNotContain("event:");
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Client Disconnect Tests")
+  class ClientDisconnectTests {
+
+    @Test
+    @DisplayName("Infinite stream stops pulling when the client disconnects")
+    void infiniteStreamStopsOnDisconnect() throws Exception {
+      // Response whose output breaks after a few writes, like a closed socket
+      BrokenPipeResponse brokenResponse = new BrokenPipeResponse(3);
+      ServletWebRequest brokenWebRequest = new ServletWebRequest(mockRequest, brokenResponse);
+      WebAsyncUtils.getAsyncManager(brokenWebRequest)
+          .setAsyncWebRequest(new StandardServletAsyncWebRequest(mockRequest, brokenResponse));
+
+      VStreamPath<Integer> path = Path.vstreamIterate(0, n -> n + 1);
+
+      handler.handleReturnValue(path, returnType, mavContainer, brokenWebRequest);
+
+      // Without checkError() detection this would pull (and leak a virtual thread) forever
+      verify(metricsService, timeout(2000)).recordVStreamError("ClientDisconnected");
+      verify(metricsService, never()).recordVStreamSuccess();
+    }
+  }
+
+  /** A response whose output stream starts failing after {@code allowedWrites} write calls. */
+  static final class BrokenPipeResponse extends MockHttpServletResponse {
+    private final AtomicInteger remaining;
+    private PrintWriter brokenWriter;
+
+    BrokenPipeResponse(int allowedWrites) {
+      this.remaining = new AtomicInteger(allowedWrites);
+    }
+
+    @Override
+    public synchronized PrintWriter getWriter() {
+      if (brokenWriter == null) {
+        OutputStream failing =
+            new OutputStream() {
+              @Override
+              public void write(int b) throws IOException {
+                if (remaining.get() <= 0) {
+                  throw new IOException("Broken pipe");
+                }
+              }
+
+              @Override
+              public void flush() throws IOException {
+                if (remaining.decrementAndGet() < 0) {
+                  throw new IOException("Broken pipe");
+                }
+              }
+            };
+        brokenWriter = new PrintWriter(failing, false);
+      }
+      return brokenWriter;
+    }
+  }
+}

--- a/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandlerTest.java
+++ b/hkj-spring/autoconfigure/src/test/java/org/higherkindedj/spring/web/returnvalue/ValidationPathReturnValueHandlerTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.higherkindedj.hkt.Semigroups;
 import org.higherkindedj.hkt.effect.Path;
 import org.higherkindedj.hkt.effect.ValidationPath;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -230,6 +231,22 @@ class ValidationPathReturnValueHandlerTest {
       printWriter.flush();
       String json = stringWriter.toString();
       assertThat(json).contains("\"errorCount\":1");
+    }
+
+    @Test
+    @DisplayName("Should count every element of a NonEmptyList error payload")
+    void shouldCountNonEmptyListErrors() throws Exception {
+      // NonEmptyList is Iterable but not a Collection — must not collapse to errorCount 1
+      ValidationPath<NonEmptyList<String>, TestUser> path =
+          Path.invalid(
+              NonEmptyList.of("Email invalid", "Name blank", "Age negative"),
+              NonEmptyList.semigroup());
+
+      handler.handleReturnValue(path, returnType, mavContainer, webRequest);
+
+      printWriter.flush();
+      String json = stringWriter.toString();
+      assertThat(json).contains("\"errorCount\":3");
     }
   }
 

--- a/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessor.java
+++ b/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessor.java
@@ -91,6 +91,19 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
       ClassName.get("org.springframework.web.service.registry", "ImportHttpServices");
   private static final ClassName RESPONSE_ERROR_DECODERS =
       ClassName.get("org.higherkindedj.spring.client", "ResponseErrorDecoders");
+  private static final ClassName RESPONSE_ERROR_DECODER =
+      ClassName.get("org.higherkindedj.spring.client", "ResponseErrorDecoder");
+
+  /**
+   * Spring binding annotations whose parameter-name attribute the processor makes explicit in
+   * generated code, so the native interface works without {@code -parameters}.
+   */
+  private static final Set<String> NAME_BINDING_ANNOTATIONS =
+      Set.of(
+          "org.springframework.web.bind.annotation.PathVariable",
+          "org.springframework.web.bind.annotation.RequestParam",
+          "org.springframework.web.bind.annotation.RequestHeader",
+          "org.springframework.web.bind.annotation.CookieValue");
 
   /** The flavour of Effect Path a client method returns. */
   private enum PathKind {
@@ -261,24 +274,50 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
             .addTypeVariables(typeVars)
             .addSuperinterface(ifaceType)
             .addJavadoc("Generated Effect-Path client. Do not edit.\n")
-            .addField(nativeType, "http", Modifier.PRIVATE, Modifier.FINAL)
-            .addField(DECODER_FACTORY, "decoderFactory", Modifier.PRIVATE, Modifier.FINAL)
-            .addMethod(
-                MethodSpec.constructorBuilder()
-                    .addModifiers(Modifier.PUBLIC)
-                    .addParameter(nativeType, "http")
-                    .addParameter(DECODER_FACTORY, "decoderFactory")
-                    .addStatement("this.http = http")
-                    .addStatement("this.decoderFactory = decoderFactory")
-                    .build());
+            .addField(nativeType, "http", Modifier.PRIVATE, Modifier.FINAL);
+
+    MethodSpec.Builder constructor =
+        MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(nativeType, "http")
+            .addParameter(DECODER_FACTORY, "decoderFactory")
+            .addStatement("this.http = http");
+
+    // Decoders are constructor-initialised final fields so the (stateless, thread-safe)
+    // facade does not rebuild the decoder chain on every HTTP call.
+    Set<String> usedFieldNames = new HashSet<>();
+    List<@Nullable String> decoderFields = new ArrayList<>();
+    for (int i = 0; i < methods.size(); i++) {
+      ExecutableElement method = methods.get(i);
+      ReturnInfo info = infos.get(i);
+      if (info.kind() == PathKind.MAYBE) {
+        decoderFields.add(null);
+        continue;
+      }
+      String fieldName = method.getSimpleName() + "Decoder";
+      int suffix = 2;
+      while (!usedFieldNames.add(fieldName)) {
+        fieldName = method.getSimpleName() + "Decoder" + suffix++;
+      }
+      builder.addField(
+          ParameterizedTypeName.get(RESPONSE_ERROR_DECODER, rawClass(info.error())),
+          fieldName,
+          Modifier.PRIVATE,
+          Modifier.FINAL);
+      constructor.addStatement("this.$L = $L", fieldName, decoderExpression(method, info));
+      decoderFields.add(fieldName);
+    }
+
+    builder.addMethod(constructor.build());
 
     for (int i = 0; i < methods.size(); i++) {
-      builder.addMethod(buildFacadeMethod(methods.get(i), infos.get(i)));
+      builder.addMethod(buildFacadeMethod(methods.get(i), infos.get(i), decoderFields.get(i)));
     }
     return builder.build();
   }
 
-  private MethodSpec buildFacadeMethod(ExecutableElement method, ReturnInfo info) {
+  private MethodSpec buildFacadeMethod(
+      ExecutableElement method, ReturnInfo info, @Nullable String decoderField) {
     String name = method.getSimpleName().toString();
     MethodSpec.Builder facadeMethod =
         MethodSpec.methodBuilder(name)
@@ -308,16 +347,10 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
         switch (info.kind()) {
           case EITHER ->
               CodeBlock.of(
-                  "return $T.either($L, $L)",
-                  HKJ_CLIENT_EXCHANGE,
-                  call,
-                  decoderExpression(method, info));
+                  "return $T.either($L, this.$L)", HKJ_CLIENT_EXCHANGE, call, decoderField);
           case EITHER_VTASK ->
               CodeBlock.of(
-                  "return $T.eitherVTask($L, $L)",
-                  HKJ_CLIENT_EXCHANGE,
-                  call,
-                  decoderExpression(method, info));
+                  "return $T.eitherVTask($L, this.$L)", HKJ_CLIENT_EXCHANGE, call, decoderField);
           case MAYBE -> CodeBlock.of("return $T.maybe($L)", HKJ_CLIENT_EXCHANGE, call);
         });
     return facadeMethod.build();
@@ -332,12 +365,12 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
     ClassName errorRaw = rawClass(info.error());
     List<StatusOverride> overrides = readStatusOverrides(method, info.error());
     if (overrides.isEmpty()) {
-      return CodeBlock.of("this.decoderFactory.create($T.class)", errorRaw);
+      return CodeBlock.of("decoderFactory.create($T.class)", errorRaw);
     }
     CodeBlock.Builder builder =
         CodeBlock.builder()
             .add(
-                "$T.<$T>forDefault(this.decoderFactory, $T.class)",
+                "$T.<$T>forDefault(decoderFactory, $T.class)",
                 RESPONSE_ERROR_DECODERS,
                 errorRaw,
                 errorRaw);
@@ -415,7 +448,10 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
         .addJavadoc(
             "Registers the {@link $T} HTTP Service group and the client bean. Generated; do not edit.\n",
             nativeName)
-        .addAnnotation(CONFIGURATION)
+        .addAnnotation(
+            AnnotationSpec.builder(CONFIGURATION)
+                .addMember("proxyBeanMethods", "$L", false)
+                .build())
         .addAnnotation(
             AnnotationSpec.builder(IMPORT_HTTP_SERVICES)
                 .addMember("group", "$S", group)
@@ -427,15 +463,57 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
 
   // ---- analysis helpers ---------------------------------------------------------------------
 
-  /** Copies a parameter's type, name and binding annotations onto the native interface method. */
-  private static ParameterSpec copyParameter(VariableElement parameter) {
+  /**
+   * Copies a parameter's type, name and binding annotations onto the native interface method. A
+   * name-binding annotation ({@code @PathVariable}, {@code @RequestParam}, …) without an explicit
+   * name gets one injected from the source parameter — the processor knows the name even when the
+   * consuming build does not compile with {@code -parameters}.
+   */
+  private ParameterSpec copyParameter(VariableElement parameter) {
+    String parameterName = parameter.getSimpleName().toString();
     ParameterSpec.Builder builder =
-        ParameterSpec.builder(
-            TypeName.get(parameter.asType()), parameter.getSimpleName().toString());
+        ParameterSpec.builder(TypeName.get(parameter.asType()), parameterName);
     for (AnnotationMirror mirror : parameter.getAnnotationMirrors()) {
-      builder.addAnnotation(AnnotationSpec.get(mirror));
+      AnnotationSpec spec = AnnotationSpec.get(mirror);
+      if (needsExplicitName(mirror, parameter)) {
+        spec = spec.toBuilder().addMember("value", "$S", parameterName).build();
+      }
+      builder.addAnnotation(spec);
     }
     return builder.build();
+  }
+
+  /**
+   * True for a name-binding annotation that declares neither {@code value} nor {@code name} and is
+   * not an <em>aggregate</em> binder. A {@code Map}/{@code MultiValueMap} parameter on
+   * {@code @RequestParam}/{@code @RequestHeader}/{@code @CookieValue}, or a {@code Map} on
+   * {@code @PathVariable}, binds <em>every</em> name/value pair when left unnamed — injecting a
+   * name would change it into a single-entry binder, so it must stay unnamed.
+   */
+  private boolean needsExplicitName(AnnotationMirror mirror, VariableElement parameter) {
+    String annotationType = mirror.getAnnotationType().toString();
+    if (!NAME_BINDING_ANNOTATIONS.contains(annotationType)) {
+      return false;
+    }
+    if (isMapType(parameter.asType())) {
+      return false;
+    }
+    return mirror.getElementValues().keySet().stream()
+        .map(member -> member.getSimpleName().toString())
+        .noneMatch(member -> member.equals("value") || member.equals("name"));
+  }
+
+  /**
+   * True when {@code type} is (a subtype of) {@link java.util.Map} — including {@code
+   * MultiValueMap}.
+   */
+  private boolean isMapType(TypeMirror type) {
+    var types = processingEnv.getTypeUtils();
+    TypeElement mapElement = processingEnv.getElementUtils().getTypeElement("java.util.Map");
+    if (mapElement == null) {
+      return false;
+    }
+    return types.isAssignable(types.erasure(type), types.erasure(mapElement.asType()));
   }
 
   /**

--- a/hkj-spring/client-processor/src/test/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessorTest.java
+++ b/hkj-spring/client-processor/src/test/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessorTest.java
@@ -98,12 +98,14 @@ class HkjHttpClientProcessorTest {
     }
 
     @Test
-    @DisplayName("parameter binding annotations are preserved on the native interface")
+    @DisplayName("parameter binding annotations are preserved with explicit names injected")
     void parameterAnnotations() {
+      // The explicit "id" name must be injected so the generated interface binds without the
+      // consuming build needing -parameters.
       assertThat(compilation)
           .generatedSourceFile("com.example.UserApiHttpExchange")
           .contentsAsUtf8String()
-          .containsMatch("getUser\\(@PathVariable");
+          .contains("@PathVariable(\"id\")");
       assertThat(compilation)
           .generatedSourceFile("com.example.UserApiHttpExchange")
           .contentsAsUtf8String()
@@ -165,6 +167,72 @@ class HkjHttpClientProcessorTest {
           .generatedSourceFile("com.example.UserApiHttpExchange")
           .contentsAsUtf8String()
           .contains("accept = \"application/json\"");
+    }
+  }
+
+  @Nested
+  @DisplayName("aggregate Map/MultiValueMap binders are left unnamed")
+  class AggregateBinders {
+
+    // A Map/MultiValueMap parameter on @RequestParam/@RequestHeader/@CookieValue, or a Map on
+    // @PathVariable, is an aggregate binder: unnamed, it binds *every* name/value pair. Injecting a
+    // name would turn it into a single-entry binder, so the processor must leave these unnamed
+    // while still naming ordinary scalar parameters.
+    private final Compilation compilation =
+        compile(
+            JavaFileObjects.forSourceLines(
+                "com.example.AggApi",
+                "package com.example;",
+                "import java.util.Map;",
+                "import org.higherkindedj.hkt.effect.EitherPath;",
+                "import org.higherkindedj.spring.client.HkjHttpClient;",
+                "import org.springframework.util.MultiValueMap;",
+                "import org.springframework.web.bind.annotation.CookieValue;",
+                "import org.springframework.web.bind.annotation.PathVariable;",
+                "import org.springframework.web.bind.annotation.RequestHeader;",
+                "import org.springframework.web.bind.annotation.RequestParam;",
+                "import org.springframework.web.service.annotation.GetExchange;",
+                "import org.springframework.web.service.annotation.HttpExchange;",
+                "@HttpExchange(\"/agg\")",
+                "@HkjHttpClient",
+                "public interface AggApi {",
+                "  @GetExchange(\"/search\")",
+                "  EitherPath<UserError, UserDto> search(@RequestParam Map<String, String> params);",
+                "  @GetExchange(\"/headers\")",
+                "  EitherPath<UserError, UserDto> headers("
+                    + "@RequestHeader MultiValueMap<String, String> headers);",
+                "  @GetExchange(\"/cookies\")",
+                "  EitherPath<UserError, UserDto> cookies(@CookieValue Map<String, String> cookies);",
+                "  @GetExchange(\"/vars\")",
+                "  EitherPath<UserError, UserDto> vars(@PathVariable Map<String, String> vars);",
+                "  @GetExchange(\"/one\")",
+                "  EitherPath<UserError, UserDto> one(@RequestParam String q);",
+                "}"),
+            USER_DTO,
+            USER_ERROR);
+
+    @Test
+    @DisplayName("no explicit name is injected for aggregate Map/MultiValueMap parameters")
+    void leavesAggregateBindersUnnamed() {
+      assertThat(compilation).succeeded();
+      var nativeIface =
+          assertThat(compilation)
+              .generatedSourceFile("com.example.AggApiHttpExchange")
+              .contentsAsUtf8String();
+      nativeIface.doesNotContain("@RequestParam(\"params\")");
+      nativeIface.doesNotContain("@RequestHeader(\"headers\")");
+      nativeIface.doesNotContain("@CookieValue(\"cookies\")");
+      nativeIface.doesNotContain("@PathVariable(\"vars\")");
+    }
+
+    @Test
+    @DisplayName("scalar parameters alongside aggregate binders still get an explicit name")
+    void namesScalarParameters() {
+      assertThat(compilation).succeeded();
+      assertThat(compilation)
+          .generatedSourceFile("com.example.AggApiHttpExchange")
+          .contentsAsUtf8String()
+          .contains("@RequestParam(\"q\")");
     }
   }
 
@@ -233,7 +301,7 @@ class HkjHttpClientProcessorTest {
       assertThat(compilation)
           .generatedSourceFile("com.example.OsApiClient")
           .contentsAsUtf8String()
-          .contains("ResponseErrorDecoders.<ApiErr>forDefault(this.decoderFactory, ApiErr.class)");
+          .contains("ResponseErrorDecoders.<ApiErr>forDefault(decoderFactory, ApiErr.class)");
       assertThat(compilation)
           .generatedSourceFile("com.example.OsApiClient")
           .contentsAsUtf8String()

--- a/hkj-spring/client/src/main/java/org/higherkindedj/spring/client/ClientErrorResponse.java
+++ b/hkj-spring/client/src/main/java/org/higherkindedj/spring/client/ClientErrorResponse.java
@@ -27,9 +27,16 @@ import org.springframework.http.HttpStatusCode;
 public record ClientErrorResponse(
     HttpStatusCode status, @Nullable String body, @Nullable HttpHeaders headers) {
 
-  /** Canonical constructor. */
+  /**
+   * Canonical constructor; headers are snapshotted then wrapped read-only so the record is deeply
+   * immutable and unaffected by later mutation of the caller's {@link HttpHeaders} instance.
+   */
   public ClientErrorResponse {
     Objects.requireNonNull(status, "status");
+    // readOnlyHttpHeaders alone only wraps — it still aliases the caller's instance, so a later
+    // mutation there would change this record's observed headers (including retryAfter()). Copy
+    // first, then wrap the copy.
+    headers = headers == null ? null : HttpHeaders.readOnlyHttpHeaders(HttpHeaders.copyOf(headers));
   }
 
   /**

--- a/hkj-spring/effect-example/src/main/resources/application.yml
+++ b/hkj-spring/effect-example/src/main/resources/application.yml
@@ -23,8 +23,9 @@ hkj:
     free-path-include-exception-details: true
 
   effect-boundary:
+    # Master switch for the @EnableEffectBoundary registrar (default: true).
+    # Interpreter validation is always fail-fast; there is no property for it.
     enabled: true
-    startup-validation: true
 
   actuator:
     metrics-enabled: true

--- a/hkj-spring/example/TESTING.md
+++ b/hkj-spring/example/TESTING.md
@@ -924,12 +924,11 @@ hkj:
     default-error-status: 400      # Default HTTP status for errors
 
   async:
-    executor-core-pool-size: 10
-    executor-max-pool-size: 20
-    executor-queue-capacity: 100
-    executor-thread-name-prefix: "hkj-async-"
-    default-timeout-ms: 30000
+    default-timeout-ms: 30000    # Timeout applied by the CompletableFuturePath handler
 ```
+
+The starter does not create an executor: define your own `ThreadPoolTaskExecutor` bean (see
+`AsyncConfig` in this example) when your services need one.
 
 ### Disabling Async Support
 

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/config/AsyncConfig.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/config/AsyncConfig.java
@@ -11,11 +11,14 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 /**
  * Configuration for async task execution using Spring's @Async support.
  *
- * <p>This configuration creates a custom thread pool executor specifically for async operations in
- * the higher-kinded-j Spring integration, particularly for {@code
- * EitherT<CompletableFuture.Witness, E, A>} return types.
+ * <p>This configuration creates the thread pool executor used by {@link
+ * org.higherkindedj.spring.example.service.AsyncUserService} for {@code CompletableFuturePath}
+ * operations. The starter does <b>not</b> create or configure this pool — defining an executor bean
+ * in the application (and passing it to {@code CompletableFuture.supplyAsync}) is the documented
+ * pattern. Naming the bean {@code hkjAsyncExecutor} also enables the optional {@code hkj-async}
+ * actuator health indicator.
  *
- * <p>The executor is configured with:
+ * <p>The executor is hardcoded here with:
  *
  * <ul>
  *   <li>Core pool size: 10 threads
@@ -24,14 +27,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  *   <li>Thread name prefix: "hkj-async-" for easy identification
  * </ul>
  *
- * <p>These settings can be customized via application.properties using:
- *
- * <pre>
- * hkj.async.executor-core-pool-size=10
- * hkj.async.executor-max-pool-size=20
- * hkj.async.executor-queue-capacity=100
- * hkj.async.executor-thread-name-prefix=hkj-async-
- * </pre>
+ * <p>To change these settings, edit this bean (there are no {@code hkj.async.executor-*}
+ * configuration properties). The only async property the starter reads is {@code
+ * hkj.async.default-timeout-ms}, the response timeout for {@code CompletableFuturePath} requests.
  */
 @Configuration
 @EnableAsync
@@ -48,7 +46,6 @@ public class AsyncConfig {
    * <ul>
    *   <li>AsyncUserService for async database/external service calls
    *   <li>CompletableFuture.supplyAsync() calls in services
-   *   <li>EitherT async operation chains
    * </ul>
    *
    * @return configured ThreadPoolTaskExecutor

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/UserController.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/UserController.java
@@ -10,6 +10,7 @@ import org.higherkindedj.spring.example.domain.User;
 import org.higherkindedj.spring.example.domain.UserNotFoundError;
 import org.higherkindedj.spring.example.service.UserService;
 import org.springframework.web.bind.annotation.*;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * REST controller demonstrating Either-based error handling.
@@ -23,14 +24,18 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
   private final UserService userService;
+  private final JsonMapper jsonMapper;
 
   /**
    * Constructs a UserController.
    *
    * @param userService the user service
+   * @param jsonMapper the application's Jackson 3.x mapper, used by the debug endpoint to probe
+   *     whether HkjJacksonModule is actually registered
    */
-  public UserController(UserService userService) {
+  public UserController(UserService userService, JsonMapper jsonMapper) {
     this.userService = userService;
+    this.jsonMapper = jsonMapper;
   }
 
   /**
@@ -119,32 +124,37 @@ public class UserController {
   }
 
   /**
-   * Debug endpoint to confirm HKJ Jackson module configuration.
+   * Debug endpoint reporting the <em>actual</em> HKJ Jackson module state.
    *
-   * <p>Note: Jackson 3.x does not expose registered module IDs directly. This endpoint confirms
-   * HkjJacksonModule should be registered via Spring Boot auto-configuration.
+   * <p>Jackson 3.x does not expose registered module IDs directly, so instead of echoing a
+   * hardcoded value this endpoint probes real behaviour: it serialises a sample {@code Either} with
+   * the injected {@link JsonMapper} and checks whether the tagged {@code isRight} shape (produced
+   * only by HkjJacksonModule's EitherSerializer) came back.
    *
    * <p>Example response:
    *
    * <pre>
    * {
    *   "hkjModulePresent": true,
-   *   "registeredModules": ["HkjJacksonModule"],
-   *   "message": "HkjJacksonModule configured via Spring Boot auto-configuration"
+   *   "eitherProbe": "{\"isRight\":true,\"right\":\"probe\"}",
+   *   "message": "hkjModulePresent is derived by serialising a sample Either with the application's JsonMapper"
    * }
    * </pre>
    *
-   * @return a map of Jackson module configuration details
+   * @return a map describing the observed Jackson configuration
    */
   @GetMapping("/debug/jackson-modules")
   public Map<String, Object> getJacksonModules() {
+    String eitherProbe = jsonMapper.writeValueAsString(Either.<String, String>right("probe"));
+    boolean hkjModulePresent = eitherProbe.contains("\"isRight\"");
     return Map.of(
         "hkjModulePresent",
-        true,
-        "registeredModules",
-        List.of("HkjJacksonModule"),
+        hkjModulePresent,
+        "eitherProbe",
+        eitherProbe,
         "message",
-        "HkjJacksonModule configured via Spring Boot auto-configuration");
+        "hkjModulePresent is derived by serialising a sample Either with the application's"
+            + " JsonMapper");
   }
 
   /**

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/AsyncUserService.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/AsyncUserService.java
@@ -16,8 +16,15 @@ import org.springframework.stereotype.Service;
  * Service demonstrating async operations using CompletableFuturePath.
  *
  * <p>CompletableFuturePath provides a clean API for async operations with the Effect Path API.
- * Error handling uses exceptions which are automatically converted to appropriate HTTP responses by
- * the CompletableFuturePathReturnValueHandler.
+ * Error handling uses exceptions: a failed future is converted by the
+ * CompletableFuturePathReturnValueHandler to the configured async failure status (default 500) with
+ * a {@code {"success": false, "error": ...}} body.
+ *
+ * <p><b>Known limitation:</b> because failures are {@code Throwable}s rather than typed {@code
+ * Left} values, the per-error-class {@code ErrorStatusCodeStrategy} does not apply — {@link
+ * UserNotFoundException} surfaces as the async failure status (500), not 404. Endpoints that need
+ * typed-error status mapping should return {@code Either} at the boundary (see {@link
+ * UserService#findById}).
  *
  * <p>Example async chain:
  *

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/UserService.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/UserService.java
@@ -5,6 +5,7 @@ package org.higherkindedj.spring.example.service;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import org.higherkindedj.hkt.Applicative;
 import org.higherkindedj.hkt.Semigroups;
 import org.higherkindedj.hkt.either.Either;
@@ -27,6 +28,10 @@ public class UserService {
 
   // In-memory "database" for the example
   private final Map<String, User> users = new ConcurrentHashMap<>();
+
+  // Monotonic id generator: seeded past the pre-populated users so generated ids
+  // never collide, even after deletions or under concurrent creates.
+  private final AtomicLong idGenerator = new AtomicLong(3);
 
   /** Creates a new user service with pre-populated test data. */
   public UserService() {
@@ -95,7 +100,7 @@ public class UserService {
       return Either.left(new ValidationError("lastName", "Last name cannot be empty"));
     }
 
-    String id = String.valueOf(users.size() + 1);
+    String id = String.valueOf(idGenerator.incrementAndGet());
     User user = new User(id, email, firstName, lastName);
     users.put(id, user);
     return Either.right(user);
@@ -171,7 +176,7 @@ public class UserService {
             ValidatedKindHelper.VALIDATED.widen(validatedFirstName),
             ValidatedKindHelper.VALIDATED.widen(validatedLastName),
             (e, f, l) -> {
-              String id = String.valueOf(users.size() + 1);
+              String id = String.valueOf(idGenerator.incrementAndGet());
               User user = new User(id, e, f, l);
               users.put(id, user);
               return user;

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/VirtualThreadUserService.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/service/VirtualThreadUserService.java
@@ -50,8 +50,15 @@ public class VirtualThreadUserService {
    * <p>The computation is deferred — nothing executes until the Spring handler invokes the VTask.
    * When executed, it runs on a virtual thread automatically.
    *
+   * <p><b>Known limitation:</b> {@code VTaskPathReturnValueHandler} carries failures as exceptions,
+   * not typed {@code Left} values, so folding the {@link UserNotFoundError} into a {@code
+   * RuntimeException} here means a missing user maps to the configured VTask failure status
+   * (default 500), <em>not</em> 404 — the per-error-class {@code ErrorStatusCodeStrategy} does not
+   * apply to VTask failures. Endpoints that need {@code Left(UserNotFoundError)} → 404 semantics
+   * should return {@code Either} at the boundary instead (see {@link UserService#findById}).
+   *
    * @param id the user ID to find
-   * @return VTaskPath containing the User, or failing with an exception
+   * @return VTaskPath containing the User, or failing with an exception (→ 500)
    */
   public VTaskPath<User> findById(String id) {
     return Path.vtask(

--- a/hkj-spring/example/src/main/resources/application.yml
+++ b/hkj-spring/example/src/main/resources/application.yml
@@ -15,17 +15,14 @@ logging:
 hkj:
   # Web/MVC configuration
   web:
-    # Enable Either return value handler (default: true)
-    either-response-enabled: true
+    # Enable EitherPath return value handler (default: true)
+    either-path-enabled: true
 
-    # Enable Validated return value handler (default: true)
-    validated-response-enabled: true
+    # Enable ValidationPath return value handler (default: true)
+    validation-path-enabled: true
 
     # Default HTTP status for errors when type is unknown (default: 400)
     default-error-status: 400
-
-    # Enable EitherT async support - for future use (default: true)
-    async-either-t-enabled: true
 
     # Custom error status mappings
     # Maps error class simple names to HTTP status codes
@@ -35,42 +32,17 @@ hkj:
       AuthorizationError: 403
       AuthenticationError: 401
 
-  # Validation configuration
-  validation:
-    # Enable validation support (default: true)
-    enabled: true
-
-    # Accumulate all errors vs fail-fast (default: true)
-    accumulate-errors: true
-
-    # Maximum errors to accumulate, 0 = unlimited (default: 0)
-    max-errors: 0
-
   # JSON serialization configuration
   json:
-    # Enable custom Jackson serializers for Either, Validated (default: true)
+    # Enable custom Jackson serializers for Either, Validated,
+    # EitherOrBoth, and NonEmptyList (default: true).
+    # Nested Either values serialise as {"isRight": true/false, "right"/"left": value}
     custom-serializers-enabled: true
 
-    # Either JSON format: TAGGED or SIMPLE (default: TAGGED)
-    # TAGGED: {"isRight": true/false, "right/left": value}
-    # SIMPLE: {"value": ...} or {"error": ...}
-    either-format: TAGGED
-
-  # Async configuration (for future EitherT support)
+  # Async configuration (CompletableFuturePath responses)
+  # The thread pool itself is the application's own hkjAsyncExecutor bean (see AsyncConfig)
   async:
-    # Core thread pool size (default: 10)
-    executor-core-pool-size: 10
-
-    # Max thread pool size (default: 20)
-    executor-max-pool-size: 20
-
-    # Queue capacity (default: 100)
-    executor-queue-capacity: 100
-
-    # Thread name prefix (default: "hkj-async-")
-    executor-thread-name-prefix: "hkj-async-"
-
-    # Default timeout in milliseconds (default: 30000)
+    # Response timeout in milliseconds (default: 30000)
     default-timeout-ms: 30000
 
   # Virtual thread configuration (for VTaskPath and VStreamPath handlers)

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/EndToEndIntegrationTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/EndToEndIntegrationTest.java
@@ -282,7 +282,7 @@ class EndToEndIntegrationTest {
           .perform(get("/api/users/debug/jackson-modules"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.hkjModulePresent").value(true))
-          .andExpect(jsonPath("$.registeredModules", hasItem("HkjJacksonModule")));
+          .andExpect(jsonPath("$.eitherProbe").exists());
     }
 
     @Test
@@ -457,7 +457,7 @@ class EndToEndIntegrationTest {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.hkjModulePresent").value(true));
 
-      // Verify either-format=TAGGED (default in application.yml)
+      // Verify the fixed nested-Either JSON shape (isRight/right)
       MvcResult result =
           mockMvc.perform(get("/api/users/batch")).andExpect(status().isOk()).andReturn();
 

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerIntegrationTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerIntegrationTest.java
@@ -47,7 +47,7 @@ class UserControllerIntegrationTest {
       mockMvc
           .perform(get("/api/users/{id}", "1"))
           .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.id").value("1"))
           .andExpect(jsonPath("$.email").value("alice@example.com"))
           .andExpect(jsonPath("$.firstName").value("Alice"))
@@ -60,7 +60,7 @@ class UserControllerIntegrationTest {
       mockMvc
           .perform(get("/api/users/{id}", "2"))
           .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.id").value("2"))
           .andExpect(jsonPath("$.email").value("bob@example.com"))
           .andExpect(jsonPath("$.firstName").value("Bob"))
@@ -73,7 +73,7 @@ class UserControllerIntegrationTest {
       mockMvc
           .perform(get("/api/users/{id}", "999"))
           .andExpect(status().isNotFound())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.success").value(false))
           .andExpect(jsonPath("$.error").exists())
           .andExpect(jsonPath("$.error.userId").value("999"));
@@ -85,7 +85,7 @@ class UserControllerIntegrationTest {
       mockMvc
           .perform(get("/api/users/{id}", "nonexistent"))
           .andExpect(status().isNotFound())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.success").value(false))
           .andExpect(jsonPath("$.error.userId").value("nonexistent"));
     }
@@ -101,7 +101,7 @@ class UserControllerIntegrationTest {
       mockMvc
           .perform(get("/api/users/batch"))
           .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.batchId").exists())
           .andExpect(jsonPath("$.results").isArray())
           .andExpect(jsonPath("$.results", hasSize(3)));
@@ -148,24 +148,27 @@ class UserControllerIntegrationTest {
   class GetJacksonModulesTests {
 
     @Test
-    @DisplayName("Should return Jackson modules information")
+    @DisplayName("Should return Jackson module probe information")
     void shouldReturnJacksonModulesInfo() throws Exception {
       mockMvc
           .perform(get("/api/users/debug/jackson-modules"))
           .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("$.registeredModules").isArray())
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.eitherProbe").isString())
           .andExpect(jsonPath("$.hkjModulePresent").exists());
     }
 
     @Test
-    @DisplayName("Should confirm HkjJacksonModule is registered")
+    @DisplayName("Should confirm HkjJacksonModule is registered by probing real serialisation")
     void shouldConfirmHkjModuleRegistered() throws Exception {
+      // hkjModulePresent is computed by serialising a sample Either with the app's JsonMapper,
+      // so this asserts observed mapper behaviour rather than a hardcoded constant.
       mockMvc
           .perform(get("/api/users/debug/jackson-modules"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.hkjModulePresent").value(true))
-          .andExpect(jsonPath("$.registeredModules", hasItem("HkjJacksonModule")));
+          .andExpect(jsonPath("$.eitherProbe", containsString("\"isRight\"")))
+          .andExpect(jsonPath("$.eitherProbe", containsString("\"right\"")));
     }
   }
 

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerWebMvcSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerWebMvcSliceTest.java
@@ -36,14 +36,19 @@ import org.springframework.test.web.servlet.MockMvc;
  *
  * <ul>
  *   <li>{@link HkjJacksonAutoConfiguration} (registers {@code HkjJacksonModule}) isn't loaded, so
- *       {@code Either} / {@code Validated} serialize as their raw fields rather than the tagged
- *       {@code {success, value}} / {@code {success, error}} shape.
+ *       nested {@code Either} / {@code Validated} values serialise as their raw fields rather than
+ *       the tagged {@code {"isRight": ..., "right"/"left": ...}} / {@code {"valid": ...,
+ *       "value"/"errors": ...}} shapes. (Top-level success values are unwrapped by the handlers;
+ *       only Left errors gain the {@code {"success": false, "error": ...}} envelope.)
  *   <li>{@link HkjWebMvcAutoConfiguration} (registers the {@code *ReturnValueHandler}s and the
  *       {@code ErrorStatusCodeMapper}) isn't loaded, so top-level {@code Either} values are not
  *       unwrapped and left errors don't map to status codes like 404/400.
  * </ul>
  *
- * <p>Importing all three auto-configurations below restores production behaviour inside the slice:
+ * <p>Importing all three auto-configurations below restores production behaviour inside the slice —
+ * so in <b>this</b> test nested {@code Either} / {@code Validated} values <b>do</b> serialise with
+ * the tagged shapes above, and top-level values are unwrapped with left errors mapped to status
+ * codes:
  *
  * <ul>
  *   <li>{@link HkjAutoConfiguration} — binds {@code HkjProperties} (required by the Web MVC
@@ -79,7 +84,7 @@ class UserControllerWebMvcSliceTest {
     mockMvc
         .perform(get("/api/users/{id}", "1"))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value("1"))
         .andExpect(jsonPath("$.email").value("alice@example.com"))
         // Top-level Either is unwrapped — the Either wrapper fields must NOT leak.
@@ -96,7 +101,7 @@ class UserControllerWebMvcSliceTest {
     mockMvc
         .perform(get("/api/users/{id}", "999"))
         .andExpect(status().isNotFound())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.success").value(false))
         .andExpect(jsonPath("$.error").exists())
         .andExpect(jsonPath("$.error.userId").value("999"));

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/ValidationControllerIntegrationTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/ValidationControllerIntegrationTest.java
@@ -60,7 +60,7 @@ class ValidationControllerIntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(requestBody))
           .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.id").exists())
           .andExpect(jsonPath("$.email").value("test@example.com"))
           .andExpect(jsonPath("$.firstName").value("John"))
@@ -85,7 +85,7 @@ class ValidationControllerIntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(requestBody))
           .andExpect(status().isBadRequest())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.valid").value(false))
           .andExpect(jsonPath("$.errors").isArray())
           .andExpect(jsonPath("$.errors", hasSize(3)));
@@ -230,7 +230,7 @@ class ValidationControllerIntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(requestBody))
           .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.batchId").exists())
           .andExpect(jsonPath("$.results").isArray())
           .andExpect(jsonPath("$.results", hasSize(3)));

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/integration/AsyncControllerIntegrationTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/integration/AsyncControllerIntegrationTest.java
@@ -54,7 +54,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value("1"))
         .andExpect(jsonPath("$.email").value("alice@example.com"))
         .andExpect(jsonPath("$.firstName").value("Alice"))
@@ -82,7 +82,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isInternalServerError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.success").value(false));
   }
 
@@ -107,7 +107,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value("2"))
         .andExpect(jsonPath("$.email").value("bob@example.com"))
         .andExpect(jsonPath("$.firstName").value("Bob"))
@@ -126,7 +126,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isInternalServerError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.success").value(false));
   }
 
@@ -154,7 +154,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.user.id").value("1"))
         .andExpect(jsonPath("$.user.email").value("alice@example.com"))
         .andExpect(jsonPath("$.profile.userId").value("1"))
@@ -184,7 +184,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isInternalServerError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.success").value(false));
   }
 
@@ -211,7 +211,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value("1"))
         .andExpect(jsonPath("$.email").value("alice.updated@example.com"))
         .andExpect(jsonPath("$.firstName").value("Alice"))
@@ -240,7 +240,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isInternalServerError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.success").value(false));
   }
 
@@ -266,7 +266,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isInternalServerError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.success").value(false));
   }
 
@@ -288,7 +288,7 @@ class AsyncControllerIntegrationTest {
     mockMvc
         .perform(asyncDispatch(mvcResult))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.status").value("healthy"))
         .andExpect(jsonPath("$.message").value("Async operations are working"));
   }


### PR DESCRIPTION
Addresses the main checklist of #642 (the "Follow-ups" section of that issue remains open — see below).

## What's fixed

**Security** — the JWT converter no longer fails open (claim-extraction failure → `BadCredentialsException`, never an authenticated token); demo credentials moved behind an explicit `ValidatedUserDetailsService.withSampleUsers()` factory; `EitherAuthorizationManager` policy is constructor-injected `AuthorizationRule` composition with `denyPathPrefix` matching the decoded path via `PathPatternRequestMatcher` (percent-encoding bypass closed, with a regression test).

**Async handler lifecycle** — CF/VTask handlers gate the timeout and completion callbacks through a single-writer CAS (no write-after-timeout on recycled responses), settle the `DeferredResult` on timeout, cancel the future, unwrap only `CompletionException`/`ExecutionException`, and keep recording VTask metrics when the timeout wins the race. The VStream SSE handler detects client disconnects via `checkError()` (no leaked virtual threads on infinite streams), re-checks the abort signal after blocking pulls, and wires the previously dead `vstream-failure-status` via first-pull-then-commit.

**Response writing** — UTF-8 declared on every JSON response; `NonEmptyList` (Iterable, not Collection) now honoured by `ErrorResponseHeaders` and `errorCount`; Maybe `Nothing` writes no body on 204/304; a startup warning fires when a competing `WebMvcRegistrations` bean would silently disable all Path handlers.

**Jackson** — contextual resolution fixed for HKJ types inside collections/maps (`List<Either<E, A>>` bean fields no longer bind to `LinkedHashMap`), with property-type-first ordering so nested `Either`-in-bean-in-`Either` stays correct; null branch values report clean `DatabindException`s; strict boolean discriminators.

**Auto-configuration** — `/actuator/hkj` no longer breaks startup when metrics are disabled; async health indicator qualified; `@Interpreter.profile` implemented (profile-restricted interpreters shadow unrestricted ones, ambiguity fails fast); `hkj.effect-boundary.enabled` actually consulted; dead config keys removed (`hkj.validation.*`, `hkj.json.*-format`, `hkj.async.executor-*`, `startup-validation`, `interpreter-selection`).

**Client** — generated code injects explicit `@PathVariable`/`@RequestParam` names (no `-parameters` dependency), `proxyBeanMethods = false`, decoders hoisted to constructor-initialised fields; `ClientErrorResponse` headers wrapped read-only.

**Docs + examples** — all five book spring chapters reconciled with the implementation (`Validated.validateAll` and EitherT-from-controller snippets replaced, JSON shapes/config keys/metric names corrected, EitherOrBoth + `X-Hkj-Warnings` documented); CONFIGURATION/SECURITY/ACTUATOR/EFFECT_BOUNDARY/JACKSON_SERIALIZATION.md updated; example apps use real config keys and a real Jackson-module probe.

## Deliberate behaviour changes (please sanity-check)

1. **`hkj.security.validated-user-details` now defaults to `false`** (was `true`). Rationale: `ValidatedUserDetailsService` implements `UserDetailsService`, so once it is the unique bean of that type Spring Security adopts it as the global user store — and it now starts empty, which would silently break form/basic login for anyone enabling `hkj.security.enabled` just for the JWT converter.
2. **Missing authorities claim now rejects the JWT** (401) instead of authenticating with empty authorities (a present-but-empty list still authenticates; a lenient flag now restores role-less-token behaviour — see the review comment). Strict-by-default; IdPs issuing tokens without the claim need a custom converter or a different `jwt-authorities-claim`. Called out in SECURITY.md.
3. **SSE commit timing**: headers now flush after the *first pull step* resolves (previously immediately). This is what makes `vstream-failure-status` real for streams that fail at their start. Streams that idle a long time before their first step should emit an early heartbeat element (documented). If prompt `EventSource.onopen` matters more than start-failure statuses, this is the knob to revisit.
4. **Interpreter resolution can now fail at startup** where it previously picked scan-order-first: two unrestricted interpreters for one algebra, or a sole interpreter whose profile is inactive. Both were silent misconfigurations before.
5. **Generated clients build their error decoder once** (constructor) instead of per call — a custom `ResponseErrorDecoderFactory` whose output depends on ambient state now sees construction-time state only.

## Not in this PR (still open on #642)

- Processor: `Types.asMemberOf` substitution for generic super-interfaces + hierarchy-wide `@HttpExchange` lookup
- `ResponseErrorDecoder` fallback combinators for non-envelope error bodies
- hkj-core: reconcile `VStream.bracket` javadoc with short-circuit terminal behaviour
- Consolidation refactors (shared async gate for CF/VTask, `PathResponseWriter`, shared error-body builder, registrar FactoryBean dedup)
- Deeper task cancellation (VTask virtual threads are not interrupted by `CompletableFuture.cancel`; comments are now honest about this)

## Verification

- `:hkj-spring:autoconfigure`, `:client`, `:client-processor`, `:example`, `:effect-example`, `:client-example`, `:starter` — full builds + tests green
- `:hkj-examples:bookVerify` (book snippet compile gate) green
- New tests: CF timeout single-writer race, VStream SSE behaviour (completion/pre-commit failure/disconnect), interpreter profile/ambiguity resolution, collection-nested + doubly-nested contextual deserialisation, null-branch guards, NonEmptyList header/count handling, percent-encoded deny-path regression
- Multi-agent review pass (6 finder angles) run on the diff; all confirmed findings fixed in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `EitherOrBothPath` and `FreePath` return handling with fixed response shapes and `X-Hkj-Warnings`.
  * Improved EffectBoundary integration with profile-aware interpreter selection and fail-fast validation.
* **Bug Fixes**
  * Hardened async and SSE streaming to prevent late/duplicate writes and improve timeout/disconnect behavior.
  * Standardized JSON content-type handling and improved error/header propagation across return handlers.
* **Breaking Changes**
  * Removed legacy JSON “format” toggles; JSON shapes are fixed and `custom-serializers-enabled` is the main switch.
  * Security defaults tightened: validated user details is opt-in; JWT authority extraction is stricter by default.
* **Documentation**
  * Updated Spring integration guides, configuration reference, actuator/Jackson/security docs, and examples/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->