### PR TITLE
@GenerateMapping: bean-shaped wire targets (#628)

### DIFF
--- a/.claude/skills/hkj-mapping/SKILL.md
+++ b/.claude/skills/hkj-mapping/SKILL.md
@@ -188,10 +188,12 @@ rejected outright: the projection's `asLens()` write-back could never honour a c
   key.
 - **The mapped record need not be yours.** The annotation sits on *your spec interface*, never on
   the record, so third-party and library records map fine.
-- **The wire need not be a record.** A bean-shaped DTO (getters/setters, or an immutable one with a
-  static `builder()`/`newBuilder()`) maps too - `build` fills through setters or the builder, `parse`
-  reads through getters. A `null` bean property becomes a located `FieldError` (never thrown), and a
-  domain `Optional<T>` bridges to a nullable bean property `T`. See `reference/mapping-example.md`.
+- **The wire need not be a record.** A bean-shaped DTO maps too - detected in three shapes: a no-args
+  constructor with `setX` setters; an immutable bean with a static `builder()`/`newBuilder()`
+  (Lombok, Immutables, AutoValue, protobuf); or the JAXB convention, where a getter-only `List` is
+  filled with `getItems().addAll(...)`. `build` fills through setters or the builder, `parse` reads
+  through getters. A `null` bean property becomes a located `FieldError` (never thrown), and a domain
+  `Optional<T>` bridges to a nullable bean property `T`. See `reference/mapping-example.md`.
 - **`parse` is capped at 16 components**: it is assembled via `Validated.fields()`.
 - **It is law-checked.** Assert `build`/`parse` round-trip with `MappingLaws.assertMappingLaws(...)`
   from `hkj-test`.

--- a/.claude/skills/hkj-mapping/SKILL.md
+++ b/.claude/skills/hkj-mapping/SKILL.md
@@ -188,6 +188,10 @@ rejected outright: the projection's `asLens()` write-back could never honour a c
   key.
 - **The mapped record need not be yours.** The annotation sits on *your spec interface*, never on
   the record, so third-party and library records map fine.
+- **The wire need not be a record.** A bean-shaped DTO (getters/setters, or an immutable one with a
+  static `builder()`/`newBuilder()`) maps too - `build` fills through setters or the builder, `parse`
+  reads through getters. A `null` bean property becomes a located `FieldError` (never thrown), and a
+  domain `Optional<T>` bridges to a nullable bean property `T`. See `reference/mapping-example.md`.
 - **`parse` is capped at 16 components**: it is assembled via `Validated.fields()`.
 - **It is law-checked.** Assert `build`/`parse` round-trip with `MappingLaws.assertMappingLaws(...)`
   from `hkj-test`.

--- a/.claude/skills/hkj-mapping/reference/mapping-example.md
+++ b/.claude/skills/hkj-mapping/reference/mapping-example.md
@@ -179,11 +179,14 @@ public interface ContactMapping extends MappingSpec<Contact, ContactDto> {
 }
 ```
 
-A bean property is `null` when unset, and a leaf's `parse` rejects `null`, so every reference read is
-null-guarded: a missing field becomes a located `FieldError` (`email: must not be null`) rather than
-throwing, and `parse` stays total and accumulating. An immutable bean with a static `builder()` or
-`newBuilder()` (Lombok, Immutables, AutoValue, protobuf) maps identically - `build` goes through the
-builder. A domain `Optional<T>` bridges to a nullable bean property `T` (empty maps to absent).
+A bean property is `null` when unset, and a leaf's `parse` throws on a `null` source, so the mapper
+null-guards each nullable getter result *before* handing it to the leaf: a missing field becomes a
+located `FieldError` (`email: must not be null`) instead of an NPE, and `parse` stays total and
+accumulating. Three construction shapes are detected: a no-args constructor with setters (above); an
+immutable bean with a static `builder()`/`newBuilder()` (Lombok, Immutables, AutoValue, protobuf),
+where `build` goes through the builder; and the JAXB convention, where a getter-only `List` (its
+getter returns a live mutable list, no setter) is filled with `getItems().addAll(...)`. A domain
+`Optional<T>` bridges to a nullable bean property `T` (empty maps to absent).
 
 ## Prove the Round-Trip
 

--- a/.claude/skills/hkj-mapping/reference/mapping-example.md
+++ b/.claude/skills/hkj-mapping/reference/mapping-example.md
@@ -144,6 +144,47 @@ public interface PersonMapping extends MappingSpec<Person, PersonDto> {
 }
 ```
 
+## Bean-Shaped DTOs
+
+The wire you were handed is rarely a record. JAXB, protobuf-lite and most OpenAPI generators emit a
+**bean**: a mutable class with getters and setters, or an immutable one with a builder. It maps the
+same way, with every feature above. Only the shape changes: `build` fills through setters (or a
+builder), `parse` reads through getters. The annotation still sits on your spec, never on the bean,
+so a third-party DTO maps without being touched.
+
+<!-- verify -->
+```java
+public record Contact(String name, EmailAddress email) {}
+
+// A generated getter/setter DTO - not a record, not annotatable.
+public class ContactDto {
+  private String name;
+  private String email;
+
+  public String getName()             { return name; }
+  public void setName(String name)    { this.name = name; }
+  public String getEmail()            { return email; }
+  public void setEmail(String email)  { this.email = email; }
+}
+
+@GenerateMapping
+public interface ContactMapping extends MappingSpec<Contact, ContactDto> {
+  default ValidatedPrism<String, EmailAddress> email() {
+    return ValidatedPrism.of(
+        raw -> raw.contains("@")
+            ? Validated.validNel(new EmailAddress(raw))
+            : Validated.invalidNel(FieldError.of("not an email address")),
+        EmailAddress::value);
+  }
+}
+```
+
+A bean property is `null` when unset, and a leaf's `parse` rejects `null`, so every reference read is
+null-guarded: a missing field becomes a located `FieldError` (`email: must not be null`) rather than
+throwing, and `parse` stays total and accumulating. An immutable bean with a static `builder()` or
+`newBuilder()` (Lombok, Immutables, AutoValue, protobuf) maps identically - `build` goes through the
+builder. A domain `Optional<T>` bridges to a nullable bean property `T` (empty maps to absent).
+
 ## Prove the Round-Trip
 
 Defect 3 from the top: nobody checked that the two directions agree. `MappingLaws` does:

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateMapping.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateMapping.java
@@ -29,6 +29,13 @@ import java.lang.annotation.Target;
  *   <li>Record components mapped by another spec in the same compilation nest automatically, and
  *       {@code List}/{@code Optional} components lift through the element's leaf or spec.
  *   <li>Sealed interface pairs dispatch over their permitted subtype pairs, one spec per pair.
+ *   <li>The wire may be a bean-shaped class (issue #628) instead of a record: a mutable class with
+ *       a no-args constructor and getters/setters, or an immutable one with a builder. {@code
+ *       build} fills it through setters or a builder and {@code parse} reads it through getters. An
+ *       unset bean property is null, so every reference-typed read is null-guarded into a located
+ *       {@code FieldError}; those guards make an {@code asIso()} truthful only for an all-primitive
+ *       bean. A domain {@code Optional<T>} bridges to a nullable bean property {@code T} (empty
+ *       maps to absent). The domain stays a record.
  *   <li>A lossless mapping additionally gets {@code asIso()}; a wire record with fewer components
  *       maps as a projection with {@code asLens()} and no {@code parse} (truthful types); every
  *       parse-capable mapping gets {@code asValidatedPrism()} so it plugs in wherever a leaf does.

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/MappingSpec.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/MappingSpec.java
@@ -21,7 +21,14 @@ package org.higherkindedj.optics.annotations;
  * //   Validated<NonEmptyList<FieldError>, User> parse(UserDto)   (accumulating, located)
  * }</pre>
  *
- * @param <A> the domain type (a record)
- * @param <B> the wire type (a record)
+ * <p>The wire type {@code B} may be a record or a bean-shaped class (issue #628): a mutable class
+ * with a no-args constructor and getters/setters, or an immutable one with a builder. The bean is
+ * read through getters and written through setters or a builder; every reference-typed read is
+ * null-guarded, so an unset property parses to a located {@code FieldError} rather than throwing.
+ * The domain type {@code A} stays a record (or a sealed interface of records), since {@code parse}
+ * assembles it through its canonical constructor.
+ *
+ * @param <A> the domain type (a record or a sealed interface of records)
+ * @param <B> the wire type (a record or a bean-shaped class)
  */
 public interface MappingSpec<A, B> {}

--- a/hkj-book/src/optics/record_mapping.md
+++ b/hkj-book/src/optics/record_mapping.md
@@ -190,7 +190,33 @@ The overloads follow the tiers:
 A spec with a derived field *and* a fallible leaf is better served by the fallible overload, given a parseable wire value whose derived components match what `build` would produce (this keeps the no-parse check). Reserve the domain-sample overload for total-parse mappings, where no wire value can fail.
 
 ~~~admonish tip title="Mapping types you don't own"
-The annotation sits on *your* spec interface, never on the mapped types, so third-party records and sealed hierarchies from compiled libraries map without being annotatable: `interface VendorOrderMapping extends MappingSpec<com.vendor.OrderRecord, OrderDto> {}` works today. Bean-shaped foreign types (getter/setter DTOs) are the one un-owned shape that the mapping processor does not currently support.
+The annotation sits on *your* spec interface, never on the mapped types, so third-party records, sealed hierarchies, and bean-shaped DTOs from compiled libraries map without being annotatable: `interface VendorOrderMapping extends MappingSpec<com.vendor.OrderRecord, OrderDto> {}` works today. Bean-shaped wire types (getter/setter DTOs) are covered too; see [Bean-shaped wire targets](#bean-shaped-wire-targets) below.
+~~~
+
+---
+
+## Bean-shaped wire targets
+
+The wire side need not be a record. A **bean** (a mutable class with a no-args constructor and getters/setters, or an immutable one with a builder) maps the same way, with the same features (renames, leaves, derived fields, container lifting, nesting). Only *how* the wire is read and written changes: `build` fills through setters or a builder, and `parse` reads through getters.
+
+``` java
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:bean_spec}}
+```
+
+``` java
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:bean_usage}}
+```
+
+The design decisions worth knowing:
+
+- **Null is located, never thrown.** An unset bean property is `null`, and a leaf's `parse` rejects `null`. So every reference-typed read is null-guarded: a `null` becomes a located `FieldError` (`must not be null`) under the field's label, and `parse` stays total and accumulating. A `null` never reaches a leaf. Primitive reads are never null and need no guard.
+- **Honest tiers.** Those null guards make reference components fallible, so a bean mapping withholds `asIso()` automatically; an all-primitive bean (whose reads can never be null) still earns it. Nesting is unaffected: a bean mapping exposes `asValidatedPrism()` like any other, so record specs nest it and containers lift it.
+- **Construction strategy** is detected from the bean's shape, tried in order: a public no-args constructor with `setX` setters (and, for a getter-only `List`, the JAXB convention `getItems().addAll(...)`); then a static `builder()`/`newBuilder()` whose setters fill it and whose `build()` yields the wire. A bean that fits neither gets a what/why/fix diagnostic.
+- **Optionality bridges through `null`.** Beans never declare `Optional`, so a domain `Optional<T>` maps to a nullable bean property `T`: empty bridges to absent (`build` skips the write, leaving the property unset; `parse` reads `Optional.ofNullable(...)`), and a present value still validates through its leaf.
+- **The domain stays a record.** `parse` assembles the domain through its canonical constructor, so only the *wire* may be bean-shaped; a bean domain gets a diagnostic.
+
+~~~admonish note title="Not yet: bean projections and read-only beans"
+A bean *projection* (a bean with fewer properties than the domain) with a reference property, and read-only (parse-only) or write-only (build-only) beans, are follow-ons. An all-primitive bean projection maps as a lawful `asLens()` today; a reference-typed one is reported with a pointer to the planned validated-`patch` tier rather than emitting an unlawful lens.
 ~~~
 
 ---

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -28,6 +28,10 @@ _Breaking changes / migration:_
 - **A JWT whose authorities claim is missing or malformed is now rejected with `BadCredentialsException` (HTTP 401)** rather than authenticating with empty authorities. If your IdP legitimately issues role-less tokens, set `hkj.security.reject-missing-authorities-claim: false` to restore lenient handling for the missing-claim case (a malformed claim is always rejected).
 - **Effect-boundary interpreter resolution now fails fast at startup** on an ambiguous match (two equally-specific eligible interpreters for one algebra) or when the only interpreter for an algebra is gated behind an inactive `@Interpreter(profile = ...)`. Both were previously silent scan-order selections.
 
+**Bean-shaped `@GenerateMapping` wire targets ([#628](https://github.com/higher-kinded-j/higher-kinded-j/issues/628))**
+
+`@GenerateMapping` now maps a record domain to a **bean-shaped wire**, not only a record: a mutable class with a no-args constructor and getters/setters, or an immutable one with a builder (`builder()`/`newBuilder()`), with the JAXB getter-only collection convention (`getItems().addAll(...)`) also recognised. The full feature set carries over: renames, leaves, derived fields, `List`/`Optional`/`Map` lifting, and nesting both ways. Because an unset bean property is `null`, every reference-typed `parse` read is null-guarded into a located `FieldError`, so `parse` stays total and accumulating; those guards make `asIso()` truthful only for an all-primitive bean. A domain `Optional<T>` bridges to a nullable bean property `T` (empty to absent). See [Bean-shaped wire targets](optics/record_mapping.md#bean-shaped-wire-targets). The validated-`patch` projection tier, read-only/write-only bean tiers, and Optional-through-nested-spec bridging remain follow-ons.
+
 ---
 
 ### [v0.4.8](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.8) (17 July 2026)

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java
@@ -67,6 +67,16 @@ public final class RecordMappingBook {
     // ANCHOR_END: projection_usage
     System.out.println(moved);
 
+    // ANCHOR: bean_usage
+    Customer ada = new Customer("Ada", new EmailAddress("ada@corp.example"));
+    ContactBean bean =
+        ContactMappingImpl.INSTANCE.build(ada); // new ContactBean(); setName; setEmail
+    Validated<NonEmptyList<FieldError>, Customer> fromBean =
+        ContactMappingImpl.INSTANCE.parse(bean);
+    // A null bean property parses to a located FieldError, e.g. [email: must not be null].
+    // ANCHOR_END: bean_usage
+    System.out.println(bean.getName() + " / " + fromBean);
+
     // ANCHOR: merge_usage
     Dashboard dashboard =
         DashboardAssemblyImpl.INSTANCE.assemble(
@@ -207,6 +217,40 @@ interface DashboardAssembly {
 }
 
 // ANCHOR_END: merge_spec
+
+// ANCHOR: bean_spec
+// A generated, mutable getter/setter DTO - not a record, so not annotatable. The spec still sits
+// on your interface, never on the bean, so a third-party bean maps without being touched.
+class ContactBean {
+  private String name;
+  private String email;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}
+
+@GenerateMapping
+interface ContactMapping extends MappingSpec<Customer, ContactBean> {
+  // build() writes through setters; parse() reads through getters, null-guarded and located.
+  default ValidatedPrism<String, EmailAddress> email() {
+    return EmailCodecs.EMAIL;
+  }
+}
+
+// ANCHOR_END: bean_spec
 
 // ANCHOR: nested_merge_spec
 record Wrapper(CustomerDto customer) {} // the wire side

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/BeanBoundaryExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/BeanBoundaryExample.java
@@ -1,0 +1,152 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.annotations.GenerateMapping;
+import org.higherkindedj.optics.annotations.MappingSpec;
+import org.higherkindedj.optics.validated.ValidatedPrism;
+
+/**
+ * A small end-to-end story for bean-shaped wire targets (issue #628): mapping a domain record
+ * across an I/O boundary where the wire is a <em>bean</em>, not a record.
+ *
+ * <p>Real boundaries hand you bean-shaped DTOs, not records: a JSON/JAXB/protobuf binder fills a
+ * mutable getter/setter request object on the way in, and you build an immutable response (often
+ * via a builder) on the way out. {@code @GenerateMapping} maps both directions with the same spec
+ * you would write for a record wire; only how the bean is read (getters) and written (setters or a
+ * builder) changes.
+ *
+ * <ul>
+ *   <li><b>Inbound</b>: {@code parse(UserRequest)} reads the mutable request through its getters
+ *       and accumulates every problem, located by field. An unset property is {@code null}, so each
+ *       reference read is null-guarded into a located {@code FieldError} rather than throwing.
+ *   <li><b>Outbound</b>: {@code build(User)} fills an immutable {@code UserView} through its {@code
+ *       builder()}.
+ * </ul>
+ *
+ * <p>The annotation sits on the spec, never on the DTOs, so the DTOs could be third-party generated
+ * types you do not own. {@code BeanBoundaryExampleTest} law-checks both mappings through {@code
+ * MappingLaws}.
+ */
+public final class BeanBoundaryExample {
+
+  public record EmailAddress(String value) {}
+
+  public record User(String name, EmailAddress email) {}
+
+  /** Inbound: a mutable getter/setter request DTO, as a JSON or form binder would populate it. */
+  public static final class UserRequest {
+    private String name;
+    private String email;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public void setEmail(String email) {
+      this.email = email;
+    }
+  }
+
+  @GenerateMapping
+  public interface UserRequestMapping extends MappingSpec<User, UserRequest> {
+    default ValidatedPrism<String, EmailAddress> email() {
+      return emailPrism();
+    }
+  }
+
+  /** Outbound: an immutable response DTO built through a static {@code builder()}. */
+  public static final class UserView {
+    private final String name;
+    private final String email;
+
+    private UserView(String name, String email) {
+      this.name = name;
+      this.email = email;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static final class Builder {
+      private String name;
+      private String email;
+
+      public Builder name(String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Builder email(String email) {
+        this.email = email;
+        return this;
+      }
+
+      public UserView build() {
+        return new UserView(name, email);
+      }
+    }
+  }
+
+  @GenerateMapping
+  public interface UserViewMapping extends MappingSpec<User, UserView> {
+    default ValidatedPrism<String, EmailAddress> email() {
+      return emailPrism();
+    }
+  }
+
+  static ValidatedPrism<String, EmailAddress> emailPrism() {
+    return ValidatedPrism.of(
+        raw ->
+            raw.contains("@")
+                ? Validated.validNel(new EmailAddress(raw))
+                : Validated.invalidNel(FieldError.of("not an email address")),
+        EmailAddress::value);
+  }
+
+  public static void main(String[] args) {
+    System.out.println("=== Inbound: parse a mutable request DTO ===");
+    UserRequest good = new UserRequest();
+    good.setName("Ada");
+    good.setEmail("ada@corp.example");
+    System.out.println(
+        "Valid request:   " + BeanBoundaryExampleUserRequestMappingImpl.INSTANCE.parse(good));
+
+    UserRequest bad = new UserRequest();
+    bad.setEmail("not-an-email"); // name left unset (null)
+    System.out.println(
+        "Bad request:     " + BeanBoundaryExampleUserRequestMappingImpl.INSTANCE.parse(bad));
+    System.out.println(
+        "Expected: Valid(User) for the good one; for the bad one, BOTH problems at once - the unset"
+            + " name located as \"name\" (must not be null) and the malformed \"email\" - never a"
+            + " thrown NullPointerException\n");
+
+    System.out.println("=== Outbound: build an immutable view DTO via its builder ===");
+    User ada = new User("Ada", new EmailAddress("ada@corp.example"));
+    UserView view = BeanBoundaryExampleUserViewMappingImpl.INSTANCE.build(ada);
+    System.out.println(
+        "Built view:      UserView[name=" + view.getName() + ", email=" + view.getEmail() + "]");
+    System.out.println("Expected: UserView constructed through UserView.builder()");
+  }
+
+  private BeanBoundaryExample() {}
+}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/GenerateMappingExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/GenerateMappingExample.java
@@ -25,8 +25,10 @@ import org.higherkindedj.optics.validated.ValidatedPrism;
  * key); a derived wire field (a {@code Getter} default method filled on {@code build} and ignored
  * by {@code parse}); nesting (a spec delegating to a sibling spec, failures located by dotted
  * path); a self-recursive mapping over a tree; sealed-interface dispatch over permitted subtype
- * pairs; and a lossy projection (Lens tier) whose {@code asLens()} writes the projected components
- * back.
+ * pairs; a lossy projection (Lens tier) whose {@code asLens()} writes the projected components
+ * back; and bean-shaped wire targets (issue #628) - a mutable getter/setter DTO and an immutable
+ * builder DTO - where {@code build} fills through setters or a builder and {@code parse} reads
+ * through getters, null-guarding every reference read into a located {@code FieldError}.
  *
  * <p>The law-checked guarantee is runnable too: {@code GenerateMappingExampleLawsTest} in this
  * module's test sources law-checks every mapping below through the published {@code MappingLaws}
@@ -162,6 +164,91 @@ public final class GenerateMappingExample {
   @GenerateMapping
   public interface EmployeeCardMapping extends MappingSpec<Employee, EmployeeCardDto> {}
 
+  public record Account(String owner, EmailAddress email) {}
+
+  // A mutable getter/setter DTO - the shape a JAXB, Jackson or OpenAPI generator emits. It is not a
+  // record and is not annotatable, yet it maps: build fills it through setters, parse reads it back
+  // through getters. An unset property is null, so every reference read is null-guarded (below).
+  public static final class AccountDto {
+    private String owner;
+    private String email;
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public void setOwner(String owner) {
+      this.owner = owner;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public void setEmail(String email) {
+      this.email = email;
+    }
+  }
+
+  @GenerateMapping
+  public interface AccountMapping extends MappingSpec<Account, AccountDto> {
+    default ValidatedPrism<String, EmailAddress> email() {
+      return ValidatedPrism.of(
+          raw ->
+              raw.contains("@")
+                  ? Validated.validNel(new EmailAddress(raw))
+                  : Validated.invalidNel(FieldError.of("not an email address")),
+          EmailAddress::value);
+    }
+  }
+
+  public record Point(int x, String label) {}
+
+  // An immutable bean built through a static builder() - the Lombok / Immutables / AutoValue shape.
+  public static final class PointDto {
+    private final int x;
+    private final String label;
+
+    private PointDto(int x, String label) {
+      this.x = x;
+      this.label = label;
+    }
+
+    public int getX() {
+      return x;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static final class Builder {
+      private int x;
+      private String label;
+
+      public Builder x(int x) {
+        this.x = x;
+        return this;
+      }
+
+      public Builder label(String label) {
+        this.label = label;
+        return this;
+      }
+
+      public PointDto build() {
+        return new PointDto(x, label);
+      }
+    }
+  }
+
+  @GenerateMapping
+  public interface PointMapping extends MappingSpec<Point, PointDto> {}
+
   public static void main(String[] args) {
     System.out.println("=== Validated Mapping Example ===");
     Customer ada = new Customer("Ada", new EmailAddress("ada@corp.example"));
@@ -290,7 +377,35 @@ public final class GenerateMappingExample {
     System.out.println("Written back: " + moved);
     System.out.println(
         "Expected: build drops age; asLens().set writes name and department back and keeps"
-            + " age=36");
+            + " age=36\n");
+
+    System.out.println("=== Bean-Shaped Wire Example (getters/setters, null-guarded parse) ===");
+    Account account = new Account("Ada", new EmailAddress("ada@corp.example"));
+    AccountDto accountDto = GenerateMappingExampleAccountMappingImpl.INSTANCE.build(account);
+    System.out.println(
+        "Built:        AccountDto[owner="
+            + accountDto.getOwner()
+            + ", email="
+            + accountDto.getEmail()
+            + "]");
+    System.out.println(
+        "Round trip:   " + GenerateMappingExampleAccountMappingImpl.INSTANCE.parse(accountDto));
+    AccountDto missing = new AccountDto();
+    missing.setOwner("Bob"); // email left unset (null)
+    System.out.println(
+        "Located fail: " + GenerateMappingExampleAccountMappingImpl.INSTANCE.parse(missing));
+    System.out.println(
+        "Expected: build via setters, Valid(round trip), and the unset email located at \"email\""
+            + " as must-not-be-null (a null never reaches the leaf)\n");
+
+    System.out.println("=== Builder-Based Bean Example (immutable DTO via builder()) ===");
+    Point origin = new Point(3, "origin");
+    PointDto pointDto = GenerateMappingExamplePointMappingImpl.INSTANCE.build(origin);
+    System.out.println(
+        "Built:        PointDto[x=" + pointDto.getX() + ", label=" + pointDto.getLabel() + "]");
+    System.out.println(
+        "Round trip:   " + GenerateMappingExamplePointMappingImpl.INSTANCE.parse(pointDto));
+    System.out.println("Expected: built through Point.builder(); the round trip is Valid");
   }
 
   private GenerateMappingExample() {}

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/GenerateMappingExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/GenerateMappingExample.java
@@ -405,7 +405,7 @@ public final class GenerateMappingExample {
         "Built:        PointDto[x=" + pointDto.getX() + ", label=" + pointDto.getLabel() + "]");
     System.out.println(
         "Round trip:   " + GenerateMappingExamplePointMappingImpl.INSTANCE.parse(pointDto));
-    System.out.println("Expected: built through Point.builder(); the round trip is Valid");
+    System.out.println("Expected: built through PointDto.builder(); the round trip is Valid");
   }
 
   private GenerateMappingExample() {}

--- a/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
@@ -53,7 +53,7 @@ class BookSnippetVerificationTest {
    * copy of it, so those snippets no longer need a marker. That is the only reason this number may
    * fall.
    */
-  private static final int MINIMUM_VERIFIED_SNIPPETS = 215;
+  private static final int MINIMUM_VERIFIED_SNIPPETS = 216;
 
   /**
    * Every documentation root whose code is verified. The book was the first; the skills are the

--- a/hkj-examples/src/test/java/org/higherkindedj/example/optics/BeanBoundaryExampleTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/optics/BeanBoundaryExampleTest.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.example.optics.BeanBoundaryExample.EmailAddress;
+import org.higherkindedj.example.optics.BeanBoundaryExample.User;
+import org.higherkindedj.example.optics.BeanBoundaryExample.UserRequest;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.optics.laws.MappingLaws;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link BeanBoundaryExample}: both bean mappings are law-checked through {@code
+ * MappingLaws}, and the inbound parse accumulates and locates problems (including an unset
+ * property) rather than throwing.
+ */
+@DisplayName("BeanBoundaryExample: bean DTOs at an I/O boundary")
+class BeanBoundaryExampleTest {
+
+  @Test
+  @DisplayName("inbound mapping: the domain round trip through the request bean is lawful")
+  void userRequestMappingIsLawful() {
+    // The bean has no value equals(), so the domain-sample overload is the comparable law:
+    // parse(build(user)) == Valid(user).
+    MappingLaws.assertMappingLaws(
+        BeanBoundaryExampleUserRequestMappingImpl.INSTANCE.asValidatedPrism(),
+        new User("Ada", new EmailAddress("ada@corp.example")));
+  }
+
+  @Test
+  @DisplayName("outbound mapping: the domain round trip through the builder view bean is lawful")
+  void userViewMappingIsLawful() {
+    MappingLaws.assertMappingLaws(
+        BeanBoundaryExampleUserViewMappingImpl.INSTANCE.asValidatedPrism(),
+        new User("Grace", new EmailAddress("grace@corp.example")));
+  }
+
+  @Test
+  @DisplayName("inbound parse accumulates every problem and locates an unset property, not an NPE")
+  void inboundParseAccumulatesAndLocates() {
+    UserRequest bad = new UserRequest();
+    bad.setEmail("not-an-email"); // name deliberately left unset (null)
+
+    var parsed = BeanBoundaryExampleUserRequestMappingImpl.INSTANCE.parse(bad);
+
+    assertThat(parsed.isInvalid()).isTrue();
+    assertThat(parsed.getError().toJavaList())
+        .containsExactly(
+            new FieldError(List.of("name"), "must not be null"),
+            new FieldError(List.of("email"), "not an email address"));
+  }
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/optics/GenerateMappingExampleLawsTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/optics/GenerateMappingExampleLawsTest.java
@@ -5,15 +5,18 @@ package org.higherkindedj.example.optics;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.higherkindedj.example.optics.GenerateMappingExample.Account;
 import org.higherkindedj.example.optics.GenerateMappingExample.Bank;
 import org.higherkindedj.example.optics.GenerateMappingExample.Card;
 import org.higherkindedj.example.optics.GenerateMappingExample.CustomerDto;
 import org.higherkindedj.example.optics.GenerateMappingExample.DirectoryDto;
+import org.higherkindedj.example.optics.GenerateMappingExample.EmailAddress;
 import org.higherkindedj.example.optics.GenerateMappingExample.Employee;
 import org.higherkindedj.example.optics.GenerateMappingExample.EmployeeCardDto;
 import org.higherkindedj.example.optics.GenerateMappingExample.InvoiceDto;
 import org.higherkindedj.example.optics.GenerateMappingExample.Person;
 import org.higherkindedj.example.optics.GenerateMappingExample.PersonDto;
+import org.higherkindedj.example.optics.GenerateMappingExample.Point;
 import org.higherkindedj.example.optics.GenerateMappingExample.Profile;
 import org.higherkindedj.example.optics.GenerateMappingExample.TeamDto;
 import org.higherkindedj.example.optics.GenerateMappingExample.Tree;
@@ -115,5 +118,22 @@ class GenerateMappingExampleLawsTest {
         new Employee("Ada", "Engineering", 36),
         new EmployeeCardDto("Grace", "Compilers"),
         new EmployeeCardDto("Alan", "Computing"));
+  }
+
+  @Test
+  @DisplayName("bean tier: AccountMapping's domain round trip is lawful (the bean has no equals)")
+  void accountMappingIsLawful() {
+    // A bean wire has no value equals(), so only the domain round trip is comparable: the
+    // domain-sample overload asserts parse(build(account)) == Valid(account).
+    MappingLaws.assertMappingLaws(
+        GenerateMappingExampleAccountMappingImpl.INSTANCE.asValidatedPrism(),
+        new Account("Ada", new EmailAddress("ada@corp.example")));
+  }
+
+  @Test
+  @DisplayName("builder-bean tier: PointMapping's domain round trip is lawful")
+  void pointMappingIsLawful() {
+    MappingLaws.assertMappingLaws(
+        GenerateMappingExamplePointMappingImpl.INSTANCE.asValidatedPrism(), new Point(3, "origin"));
   }
 }

--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -100,6 +100,8 @@ tasks.jacocoTestCoverageVerification {
                 "org.higherkindedj.optics.processing.ErrorEnvelopeProcessor*",
                 "org.higherkindedj.optics.processing.MappingProcessor*",
                 "org.higherkindedj.optics.processing.MergeProcessor*",
+                "org.higherkindedj.optics.processing.BeanPropertyAnalyser*",
+                "org.higherkindedj.optics.processing.WireShape*",
             )
             limit {
                 counter = "LINE"

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
@@ -25,8 +25,8 @@ import org.higherkindedj.optics.processing.util.Diagnostics;
  * of a fixed ladder of strategies, tried in order:
  *
  * <ol>
- *   <li>a public no-args constructor with {@code setX} setters (and, for a getter-only {@code
- *       List}, the JAXB collection convention {@code getX().addAll(...)});
+ *   <li>a no-args constructor with {@code setX} setters (and, for a getter-only {@code List}, the
+ *       JAXB collection convention {@code getX().addAll(...)});
  *   <li>a builder: a static {@code builder()} or {@code newBuilder()} returning a builder whose
  *       property-named or {@code setX} setters fill it and whose {@code build()} yields the wire.
  * </ol>
@@ -55,7 +55,7 @@ final class BeanPropertyAnalyser {
   WireShape.BeanShape analyse(TypeElement spec, TypeElement bean, String tag) {
     Map<String, ExecutableElement> getters = collectGetters(bean);
 
-    if (hasPublicNoArgsConstructor(bean)) {
+    if (hasUsableNoArgsConstructor(bean)) {
       Map<String, ExecutableElement> setters = collectSetters(bean);
       List<WireShape.BeanProperty> properties = new ArrayList<>();
       for (Map.Entry<String, ExecutableElement> entry : getters.entrySet()) {
@@ -121,7 +121,7 @@ final class BeanPropertyAnalyser {
   /** The number of mappable properties under the selected strategy, for the parse arithmetic. */
   int propertyCount(TypeElement bean) {
     Map<String, ExecutableElement> getters = collectGetters(bean);
-    if (hasPublicNoArgsConstructor(bean)) {
+    if (hasUsableNoArgsConstructor(bean)) {
       Map<String, ExecutableElement> setters = collectSetters(bean);
       long count =
           getters.entrySet().stream()
@@ -274,7 +274,7 @@ final class BeanPropertyAnalyser {
         "'"
             + bean.getSimpleName()
             + "' is not a usable bean-shaped wire: no construction strategy fits it.",
-        "The mapper fills a bean through a public no-args constructor with getX/setX pairs (or a"
+        "The mapper fills a bean through a no-args constructor with getX/setX pairs (or a"
             + " getter-only List, filled with getX().addAll(...)), or through a static"
             + " builder()/newBuilder() whose setters fill it and whose build() yields the wire; '"
             + bean.getSimpleName()
@@ -314,9 +314,14 @@ final class BeanPropertyAnalyser {
     return setter.getParameters().getFirst().asType();
   }
 
-  private boolean hasPublicNoArgsConstructor(TypeElement bean) {
+  /**
+   * A no-args constructor the generated impl can call. The impl is emitted in the spec's package,
+   * so any non-private constructor of a co-located bean is reachable; a public one is reachable
+   * from any package (as a compiled third-party bean's would be).
+   */
+  private boolean hasUsableNoArgsConstructor(TypeElement bean) {
     return ElementFilter.constructorsIn(bean.getEnclosedElements()).stream()
-        .anyMatch(c -> c.getParameters().isEmpty() && c.getModifiers().contains(Modifier.PUBLIC));
+        .anyMatch(c -> c.getParameters().isEmpty() && !c.getModifiers().contains(Modifier.PRIVATE));
   }
 
   /** The JavaBeans {@code Introspector.decapitalize} rule: {@code getURL} -> {@code URL}. */

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import org.higherkindedj.optics.processing.util.Diagnostics;
+
+/**
+ * Discovers the JavaBeans property model of a bean-shaped wire type for {@code @GenerateMapping}
+ * (issue #628). A slice-B bean is a mutable JavaBean: a public no-args constructor plus canonical
+ * {@code getX}/{@code isX} getters paired with {@code setX} setters. The property set is the
+ * intersection of readable and writable names — the canonical mutable property — so a computed
+ * getter with no setter, or a setter with no getter, is not treated as a mappable component.
+ *
+ * <p>Getters and setters are gathered from {@link javax.lang.model.util.Elements#getAllMembers}, so
+ * a bean inherits properties from its superclasses (as JAXB-generated beans do); methods declared
+ * on {@link Object} (notably {@code getClass}) and non-public or static methods are excluded.
+ */
+final class BeanPropertyAnalyser {
+
+  private final ProcessingEnvironment env;
+
+  BeanPropertyAnalyser(ProcessingEnvironment env) {
+    this.env = env;
+  }
+
+  /**
+   * Analyses {@code bean} into a {@link WireShape.BeanShape}, or reports a what/why/fix diagnostic
+   * and returns null. Reports when a getter and setter disagree on type, or when the bean is
+   * neither constructible (no no-args constructor) nor has any mappable property.
+   */
+  WireShape.BeanShape analyse(TypeElement spec, TypeElement bean, String tag) {
+    Map<String, ExecutableElement> getters = new LinkedHashMap<>();
+    Map<String, ExecutableElement> setters = new LinkedHashMap<>();
+    collectAccessors(bean, getters, setters);
+
+    List<WireShape.BeanProperty> properties = new ArrayList<>();
+    for (Map.Entry<String, ExecutableElement> entry : getters.entrySet()) {
+      String name = entry.getKey();
+      ExecutableElement setter = setters.get(name);
+      if (setter == null) {
+        continue; // getter-only: a computed/read-only property (degraded tiers arrive in slice D).
+      }
+      TypeMirror getterType = entry.getValue().getReturnType();
+      TypeMirror setterType = setter.getParameters().getFirst().asType();
+      if (!env.getTypeUtils().isSameType(getterType, setterType)) {
+        Diagnostics.error(
+            env.getMessager(),
+            spec,
+            tag,
+            "bean property '"
+                + name
+                + "' on '"
+                + bean.getSimpleName()
+                + "' has a getter and setter of different types ("
+                + getterType
+                + " vs "
+                + setterType
+                + ").",
+            "A mappable property has one type; the mapper cannot guess which of the two the"
+                + " component should carry.",
+            "Align the getter and setter types on the bean, or drop one of them.");
+        return null;
+      }
+      properties.add(
+          new WireShape.BeanProperty(
+              name,
+              getterType,
+              entry.getValue().getSimpleName().toString(),
+              setter.getSimpleName().toString()));
+    }
+
+    if (!hasPublicNoArgsConstructor(bean) || properties.isEmpty()) {
+      Diagnostics.error(
+          env.getMessager(),
+          spec,
+          tag,
+          "'"
+              + bean.getSimpleName()
+              + "' is not a usable bean-shaped wire: it needs a public no-args constructor and at"
+              + " least one getter/setter property pair.",
+          "The mapper builds the wire with 'new "
+              + bean.getSimpleName()
+              + "()' and fills it through setters, reading it back through getters; "
+              + bean.getSimpleName()
+              + (hasPublicNoArgsConstructor(bean)
+                  ? " exposes no getter/setter property pair."
+                  : " has no public no-args constructor."),
+          "Give it a public no-args constructor and matching getX/setX pairs, use a record, or a"
+              + " builder-based bean (support arrives with the builder strategy).");
+      return null;
+    }
+    return new WireShape.BeanShape(
+        bean, properties, new WireShape.ConstructionStrategy.NoArgsSetters());
+  }
+
+  /** The number of canonical getter/setter property pairs, for the registry's parse arithmetic. */
+  int propertyCount(TypeElement bean) {
+    Map<String, ExecutableElement> getters = new LinkedHashMap<>();
+    Map<String, ExecutableElement> setters = new LinkedHashMap<>();
+    collectAccessors(bean, getters, setters);
+    return (int) getters.keySet().stream().filter(setters::containsKey).count();
+  }
+
+  private void collectAccessors(
+      TypeElement bean,
+      Map<String, ExecutableElement> getters,
+      Map<String, ExecutableElement> setters) {
+    for (Element member : env.getElementUtils().getAllMembers(bean)) {
+      if (member.getKind() != ElementKind.METHOD) {
+        continue;
+      }
+      ExecutableElement method = (ExecutableElement) member;
+      Set<Modifier> modifiers = method.getModifiers();
+      if (!modifiers.contains(Modifier.PUBLIC) || modifiers.contains(Modifier.STATIC)) {
+        continue;
+      }
+      if (declaredOnObject(method)) {
+        continue;
+      }
+      String methodName = method.getSimpleName().toString();
+      int params = method.getParameters().size();
+      if (params == 0 && method.getReturnType().getKind() != TypeKind.VOID) {
+        if (methodName.length() > 3 && methodName.startsWith("get")) {
+          getters.putIfAbsent(decapitalise(methodName.substring(3)), method);
+        } else if (methodName.length() > 2
+            && methodName.startsWith("is")
+            && method.getReturnType().getKind() == TypeKind.BOOLEAN) {
+          // The JavaBeans 'is' getter is for primitive boolean only.
+          getters.putIfAbsent(decapitalise(methodName.substring(2)), method);
+        }
+      } else if (params == 1 && methodName.length() > 3 && methodName.startsWith("set")) {
+        // Void or fluent (returns the bean) setters both work: build calls the setter as a
+        // statement, discarding any fluent return.
+        setters.putIfAbsent(decapitalise(methodName.substring(3)), method);
+      }
+    }
+  }
+
+  private boolean declaredOnObject(ExecutableElement method) {
+    Element enclosing = method.getEnclosingElement();
+    return enclosing instanceof TypeElement type
+        && type.getQualifiedName().contentEquals("java.lang.Object");
+  }
+
+  private boolean hasPublicNoArgsConstructor(TypeElement bean) {
+    return ElementFilter.constructorsIn(bean.getEnclosedElements()).stream()
+        .anyMatch(c -> c.getParameters().isEmpty() && c.getModifiers().contains(Modifier.PUBLIC));
+  }
+
+  /** The JavaBeans {@code Introspector.decapitalize} rule: {@code getURL} -> {@code URL}. */
+  static String decapitalise(String name) {
+    if (name.isEmpty()) {
+      return name;
+    }
+    if (name.length() > 1
+        && Character.isUpperCase(name.charAt(0))
+        && Character.isUpperCase(name.charAt(1))) {
+      return name;
+    }
+    char[] chars = name.toCharArray();
+    chars[0] = Character.toLowerCase(chars[0]);
+    return new String(chars);
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
@@ -55,7 +55,7 @@ final class BeanPropertyAnalyser {
   WireShape.BeanShape analyse(TypeElement spec, TypeElement bean, String tag) {
     Map<String, ExecutableElement> getters = collectGetters(bean);
 
-    if (hasUsableNoArgsConstructor(bean)) {
+    if (hasUsableNoArgsConstructor(spec, bean)) {
       Map<String, ExecutableElement> setters = collectSetters(bean);
       List<WireShape.BeanProperty> properties = new ArrayList<>();
       for (Map.Entry<String, ExecutableElement> entry : getters.entrySet()) {
@@ -119,9 +119,9 @@ final class BeanPropertyAnalyser {
   }
 
   /** The number of mappable properties under the selected strategy, for the parse arithmetic. */
-  int propertyCount(TypeElement bean) {
+  int propertyCount(TypeElement spec, TypeElement bean) {
     Map<String, ExecutableElement> getters = collectGetters(bean);
-    if (hasUsableNoArgsConstructor(bean)) {
+    if (hasUsableNoArgsConstructor(spec, bean)) {
       Map<String, ExecutableElement> setters = collectSetters(bean);
       long count =
           getters.entrySet().stream()
@@ -315,13 +315,21 @@ final class BeanPropertyAnalyser {
   }
 
   /**
-   * A no-args constructor the generated impl can call. The impl is emitted in the spec's package,
-   * so any non-private constructor of a co-located bean is reachable; a public one is reachable
-   * from any package (as a compiled third-party bean's would be).
+   * A no-args constructor the generated impl can call. The impl is emitted in the <em>spec's</em>
+   * package, so a public constructor is always reachable (as a compiled third-party bean's would
+   * be), while a {@code protected} or package-private one is reachable only when the bean is
+   * co-located with the spec. A non-public constructor on a bean in another package would make
+   * {@code new Wire()} illegal in the generated impl, so it is not treated as usable.
    */
-  private boolean hasUsableNoArgsConstructor(TypeElement bean) {
+  private boolean hasUsableNoArgsConstructor(TypeElement spec, TypeElement bean) {
+    boolean samePackage =
+        env.getElementUtils().getPackageOf(spec).equals(env.getElementUtils().getPackageOf(bean));
     return ElementFilter.constructorsIn(bean.getEnclosedElements()).stream()
-        .anyMatch(c -> c.getParameters().isEmpty() && !c.getModifiers().contains(Modifier.PRIVATE));
+        .anyMatch(
+            c ->
+                c.getParameters().isEmpty()
+                    && (c.getModifiers().contains(Modifier.PUBLIC)
+                        || (samePackage && !c.getModifiers().contains(Modifier.PRIVATE))));
   }
 
   /** The JavaBeans {@code Introspector.decapitalize} rule: {@code getURL} -> {@code URL}. */

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
@@ -237,10 +237,11 @@ final class BeanPropertyAnalyser {
     if (factory == null) {
       factory = builderFactory(bean, "newBuilder");
     }
-    if (factory == null || !(factory.getReturnType() instanceof DeclaredType builderMirror)) {
+    if (factory == null) {
       return null;
     }
-    TypeElement builderType = (TypeElement) builderMirror.asElement();
+    // builderFactory only returns a factory whose return kind is DECLARED, so the cast is total.
+    TypeElement builderType = (TypeElement) ((DeclaredType) factory.getReturnType()).asElement();
     boolean buildsWire =
         publicInstanceMethods(builderType).stream()
             .anyMatch(
@@ -300,9 +301,10 @@ final class BeanPropertyAnalyser {
   }
 
   private boolean declaredOnObject(ExecutableElement method) {
-    Element enclosing = method.getEnclosingElement();
-    return enclosing instanceof TypeElement type
-        && type.getQualifiedName().contentEquals("java.lang.Object");
+    // A method's enclosing element is always the declaring type.
+    return ((TypeElement) method.getEnclosingElement())
+        .getQualifiedName()
+        .contentEquals("java.lang.Object");
   }
 
   private boolean isList(TypeMirror type) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/BeanPropertyAnalyser.java
@@ -13,6 +13,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -20,16 +21,25 @@ import org.higherkindedj.optics.processing.util.Diagnostics;
 
 /**
  * Discovers the JavaBeans property model of a bean-shaped wire type for {@code @GenerateMapping}
- * (issue #628). A slice-B bean is a mutable JavaBean: a public no-args constructor plus canonical
- * {@code getX}/{@code isX} getters paired with {@code setX} setters. The property set is the
- * intersection of readable and writable names — the canonical mutable property — so a computed
- * getter with no setter, or a setter with no getter, is not treated as a mappable component.
+ * (issue #628). A bean is read through {@code getX}/{@code isX} getters and constructed through one
+ * of a fixed ladder of strategies, tried in order:
  *
- * <p>Getters and setters are gathered from {@link javax.lang.model.util.Elements#getAllMembers}, so
- * a bean inherits properties from its superclasses (as JAXB-generated beans do); methods declared
- * on {@link Object} (notably {@code getClass}) and non-public or static methods are excluded.
+ * <ol>
+ *   <li>a public no-args constructor with {@code setX} setters (and, for a getter-only {@code
+ *       List}, the JAXB collection convention {@code getX().addAll(...)});
+ *   <li>a builder: a static {@code builder()} or {@code newBuilder()} returning a builder whose
+ *       property-named or {@code setX} setters fill it and whose {@code build()} yields the wire.
+ * </ol>
+ *
+ * <p>The mapped property set is the intersection of readable and writable names, so a computed
+ * getter with no writer is not treated as a mappable component. Getters and setters are gathered
+ * from {@link javax.lang.model.util.Elements#getAllMembers}, so a bean inherits properties from its
+ * superclasses (as JAXB-generated beans do); {@link Object} methods and non-public or static
+ * accessors are excluded.
  */
 final class BeanPropertyAnalyser {
+
+  private static final String LIST = "java.util.List";
 
   private final ProcessingEnvironment env;
 
@@ -39,121 +49,269 @@ final class BeanPropertyAnalyser {
 
   /**
    * Analyses {@code bean} into a {@link WireShape.BeanShape}, or reports a what/why/fix diagnostic
-   * and returns null. Reports when a getter and setter disagree on type, or when the bean is
-   * neither constructible (no no-args constructor) nor has any mappable property.
+   * and returns null. Reports when a getter and its writer disagree on type, or when the bean is
+   * neither a mutable JavaBean nor a builder-based bean with a readable property.
    */
   WireShape.BeanShape analyse(TypeElement spec, TypeElement bean, String tag) {
-    Map<String, ExecutableElement> getters = new LinkedHashMap<>();
-    Map<String, ExecutableElement> setters = new LinkedHashMap<>();
-    collectAccessors(bean, getters, setters);
+    Map<String, ExecutableElement> getters = collectGetters(bean);
 
-    List<WireShape.BeanProperty> properties = new ArrayList<>();
-    for (Map.Entry<String, ExecutableElement> entry : getters.entrySet()) {
-      String name = entry.getKey();
-      ExecutableElement setter = setters.get(name);
-      if (setter == null) {
-        continue; // getter-only: a computed/read-only property (degraded tiers arrive in slice D).
-      }
-      TypeMirror getterType = entry.getValue().getReturnType();
-      TypeMirror setterType = setter.getParameters().getFirst().asType();
-      if (!env.getTypeUtils().isSameType(getterType, setterType)) {
-        Diagnostics.error(
-            env.getMessager(),
-            spec,
-            tag,
-            "bean property '"
-                + name
-                + "' on '"
-                + bean.getSimpleName()
-                + "' has a getter and setter of different types ("
-                + getterType
-                + " vs "
-                + setterType
-                + ").",
-            "A mappable property has one type; the mapper cannot guess which of the two the"
-                + " component should carry.",
-            "Align the getter and setter types on the bean, or drop one of them.");
-        return null;
-      }
-      properties.add(
-          new WireShape.BeanProperty(
-              name,
-              getterType,
-              entry.getValue().getSimpleName().toString(),
-              setter.getSimpleName().toString()));
-    }
-
-    if (!hasPublicNoArgsConstructor(bean) || properties.isEmpty()) {
-      Diagnostics.error(
-          env.getMessager(),
-          spec,
-          tag,
-          "'"
-              + bean.getSimpleName()
-              + "' is not a usable bean-shaped wire: it needs a public no-args constructor and at"
-              + " least one getter/setter property pair.",
-          "The mapper builds the wire with 'new "
-              + bean.getSimpleName()
-              + "()' and fills it through setters, reading it back through getters; "
-              + bean.getSimpleName()
-              + (hasPublicNoArgsConstructor(bean)
-                  ? " exposes no getter/setter property pair."
-                  : " has no public no-args constructor."),
-          "Give it a public no-args constructor and matching getX/setX pairs, use a record, or a"
-              + " builder-based bean (support arrives with the builder strategy).");
-      return null;
-    }
-    return new WireShape.BeanShape(
-        bean, properties, new WireShape.ConstructionStrategy.NoArgsSetters());
-  }
-
-  /** The number of canonical getter/setter property pairs, for the registry's parse arithmetic. */
-  int propertyCount(TypeElement bean) {
-    Map<String, ExecutableElement> getters = new LinkedHashMap<>();
-    Map<String, ExecutableElement> setters = new LinkedHashMap<>();
-    collectAccessors(bean, getters, setters);
-    return (int) getters.keySet().stream().filter(setters::containsKey).count();
-  }
-
-  private void collectAccessors(
-      TypeElement bean,
-      Map<String, ExecutableElement> getters,
-      Map<String, ExecutableElement> setters) {
-    for (Element member : env.getElementUtils().getAllMembers(bean)) {
-      if (member.getKind() != ElementKind.METHOD) {
-        continue;
-      }
-      ExecutableElement method = (ExecutableElement) member;
-      Set<Modifier> modifiers = method.getModifiers();
-      if (!modifiers.contains(Modifier.PUBLIC) || modifiers.contains(Modifier.STATIC)) {
-        continue;
-      }
-      if (declaredOnObject(method)) {
-        continue;
-      }
-      String methodName = method.getSimpleName().toString();
-      int params = method.getParameters().size();
-      if (params == 0 && method.getReturnType().getKind() != TypeKind.VOID) {
-        if (methodName.length() > 3 && methodName.startsWith("get")) {
-          getters.putIfAbsent(decapitalise(methodName.substring(3)), method);
-        } else if (methodName.length() > 2
-            && methodName.startsWith("is")
-            && method.getReturnType().getKind() == TypeKind.BOOLEAN) {
-          // The JavaBeans 'is' getter is for primitive boolean only.
-          getters.putIfAbsent(decapitalise(methodName.substring(2)), method);
+    if (hasPublicNoArgsConstructor(bean)) {
+      Map<String, ExecutableElement> setters = collectSetters(bean);
+      List<WireShape.BeanProperty> properties = new ArrayList<>();
+      for (Map.Entry<String, ExecutableElement> entry : getters.entrySet()) {
+        String name = entry.getKey();
+        TypeMirror getterType = entry.getValue().getReturnType();
+        String getter = entry.getValue().getSimpleName().toString();
+        ExecutableElement setter = setters.get(name);
+        if (setter != null) {
+          if (typesDiffer(spec, bean, tag, name, getterType, paramType(setter))) {
+            return null;
+          }
+          properties.add(
+              new WireShape.BeanProperty(
+                  name,
+                  getterType,
+                  getter,
+                  new WireShape.WriteSite.Setter(setter.getSimpleName().toString())));
+        } else if (isList(getterType)) {
+          properties.add(
+              new WireShape.BeanProperty(
+                  name, getterType, getter, new WireShape.WriteSite.CollectionAdd(getter)));
         }
-      } else if (params == 1 && methodName.length() > 3 && methodName.startsWith("set")) {
+      }
+      if (!properties.isEmpty()) {
+        return new WireShape.BeanShape(
+            bean, properties, new WireShape.ConstructionStrategy.NoArgsSetters());
+      }
+    }
+
+    BuilderModel builder = findBuilderModel(bean);
+    if (builder != null) {
+      Map<String, ExecutableElement> builderSetters = collectBuilderSetters(builder.builderType());
+      List<WireShape.BeanProperty> properties = new ArrayList<>();
+      for (Map.Entry<String, ExecutableElement> entry : getters.entrySet()) {
+        String name = entry.getKey();
+        ExecutableElement builderSetter = builderSetters.get(name);
+        if (builderSetter == null) {
+          continue;
+        }
+        TypeMirror getterType = entry.getValue().getReturnType();
+        if (typesDiffer(spec, bean, tag, name, getterType, paramType(builderSetter))) {
+          return null;
+        }
+        properties.add(
+            new WireShape.BeanProperty(
+                name,
+                getterType,
+                entry.getValue().getSimpleName().toString(),
+                new WireShape.WriteSite.Setter(builderSetter.getSimpleName().toString())));
+      }
+      if (!properties.isEmpty()) {
+        return new WireShape.BeanShape(
+            bean,
+            properties,
+            new WireShape.ConstructionStrategy.Builder(builder.factory(), builder.buildMethod()));
+      }
+    }
+
+    reportUnusable(spec, bean, tag);
+    return null;
+  }
+
+  /** The number of mappable properties under the selected strategy, for the parse arithmetic. */
+  int propertyCount(TypeElement bean) {
+    Map<String, ExecutableElement> getters = collectGetters(bean);
+    if (hasPublicNoArgsConstructor(bean)) {
+      Map<String, ExecutableElement> setters = collectSetters(bean);
+      long count =
+          getters.entrySet().stream()
+              .filter(e -> setters.containsKey(e.getKey()) || isList(e.getValue().getReturnType()))
+              .count();
+      if (count > 0) {
+        return (int) count;
+      }
+    }
+    BuilderModel builder = findBuilderModel(bean);
+    if (builder != null) {
+      Map<String, ExecutableElement> builderSetters = collectBuilderSetters(builder.builderType());
+      long count = getters.keySet().stream().filter(builderSetters::containsKey).count();
+      if (count > 0) {
+        return (int) count;
+      }
+    }
+    return 0;
+  }
+
+  private boolean typesDiffer(
+      TypeElement spec,
+      TypeElement bean,
+      String tag,
+      String name,
+      TypeMirror getterType,
+      TypeMirror writerType) {
+    if (env.getTypeUtils().isSameType(getterType, writerType)) {
+      return false;
+    }
+    Diagnostics.error(
+        env.getMessager(),
+        spec,
+        tag,
+        "bean property '"
+            + name
+            + "' on '"
+            + bean.getSimpleName()
+            + "' is read and written at different types ("
+            + getterType
+            + " vs "
+            + writerType
+            + ").",
+        "A mappable property has one type; the mapper cannot guess which of the two the component"
+            + " should carry.",
+        "Align the getter and its setter (or builder setter) on the bean, or drop one of them.");
+    return true;
+  }
+
+  private Map<String, ExecutableElement> collectGetters(TypeElement bean) {
+    Map<String, ExecutableElement> getters = new LinkedHashMap<>();
+    for (ExecutableElement method : publicInstanceMethods(bean)) {
+      String methodName = method.getSimpleName().toString();
+      if (!method.getParameters().isEmpty() || method.getReturnType().getKind() == TypeKind.VOID) {
+        continue;
+      }
+      if (methodName.length() > 3 && methodName.startsWith("get")) {
+        getters.putIfAbsent(decapitalise(methodName.substring(3)), method);
+      } else if (methodName.length() > 2
+          && methodName.startsWith("is")
+          && method.getReturnType().getKind() == TypeKind.BOOLEAN) {
+        // The JavaBeans 'is' getter is for primitive boolean only.
+        getters.putIfAbsent(decapitalise(methodName.substring(2)), method);
+      }
+    }
+    return getters;
+  }
+
+  private Map<String, ExecutableElement> collectSetters(TypeElement bean) {
+    Map<String, ExecutableElement> setters = new LinkedHashMap<>();
+    for (ExecutableElement method : publicInstanceMethods(bean)) {
+      String methodName = method.getSimpleName().toString();
+      if (method.getParameters().size() == 1
+          && methodName.length() > 3
+          && methodName.startsWith("set")) {
         // Void or fluent (returns the bean) setters both work: build calls the setter as a
         // statement, discarding any fluent return.
         setters.putIfAbsent(decapitalise(methodName.substring(3)), method);
       }
     }
+    return setters;
+  }
+
+  /**
+   * The builder's setters, keyed by property. Both the property-named convention ({@code name(T)},
+   * as Lombok/Immutables/AutoValue emit) and the {@code setX} convention (as protobuf emits) are
+   * accepted; when a property has both, the property-named one wins.
+   */
+  private Map<String, ExecutableElement> collectBuilderSetters(TypeElement builderType) {
+    Map<String, ExecutableElement> setX = new LinkedHashMap<>();
+    Map<String, ExecutableElement> propertyNamed = new LinkedHashMap<>();
+    for (ExecutableElement method : publicInstanceMethods(builderType)) {
+      if (method.getParameters().size() != 1) {
+        continue;
+      }
+      String methodName = method.getSimpleName().toString();
+      if (methodName.length() > 3 && methodName.startsWith("set")) {
+        setX.putIfAbsent(decapitalise(methodName.substring(3)), method);
+      } else {
+        propertyNamed.putIfAbsent(decapitalise(methodName), method);
+      }
+    }
+    Map<String, ExecutableElement> merged = new LinkedHashMap<>(setX);
+    merged.putAll(propertyNamed);
+    return merged;
+  }
+
+  /** A builder factory + terminal build method discovered on a bean. */
+  private record BuilderModel(String factory, String buildMethod, TypeElement builderType) {}
+
+  private BuilderModel findBuilderModel(TypeElement bean) {
+    ExecutableElement factory = builderFactory(bean, "builder");
+    if (factory == null) {
+      factory = builderFactory(bean, "newBuilder");
+    }
+    if (factory == null || !(factory.getReturnType() instanceof DeclaredType builderMirror)) {
+      return null;
+    }
+    TypeElement builderType = (TypeElement) builderMirror.asElement();
+    boolean buildsWire =
+        publicInstanceMethods(builderType).stream()
+            .anyMatch(
+                m ->
+                    m.getSimpleName().contentEquals("build")
+                        && m.getParameters().isEmpty()
+                        && env.getTypeUtils().isSameType(m.getReturnType(), bean.asType()));
+    return buildsWire
+        ? new BuilderModel(factory.getSimpleName().toString(), "build", builderType)
+        : null;
+  }
+
+  private ExecutableElement builderFactory(TypeElement bean, String name) {
+    return ElementFilter.methodsIn(bean.getEnclosedElements()).stream()
+        .filter(
+            m ->
+                m.getSimpleName().contentEquals(name)
+                    && m.getModifiers().contains(Modifier.PUBLIC)
+                    && m.getModifiers().contains(Modifier.STATIC)
+                    && m.getParameters().isEmpty()
+                    && m.getReturnType().getKind() == TypeKind.DECLARED)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private void reportUnusable(TypeElement spec, TypeElement bean, String tag) {
+    Diagnostics.error(
+        env.getMessager(),
+        spec,
+        tag,
+        "'"
+            + bean.getSimpleName()
+            + "' is not a usable bean-shaped wire: no construction strategy fits it.",
+        "The mapper fills a bean through a public no-args constructor with getX/setX pairs (or a"
+            + " getter-only List, filled with getX().addAll(...)), or through a static"
+            + " builder()/newBuilder() whose setters fill it and whose build() yields the wire; '"
+            + bean.getSimpleName()
+            + "' matches neither with a readable property.",
+        "Give it a no-args constructor with matching getX/setX pairs, a builder, or use a record.");
+  }
+
+  private List<ExecutableElement> publicInstanceMethods(TypeElement type) {
+    List<ExecutableElement> methods = new ArrayList<>();
+    for (Element member : env.getElementUtils().getAllMembers(type)) {
+      if (member.getKind() != ElementKind.METHOD) {
+        continue;
+      }
+      ExecutableElement method = (ExecutableElement) member;
+      Set<Modifier> modifiers = method.getModifiers();
+      if (modifiers.contains(Modifier.PUBLIC)
+          && !modifiers.contains(Modifier.STATIC)
+          && !declaredOnObject(method)) {
+        methods.add(method);
+      }
+    }
+    return methods;
   }
 
   private boolean declaredOnObject(ExecutableElement method) {
     Element enclosing = method.getEnclosingElement();
     return enclosing instanceof TypeElement type
         && type.getQualifiedName().contentEquals("java.lang.Object");
+  }
+
+  private boolean isList(TypeMirror type) {
+    return type instanceof DeclaredType declared
+        && ((TypeElement) declared.asElement()).getQualifiedName().contentEquals(LIST);
+  }
+
+  private TypeMirror paramType(ExecutableElement setter) {
+    return setter.getParameters().getFirst().asType();
   }
 
   private boolean hasPublicNoArgsConstructor(TypeElement bean) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -67,6 +67,14 @@ import org.higherkindedj.optics.processing.util.Diagnostics;
  * plus a lawful {@code asLens()} write-back, and no {@code parse} (truthful types). Sealed
  * interface pairs dispatch {@code build}/{@code parse} over their permitted subtype pairs, each
  * delegating to its own spec.
+ *
+ * <p>The wire may be a bean-shaped class instead of a record (issue #628, {@link WireShape}):
+ * {@code build} fills it through setters or a builder and {@code parse} reads it through getters.
+ * Since an unset bean property is null, every reference-typed read is null-guarded into a located
+ * {@code FieldError}, which makes {@code asIso()} truthful only for an all-primitive bean; a domain
+ * {@code Optional<T>} bridges to a nullable bean property {@code T}. A reference-typed bean
+ * projection is deferred (the validated-patch tier); an all-primitive one keeps the {@code
+ * asLens()} projection.
  */
 @AutoService(Processor.class)
 @SupportedAnnotationTypes("org.higherkindedj.optics.annotations.GenerateMapping")
@@ -140,7 +148,7 @@ public class MappingProcessor extends AbstractProcessor {
       int wireCount =
           recordPair
               ? wireRecord.getRecordComponents().size()
-              : beanPair ? beanAnalyser.propertyCount(wireBean) : 0;
+              : beanPair ? beanAnalyser.propertyCount(spec, wireBean) : 0;
       boolean parseCapable =
           sealedPair
               || domainRecord.getRecordComponents().size()
@@ -826,8 +834,7 @@ public class MappingProcessor extends AbstractProcessor {
       // Optional bridge (#628): a domain Optional<DE> maps to a nullable bean property PE, since
       // beans never declare Optional. Empty <-> null/absent; the element is copied (identity) or
       // mapped through a leaf, exactly as an Optional element would be. (An Optional bridge through
-      // a
-      // nested spec is a follow-up.)
+      // a nested spec is a follow-up.)
       if (wire instanceof WireShape.BeanShape && domainElement != null && wireElement == null) {
         TypeMirror wireType = wireComponent.type();
         if (processingEnv.getTypeUtils().isSameType(wireType, domainElement)) {
@@ -844,7 +851,39 @@ public class MappingProcessor extends AbstractProcessor {
                   CodeBlock.of("$L()", bridgeLeaf.getSimpleName())));
           continue;
         }
-        // No identity or leaf for the element: fall through to the no-usable-source diagnostic.
+        // A bridge is the only way to map a domain Optional to a plain bean property, so a failed
+        // one is a dedicated diagnostic that names the ELEMENT types (not the whole Optional) — a
+        // leaf over Optional<DE> would be matched as a plain leaf and bypass the bridge.
+        Diagnostics.error(
+            processingEnv.getMessager(),
+            spec,
+            TAG,
+            "domain field '"
+                + domain.getSimpleName()
+                + "."
+                + name
+                + "' is Optional<"
+                + domainElement
+                + ">, bridged to the nullable bean property '"
+                + wireName
+                + "' of type "
+                + wireType
+                + ", but the element types differ and no leaf converts them.",
+            "A domain Optional bridges to a nullable bean property (empty maps to absent); the"
+                + " present element is copied when the types match, or mapped through a leaf named"
+                + " after the domain component returning ValidatedPrism<"
+                + wireType
+                + ", "
+                + domainElement
+                + "> (the element types, not the Optional).",
+            "Add 'default ValidatedPrism<"
+                + wireType
+                + ", "
+                + domainElement
+                + "> "
+                + name
+                + "()' to the spec, or align the element types.");
+        return null;
       }
       DeclaredType wireMapType = asMapType(wireComponent.type());
       DeclaredType domainMapType = asMapType(domainComponent.asType());
@@ -1647,10 +1686,10 @@ public class MappingProcessor extends AbstractProcessor {
   }
 
   /**
-   * The {@code build} method. {@code body} is the complete, terminated build statement(s) — a
-   * record or bean wire supplies these via {@link WireShape#buildStatements}, and the sealed path
-   * supplies a terminated {@code return switch} — so they are emitted verbatim with {@code
-   * addCode}.
+   * The {@code build} method. {@code body} is the complete, terminated build statement(s): a record
+   * wire supplies them via {@link WireShape.RecordShape#buildStatements}, a bean wire via {@link
+   * #beanBuildBody}, and the sealed path via a terminated {@code return switch} — so all three are
+   * emitted verbatim with {@code addCode}.
    */
   private static MethodSpec buildMethod(TypeName domainName, TypeName wireName, CodeBlock body) {
     return MethodSpec.methodBuilder("build")

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -305,34 +305,49 @@ public class MappingProcessor extends AbstractProcessor {
       return;
     }
 
-    Map<String, String> renames = collectRenames(spec, domain, wire);
+    WireShape wireShape = recordWireShape(wire);
+
+    Map<String, String> renames = collectRenames(spec, domain, wireShape);
     if (renames == null) {
       return;
     }
 
-    List<DerivedField> derived = collectDerived(spec, domain, wire, renames);
+    List<DerivedField> derived = collectDerived(spec, domain, wireShape, renames);
     if (derived == null) {
       return;
     }
 
-    if (wire.getRecordComponents().size() - derived.size() < domain.getRecordComponents().size()) {
+    if (wireShape.componentCount() - derived.size() < domain.getRecordComponents().size()) {
       if (!derived.isEmpty()) {
         reportProjectionWithDerived(spec, domain, wire, derived);
         return;
       }
-      List<Correspondence> projection = classifyProjection(spec, domain, wire, renames);
+      List<Correspondence> projection = classifyProjection(spec, domain, wireShape, renames);
       if (projection == null) {
         return;
       }
-      writeLensImpl(spec, domain, wire, projection);
+      writeLensImpl(spec, domain, wireShape, projection);
       return;
     }
 
-    List<Correspondence> correspondences = classify(spec, registry, domain, wire, renames, derived);
+    List<Correspondence> correspondences =
+        classify(spec, registry, domain, wireShape, renames, derived);
     if (correspondences == null) {
       return;
     }
-    writeImpl(spec, domain, wire, correspondences);
+    writeImpl(spec, domain, wireShape, correspondences);
+  }
+
+  /** Wraps a record wire in a {@link WireShape}: accessor is the component name, positional build. */
+  private static WireShape recordWireShape(TypeElement wire) {
+    List<WireShape.WireComponent> components =
+        wire.getRecordComponents().stream()
+            .map(
+                c ->
+                    new WireShape.WireComponent(
+                        c.getSimpleName().toString(), c.asType(), c.getSimpleName().toString()))
+            .toList();
+    return new WireShape.RecordShape(wire, components);
   }
 
   private enum Kind {
@@ -408,7 +423,7 @@ public class MappingProcessor extends AbstractProcessor {
   }
 
   private Map<String, String> collectRenames(
-      TypeElement spec, TypeElement domain, TypeElement wire) {
+      TypeElement spec, TypeElement domain, WireShape wire) {
     Map<String, String> renames = new LinkedHashMap<>();
     for (ExecutableElement method : ElementFilter.methodsIn(spec.getEnclosedElements())) {
       MapField mapField = method.getAnnotation(MapField.class);
@@ -438,9 +453,7 @@ public class MappingProcessor extends AbstractProcessor {
             "Rename the method to a domain component, or remove @MapField.");
         return null;
       }
-      boolean onWire =
-          wire.getRecordComponents().stream()
-              .anyMatch(c -> c.getSimpleName().contentEquals(mapField.to()));
+      boolean onWire = wire.componentNamed(mapField.to()).isPresent();
       if (!onWire) {
         Diagnostics.error(
             processingEnv.getMessager(),
@@ -451,9 +464,13 @@ public class MappingProcessor extends AbstractProcessor {
                 + "\") on '"
                 + name
                 + "' names no component of "
-                + wire.getSimpleName()
+                + wire.element().getSimpleName()
                 + ".",
-            "Found on " + wire.getSimpleName() + ": " + wireNames(wire.getRecordComponents()) + ".",
+            "Found on "
+                + wire.element().getSimpleName()
+                + ": "
+                + wire.componentNames()
+                + ".",
             "Point 'to' at an existing wire component.");
         return null;
       }
@@ -503,7 +520,7 @@ public class MappingProcessor extends AbstractProcessor {
    * ignores it. Returns null after reporting a malformed declaration.
    */
   private List<DerivedField> collectDerived(
-      TypeElement spec, TypeElement domain, TypeElement wire, Map<String, String> renames) {
+      TypeElement spec, TypeElement domain, WireShape wire, Map<String, String> renames) {
     List<DerivedField> derived = new ArrayList<>();
     for (ExecutableElement method : ElementFilter.methodsIn(spec.getEnclosedElements())) {
       if (!isDerivedCandidate(method)) {
@@ -529,11 +546,7 @@ public class MappingProcessor extends AbstractProcessor {
                 + " component it derives.");
         return null;
       }
-      RecordComponentElement wireComponent =
-          wire.getRecordComponents().stream()
-              .filter(c -> c.getSimpleName().contentEquals(name))
-              .findFirst()
-              .orElse(null);
+      WireShape.WireComponent wireComponent = wire.componentNamed(name).orElse(null);
       if (wireComponent == null) {
         Diagnostics.error(
             processingEnv.getMessager(),
@@ -542,13 +555,13 @@ public class MappingProcessor extends AbstractProcessor {
             "derived field method '"
                 + name
                 + "' names no component of "
-                + wire.getSimpleName()
+                + wire.element().getSimpleName()
                 + ".",
             "A default method returning Getter declares a derived wire field, so its name must be"
                 + " the wire component build fills. Found on "
-                + wire.getSimpleName()
+                + wire.element().getSimpleName()
                 + ": "
-                + wireNames(wire.getRecordComponents())
+                + wire.componentNames()
                 + ".",
             "Rename the method after the wire component it derives, or remove it.");
         return null;
@@ -561,7 +574,7 @@ public class MappingProcessor extends AbstractProcessor {
                   .isSameType(returnType.getTypeArguments().getFirst(), domain.asType())
               && processingEnv
                   .getTypeUtils()
-                  .isSameType(returnType.getTypeArguments().get(1), wireComponent.asType());
+                  .isSameType(returnType.getTypeArguments().get(1), wireComponent.type());
       if (!shapeMatches) {
         Diagnostics.error(
             processingEnv.getMessager(),
@@ -572,7 +585,7 @@ public class MappingProcessor extends AbstractProcessor {
                 + "' must return Getter<"
                 + domain.getSimpleName()
                 + ", "
-                + wireComponent.asType()
+                + wireComponent.type()
                 + "> but returns '"
                 + method.getReturnType()
                 + "'.",
@@ -582,7 +595,7 @@ public class MappingProcessor extends AbstractProcessor {
             "Declare 'default Getter<"
                 + domain.getSimpleName()
                 + ", "
-                + wireComponent.asType()
+                + wireComponent.type()
                 + "> "
                 + name
                 + "()'.");
@@ -643,11 +656,11 @@ public class MappingProcessor extends AbstractProcessor {
       TypeElement spec,
       List<RegisteredSpec> registry,
       TypeElement domain,
-      TypeElement wire,
+      WireShape wire,
       Map<String, String> renames,
       List<DerivedField> derived) {
     List<Correspondence> result = new ArrayList<>();
-    List<? extends RecordComponentElement> wireComponents = wire.getRecordComponents();
+    List<WireShape.WireComponent> wireComponents = wire.components();
     List<String> domainNames =
         domain.getRecordComponents().stream().map(c -> c.getSimpleName().toString()).toList();
 
@@ -657,7 +670,7 @@ public class MappingProcessor extends AbstractProcessor {
           spec,
           TAG,
           "'"
-              + wire.getSimpleName()
+              + wire.element().getSimpleName()
               + "' has more components than '"
               + domain.getSimpleName()
               + "'.",
@@ -695,11 +708,7 @@ public class MappingProcessor extends AbstractProcessor {
     for (RecordComponentElement domainComponent : domain.getRecordComponents()) {
       String name = domainComponent.getSimpleName().toString();
       String wireName = renames.getOrDefault(name, name);
-      RecordComponentElement wireComponent =
-          wireComponents.stream()
-              .filter(c -> c.getSimpleName().toString().equals(wireName))
-              .findFirst()
-              .orElse(null);
+      WireShape.WireComponent wireComponent = wire.componentNamed(wireName).orElse(null);
       if (wireComponent == null) {
         Diagnostics.error(
             processingEnv.getMessager(),
@@ -712,7 +721,7 @@ public class MappingProcessor extends AbstractProcessor {
                 + "' has no wire counterpart named '"
                 + wireName
                 + "'.",
-            "Found on " + wire.getSimpleName() + ": " + wireNames(wireComponents) + ".",
+            "Found on " + wire.element().getSimpleName() + ": " + wire.componentNames() + ".",
             "Align the component names, or add a '@MapField(to = ...)' rename on the spec.");
         return null;
       }
@@ -737,7 +746,7 @@ public class MappingProcessor extends AbstractProcessor {
       // An explicit leaf always wins — even over a same-typed identity match, so a
       // ValidatedPrism<X, X> can validate or normalise a component the types alone would copy.
       ExecutableElement directLeaf =
-          findLeaf(spec, name, wireComponent.asType(), domainComponent.asType());
+          findLeaf(spec, name, wireComponent.type(), domainComponent.asType());
       if (directLeaf != null) {
         result.add(
             new Correspondence(
@@ -750,18 +759,16 @@ public class MappingProcessor extends AbstractProcessor {
       // precedent).
       Correspondence containerLeaf =
           containerLeafCorrespondence(
-              spec, name, wireName, wireComponent.asType(), domainComponent.asType());
+              spec, name, wireName, wireComponent.type(), domainComponent.asType());
       if (containerLeaf != null) {
         result.add(containerLeaf);
         continue;
       }
-      if (processingEnv
-          .getTypeUtils()
-          .isSameType(domainComponent.asType(), wireComponent.asType())) {
+      if (processingEnv.getTypeUtils().isSameType(domainComponent.asType(), wireComponent.type())) {
         result.add(new Correspondence(name, wireName, Kind.IDENTITY, null));
         continue;
       }
-      TypeMirror wireElement = containerElement(wireComponent.asType(), "java.util.List");
+      TypeMirror wireElement = containerElement(wireComponent.type(), "java.util.List");
       TypeMirror domainElement = containerElement(domainComponent.asType(), "java.util.List");
       if (wireElement != null && domainElement != null) {
         PrismResolution lifted =
@@ -774,7 +781,7 @@ public class MappingProcessor extends AbstractProcessor {
           continue;
         }
       }
-      wireElement = containerElement(wireComponent.asType(), "java.util.Optional");
+      wireElement = containerElement(wireComponent.type(), "java.util.Optional");
       domainElement = containerElement(domainComponent.asType(), "java.util.Optional");
       if (wireElement != null && domainElement != null) {
         PrismResolution lifted =
@@ -787,7 +794,7 @@ public class MappingProcessor extends AbstractProcessor {
           continue;
         }
       }
-      DeclaredType wireMapType = asMapType(wireComponent.asType());
+      DeclaredType wireMapType = asMapType(wireComponent.type());
       DeclaredType domainMapType = asMapType(domainComponent.asType());
       if (wireMapType != null && domainMapType != null) {
         if (wireMapType.getTypeArguments().isEmpty()
@@ -852,7 +859,7 @@ public class MappingProcessor extends AbstractProcessor {
         // elements.
       }
       PrismResolution direct =
-          resolveNestedSpec(spec, registry, name, wireComponent.asType(), domainComponent.asType());
+          resolveNestedSpec(spec, registry, name, wireComponent.type(), domainComponent.asType());
       if (direct.ambiguous()) {
         return null;
       }
@@ -861,21 +868,25 @@ public class MappingProcessor extends AbstractProcessor {
             processingEnv.getMessager(),
             spec,
             TAG,
-            "target field '" + wire.getSimpleName() + "." + wireName + "' has no usable source.",
+            "target field '"
+                + wire.element().getSimpleName()
+                + "."
+                + wireName
+                + "' has no usable source.",
             "The types differ ("
-                + wireComponent.asType()
+                + wireComponent.type()
                 + " vs "
                 + domainComponent.asType()
                 + ") and no matching leaf method was found."
                 + leafNearMissHint(spec, name)
-                + projectionSpecHint(registry, wireComponent.asType(), domainComponent.asType())
+                + projectionSpecHint(registry, wireComponent.type(), domainComponent.asType())
                 + " Found on "
                 + domain.getSimpleName()
                 + ": "
                 + domainNames
                 + ".",
             "Add 'default ValidatedPrism<"
-                + wireComponent.asType()
+                + wireComponent.type()
                 + ", "
                 + domainComponent.asType()
                 + "> "
@@ -905,13 +916,13 @@ public class MappingProcessor extends AbstractProcessor {
    * write-back partial).
    */
   private List<Correspondence> classifyProjection(
-      TypeElement spec, TypeElement domain, TypeElement wire, Map<String, String> renames) {
+      TypeElement spec, TypeElement domain, WireShape wire, Map<String, String> renames) {
     Map<String, String> domainByWire = new LinkedHashMap<>();
     renames.forEach((domainName, wireName) -> domainByWire.put(wireName, domainName));
     Set<String> usedDomain = new LinkedHashSet<>();
     List<Correspondence> result = new ArrayList<>();
-    for (RecordComponentElement wireComponent : wire.getRecordComponents()) {
-      String wireName = wireComponent.getSimpleName().toString();
+    for (WireShape.WireComponent wireComponent : wire.components()) {
+      String wireName = wireComponent.name();
       String name = domainByWire.getOrDefault(wireName, wireName);
       RecordComponentElement domainComponent =
           domain.getRecordComponents().stream()
@@ -924,12 +935,12 @@ public class MappingProcessor extends AbstractProcessor {
             spec,
             TAG,
             "projection field '"
-                + wire.getSimpleName()
+                + wire.element().getSimpleName()
                 + "."
                 + wireName
                 + "' has no domain source.",
             "'"
-                + wire.getSimpleName()
+                + wire.element().getSimpleName()
                 + "' is smaller than '"
                 + domain.getSimpleName()
                 + "', so it maps as a projection (Lens tier): every wire component must name a"
@@ -954,21 +965,19 @@ public class MappingProcessor extends AbstractProcessor {
                 + " component.");
         return null;
       }
-      if (!processingEnv
-          .getTypeUtils()
-          .isSameType(domainComponent.asType(), wireComponent.asType())) {
+      if (!processingEnv.getTypeUtils().isSameType(domainComponent.asType(), wireComponent.type())) {
         Diagnostics.error(
             processingEnv.getMessager(),
             spec,
             TAG,
             "projection field '"
-                + wire.getSimpleName()
+                + wire.element().getSimpleName()
                 + "."
                 + wireName
                 + "' changes type ("
                 + domainComponent.asType()
                 + " -> "
-                + wireComponent.asType()
+                + wireComponent.type()
                 + ").",
             "A projection (Lens tier) writes wire values straight back into the domain, so the"
                 + " types must match exactly; a leaf would make the write-back fallible.",
@@ -1096,64 +1105,58 @@ public class MappingProcessor extends AbstractProcessor {
         .orElse("");
   }
 
+  /** The expression {@code build} fills a wire component with, from its correspondence. */
+  private static CodeBlock buildValue(WireShape.WireComponent wc, List<Correspondence> comps) {
+    Correspondence c =
+        comps.stream().filter(x -> x.wireName().equals(wc.name())).findFirst().orElseThrow();
+    return switch (c.kind()) {
+      case LEAF -> CodeBlock.of("$L.build(domain.$L())", c.prism(), c.name());
+      case LIST -> CodeBlock.of("$L.buildAll(domain.$L())", c.prism(), c.name());
+      case OPTIONAL -> CodeBlock.of("domain.$L().map($L::build)", c.name(), c.prism());
+      case MAP -> CodeBlock.of("$L.buildValues(domain.$L())", c.prism(), c.name());
+      case IDENTITY -> CodeBlock.of("domain.$L()", c.name());
+      case DERIVED -> CodeBlock.of("$L.get(domain)", c.prism());
+    };
+  }
+
+  /** The read expression for the wire component named {@code wireName}, from the {@code wire} var. */
+  private static CodeBlock wireRead(WireShape wire, String wireName) {
+    return wire.componentNamed(wireName).orElseThrow().readFrom("wire");
+  }
+
   private void writeImpl(
-      TypeElement spec, TypeElement domain, TypeElement wire, List<Correspondence> comps) {
+      TypeElement spec, TypeElement domain, WireShape wire, List<Correspondence> comps) {
     ClassName specName = ClassName.get(spec);
     ClassName implName = implClassName(spec);
     TypeName domainName = TypeName.get(domain.asType());
-    TypeName wireName = TypeName.get(wire.asType());
+    TypeName wireName = TypeName.get(wire.element().asType());
     TypeName parseReturn =
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
 
-    CodeBlock.Builder buildArgs = CodeBlock.builder();
-    boolean first = true;
-    for (RecordComponentElement wireComponent : wire.getRecordComponents()) {
-      String name = wireComponent.getSimpleName().toString();
-      Correspondence c =
-          comps.stream().filter(x -> x.wireName().equals(name)).findFirst().orElseThrow();
-      if (!first) {
-        buildArgs.add(", ");
-      }
-      first = false;
-      buildArgs.add(
-          switch (c.kind()) {
-            case LEAF -> CodeBlock.of("$L.build(domain.$L())", c.prism(), c.name());
-            case LIST -> CodeBlock.of("$L.buildAll(domain.$L())", c.prism(), c.name());
-            case OPTIONAL -> CodeBlock.of("domain.$L().map($L::build)", c.name(), c.prism());
-            case MAP -> CodeBlock.of("$L.buildValues(domain.$L())", c.prism(), c.name());
-            case IDENTITY -> CodeBlock.of("domain.$L()", c.name());
-            case DERIVED -> CodeBlock.of("$L.get(domain)", c.prism());
-          });
-    }
+    CodeBlock buildBody = wire.buildStatements(wireName, wc -> buildValue(wc, comps));
 
     ClassName optional = ClassName.get("java.util", "Optional");
     CodeBlock.Builder parseChain = CodeBlock.builder().add("return $T.fields()", VALIDATED);
     for (Correspondence c : comps) {
+      CodeBlock read = wireRead(wire, c.wireName());
       parseChain.add(
           switch (c.kind()) {
-            case LEAF ->
-                CodeBlock.of(
-                    "\n.field($S, $L.parse(wire.$L()))", c.name(), c.prism(), c.wireName());
-            case LIST ->
-                CodeBlock.of(
-                    "\n.field($S, $L.parseAll(wire.$L()))", c.name(), c.prism(), c.wireName());
+            case LEAF -> CodeBlock.of("\n.field($S, $L.parse($L))", c.name(), c.prism(), read);
+            case LIST -> CodeBlock.of("\n.field($S, $L.parseAll($L))", c.name(), c.prism(), read);
             case OPTIONAL ->
                 CodeBlock.of(
-                    "\n.field($S, wire.$L().map(v -> $L.parse(v).map($T::of)).orElseGet(() ->"
+                    "\n.field($S, $L.map(v -> $L.parse(v).map($T::of)).orElseGet(() ->"
                         + " $T.validNel($T.empty())))",
                     c.name(),
-                    c.wireName(),
+                    read,
                     c.prism(),
                     optional,
                     VALIDATED,
                     optional);
             case MAP ->
-                CodeBlock.of(
-                    "\n.field($S, $L.parseValues(wire.$L()))", c.name(), c.prism(), c.wireName());
-            case IDENTITY ->
-                CodeBlock.of(
-                    "\n.field($S, $T.validNel(wire.$L()))", c.name(), VALIDATED, c.wireName());
+                CodeBlock.of("\n.field($S, $L.parseValues($L))", c.name(), c.prism(), read);
+            case IDENTITY -> CodeBlock.of("\n.field($S, $T.validNel($L))", c.name(), VALIDATED, read);
             // A derived component carries no domain data; parse reconstructs without it.
             case DERIVED -> CodeBlock.of("");
           });
@@ -1170,7 +1173,7 @@ public class MappingProcessor extends AbstractProcessor {
         reverseArgs.add(", ");
       }
       firstReverse = false;
-      reverseArgs.add("wire.$L()", c.wireName());
+      reverseArgs.add(wireRead(wire, c.wireName()));
     }
 
     TypeSpec.Builder implBuilder =
@@ -1180,11 +1183,7 @@ public class MappingProcessor extends AbstractProcessor {
                 specName,
                 "Generated bidirectional mapping for {@link $T}: total {@code build} and"
                     + " accumulating, located {@code parse}.\n")
-            .addMethod(
-                buildMethod(
-                    domainName,
-                    wireName,
-                    CodeBlock.of("return new $T($L)", wireName, buildArgs.build())))
+            .addMethod(buildMethod(domainName, wireName, buildBody))
             .addMethod(
                 MethodSpec.methodBuilder("parse")
                     .addModifiers(Modifier.PUBLIC)
@@ -1218,26 +1217,25 @@ public class MappingProcessor extends AbstractProcessor {
   }
 
   private void writeLensImpl(
-      TypeElement spec, TypeElement domain, TypeElement wire, List<Correspondence> comps) {
+      TypeElement spec, TypeElement domain, WireShape wire, List<Correspondence> comps) {
     ClassName specName = ClassName.get(spec);
     TypeName domainName = TypeName.get(domain.asType());
-    TypeName wireName = TypeName.get(wire.asType());
+    TypeName wireName = TypeName.get(wire.element().asType());
 
-    CodeBlock.Builder buildArgs = CodeBlock.builder();
-    boolean first = true;
-    for (RecordComponentElement wireComponent : wire.getRecordComponents()) {
-      String name = wireComponent.getSimpleName().toString();
-      Correspondence c =
-          comps.stream().filter(x -> x.wireName().equals(name)).findFirst().orElseThrow();
-      if (!first) {
-        buildArgs.add(", ");
-      }
-      first = false;
-      buildArgs.add("domain.$L()", c.name());
-    }
+    CodeBlock buildBody =
+        wire.buildStatements(
+            wireName,
+            wc ->
+                CodeBlock.of(
+                    "domain.$L()",
+                    comps.stream()
+                        .filter(x -> x.wireName().equals(wc.name()))
+                        .findFirst()
+                        .orElseThrow()
+                        .name()));
 
     CodeBlock.Builder setArgs = CodeBlock.builder();
-    first = true;
+    boolean first = true;
     for (RecordComponentElement domainComponent : domain.getRecordComponents()) {
       String name = domainComponent.getSimpleName().toString();
       Correspondence c = comps.stream().filter(x -> x.name().equals(name)).findFirst().orElse(null);
@@ -1248,7 +1246,7 @@ public class MappingProcessor extends AbstractProcessor {
       if (c == null) {
         setArgs.add("domain.$L()", name);
       } else {
-        setArgs.add("wire.$L()", c.wireName());
+        setArgs.add(wireRead(wire, c.wireName()));
       }
     }
 
@@ -1261,11 +1259,7 @@ public class MappingProcessor extends AbstractProcessor {
                 "Generated projection mapping for {@link $T}: total {@code build} and a lawful"
                     + " {@code asLens()} write-back. No {@code parse} is emitted — the dropped"
                     + " components cannot be reconstructed (truthful types).\n")
-            .addMethod(
-                buildMethod(
-                    domainName,
-                    wireName,
-                    CodeBlock.of("return new $T($L)", wireName, buildArgs.build())))
+            .addMethod(buildMethod(domainName, wireName, buildBody))
             .addMethod(
                 MethodSpec.methodBuilder("asLens")
                     .addModifiers(Modifier.PUBLIC)
@@ -1424,7 +1418,11 @@ public class MappingProcessor extends AbstractProcessor {
                 "Generated sealed-dispatch mapping for {@link $T}: {@code build} and {@code"
                     + " parse} switch over the permitted subtype pairs, each delegating to its"
                     + " own mapping.\n")
-            .addMethod(buildMethod(domainName, wireName, buildSwitch.build()))
+            .addMethod(
+                buildMethod(
+                    domainName,
+                    wireName,
+                    CodeBlock.builder().addStatement("$L", buildSwitch.build()).build()))
             .addMethod(
                 MethodSpec.methodBuilder("parse")
                     .addModifiers(Modifier.PUBLIC)
@@ -1453,13 +1451,18 @@ public class MappingProcessor extends AbstractProcessor {
         .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
   }
 
+  /**
+   * The {@code build} method. {@code body} is the complete, terminated build statement(s) — a record
+   * or bean wire supplies these via {@link WireShape#buildStatements}, and the sealed path supplies
+   * a terminated {@code return switch} — so they are emitted verbatim with {@code addCode}.
+   */
   private static MethodSpec buildMethod(TypeName domainName, TypeName wireName, CodeBlock body) {
     return MethodSpec.methodBuilder("build")
         .addModifiers(Modifier.PUBLIC)
         .returns(wireName)
         .addParameter(domainName, "domain")
         .addStatement("$T.requireNonNull(domain, $S)", OBJECTS, "domain must not be null")
-        .addStatement("$L", body)
+        .addCode(body)
         .build();
   }
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -343,6 +343,15 @@ public class MappingProcessor extends AbstractProcessor {
         reportProjectionWithDerived(spec, domain, wireShape, derived);
         return;
       }
+      // A projection's asLens() writes wire reads straight back into the domain. A record (or an
+      // all-primitive bean) can never read null, so the write-back is lawful; a bean with any
+      // reference property could read null, which the lawful lens cannot express — that maps as a
+      // validated patch instead (a follow-up), so it is deferred here rather than emitted
+      // unlawfully.
+      if (wireShape instanceof WireShape.BeanShape && !allPrimitive(wireShape)) {
+        reportBeanProjectionDeferred(spec, domain, wireShape);
+        return;
+      }
       List<Correspondence> projection = classifyProjection(spec, domain, wireShape, renames);
       if (projection == null) {
         return;
@@ -378,6 +387,8 @@ public class MappingProcessor extends AbstractProcessor {
     LEAF,
     LIST,
     OPTIONAL,
+    // A domain Optional<T> bridged to a nullable bean property T (#628): empty <-> null/absent.
+    OPTIONAL_BRIDGE,
     MAP,
     DERIVED
   }
@@ -812,6 +823,29 @@ public class MappingProcessor extends AbstractProcessor {
           continue;
         }
       }
+      // Optional bridge (#628): a domain Optional<DE> maps to a nullable bean property PE, since
+      // beans never declare Optional. Empty <-> null/absent; the element is copied (identity) or
+      // mapped through a leaf, exactly as an Optional element would be. (An Optional bridge through
+      // a
+      // nested spec is a follow-up.)
+      if (wire instanceof WireShape.BeanShape && domainElement != null && wireElement == null) {
+        TypeMirror wireType = wireComponent.type();
+        if (processingEnv.getTypeUtils().isSameType(wireType, domainElement)) {
+          result.add(new Correspondence(name, wireName, Kind.OPTIONAL_BRIDGE, null));
+          continue;
+        }
+        ExecutableElement bridgeLeaf = findLeaf(spec, name, wireType, domainElement);
+        if (bridgeLeaf != null) {
+          result.add(
+              new Correspondence(
+                  name,
+                  wireName,
+                  Kind.OPTIONAL_BRIDGE,
+                  CodeBlock.of("$L()", bridgeLeaf.getSimpleName())));
+          continue;
+        }
+        // No identity or leaf for the element: fall through to the no-usable-source diagnostic.
+      }
       DeclaredType wireMapType = asMapType(wireComponent.type());
       DeclaredType domainMapType = asMapType(domainComponent.asType());
       if (wireMapType != null && domainMapType != null) {
@@ -1133,10 +1167,43 @@ public class MappingProcessor extends AbstractProcessor {
       case LEAF -> CodeBlock.of("$L.build(domain.$L())", c.prism(), c.name());
       case LIST -> CodeBlock.of("$L.buildAll(domain.$L())", c.prism(), c.name());
       case OPTIONAL -> CodeBlock.of("domain.$L().map($L::build)", c.name(), c.prism());
+      // The domain Optional is carried as-is (identity) or its element built through the leaf; the
+      // conditional ifPresent write lives in beanBuildBody, so an empty Optional skips the write.
+      case OPTIONAL_BRIDGE ->
+          c.prism() == null
+              ? CodeBlock.of("domain.$L()", c.name())
+              : CodeBlock.of("domain.$L().map($L::build)", c.name(), c.prism());
       case MAP -> CodeBlock.of("$L.buildValues(domain.$L())", c.prism(), c.name());
       case IDENTITY -> CodeBlock.of("domain.$L()", c.name());
       case DERIVED -> CodeBlock.of("$L.get(domain)", c.prism());
     };
+  }
+
+  /**
+   * The bean {@code build} body: the strategy frames the construction, and each property writes its
+   * build value between the frame. An {@code Optional}-bridged property writes conditionally, so an
+   * empty domain Optional leaves the bean property unset (protecting null-hostile setters).
+   */
+  private static CodeBlock beanBuildBody(
+      WireShape.BeanShape bean, TypeName wireType, List<Correspondence> comps) {
+    WireShape.ConstructionStrategy strategy = bean.strategy();
+    String receiver = strategy.receiver();
+    CodeBlock.Builder body = CodeBlock.builder().add(strategy.prologue(wireType));
+    for (WireShape.BeanProperty property : bean.properties()) {
+      Correspondence c =
+          comps.stream()
+              .filter(x -> x.wireName().equals(property.name()))
+              .findFirst()
+              .orElseThrow();
+      CodeBlock value = buildValue(property.asWireComponent(), comps);
+      if (c.kind() == Kind.OPTIONAL_BRIDGE) {
+        body.addStatement(
+            "$L.ifPresent(v -> $L)", value, property.write().write(receiver, CodeBlock.of("v")));
+      } else {
+        body.addStatement("$L", property.write().write(receiver, value));
+      }
+    }
+    return body.add(strategy.epilogue()).build();
   }
 
   /**
@@ -1152,7 +1219,11 @@ public class MappingProcessor extends AbstractProcessor {
    * read at all).
    */
   private static boolean beanGuard(Correspondence c, WireShape wire) {
-    if (!(wire instanceof WireShape.BeanShape) || c.kind() == Kind.DERIVED) {
+    // Derived fields are not read; an Optional bridge maps null to Optional.empty, so both are
+    // null-safe and never guarded.
+    if (!(wire instanceof WireShape.BeanShape)
+        || c.kind() == Kind.DERIVED
+        || c.kind() == Kind.OPTIONAL_BRIDGE) {
       return false;
     }
     if (c.kind() == Kind.IDENTITY) {
@@ -1204,7 +1275,11 @@ public class MappingProcessor extends AbstractProcessor {
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
 
-    CodeBlock buildBody = wire.buildStatements(wireName, wc -> buildValue(wc, comps));
+    CodeBlock buildBody =
+        switch (wire) {
+          case WireShape.RecordShape r -> r.buildStatements(wireName, wc -> buildValue(wc, comps));
+          case WireShape.BeanShape b -> beanBuildBody(b, wireName, comps);
+        };
 
     ClassName optional = ClassName.get("java.util", "Optional");
     CodeBlock.Builder parseChain = CodeBlock.builder().add("return $T.fields()", VALIDATED);
@@ -1256,6 +1331,26 @@ public class MappingProcessor extends AbstractProcessor {
                     ? CodeBlock.of(
                         "\n.field($S, ifPresent($L, $T::validNel))", c.name(), read, VALIDATED)
                     : CodeBlock.of("\n.field($S, $T.validNel($L))", c.name(), VALIDATED, read);
+            // A nullable bean read bridges to the domain Optional: null becomes Optional.empty, so
+            // it is never guarded and never fails on absence.
+            case OPTIONAL_BRIDGE ->
+                c.prism() == null
+                    ? CodeBlock.of(
+                        "\n.field($S, $T.validNel($T.ofNullable($L)))",
+                        c.name(),
+                        VALIDATED,
+                        optional,
+                        read)
+                    : CodeBlock.of(
+                        "\n.field($S, $T.ofNullable($L).map(v -> $L.parse(v).map($T::of)).orElseGet("
+                            + "() -> $T.validNel($T.empty())))",
+                        c.name(),
+                        optional,
+                        read,
+                        c.prism(),
+                        optional,
+                        VALIDATED,
+                        optional);
             // A derived component carries no domain data; parse reconstructs without it.
             case DERIVED -> CodeBlock.of("");
           });
@@ -1329,16 +1424,10 @@ public class MappingProcessor extends AbstractProcessor {
     TypeName wireName = TypeName.get(wire.element().asType());
 
     CodeBlock buildBody =
-        wire.buildStatements(
-            wireName,
-            wc ->
-                CodeBlock.of(
-                    "domain.$L()",
-                    comps.stream()
-                        .filter(x -> x.wireName().equals(wc.name()))
-                        .findFirst()
-                        .orElseThrow()
-                        .name()));
+        switch (wire) {
+          case WireShape.RecordShape r -> r.buildStatements(wireName, wc -> buildValue(wc, comps));
+          case WireShape.BeanShape b -> beanBuildBody(b, wireName, comps);
+        };
 
     CodeBlock.Builder setArgs = CodeBlock.builder();
     boolean first = true;
@@ -1708,6 +1797,33 @@ public class MappingProcessor extends AbstractProcessor {
         "Records map component-wise; sealed hierarchies map by dispatching over their permitted"
             + " subtype pairs; a record domain may also map to a bean-shaped wire.",
         "Use two record types, two sealed interface types, or a record domain with a bean wire.");
+  }
+
+  /** Whether every wire component is a primitive (so no read can be null). */
+  private static boolean allPrimitive(WireShape wire) {
+    return wire.components().stream().allMatch(c -> c.type().getKind().isPrimitive());
+  }
+
+  /**
+   * A bean projection with a reference property maps as a validated patch rather than a lawful lens
+   * (a null read cannot be written back through a total {@code set}); that tier is a follow-up.
+   */
+  private void reportBeanProjectionDeferred(TypeElement spec, TypeElement domain, WireShape wire) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "'"
+            + wire.element().getSimpleName()
+            + "' is a bean projection of '"
+            + domain.getSimpleName()
+            + "' with a reference-typed property, which is not yet supported.",
+        "A projection maps as build() plus a lawful asLens() write-back, but a bean's reference"
+            + " property can read null, which a total lens set cannot honour; that shape maps as a"
+            + " validated patch(domain, wire), a follow-up to the bean mapper. An all-primitive bean"
+            + " projection (no null possible) is supported today.",
+        "Map the full bean (add the dropped domain components to it), use a record wire for the"
+            + " projection, or wait for the validated patch tier.");
   }
 
   /** The wire (against a record domain) must be a record or a bean-shaped class. */

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -11,6 +11,8 @@ import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
+import com.palantir.javapoet.TypeVariableName;
+import com.palantir.javapoet.WildcardTypeName;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -21,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.FilerException;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -95,7 +98,7 @@ public class MappingProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    List<RegisteredSpec> registry = scanRegistry(roundEnv);
+    List<RegisteredSpec> registry = scanRegistry(processingEnv, roundEnv);
     for (Element element : roundEnv.getElementsAnnotatedWith(GenerateMapping.class)) {
       processSpec(element, registry);
     }
@@ -104,10 +107,13 @@ public class MappingProcessor extends AbstractProcessor {
 
   /**
    * Scans the round for valid {@code @GenerateMapping} specs. Shared with {@link MergeProcessor},
-   * whose nested fills resolve against the same parse-capable specs.
+   * whose nested fills resolve against the same parse-capable specs. A record domain may pair with
+   * a record wire or a bean-shaped wire; the bean's parse-capability is computed from its
+   * getter/setter property count.
    */
-  static List<RegisteredSpec> scanRegistry(RoundEnvironment roundEnv) {
+  static List<RegisteredSpec> scanRegistry(ProcessingEnvironment env, RoundEnvironment roundEnv) {
     List<RegisteredSpec> registry = new ArrayList<>();
+    BeanPropertyAnalyser beanAnalyser = new BeanPropertyAnalyser(env);
     for (Element element : roundEnv.getElementsAnnotatedWith(GenerateMapping.class)) {
       if (element.getKind() != ElementKind.INTERFACE) {
         continue;
@@ -121,18 +127,24 @@ public class MappingProcessor extends AbstractProcessor {
       TypeMirror wireArg = specSuper.getTypeArguments().get(1);
       TypeElement domainRecord = asRecord(domainArg);
       TypeElement wireRecord = asRecord(wireArg);
+      TypeElement wireBean = wireRecord == null ? asBean(wireArg) : null;
       boolean recordPair = domainRecord != null && wireRecord != null;
+      boolean beanPair = domainRecord != null && wireBean != null;
       boolean sealedPair = asSealed(domainArg) != null && asSealed(wireArg) != null;
-      if (!recordPair && !sealedPair) {
+      if (!recordPair && !beanPair && !sealedPair) {
         continue;
       }
-      // Only parse-capable specs may be nested into: equal-count record pairs (derived wire
+      // Only parse-capable specs may be nested into: equal-count record/bean pairs (derived wire
       // fields do not count against the wire, since parse ignores them) and sealed pairs.
       // Projections (smaller wire, no parse) register too, so failed lookups can name them.
+      int wireCount =
+          recordPair
+              ? wireRecord.getRecordComponents().size()
+              : beanPair ? beanAnalyser.propertyCount(wireBean) : 0;
       boolean parseCapable =
           sealedPair
               || domainRecord.getRecordComponents().size()
-                  == wireRecord.getRecordComponents().size() - derivedCandidateCount(spec);
+                  == wireCount - derivedCandidateCount(spec);
       registry.add(new RegisteredSpec(domainArg, wireArg, implClassName(spec), spec, parseCapable));
     }
     return registry;
@@ -285,27 +297,36 @@ public class MappingProcessor extends AbstractProcessor {
       return;
     }
 
-    TypeElement domain = asRecord(specSuper.getTypeArguments().get(0));
-    TypeElement wire = asRecord(specSuper.getTypeArguments().get(1));
-    if (domain == null || wire == null) {
-      Diagnostics.error(
-          processingEnv.getMessager(),
-          element,
-          TAG,
-          "the MappingSpec type arguments of '"
-              + spec.getSimpleName()
-              + "' must both be records, or both sealed interfaces.",
-          "Records map component-wise; sealed hierarchies map by dispatching over their permitted"
-              + " subtype pairs.",
-          "Use two record types, or two sealed interface types.");
+    TypeMirror domainArg = specSuper.getTypeArguments().get(0);
+    TypeMirror wireArg = specSuper.getTypeArguments().get(1);
+    TypeElement domain = asRecord(domainArg);
+    if (domain == null) {
+      reportUnsupportedDomain(spec, domainArg);
       return;
     }
 
-    if (!checkNotGeneric(spec, domain, wire)) {
-      return;
+    // The wire may be a record (component-wise) or a bean-shaped class (getters/setters).
+    TypeElement wireRecord = asRecord(wireArg);
+    WireShape wireShape;
+    if (wireRecord != null) {
+      if (!checkNotGeneric(spec, domain, wireRecord)) {
+        return;
+      }
+      wireShape = recordWireShape(wireRecord);
+    } else {
+      TypeElement wireBean = asBean(wireArg);
+      if (wireBean == null) {
+        reportUnsupportedWire(spec, wireArg);
+        return;
+      }
+      if (!checkNotGeneric(spec, domain, wireBean)) {
+        return;
+      }
+      wireShape = new BeanPropertyAnalyser(processingEnv).analyse(spec, wireBean, TAG);
+      if (wireShape == null) {
+        return;
+      }
     }
-
-    WireShape wireShape = recordWireShape(wire);
 
     Map<String, String> renames = collectRenames(spec, domain, wireShape);
     if (renames == null) {
@@ -319,7 +340,7 @@ public class MappingProcessor extends AbstractProcessor {
 
     if (wireShape.componentCount() - derived.size() < domain.getRecordComponents().size()) {
       if (!derived.isEmpty()) {
-        reportProjectionWithDerived(spec, domain, wire, derived);
+        reportProjectionWithDerived(spec, domain, wireShape, derived);
         return;
       }
       List<Correspondence> projection = classifyProjection(spec, domain, wireShape, renames);
@@ -338,7 +359,9 @@ public class MappingProcessor extends AbstractProcessor {
     writeImpl(spec, domain, wireShape, correspondences);
   }
 
-  /** Wraps a record wire in a {@link WireShape}: accessor is the component name, positional build. */
+  /**
+   * Wraps a record wire in a {@link WireShape}: accessor is the component name, positional build.
+   */
   private static WireShape recordWireShape(TypeElement wire) {
     List<WireShape.WireComponent> components =
         wire.getRecordComponents().stream()
@@ -422,8 +445,7 @@ public class MappingProcessor extends AbstractProcessor {
     return PrismResolution.NONE;
   }
 
-  private Map<String, String> collectRenames(
-      TypeElement spec, TypeElement domain, WireShape wire) {
+  private Map<String, String> collectRenames(TypeElement spec, TypeElement domain, WireShape wire) {
     Map<String, String> renames = new LinkedHashMap<>();
     for (ExecutableElement method : ElementFilter.methodsIn(spec.getEnclosedElements())) {
       MapField mapField = method.getAnnotation(MapField.class);
@@ -466,11 +488,7 @@ public class MappingProcessor extends AbstractProcessor {
                 + "' names no component of "
                 + wire.element().getSimpleName()
                 + ".",
-            "Found on "
-                + wire.element().getSimpleName()
-                + ": "
-                + wire.componentNames()
-                + ".",
+            "Found on " + wire.element().getSimpleName() + ": " + wire.componentNames() + ".",
             "Point 'to' at an existing wire component.");
         return null;
       }
@@ -633,16 +651,16 @@ public class MappingProcessor extends AbstractProcessor {
    * never honour the value being set (an unlawful lens).
    */
   private void reportProjectionWithDerived(
-      TypeElement spec, TypeElement domain, TypeElement wire, List<DerivedField> derived) {
+      TypeElement spec, TypeElement domain, WireShape wire, List<DerivedField> derived) {
     Diagnostics.error(
         processingEnv.getMessager(),
         spec,
         TAG,
-        "'" + wire.getSimpleName() + "' combines a projection with derived fields.",
+        "'" + wire.element().getSimpleName() + "' combines a projection with derived fields.",
         "Setting the derived fields "
             + derived.stream().map(DerivedField::wireName).toList()
             + " aside, '"
-            + wire.getSimpleName()
+            + wire.element().getSimpleName()
             + "' has fewer components than '"
             + domain.getSimpleName()
             + "', which is the projection shape (Lens tier). A projection's asLens() writes wire"
@@ -965,7 +983,9 @@ public class MappingProcessor extends AbstractProcessor {
                 + " component.");
         return null;
       }
-      if (!processingEnv.getTypeUtils().isSameType(domainComponent.asType(), wireComponent.type())) {
+      if (!processingEnv
+          .getTypeUtils()
+          .isSameType(domainComponent.asType(), wireComponent.type())) {
         Diagnostics.error(
             processingEnv.getMessager(),
             spec,
@@ -1119,9 +1139,59 @@ public class MappingProcessor extends AbstractProcessor {
     };
   }
 
-  /** The read expression for the wire component named {@code wireName}, from the {@code wire} var. */
+  /**
+   * The read expression for the wire component named {@code wireName}, from the {@code wire} var.
+   */
   private static CodeBlock wireRead(WireShape wire, String wireName) {
     return wire.componentNamed(wireName).orElseThrow().readFrom("wire");
+  }
+
+  /**
+   * Whether a component's parse read must be null-guarded: only bean properties can be null, and
+   * only reference-typed ones (a primitive identity read cannot be null, and a derived field is not
+   * read at all).
+   */
+  private static boolean beanGuard(Correspondence c, WireShape wire) {
+    if (!(wire instanceof WireShape.BeanShape) || c.kind() == Kind.DERIVED) {
+      return false;
+    }
+    if (c.kind() == Kind.IDENTITY) {
+      return !wire.componentNamed(c.wireName()).orElseThrow().type().getKind().isPrimitive();
+    }
+    return true;
+  }
+
+  /**
+   * The {@code ifPresent} guard emitted into bean-wire impls: a null property read becomes a
+   * located {@code FieldError} (the {@code fields()} ladder attaches the component label), so a
+   * null never reaches a leaf's {@code parse}, which rejects it.
+   */
+  private static MethodSpec ifPresentHelper() {
+    TypeVariableName s = TypeVariableName.get("S");
+    TypeVariableName a = TypeVariableName.get("A");
+    TypeName validatedOfA =
+        ParameterizedTypeName.get(VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), a);
+    TypeName parseFn =
+        ParameterizedTypeName.get(
+            ClassName.get("java.util.function", "Function"),
+            WildcardTypeName.supertypeOf(s),
+            validatedOfA);
+    return MethodSpec.methodBuilder("ifPresent")
+        .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+        .addTypeVariable(s)
+        .addTypeVariable(a)
+        .returns(validatedOfA)
+        .addParameter(s, "value")
+        .addParameter(parseFn, "parse")
+        .addJavadoc(
+            "Guards a nullable bean-property read: a null becomes a located {@code FieldError},"
+                + " otherwise the value is parsed.\n")
+        .addStatement(
+            "return value == null ? $T.invalidNel($T.of($S)) : parse.apply(value)",
+            VALIDATED,
+            FIELD_ERROR,
+            "must not be null")
+        .build();
   }
 
   private void writeImpl(
@@ -1140,23 +1210,52 @@ public class MappingProcessor extends AbstractProcessor {
     CodeBlock.Builder parseChain = CodeBlock.builder().add("return $T.fields()", VALIDATED);
     for (Correspondence c : comps) {
       CodeBlock read = wireRead(wire, c.wireName());
+      // A bean property is null when unset, so its read is guarded before it reaches a leaf (whose
+      // parse rejects null) or the identity copy; the guard locates the null under the field label.
+      boolean guard = beanGuard(c, wire);
       parseChain.add(
           switch (c.kind()) {
-            case LEAF -> CodeBlock.of("\n.field($S, $L.parse($L))", c.name(), c.prism(), read);
-            case LIST -> CodeBlock.of("\n.field($S, $L.parseAll($L))", c.name(), c.prism(), read);
+            case LEAF ->
+                guard
+                    ? CodeBlock.of(
+                        "\n.field($S, ifPresent($L, $L::parse))", c.name(), read, c.prism())
+                    : CodeBlock.of("\n.field($S, $L.parse($L))", c.name(), c.prism(), read);
+            case LIST ->
+                guard
+                    ? CodeBlock.of(
+                        "\n.field($S, ifPresent($L, $L::parseAll))", c.name(), read, c.prism())
+                    : CodeBlock.of("\n.field($S, $L.parseAll($L))", c.name(), c.prism(), read);
             case OPTIONAL ->
-                CodeBlock.of(
-                    "\n.field($S, $L.map(v -> $L.parse(v).map($T::of)).orElseGet(() ->"
-                        + " $T.validNel($T.empty())))",
-                    c.name(),
-                    read,
-                    c.prism(),
-                    optional,
-                    VALIDATED,
-                    optional);
+                guard
+                    ? CodeBlock.of(
+                        "\n.field($S, ifPresent($L, o -> o.map(v ->"
+                            + " $L.parse(v).map($T::of)).orElseGet(() ->"
+                            + " $T.validNel($T.empty()))))",
+                        c.name(),
+                        read,
+                        c.prism(),
+                        optional,
+                        VALIDATED,
+                        optional)
+                    : CodeBlock.of(
+                        "\n.field($S, $L.map(v -> $L.parse(v).map($T::of)).orElseGet(() ->"
+                            + " $T.validNel($T.empty())))",
+                        c.name(),
+                        read,
+                        c.prism(),
+                        optional,
+                        VALIDATED,
+                        optional);
             case MAP ->
-                CodeBlock.of("\n.field($S, $L.parseValues($L))", c.name(), c.prism(), read);
-            case IDENTITY -> CodeBlock.of("\n.field($S, $T.validNel($L))", c.name(), VALIDATED, read);
+                guard
+                    ? CodeBlock.of(
+                        "\n.field($S, ifPresent($L, $L::parseValues))", c.name(), read, c.prism())
+                    : CodeBlock.of("\n.field($S, $L.parseValues($L))", c.name(), c.prism(), read);
+            case IDENTITY ->
+                guard
+                    ? CodeBlock.of(
+                        "\n.field($S, ifPresent($L, $T::validNel))", c.name(), read, VALIDATED)
+                    : CodeBlock.of("\n.field($S, $T.validNel($L))", c.name(), VALIDATED, read);
             // A derived component carries no domain data; parse reconstructs without it.
             case DERIVED -> CodeBlock.of("");
           });
@@ -1164,8 +1263,11 @@ public class MappingProcessor extends AbstractProcessor {
     parseChain.add("\n.apply($T::new)", domainName);
 
     // Derived fields are non-identity, so they exclude the Iso tier too: wire -> domain -> wire
-    // recomputes the derived component, an identity only for wire values already consistent.
-    boolean lossless = comps.stream().noneMatch(Correspondence::fallible);
+    // recomputes the derived component, an identity only for wire values already consistent. A
+    // bean's null-guarded reference reads are fallible too, so only an all-primitive bean stays
+    // lossless (its reads cannot be null).
+    boolean lossless = comps.stream().noneMatch(c -> c.fallible() || beanGuard(c, wire));
+    boolean needsGuardHelper = comps.stream().anyMatch(c -> beanGuard(c, wire));
     CodeBlock.Builder reverseArgs = CodeBlock.builder();
     boolean firstReverse = true;
     for (Correspondence c : comps) {
@@ -1195,6 +1297,10 @@ public class MappingProcessor extends AbstractProcessor {
             .addMethod(asValidatedPrismMethod(wireName, domainName));
 
     addRenameStubs(implBuilder, spec);
+
+    if (needsGuardHelper) {
+      implBuilder.addMethod(ifPresentHelper());
+    }
 
     if (lossless) {
       ClassName iso = ClassName.get("org.higherkindedj.optics", "Iso");
@@ -1452,9 +1558,10 @@ public class MappingProcessor extends AbstractProcessor {
   }
 
   /**
-   * The {@code build} method. {@code body} is the complete, terminated build statement(s) — a record
-   * or bean wire supplies these via {@link WireShape#buildStatements}, and the sealed path supplies
-   * a terminated {@code return switch} — so they are emitted verbatim with {@code addCode}.
+   * The {@code build} method. {@code body} is the complete, terminated build statement(s) — a
+   * record or bean wire supplies these via {@link WireShape#buildStatements}, and the sealed path
+   * supplies a terminated {@code return switch} — so they are emitted verbatim with {@code
+   * addCode}.
    */
   private static MethodSpec buildMethod(TypeName domainName, TypeName wireName, CodeBlock body) {
     return MethodSpec.methodBuilder("build")
@@ -1563,6 +1670,56 @@ public class MappingProcessor extends AbstractProcessor {
       }
     }
     return null;
+  }
+
+  /** A concrete (non-abstract, non-record, non-enum) class: a candidate bean-shaped wire (#628). */
+  private static TypeElement asBean(TypeMirror mirror) {
+    if (mirror instanceof DeclaredType declared) {
+      TypeElement type = (TypeElement) declared.asElement();
+      if (type.getKind() == ElementKind.CLASS && !type.getModifiers().contains(Modifier.ABSTRACT)) {
+        return type;
+      }
+    }
+    return null;
+  }
+
+  /** The domain must be a record (or a sealed interface, handled earlier); a bean domain is not. */
+  private void reportUnsupportedDomain(TypeElement spec, TypeMirror domainArg) {
+    if (asBean(domainArg) != null) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          spec,
+          TAG,
+          "the domain type argument '"
+              + domainArg
+              + "' is a bean-shaped class, which this mapper does not support on the domain side.",
+          "parse assembles the domain through its canonical constructor, so the domain must be a"
+              + " record (or a sealed interface of records); only the wire may be bean-shaped.",
+          "Use a record or sealed interface for the domain, mapping the bean as the wire instead.");
+      return;
+    }
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the MappingSpec type arguments of '"
+            + spec.getSimpleName()
+            + "' must both be records, or both sealed interfaces.",
+        "Records map component-wise; sealed hierarchies map by dispatching over their permitted"
+            + " subtype pairs; a record domain may also map to a bean-shaped wire.",
+        "Use two record types, two sealed interface types, or a record domain with a bean wire.");
+  }
+
+  /** The wire (against a record domain) must be a record or a bean-shaped class. */
+  private void reportUnsupportedWire(TypeElement spec, TypeMirror wireArg) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire type argument '" + wireArg + "' is neither a record nor a bean-shaped class.",
+        "A record domain maps to a record wire (component-wise) or to a bean-shaped wire read"
+            + " through getters and written through setters or a builder.",
+        "Use a record, or a concrete bean class, for the wire.");
   }
 
   private TypeMirror containerElement(TypeMirror mirror, String rawName) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MergeProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MergeProcessor.java
@@ -72,7 +72,8 @@ public class MergeProcessor extends AbstractProcessor {
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     // Nested fills resolve against the same round's @GenerateMapping specs (shared scan).
-    List<MappingProcessor.RegisteredSpec> registry = MappingProcessor.scanRegistry(roundEnv);
+    List<MappingProcessor.RegisteredSpec> registry =
+        MappingProcessor.scanRegistry(processingEnv, roundEnv);
     for (Element element : roundEnv.getElementsAnnotatedWith(GenerateMerge.class)) {
       processSpec(element, registry);
     }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import com.palantir.javapoet.CodeBlock;
+import com.palantir.javapoet.TypeName;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * The wire side of a {@code @GenerateMapping} pair, abstracted over how its components are
+ * enumerated, read and constructed. A record wire ({@link RecordShape}) reads components positionally
+ * through their accessors and constructs via the canonical constructor; a bean-shaped wire ({@link
+ * BeanShape}, issue #628) reads through getters and constructs through setters or a builder. The
+ * domain side is always a record (parse assembles it with {@code Validated.fields().apply(D::new)}),
+ * so only the wire is abstracted.
+ *
+ * <p>Classification ({@link MappingProcessor#classify}) and code generation ({@link
+ * MappingProcessor#writeImpl}) speak to the wire only through this interface: component enumeration
+ * and name lookup, the per-component read expression ({@link WireComponent#readFrom}), and the
+ * build-method body ({@link #buildStatements}).
+ */
+sealed interface WireShape permits WireShape.RecordShape {
+
+  /** The wire type element. */
+  TypeElement element();
+
+  /** The wire's components in declaration order. */
+  List<WireComponent> components();
+
+  /** The number of components. */
+  default int componentCount() {
+    return components().size();
+  }
+
+  /** The component names in declaration order (for diagnostics). */
+  default List<String> componentNames() {
+    return components().stream().map(WireComponent::name).toList();
+  }
+
+  /** The component with the given (decapitalised) name, if any. */
+  default Optional<WireComponent> componentNamed(String name) {
+    return components().stream().filter(c -> c.name().equals(name)).findFirst();
+  }
+
+  /**
+   * The complete, terminated statements of the {@code build} method body: they construct the wire
+   * value from each component's build expression (supplied by {@code valueFor}) and {@code return}
+   * it. A record emits a single {@code return new W(...)}; a bean emits setter or builder statements.
+   *
+   * @param wireType the wire type to construct
+   * @param valueFor maps each component to the expression build fills it with
+   * @return terminated statement(s) suitable for {@code MethodSpec.Builder.addCode}
+   */
+  CodeBlock buildStatements(TypeName wireType, Function<WireComponent, CodeBlock> valueFor);
+
+  /**
+   * One wire component: its (decapitalised) name, its type, and the accessor that reads it. For a
+   * record the accessor is the component name; for a bean it is the getter (for example {@code
+   * getName}).
+   */
+  record WireComponent(String name, TypeMirror type, String accessor) {
+
+    /** The read expression for this component from the given receiver variable. */
+    CodeBlock readFrom(String receiver) {
+      return CodeBlock.of("$L.$L()", receiver, accessor);
+    }
+  }
+
+  /** A record wire: positional accessors and canonical-constructor construction (today's path). */
+  record RecordShape(TypeElement element, List<WireComponent> components) implements WireShape {
+
+    @Override
+    public CodeBlock buildStatements(
+        TypeName wireType, Function<WireComponent, CodeBlock> valueFor) {
+      CodeBlock.Builder args = CodeBlock.builder();
+      boolean first = true;
+      for (WireComponent component : components) {
+        if (!first) {
+          args.add(", ");
+        }
+        first = false;
+        args.add(valueFor.apply(component));
+      }
+      return CodeBlock.builder().addStatement("return new $T($L)", wireType, args.build()).build();
+    }
+  }
+}

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
@@ -112,25 +112,56 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
   }
 
   /**
-   * One bean property: its (decapitalised) name, type, the getter that reads it and the setter that
-   * writes it. A slice-B property has both — the canonical mutable JavaBean shape.
+   * One bean property: its (decapitalised) name, type, the getter that reads it and the {@link
+   * WriteSite} that writes it (a setter, a builder setter, or a JAXB collection getter).
    */
-  record BeanProperty(String name, TypeMirror type, String getter, String setter) {
+  record BeanProperty(String name, TypeMirror type, String getter, WriteSite write) {
 
     WireComponent asWireComponent() {
       return new WireComponent(name, type, getter);
     }
   }
 
+  /** How a single bean property is written into a target (a bean instance or a builder). */
+  sealed interface WriteSite permits WriteSite.Setter, WriteSite.CollectionAdd {
+
+    /**
+     * A statement writing {@code value} into {@code receiver} (the bean {@code wire} or builder).
+     */
+    CodeBlock write(String receiver, CodeBlock value);
+
+    /** {@code receiver.setX(value)} — a setter or, in a builder frame, a builder setter. */
+    record Setter(String method) implements WriteSite {
+      @Override
+      public CodeBlock write(String receiver, CodeBlock value) {
+        return CodeBlock.of("$L.$L($L)", receiver, method, value);
+      }
+    }
+
+    /** {@code receiver.getX().addAll(value)} — the JAXB collection-getter convention. */
+    record CollectionAdd(String getter) implements WriteSite {
+      @Override
+      public CodeBlock write(String receiver, CodeBlock value) {
+        return CodeBlock.of("$L.$L().addAll($L)", receiver, getter, value);
+      }
+    }
+  }
+
   /** How a bean value is constructed from its per-property build expressions. */
-  sealed interface ConstructionStrategy permits ConstructionStrategy.NoArgsSetters {
+  sealed interface ConstructionStrategy
+      permits ConstructionStrategy.NoArgsSetters, ConstructionStrategy.Builder {
 
     CodeBlock buildStatements(
         TypeName wireType,
         List<BeanProperty> properties,
         Function<WireComponent, CodeBlock> valueFor);
 
-    /** Public no-args constructor plus setters: {@code var w = new W(); w.setX(...); return w;}. */
+    /**
+     * Public no-args constructor plus per-property writes: {@code var w = new W(); w.setX(...);
+     * return w;}. A property may write through a setter or, for a getter-only {@code List}, the
+     * JAXB collection-getter convention ({@code w.getItems().addAll(...)}), which assumes the
+     * getter returns a mutable, live list.
+     */
     record NoArgsSetters() implements ConstructionStrategy {
 
       @Override
@@ -142,9 +173,32 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
         body.addStatement("$T wire = new $T()", wireType, wireType);
         for (BeanProperty property : properties) {
           body.addStatement(
-              "wire.$L($L)", property.setter(), valueFor.apply(property.asWireComponent()));
+              "$L", property.write().write("wire", valueFor.apply(property.asWireComponent())));
         }
         body.addStatement("return wire");
+        return body.build();
+      }
+    }
+
+    /**
+     * A builder: {@code var b = W.builder(); b.name(...); return b.build();}. {@code factory} is
+     * the static builder factory ({@code builder} or {@code newBuilder}) and {@code buildMethod}
+     * the builder's terminal method; each property writes through its builder setter.
+     */
+    record Builder(String factory, String buildMethod) implements ConstructionStrategy {
+
+      @Override
+      public CodeBlock buildStatements(
+          TypeName wireType,
+          List<BeanProperty> properties,
+          Function<WireComponent, CodeBlock> valueFor) {
+        CodeBlock.Builder body = CodeBlock.builder();
+        body.addStatement("var b = $T.$L()", wireType, factory);
+        for (BeanProperty property : properties) {
+          body.addStatement(
+              "$L", property.write().write("b", valueFor.apply(property.asWireComponent())));
+        }
+        body.addStatement("return b.$L()", buildMethod);
         return body.build();
       }
     }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
@@ -20,8 +20,9 @@ import javax.lang.model.type.TypeMirror;
  *
  * <p>Classification ({@link MappingProcessor#classify}) and code generation ({@link
  * MappingProcessor#writeImpl}) speak to the wire only through this interface: component enumeration
- * and name lookup, the per-component read expression ({@link WireComponent#readFrom}), and the
- * build-method body ({@link #buildStatements}).
+ * and name lookup, and the per-component read expression ({@link WireComponent#readFrom}). The build
+ * body differs per shape (a record's canonical constructor versus a bean's {@link
+ * ConstructionStrategy}), so the processor assembles it by switching on the shape.
  */
 sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
 
@@ -47,18 +48,6 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
   }
 
   /**
-   * The complete, terminated statements of the {@code build} method body: they construct the wire
-   * value from each component's build expression (supplied by {@code valueFor}) and {@code return}
-   * it. A record emits a single {@code return new W(...)}; a bean emits setter or builder
-   * statements.
-   *
-   * @param wireType the wire type to construct
-   * @param valueFor maps each component to the expression build fills it with
-   * @return terminated statement(s) suitable for {@code MethodSpec.Builder.addCode}
-   */
-  CodeBlock buildStatements(TypeName wireType, Function<WireComponent, CodeBlock> valueFor);
-
-  /**
    * One wire component: its (decapitalised) name, its type, and the accessor that reads it. For a
    * record the accessor is the component name; for a bean it is the getter (for example {@code
    * getName}).
@@ -74,9 +63,8 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
   /** A record wire: positional accessors and canonical-constructor construction (today's path). */
   record RecordShape(TypeElement element, List<WireComponent> components) implements WireShape {
 
-    @Override
-    public CodeBlock buildStatements(
-        TypeName wireType, Function<WireComponent, CodeBlock> valueFor) {
+    /** The record build body: {@code return new W(v0, v1, ...)} in component order. */
+    CodeBlock buildStatements(TypeName wireType, Function<WireComponent, CodeBlock> valueFor) {
       CodeBlock.Builder args = CodeBlock.builder();
       boolean first = true;
       for (WireComponent component : components) {
@@ -93,7 +81,9 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
   /**
    * A bean-shaped wire (issue #628): components are read through getters and written through the
    * {@link ConstructionStrategy}. Reads are null-hostile at parse time (an unset bean property is
-   * null), which the mapping processor guards; only the construction differs from a record.
+   * null), which the mapping processor guards; only the construction differs from a record. The
+   * bean build body is assembled by the processor (per-property writes, which the strategy frames),
+   * since an {@code Optional}-bridged property writes conditionally.
    */
   record BeanShape(
       TypeElement element, List<BeanProperty> properties, ConstructionStrategy strategy)
@@ -102,12 +92,6 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
     @Override
     public List<WireComponent> components() {
       return properties.stream().map(BeanProperty::asWireComponent).toList();
-    }
-
-    @Override
-    public CodeBlock buildStatements(
-        TypeName wireType, Function<WireComponent, CodeBlock> valueFor) {
-      return strategy.buildStatements(wireType, properties, valueFor);
     }
   }
 
@@ -147,14 +131,23 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
     }
   }
 
-  /** How a bean value is constructed from its per-property build expressions. */
+  /**
+   * How a bean value is constructed: the target variable each property writes into ({@link
+   * #receiver}), and the framing {@link #prologue} and {@link #epilogue} statements. The
+   * per-property writes between them are emitted by the processor, so an {@code Optional}-bridged
+   * property can write conditionally.
+   */
   sealed interface ConstructionStrategy
       permits ConstructionStrategy.NoArgsSetters, ConstructionStrategy.Builder {
 
-    CodeBlock buildStatements(
-        TypeName wireType,
-        List<BeanProperty> properties,
-        Function<WireComponent, CodeBlock> valueFor);
+    /** The variable each property write targets (the bean instance or the builder). */
+    String receiver();
+
+    /** The opening statement that creates the target. */
+    CodeBlock prologue(TypeName wireType);
+
+    /** The closing statement that returns the built wire. */
+    CodeBlock epilogue();
 
     /**
      * Public no-args constructor plus per-property writes: {@code var w = new W(); w.setX(...);
@@ -163,20 +156,19 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
      * getter returns a mutable, live list.
      */
     record NoArgsSetters() implements ConstructionStrategy {
+      @Override
+      public String receiver() {
+        return "wire";
+      }
 
       @Override
-      public CodeBlock buildStatements(
-          TypeName wireType,
-          List<BeanProperty> properties,
-          Function<WireComponent, CodeBlock> valueFor) {
-        CodeBlock.Builder body = CodeBlock.builder();
-        body.addStatement("$T wire = new $T()", wireType, wireType);
-        for (BeanProperty property : properties) {
-          body.addStatement(
-              "$L", property.write().write("wire", valueFor.apply(property.asWireComponent())));
-        }
-        body.addStatement("return wire");
-        return body.build();
+      public CodeBlock prologue(TypeName wireType) {
+        return CodeBlock.builder().addStatement("$T wire = new $T()", wireType, wireType).build();
+      }
+
+      @Override
+      public CodeBlock epilogue() {
+        return CodeBlock.builder().addStatement("return wire").build();
       }
     }
 
@@ -186,20 +178,19 @@ sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
      * the builder's terminal method; each property writes through its builder setter.
      */
     record Builder(String factory, String buildMethod) implements ConstructionStrategy {
+      @Override
+      public String receiver() {
+        return "b";
+      }
 
       @Override
-      public CodeBlock buildStatements(
-          TypeName wireType,
-          List<BeanProperty> properties,
-          Function<WireComponent, CodeBlock> valueFor) {
-        CodeBlock.Builder body = CodeBlock.builder();
-        body.addStatement("var b = $T.$L()", wireType, factory);
-        for (BeanProperty property : properties) {
-          body.addStatement(
-              "$L", property.write().write("b", valueFor.apply(property.asWireComponent())));
-        }
-        body.addStatement("return b.$L()", buildMethod);
-        return body.build();
+      public CodeBlock prologue(TypeName wireType) {
+        return CodeBlock.builder().addStatement("var b = $T.$L()", wireType, factory).build();
+      }
+
+      @Override
+      public CodeBlock epilogue() {
+        return CodeBlock.builder().addStatement("return b.$L()", buildMethod).build();
       }
     }
   }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
@@ -12,18 +12,18 @@ import javax.lang.model.type.TypeMirror;
 
 /**
  * The wire side of a {@code @GenerateMapping} pair, abstracted over how its components are
- * enumerated, read and constructed. A record wire ({@link RecordShape}) reads components positionally
- * through their accessors and constructs via the canonical constructor; a bean-shaped wire ({@link
- * BeanShape}, issue #628) reads through getters and constructs through setters or a builder. The
- * domain side is always a record (parse assembles it with {@code Validated.fields().apply(D::new)}),
- * so only the wire is abstracted.
+ * enumerated, read and constructed. A record wire ({@link RecordShape}) reads components
+ * positionally through their accessors and constructs via the canonical constructor; a bean-shaped
+ * wire ({@link BeanShape}, issue #628) reads through getters and constructs through setters or a
+ * builder. The domain side is always a record (parse assembles it with {@code
+ * Validated.fields().apply(D::new)}), so only the wire is abstracted.
  *
  * <p>Classification ({@link MappingProcessor#classify}) and code generation ({@link
  * MappingProcessor#writeImpl}) speak to the wire only through this interface: component enumeration
  * and name lookup, the per-component read expression ({@link WireComponent#readFrom}), and the
  * build-method body ({@link #buildStatements}).
  */
-sealed interface WireShape permits WireShape.RecordShape {
+sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {
 
   /** The wire type element. */
   TypeElement element();
@@ -49,7 +49,8 @@ sealed interface WireShape permits WireShape.RecordShape {
   /**
    * The complete, terminated statements of the {@code build} method body: they construct the wire
    * value from each component's build expression (supplied by {@code valueFor}) and {@code return}
-   * it. A record emits a single {@code return new W(...)}; a bean emits setter or builder statements.
+   * it. A record emits a single {@code return new W(...)}; a bean emits setter or builder
+   * statements.
    *
    * @param wireType the wire type to construct
    * @param valueFor maps each component to the expression build fills it with
@@ -86,6 +87,66 @@ sealed interface WireShape permits WireShape.RecordShape {
         args.add(valueFor.apply(component));
       }
       return CodeBlock.builder().addStatement("return new $T($L)", wireType, args.build()).build();
+    }
+  }
+
+  /**
+   * A bean-shaped wire (issue #628): components are read through getters and written through the
+   * {@link ConstructionStrategy}. Reads are null-hostile at parse time (an unset bean property is
+   * null), which the mapping processor guards; only the construction differs from a record.
+   */
+  record BeanShape(
+      TypeElement element, List<BeanProperty> properties, ConstructionStrategy strategy)
+      implements WireShape {
+
+    @Override
+    public List<WireComponent> components() {
+      return properties.stream().map(BeanProperty::asWireComponent).toList();
+    }
+
+    @Override
+    public CodeBlock buildStatements(
+        TypeName wireType, Function<WireComponent, CodeBlock> valueFor) {
+      return strategy.buildStatements(wireType, properties, valueFor);
+    }
+  }
+
+  /**
+   * One bean property: its (decapitalised) name, type, the getter that reads it and the setter that
+   * writes it. A slice-B property has both — the canonical mutable JavaBean shape.
+   */
+  record BeanProperty(String name, TypeMirror type, String getter, String setter) {
+
+    WireComponent asWireComponent() {
+      return new WireComponent(name, type, getter);
+    }
+  }
+
+  /** How a bean value is constructed from its per-property build expressions. */
+  sealed interface ConstructionStrategy permits ConstructionStrategy.NoArgsSetters {
+
+    CodeBlock buildStatements(
+        TypeName wireType,
+        List<BeanProperty> properties,
+        Function<WireComponent, CodeBlock> valueFor);
+
+    /** Public no-args constructor plus setters: {@code var w = new W(); w.setX(...); return w;}. */
+    record NoArgsSetters() implements ConstructionStrategy {
+
+      @Override
+      public CodeBlock buildStatements(
+          TypeName wireType,
+          List<BeanProperty> properties,
+          Function<WireComponent, CodeBlock> valueFor) {
+        CodeBlock.Builder body = CodeBlock.builder();
+        body.addStatement("$T wire = new $T()", wireType, wireType);
+        for (BeanProperty property : properties) {
+          body.addStatement(
+              "wire.$L($L)", property.setter(), valueFor.apply(property.asWireComponent()));
+        }
+        body.addStatement("return wire");
+        return body.build();
+      }
     }
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WireShape.java
@@ -20,8 +20,8 @@ import javax.lang.model.type.TypeMirror;
  *
  * <p>Classification ({@link MappingProcessor#classify}) and code generation ({@link
  * MappingProcessor#writeImpl}) speak to the wire only through this interface: component enumeration
- * and name lookup, and the per-component read expression ({@link WireComponent#readFrom}). The build
- * body differs per shape (a record's canonical constructor versus a bean's {@link
+ * and name lookup, and the per-component read expression ({@link WireComponent#readFrom}). The
+ * build body differs per shape (a record's canonical constructor versus a bean's {@link
  * ConstructionStrategy}), so the processor assembles it by switching on the shape.
  */
 sealed interface WireShape permits WireShape.RecordShape, WireShape.BeanShape {

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedMappingLawsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedMappingLawsTest.java
@@ -571,4 +571,83 @@ class GeneratedMappingLawsTest {
     MappingLaws.assertMappingLaws(
         asValidatedPrism(impl), result.newInstance("com.example.Profile", "Ada", "Lovelace"));
   }
+
+  @Test
+  @DisplayName(
+      "bean-wire tier: a bean mapping's domain round trip is lawful through the published harness")
+  void beanWireTierIsLawful() throws ReflectiveOperationException {
+    JavaFileObject domain =
+        JavaFileObjects.forSourceString(
+            "com.example.User",
+            """
+            package com.example;
+
+            import java.util.Optional;
+
+            public record User(String name, EmailAddress email, Optional<String> nickname) {}
+            """);
+    // The wire is a mutable JavaBean: no equals(), so only the domain round trip is comparable.
+    JavaFileObject wire =
+        JavaFileObjects.forSourceString(
+            "com.example.UserDto",
+            """
+            package com.example;
+
+            public class UserDto {
+              private String name;
+              private String email;
+              private String nickname;
+
+              public String getName() { return name; }
+              public void setName(String name) { this.name = name; }
+              public String getEmail() { return email; }
+              public void setEmail(String email) { this.email = email; }
+              public String getNickname() { return nickname; }
+              public void setNickname(String nickname) { this.nickname = nickname; }
+            }
+            """);
+    JavaFileObject spec =
+        JavaFileObjects.forSourceString(
+            "com.example.UserMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.hkt.validated.FieldError;
+            import org.higherkindedj.hkt.validated.Validated;
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+            import org.higherkindedj.optics.validated.ValidatedPrism;
+
+            @GenerateMapping
+            public interface UserMapping extends MappingSpec<User, UserDto> {
+              default ValidatedPrism<String, EmailAddress> email() {
+                return emailPrism();
+              }
+
+            """
+                + EMAIL_PRISM
+                + """
+            }
+            """);
+
+    var result = compileMapping(EMAIL, domain, wire, spec);
+    Object impl = implInstance(result, "com.example.UserMappingImpl");
+
+    // parse(build(user)) == Valid(user), compared on the domain record (the bean has no equals).
+    // Exercises the null-guarded getter reads and the Optional<->nullable bridge on the round trip.
+    MappingLaws.assertMappingLaws(
+        asValidatedPrism(impl),
+        result.newInstance(
+            "com.example.User",
+            "Ada",
+            result.newInstance("com.example.EmailAddress", "ada@example.org"),
+            Optional.of("countess")));
+    MappingLaws.assertMappingLaws(
+        asValidatedPrism(impl),
+        result.newInstance(
+            "com.example.User",
+            "Grace",
+            result.newInstance("com.example.EmailAddress", "grace@example.org"),
+            Optional.empty()));
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -565,6 +565,254 @@ class MappingProcessorBeanTest {
   }
 
   @Nested
+  @DisplayName("Builder and collection strategies")
+  class BuilderAndCollection {
+
+    @Test
+    @DisplayName("a Lombok-style bean builds through builder() and property-named setters")
+    void lombokStyleBuilder() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Point",
+              """
+              package com.example;
+
+              public record Point(int x, String label) {}
+              """);
+      // An immutable bean: no setters, no no-args constructor, only a builder.
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.PointDto",
+              """
+              package com.example;
+
+              public final class PointDto {
+                private final int x;
+                private final String label;
+                private PointDto(int x, String label) { this.x = x; this.label = label; }
+                public int getX() { return x; }
+                public String getLabel() { return label; }
+                public static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  private int x;
+                  private String label;
+                  public Builder x(int x) { this.x = x; return this; }
+                  public Builder label(String label) { this.label = label; return this; }
+                  public PointDto build() { return new PointDto(x, label); }
+                }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.PointMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface PointMapping extends MappingSpec<Point, PointDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.PointMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("var b = PointDto.builder();")
+          .contains("b.x(domain.x());")
+          .contains("b.label(domain.label());")
+          .contains("return b.build();")
+          .contains(".field(\"label\", ifPresent(wire.getLabel(), Validated::validNel))");
+
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.PointMappingImpl").getField("INSTANCE").get(null);
+        Object point = result.newInstance("com.example.Point", 3, "origin");
+        Object dto = invoke(impl, "build", point);
+        Assertions.assertThat(invoke(dto, "getX")).isEqualTo(3);
+        Assertions.assertThat(invoke(dto, "getLabel")).isEqualTo("origin");
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsed =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dto);
+        Assertions.assertThat(parsed.get()).isEqualTo(point);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("a protobuf-style bean builds through newBuilder() and setX setters")
+    void protobufStyleBuilder() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Msg",
+              """
+              package com.example;
+
+              public record Msg(String subject) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.MsgProto",
+              """
+              package com.example;
+
+              public final class MsgProto {
+                private final String subject;
+                private MsgProto(String subject) { this.subject = subject; }
+                public String getSubject() { return subject; }
+                public static Builder newBuilder() { return new Builder(); }
+                public static final class Builder {
+                  private String subject;
+                  public Builder setSubject(String subject) { this.subject = subject; return this; }
+                  public MsgProto build() { return new MsgProto(subject); }
+                }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.MsgMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface MsgMapping extends MappingSpec<Msg, MsgProto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.MsgMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("var b = MsgProto.newBuilder();")
+          .contains("b.setSubject(domain.subject());")
+          .contains("return b.build();");
+    }
+
+    @Test
+    @DisplayName("a JAXB-style getter-only List is filled via getX().addAll(...)")
+    void jaxbCollectionGetter() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Doc",
+              """
+              package com.example;
+
+              import java.util.List;
+
+              public record Doc(String title, List<String> tags) {}
+              """);
+      // JAXB convention: the List has a getter that lazily returns a live mutable list, no setter.
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.DocDto",
+              """
+              package com.example;
+
+              import java.util.ArrayList;
+              import java.util.List;
+
+              public class DocDto {
+                private String title;
+                private List<String> tags;
+                public String getTitle() { return title; }
+                public void setTitle(String title) { this.title = title; }
+                public List<String> getTags() {
+                  if (tags == null) { tags = new ArrayList<>(); }
+                  return tags;
+                }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.DocMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface DocMapping extends MappingSpec<Doc, DocDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.DocMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("wire.setTitle(domain.title());")
+          .contains("wire.getTags().addAll(domain.tags());")
+          .contains(".field(\"tags\", ifPresent(wire.getTags(), Validated::validNel))");
+
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl = result.loadClass("com.example.DocMappingImpl").getField("INSTANCE").get(null);
+        Object doc =
+            result
+                .loadClass("com.example.Doc")
+                .getDeclaredConstructor(String.class, List.class)
+                .newInstance("spec", List.of("a", "b"));
+        Object dto = invoke(impl, "build", doc);
+        Assertions.assertThat((List<?>) invoke(dto, "getTags")).isEqualTo(List.of("a", "b"));
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsed =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dto);
+        Assertions.assertThat(parsed.get()).isEqualTo(doc);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("a fluent setter (returning the bean) is accepted")
+    void fluentSetter() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Tag",
+              """
+              package com.example;
+
+              public record Tag(String value) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.TagDto",
+              """
+              package com.example;
+
+              public class TagDto {
+                private String value;
+                public String getValue() { return value; }
+                public TagDto setValue(String value) { this.value = value; return this; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.TagMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface TagMapping extends MappingSpec<Tag, TagDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.TagMappingImpl");
+      Assertions.assertThat(generated).contains("wire.setValue(domain.value());");
+    }
+  }
+
+  @Nested
   @DisplayName("Diagnostics")
   class Diagnostics {
 
@@ -609,14 +857,14 @@ class MappingProcessorBeanTest {
           compile(D, wire, spec("public interface M extends MappingSpec<D, WDto> {}"));
       assertThat(compilation).failed();
       assertThat(compilation)
-          .hadErrorContaining(
-              "bean property 'a' on 'WDto' has a getter and setter of different types");
-      assertThat(compilation).hadErrorContaining("Align the getter and setter types on the bean");
+          .hadErrorContaining("bean property 'a' on 'WDto' is read and written at different types");
+      assertThat(compilation)
+          .hadErrorContaining("Align the getter and its setter (or builder setter)");
     }
 
     @Test
-    @DisplayName("a bean with no public no-args constructor is rejected")
-    void noNoArgsConstructor() {
+    @DisplayName("a bean that is neither constructible nor a builder is rejected")
+    void noConstructionStrategy() {
       JavaFileObject wire =
           JavaFileObjects.forSourceString(
               "com.example.WDto",
@@ -634,7 +882,7 @@ class MappingProcessorBeanTest {
           compile(D, wire, spec("public interface M extends MappingSpec<D, WDto> {}"));
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("'WDto' is not a usable bean-shaped wire");
-      assertThat(compilation).hadErrorContaining("has no public no-args constructor");
+      assertThat(compilation).hadErrorContaining("no construction strategy fits it");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -1072,7 +1072,13 @@ class MappingProcessorBeanTest {
       Compilation compilation = compile(domain, wire, spec);
       assertThat(compilation).failed();
       assertThat(compilation)
-          .hadErrorContaining("target field 'BoxDto.count' has no usable source");
+          .hadErrorContaining(
+              "domain field 'Box.count' is Optional<java.lang.Integer>, bridged to the nullable"
+                  + " bean property 'count' of type java.lang.String");
+      assertThat(compilation)
+          .hadErrorContaining(
+              "ValidatedPrism<java.lang.String, java.lang.Integer> (the element types, not the"
+                  + " Optional)");
     }
 
     @Test
@@ -1261,6 +1267,99 @@ class MappingProcessorBeanTest {
           .hadErrorContaining(
               "'EmployeeCardDto' is a bean projection of 'Employee' with a reference-typed property");
       assertThat(compilation).hadErrorContaining("maps as a validated patch");
+    }
+  }
+
+  @Nested
+  @DisplayName("Constructor accessibility")
+  class ConstructorAccessibility {
+
+    @Test
+    @DisplayName("a same-package bean with a package-private constructor is usable")
+    void samePackageNonPublicConstructor() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.D",
+              """
+              package com.example;
+
+              public record D(String a) {}
+              """);
+      // Package-private class (so an implicit package-private constructor), co-located with the
+      // spec.
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.SameBean",
+              """
+              package com.example;
+
+              class SameBean {
+                private String a;
+                public String getA() { return a; }
+                public void setA(String a) { this.a = a; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.SameMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface SameMapping extends MappingSpec<D, SameBean> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      Assertions.assertThat(generatedSource(compilation, "com.example.SameMappingImpl"))
+          .contains("SameBean wire = new SameBean();");
+    }
+
+    @Test
+    @DisplayName("a cross-package bean with a non-public constructor is rejected, not miscompiled")
+    void crossPackageNonPublicConstructor() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.D",
+              """
+              package com.example;
+
+              public record D(String a) {}
+              """);
+      // A public class in another package whose no-args constructor is package-private: the impl
+      // (emitted in com.example) could not call `new Foreign()`.
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.other.Foreign",
+              """
+              package com.other;
+
+              public class Foreign {
+                Foreign() {}
+                private String a;
+                public String getA() { return a; }
+                public void setA(String a) { this.a = a; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ForeignMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface ForeignMapping extends MappingSpec<D, com.other.Foreign> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'Foreign' is not a usable bean-shaped wire");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -813,6 +813,458 @@ class MappingProcessorBeanTest {
   }
 
   @Nested
+  @DisplayName("Optional bridging")
+  class OptionalBridging {
+
+    @Test
+    @DisplayName(
+        "a domain Optional maps to a nullable bean property, skipping the write when empty")
+    void identityBridge() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Profile",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public record Profile(String handle, Optional<String> bio) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.ProfileDto",
+              """
+              package com.example;
+
+              public class ProfileDto {
+                private String handle;
+                private String bio;
+                public String getHandle() { return handle; }
+                public void setHandle(String handle) { this.handle = handle; }
+                public String getBio() { return bio; }
+                public void setBio(String bio) { this.bio = bio; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ProfileMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface ProfileMapping extends MappingSpec<Profile, ProfileDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.ProfileMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("domain.bio().ifPresent(v -> wire.setBio(v));")
+          .contains(".field(\"bio\", Validated.validNel(Optional.ofNullable(wire.getBio())))")
+          .doesNotContain("asIso");
+
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.ProfileMappingImpl").getField("INSTANCE").get(null);
+        Object present =
+            result
+                .loadClass("com.example.Profile")
+                .getDeclaredConstructor(String.class, java.util.Optional.class)
+                .newInstance("ada", java.util.Optional.of("hi"));
+        Object emptyProfile =
+            result
+                .loadClass("com.example.Profile")
+                .getDeclaredConstructor(String.class, java.util.Optional.class)
+                .newInstance("ada", java.util.Optional.empty());
+
+        Object dtoPresent = invoke(impl, "build", present);
+        Assertions.assertThat(invoke(dtoPresent, "getBio")).isEqualTo("hi");
+        Object dtoEmpty = invoke(impl, "build", emptyProfile);
+        Assertions.assertThat(invoke(dtoEmpty, "getBio")).isNull();
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsedEmpty =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dtoEmpty);
+        Assertions.assertThat(parsedEmpty.get()).isEqualTo(emptyProfile);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("a domain Optional element maps through a leaf to a nullable bean property")
+    void leafBridge() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Account",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public record Account(Optional<EmailAddress> email) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.AccountDto",
+              """
+              package com.example;
+
+              public class AccountDto {
+                private String email;
+                public String getEmail() { return email; }
+                public void setEmail(String email) { this.email = email; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.AccountMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface AccountMapping extends MappingSpec<Account, AccountDto> {
+                default ValidatedPrism<String, EmailAddress> email() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+              }
+              """);
+
+      Compilation compilation = compile(EMAIL, domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.AccountMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("domain.email().map(email()::build).ifPresent(v -> wire.setEmail(v));")
+          .contains(
+              ".field(\"email\", Optional.ofNullable(wire.getEmail()).map(v ->"
+                  + " email().parse(v).map(Optional::of))");
+    }
+
+    @Test
+    @DisplayName("a bad Optional-bridged element still accumulates a located failure")
+    void bridgeElementValidation() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Account",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public record Account(Optional<EmailAddress> email) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.AccountDto",
+              """
+              package com.example;
+
+              public class AccountDto {
+                private String email;
+                public String getEmail() { return email; }
+                public void setEmail(String email) { this.email = email; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.AccountMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface AccountMapping extends MappingSpec<Account, AccountDto> {
+                default ValidatedPrism<String, EmailAddress> email() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+              }
+              """);
+
+      Compilation compilation = compile(EMAIL, domain, wire, spec);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.AccountMappingImpl").getField("INSTANCE").get(null);
+        Object dto = result.newInstance("com.example.AccountDto");
+        invoke(dto, "setEmail", "not-an-email");
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsed =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dto);
+        Assertions.assertThat(parsed.getError().toJavaList())
+            .containsExactly(new FieldError(List.of("email"), "not an email address"));
+
+        // An absent (null) email is valid: it bridges to Optional.empty.
+        Object emptyDto = result.newInstance("com.example.AccountDto");
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsedEmpty =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", emptyDto);
+        Assertions.assertThat(parsedEmpty.isValid()).isTrue();
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("a domain Optional element with no identity or leaf to the property is rejected")
+    void bridgeWithoutElementSourceRejected() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Box",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public record Box(Optional<Integer> count) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.BoxDto",
+              """
+              package com.example;
+
+              public class BoxDto {
+                private String count;
+                public String getCount() { return count; }
+                public void setCount(String count) { this.count = count; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.BoxMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface BoxMapping extends MappingSpec<Box, BoxDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("target field 'BoxDto.count' has no usable source");
+    }
+
+    @Test
+    @DisplayName("a non-Optional mismatched bean property is not a bridge and is rejected")
+    void nonOptionalMismatchNotABridge() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Thing",
+              """
+              package com.example;
+
+              public record Thing(int count) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.ThingDto",
+              """
+              package com.example;
+
+              public class ThingDto {
+                private String count;
+                public String getCount() { return count; }
+                public void setCount(String count) { this.count = count; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ThingMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface ThingMapping extends MappingSpec<Thing, ThingDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("target field 'ThingDto.count' has no usable source");
+    }
+
+    @Test
+    @DisplayName(
+        "a bean Optional property against a domain Optional (unresolvable element) is not a bridge")
+    void beanOptionalPropertyIsNotABridge() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Holder",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public record Holder(Optional<Integer> value) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.HolderDto",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public class HolderDto {
+                private Optional<String> value;
+                public Optional<String> getValue() { return value; }
+                public void setValue(Optional<String> value) { this.value = value; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.HolderMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface HolderMapping extends MappingSpec<Holder, HolderDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("target field 'HolderDto.value' has no usable source");
+    }
+  }
+
+  @Nested
+  @DisplayName("Projection tier")
+  class ProjectionTier {
+
+    @Test
+    @DisplayName("an all-primitive bean projection gains a lawful asLens")
+    void allPrimitiveProjectionAsLens() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Reading",
+              """
+              package com.example;
+
+              public record Reading(int temperature, int humidity, long timestamp) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.ReadingDto",
+              """
+              package com.example;
+
+              public class ReadingDto {
+                private int temperature;
+                private int humidity;
+                public int getTemperature() { return temperature; }
+                public void setTemperature(int temperature) { this.temperature = temperature; }
+                public int getHumidity() { return humidity; }
+                public void setHumidity(int humidity) { this.humidity = humidity; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ReadingMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface ReadingMapping extends MappingSpec<Reading, ReadingDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.ReadingMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("ReadingDto wire = new ReadingDto();")
+          .contains("wire.setTemperature(domain.temperature());")
+          .contains("public Lens<Reading, ReadingDto> asLens()")
+          .doesNotContain("parse(")
+          .doesNotContain("asValidatedPrism");
+    }
+
+    @Test
+    @DisplayName("a reference-typed bean projection is deferred to the validated patch tier")
+    void referenceProjectionDeferred() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Employee",
+              """
+              package com.example;
+
+              public record Employee(String name, String department, int age) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.EmployeeCardDto",
+              """
+              package com.example;
+
+              public class EmployeeCardDto {
+                private String name;
+                public String getName() { return name; }
+                public void setName(String name) { this.name = name; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.EmployeeCardMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface EmployeeCardMapping extends MappingSpec<Employee, EmployeeCardDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'EmployeeCardDto' is a bean projection of 'Employee' with a reference-typed property");
+      assertThat(compilation).hadErrorContaining("maps as a validated patch");
+    }
+  }
+
+  @Nested
   @DisplayName("Diagnostics")
   class Diagnostics {
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -1489,6 +1489,290 @@ class MappingProcessorBeanTest {
     }
   }
 
+  @Nested
+  @DisplayName("Property-analyser branch coverage")
+  class AnalyserBranchCoverage {
+
+    private static final JavaFileObject DOM =
+        JavaFileObjects.forSourceString(
+            "com.example.Dom",
+            """
+            package com.example;
+
+            public record Dom(String a) {}
+            """);
+
+    /** Compiles a bean-wire spec mapping {@code Dom} to the given wire class. */
+    private Compilation analyse(String wireName, String wireSource) {
+      JavaFileObject wire = JavaFileObjects.forSourceString("com.example." + wireName, wireSource);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.Map" + wireName,
+              "package com.example;\n"
+                  + "import org.higherkindedj.optics.annotations.GenerateMapping;\n"
+                  + "import org.higherkindedj.optics.annotations.MappingSpec;\n"
+                  + "@GenerateMapping public interface Map"
+                  + wireName
+                  + " extends MappingSpec<Dom, "
+                  + wireName
+                  + "> {}\n");
+      return compile(DOM, wire, spec);
+    }
+
+    @Test
+    @DisplayName("decapitalise handles the empty, acronym, single-char and normal cases")
+    void decapitaliseEdgeCases() {
+      Assertions.assertThat(BeanPropertyAnalyser.decapitalise("")).isEmpty();
+      Assertions.assertThat(BeanPropertyAnalyser.decapitalise("URL")).isEqualTo("URL");
+      Assertions.assertThat(BeanPropertyAnalyser.decapitalise("Name")).isEqualTo("name");
+      Assertions.assertThat(BeanPropertyAnalyser.decapitalise("A")).isEqualTo("a");
+    }
+
+    @Test
+    @DisplayName("non-accessor methods (void, too-short, wrong-shape) are ignored, not misread")
+    void nonAccessorMethodsIgnored() {
+      // Exercises the getter/setter recognition guards: a void method and a wrong-return is-getter
+      // are not getters; a getter-only String/int property is not a JAXB collection; "get"/"is"/
+      // "set" that are too short, and a non-get/is/set method, are all skipped.
+      Compilation compilation =
+          analyse(
+              "OddBean",
+              """
+              package com.example;
+
+              public class OddBean {
+                private String a;
+                private String b;
+                private int c;
+                public String getA() { return a; }
+                public void setA(String a) { this.a = a; }
+                public String getB() { return b; }
+                public int getC() { return c; }
+                public void reset() {}
+                public String get() { return ""; }
+                public String describe() { return ""; }
+                public String isReady() { return ""; }
+                public boolean is() { return true; }
+                public void set(String x) {}
+              }
+              """);
+      assertThat(compilation).succeeded();
+      Assertions.assertThat(generatedSource(compilation, "com.example.MapOddBean"))
+          .contains("wire.setA(domain.a());");
+    }
+
+    @Test
+    @DisplayName("a builder whose setter type disagrees with the getter is rejected")
+    void builderTypeMismatch() {
+      Compilation compilation =
+          analyse(
+              "B8",
+              """
+              package com.example;
+
+              public class B8 {
+                private B8() {}
+                private String a;
+                public String getA() { return a; }
+                public static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public Builder a(int x) { return this; }
+                  public B8 build() { return new B8(); }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("bean property 'a' on 'B8' is read and written at different types");
+    }
+
+    @Test
+    @DisplayName("a builder covering only some getters maps the covered ones")
+    void builderPartialCoverage() {
+      Compilation compilation =
+          analyse(
+              "B9",
+              """
+              package com.example;
+
+              public class B9 {
+                private B9() {}
+                private String a;
+                private String b;
+                public String getA() { return a; }
+                public String getB() { return b; }
+                public static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public Builder a(String v) { return this; }
+                  public B9 build() { return new B9(); }
+                }
+              }
+              """);
+      assertThat(compilation).succeeded();
+      Assertions.assertThat(generatedSource(compilation, "com.example.MapB9"))
+          .contains("b.a(domain.a())");
+    }
+
+    @Test
+    @DisplayName("a builder whose setters match no getter is unusable")
+    void builderNoMatchingProperty() {
+      Compilation compilation =
+          analyse(
+              "B10",
+              """
+              package com.example;
+
+              public class B10 {
+                private B10() {}
+                private String a;
+                public String getA() { return a; }
+                public static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public Builder x(String v) { return this; }
+                  public B10 build() { return new B10(); }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B10' is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a builder factory returning a non-class type is not a builder")
+    void builderFactoryNonDeclaredReturn() {
+      Compilation compilation =
+          analyse(
+              "B3",
+              """
+              package com.example;
+
+              public class B3 {
+                private B3() {}
+                private String a;
+                public String getA() { return a; }
+                public static int builder() { return 0; }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B3' is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a builder factory with parameters is not a builder")
+    void builderFactoryWithParameters() {
+      Compilation compilation =
+          analyse(
+              "B4",
+              """
+              package com.example;
+
+              public class B4 {
+                private B4() {}
+                private String a;
+                public String getA() { return a; }
+                public static Builder builder(int seed) { return new Builder(); }
+                public static final class Builder {
+                  public B4 build() { return new B4(); }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B4' is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a non-static builder factory is not a builder")
+    void builderFactoryNonStatic() {
+      Compilation compilation =
+          analyse(
+              "B5",
+              """
+              package com.example;
+
+              public class B5 {
+                private B5() {}
+                private String a;
+                public String getA() { return a; }
+                public Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public B5 build() { return new B5(); }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B5' is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a non-public builder factory is not a builder")
+    void builderFactoryNonPublic() {
+      Compilation compilation =
+          analyse(
+              "B6",
+              """
+              package com.example;
+
+              public class B6 {
+                private B6() {}
+                private String a;
+                public String getA() { return a; }
+                static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public B6 build() { return new B6(); }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B6' is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a builder whose build() takes parameters does not yield the wire")
+    void builderBuildWithParameters() {
+      Compilation compilation =
+          analyse(
+              "B7a",
+              """
+              package com.example;
+
+              public class B7a {
+                private B7a() {}
+                private String a;
+                public String getA() { return a; }
+                public static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public B7a build(int x) { return new B7a(); }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B7a' is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a builder whose build() returns another type does not yield the wire")
+    void builderBuildWrongReturn() {
+      Compilation compilation =
+          analyse(
+              "B7b",
+              """
+              package com.example;
+
+              public class B7b {
+                private B7b() {}
+                private String a;
+                public String getA() { return a; }
+                public static Builder builder() { return new Builder(); }
+                public static final class Builder {
+                  public String build() { return ""; }
+                }
+              }
+              """);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'B7b' is not a usable bean-shaped wire");
+    }
+  }
+
   private static String generatedSource(Compilation compilation, String qualifiedName) {
     return compilation.generatedSourceFiles().stream()
         .filter(f -> f.getName().contains(qualifiedName.replace('.', '/')))

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -1,0 +1,707 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.RuntimeCompilationHelper.invoke;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
+import javax.tools.JavaFileObject;
+import org.assertj.core.api.Assertions;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MappingProcessor - bean-shaped wire targets (#628)")
+class MappingProcessorBeanTest {
+
+  private static final JavaFileObject EMAIL =
+      JavaFileObjects.forSourceString(
+          "com.example.EmailAddress",
+          """
+          package com.example;
+
+          public record EmailAddress(String value) {}
+          """);
+
+  private Compilation compile(JavaFileObject... sources) {
+    return javac().withProcessors(new MappingProcessor()).compile(sources);
+  }
+
+  @Nested
+  @DisplayName("Mutable JavaBean full tier")
+  class MutableFullTier {
+
+    private static final JavaFileObject USER =
+        JavaFileObjects.forSourceString(
+            "com.example.User",
+            """
+            package com.example;
+
+            public record User(String name, EmailAddress email, int age) {}
+            """);
+
+    // A mutable getter/setter bean: not a record, not annotatable.
+    private static final JavaFileObject USER_DTO =
+        JavaFileObjects.forSourceString(
+            "com.example.UserDto",
+            """
+            package com.example;
+
+            public class UserDto {
+              private String name;
+              private String email;
+              private int age;
+
+              public String getName() { return name; }
+              public void setName(String name) { this.name = name; }
+              public String getEmail() { return email; }
+              public void setEmail(String email) { this.email = email; }
+              public int getAge() { return age; }
+              public void setAge(int age) { this.age = age; }
+            }
+            """);
+
+    private static final JavaFileObject USER_MAPPING =
+        JavaFileObjects.forSourceString(
+            "com.example.UserMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.hkt.validated.FieldError;
+            import org.higherkindedj.hkt.validated.Validated;
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+            import org.higherkindedj.optics.validated.ValidatedPrism;
+
+            @GenerateMapping
+            public interface UserMapping extends MappingSpec<User, UserDto> {
+              default ValidatedPrism<String, EmailAddress> email() {
+                return ValidatedPrism.of(
+                    raw ->
+                        raw.contains("@")
+                            ? Validated.validNel(new EmailAddress(raw))
+                            : Validated.invalidNel(FieldError.of("not an email address")),
+                    EmailAddress::value);
+              }
+            }
+            """);
+
+    @Test
+    @DisplayName("build fills via setters, parse reads via getters null-guarded, no asIso")
+    void buildViaSettersParseGuarded() {
+      Compilation compilation = compile(EMAIL, USER, USER_DTO, USER_MAPPING);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.UserMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("UserDto wire = new UserDto();")
+          .contains("wire.setName(domain.name());")
+          .contains("wire.setEmail(email().build(domain.email()));")
+          .contains("wire.setAge(domain.age());")
+          .contains("return wire;")
+          .contains(".field(\"name\", ifPresent(wire.getName(), Validated::validNel))")
+          .contains(".field(\"email\", ifPresent(wire.getEmail(), email()::parse))")
+          .contains(".field(\"age\", Validated.validNel(wire.getAge()))")
+          .contains("private static <S, A> Validated<NonEmptyList<FieldError>, A> ifPresent(")
+          .doesNotContain("asIso");
+    }
+
+    @Test
+    @DisplayName("round-trips a domain value through the bean")
+    void roundTrips() {
+      Compilation compilation = compile(EMAIL, USER, USER_DTO, USER_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.UserMappingImpl").getField("INSTANCE").get(null);
+        Object email = result.newInstance("com.example.EmailAddress", "ada@corp.example");
+        Object user = result.newInstance("com.example.User", "Ada", email, 42);
+
+        Object dto = invoke(impl, "build", user);
+        Assertions.assertThat(invoke(dto, "getName")).isEqualTo("Ada");
+        Assertions.assertThat(invoke(dto, "getEmail")).isEqualTo("ada@corp.example");
+        Assertions.assertThat(invoke(dto, "getAge")).isEqualTo(42);
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsed =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dto);
+        Assertions.assertThat(parsed.isValid()).isTrue();
+        Assertions.assertThat(parsed.get()).isEqualTo(user);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName(
+        "a null property parses to one located FieldError, accumulating, never hitting a leaf")
+    void nullPropertyLocatedAndAccumulated() {
+      Compilation compilation = compile(EMAIL, USER, USER_DTO, USER_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.UserMappingImpl").getField("INSTANCE").get(null);
+        // name null and email null: both located, and the null email never reaches email().parse
+        // (which would throw), proving the guard runs first.
+        Object dto = result.loadClass("com.example.UserDto").getDeclaredConstructor().newInstance();
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsed =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dto);
+        Assertions.assertThat(parsed.isInvalid()).isTrue();
+        Assertions.assertThat(parsed.getError().toJavaList())
+            .containsExactly(
+                new FieldError(List.of("name"), "must not be null"),
+                new FieldError(List.of("email"), "must not be null"));
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("Detection")
+  class Detection {
+
+    @Test
+    @DisplayName("a boolean isX getter is a property; an all-primitive bean gains asIso")
+    void booleanIsGetterAndAllPrimitiveIso() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Flag",
+              """
+              package com.example;
+
+              public record Flag(boolean active, int level) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.FlagDto",
+              """
+              package com.example;
+
+              public class FlagDto {
+                private boolean active;
+                private int level;
+
+                public boolean isActive() { return active; }
+                public void setActive(boolean active) { this.active = active; }
+                public int getLevel() { return level; }
+                public void setLevel(int level) { this.level = level; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.FlagMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface FlagMapping extends MappingSpec<Flag, FlagDto> {}
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.FlagMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("wire.setActive(domain.active());")
+          .contains("wire.setLevel(domain.level());")
+          .contains(".field(\"active\", Validated.validNel(wire.isActive()))")
+          .contains(".field(\"level\", Validated.validNel(wire.getLevel()))")
+          .contains("public Iso<Flag, FlagDto> asIso()")
+          .contains("Iso.of(this::build, wire -> new Flag(wire.isActive(), wire.getLevel()))")
+          .doesNotContain("ifPresent");
+    }
+
+    @Test
+    @DisplayName("getters and setters inherited from a base class are properties")
+    void inheritedAccessors() {
+      JavaFileObject base =
+          JavaFileObjects.forSourceString(
+              "com.example.NamedBase",
+              """
+              package com.example;
+
+              public class NamedBase {
+                private String name;
+                public String getName() { return name; }
+                public void setName(String name) { this.name = name; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Employee",
+              """
+              package com.example;
+
+              public record Employee(String name, String role) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.EmployeeDto",
+              """
+              package com.example;
+
+              public class EmployeeDto extends NamedBase {
+                private String role;
+                public String getRole() { return role; }
+                public void setRole(String role) { this.role = role; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.EmployeeMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface EmployeeMapping extends MappingSpec<Employee, EmployeeDto> {}
+              """);
+
+      Compilation compilation = compile(base, domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.EmployeeMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("wire.setName(domain.name());")
+          .contains("wire.setRole(domain.role());")
+          .contains("ifPresent(wire.getName(), Validated::validNel)")
+          .contains("ifPresent(wire.getRole(), Validated::validNel)");
+    }
+  }
+
+  @Nested
+  @DisplayName("Features carried over")
+  class Features {
+
+    @Test
+    @DisplayName("@MapField renames a domain component to an all-caps bean property (decapitalise)")
+    void renameToAllCapsProperty() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Site",
+              """
+              package com.example;
+
+              public record Site(String link) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.SiteDto",
+              """
+              package com.example;
+
+              public class SiteDto {
+                private String url;
+                public String getURL() { return url; }
+                public void setURL(String url) { this.url = url; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.SiteMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MapField;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface SiteMapping extends MappingSpec<Site, SiteDto> {
+                @MapField(to = "URL")
+                String link();
+              }
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.SiteMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("wire.setURL(domain.link());")
+          .contains(".field(\"link\", ifPresent(wire.getURL(), Validated::validNel))");
+    }
+
+    @Test
+    @DisplayName("a derived field fills a bean property via a Getter; parse ignores it")
+    void derivedFieldOnBean() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Person",
+              """
+              package com.example;
+
+              public record Person(String first, String last) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.PersonDto",
+              """
+              package com.example;
+
+              public class PersonDto {
+                private String first;
+                private String last;
+                private String displayName;
+                public String getFirst() { return first; }
+                public void setFirst(String first) { this.first = first; }
+                public String getLast() { return last; }
+                public void setLast(String last) { this.last = last; }
+                public String getDisplayName() { return displayName; }
+                public void setDisplayName(String displayName) { this.displayName = displayName; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.PersonMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.Getter;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface PersonMapping extends MappingSpec<Person, PersonDto> {
+                default Getter<Person, String> displayName() {
+                  return Getter.of(p -> p.first() + " " + p.last());
+                }
+              }
+              """);
+
+      Compilation compilation = compile(domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.PersonMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("wire.setDisplayName(displayName().get(domain));")
+          .contains(".field(\"first\", ifPresent(wire.getFirst(), Validated::validNel))")
+          .doesNotContain(".field(\"displayName\"")
+          .doesNotContain("asIso");
+    }
+
+    @Test
+    @DisplayName("List, Optional and Map bean properties lift through element leaves, guarded")
+    void containerLiftingOnBean() {
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Contacts",
+              """
+              package com.example;
+
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Optional;
+
+              public record Contacts(
+                  List<EmailAddress> all,
+                  Optional<EmailAddress> primary,
+                  Map<String, EmailAddress> tagged) {}
+              """);
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.ContactsDto",
+              """
+              package com.example;
+
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Optional;
+
+              public class ContactsDto {
+                private List<String> all;
+                private Optional<String> primary;
+                private Map<String, String> tagged;
+                public List<String> getAll() { return all; }
+                public void setAll(List<String> all) { this.all = all; }
+                public Optional<String> getPrimary() { return primary; }
+                public void setPrimary(Optional<String> primary) { this.primary = primary; }
+                public Map<String, String> getTagged() { return tagged; }
+                public void setTagged(Map<String, String> tagged) { this.tagged = tagged; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ContactsMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface ContactsMapping extends MappingSpec<Contacts, ContactsDto> {
+                default ValidatedPrism<String, EmailAddress> all() { return prism(); }
+                default ValidatedPrism<String, EmailAddress> primary() { return prism(); }
+                default ValidatedPrism<String, EmailAddress> tagged() { return prism(); }
+
+                private static ValidatedPrism<String, EmailAddress> prism() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+              }
+              """);
+
+      Compilation compilation = compile(EMAIL, domain, wire, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.ContactsMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("wire.setAll(all().buildAll(domain.all()));")
+          .contains("wire.setTagged(tagged().buildValues(domain.tagged()));")
+          .contains("wire.setPrimary(domain.primary().map(primary()::build));")
+          .contains(".field(\"all\", ifPresent(wire.getAll(), all()::parseAll))")
+          .contains(".field(\"tagged\", ifPresent(wire.getTagged(), tagged()::parseValues))")
+          .contains(".field(\"primary\", ifPresent(wire.getPrimary(), o -> o.map(v ->");
+    }
+
+    @Test
+    @DisplayName("a record spec nests a bean spec through its asValidatedPrism")
+    void nestedBeanSpecInsideRecord() {
+      JavaFileObject customer =
+          JavaFileObjects.forSourceString(
+              "com.example.Customer",
+              """
+              package com.example;
+
+              public record Customer(String name, EmailAddress email) {}
+              """);
+      JavaFileObject customerDto =
+          JavaFileObjects.forSourceString(
+              "com.example.CustomerDto",
+              """
+              package com.example;
+
+              public class CustomerDto {
+                private String name;
+                private String email;
+                public String getName() { return name; }
+                public void setName(String name) { this.name = name; }
+                public String getEmail() { return email; }
+                public void setEmail(String email) { this.email = email; }
+              }
+              """);
+      JavaFileObject customerMapping =
+          JavaFileObjects.forSourceString(
+              "com.example.CustomerMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface CustomerMapping extends MappingSpec<Customer, CustomerDto> {
+                default ValidatedPrism<String, EmailAddress> email() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+              }
+              """);
+      JavaFileObject order =
+          JavaFileObjects.forSourceString(
+              "com.example.Order",
+              """
+              package com.example;
+
+              public record Order(String id, Customer customer) {}
+              """);
+      JavaFileObject orderDto =
+          JavaFileObjects.forSourceString(
+              "com.example.OrderDto",
+              """
+              package com.example;
+
+              public record OrderDto(String id, CustomerDto customer) {}
+              """);
+      JavaFileObject orderMapping =
+          JavaFileObjects.forSourceString(
+              "com.example.OrderMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface OrderMapping extends MappingSpec<Order, OrderDto> {}
+              """);
+
+      Compilation compilation =
+          compile(EMAIL, customer, customerDto, customerMapping, order, orderDto, orderMapping);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.OrderMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("CustomerMappingImpl.INSTANCE.asValidatedPrism().build(domain.customer())")
+          .contains(
+              ".field(\"customer\","
+                  + " CustomerMappingImpl.INSTANCE.asValidatedPrism().parse(wire.customer()))");
+    }
+  }
+
+  @Nested
+  @DisplayName("Diagnostics")
+  class Diagnostics {
+
+    private static final JavaFileObject D =
+        JavaFileObjects.forSourceString(
+            "com.example.D",
+            """
+            package com.example;
+
+            public record D(String a) {}
+            """);
+
+    private static JavaFileObject spec(String body) {
+      return JavaFileObjects.forSourceString(
+          "com.example.M",
+          """
+          package com.example;
+
+          import org.higherkindedj.optics.annotations.GenerateMapping;
+          import org.higherkindedj.optics.annotations.MappingSpec;
+
+          @GenerateMapping
+          """
+              + body);
+    }
+
+    @Test
+    @DisplayName("a bean whose getter and setter disagree on type is rejected")
+    void getterSetterTypeMismatch() {
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.WDto",
+              """
+              package com.example;
+
+              public class WDto {
+                public String getA() { return null; }
+                public void setA(int a) {}
+              }
+              """);
+      Compilation compilation =
+          compile(D, wire, spec("public interface M extends MappingSpec<D, WDto> {}"));
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "bean property 'a' on 'WDto' has a getter and setter of different types");
+      assertThat(compilation).hadErrorContaining("Align the getter and setter types on the bean");
+    }
+
+    @Test
+    @DisplayName("a bean with no public no-args constructor is rejected")
+    void noNoArgsConstructor() {
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.WDto",
+              """
+              package com.example;
+
+              public class WDto {
+                private final String a;
+                public WDto(String a) { this.a = a; }
+                public String getA() { return a; }
+                public void setA(String a) {}
+              }
+              """);
+      Compilation compilation =
+          compile(D, wire, spec("public interface M extends MappingSpec<D, WDto> {}"));
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'WDto' is not a usable bean-shaped wire");
+      assertThat(compilation).hadErrorContaining("has no public no-args constructor");
+    }
+
+    @Test
+    @DisplayName("a wire that is a plain interface is rejected as neither record nor bean")
+    void wireIsInterface() {
+      Compilation compilation =
+          compile(D, spec("public interface M extends MappingSpec<D, Runnable> {}"));
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("is neither a record nor a bean-shaped class");
+      assertThat(compilation).hadErrorContaining("Use a record, or a concrete bean class");
+    }
+
+    @Test
+    @DisplayName("a wire that is an abstract class is rejected as neither record nor bean")
+    void wireIsAbstractClass() {
+      JavaFileObject abstractWire =
+          JavaFileObjects.forSourceString(
+              "com.example.AbstractDto",
+              """
+              package com.example;
+
+              public abstract class AbstractDto {
+                public abstract String getA();
+              }
+              """);
+      Compilation compilation =
+          compile(
+              D, abstractWire, spec("public interface M extends MappingSpec<D, AbstractDto> {}"));
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("is neither a record nor a bean-shaped class");
+    }
+
+    @Test
+    @DisplayName("a generic bean wire is rejected")
+    void genericBeanWire() {
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.BoxDto",
+              """
+              package com.example;
+
+              public class BoxDto<T> {
+                private String a;
+                public String getA() { return a; }
+                public void setA(String a) { this.a = a; }
+              }
+              """);
+      Compilation compilation =
+          compile(D, wire, spec("public interface M extends MappingSpec<D, BoxDto<String>> {}"));
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("'BoxDto' is generic, which this mapper does not support");
+    }
+  }
+
+  private static String generatedSource(Compilation compilation, String qualifiedName) {
+    return compilation.generatedSourceFiles().stream()
+        .filter(f -> f.getName().contains(qualifiedName.replace('.', '/')))
+        .findFirst()
+        .map(
+            f -> {
+              try {
+                return f.getCharContent(true).toString();
+              } catch (java.io.IOException e) {
+                throw new java.io.UncheckedIOException(e);
+              }
+            })
+        .orElseThrow(() -> new AssertionError("generated source not found: " + qualifiedName));
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
@@ -2718,8 +2718,7 @@ class MappingProcessorTest {
                   "public interface HalfMapping extends MappingSpec<Records.D, String> {}"));
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("'String' is not a usable bean-shaped wire");
-      assertThat(compilation)
-          .hadErrorContaining("public no-args constructor and at least one getter/setter property");
+      assertThat(compilation).hadErrorContaining("no construction strategy fits it");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
@@ -2707,8 +2707,9 @@ class MappingProcessorTest {
     }
 
     @Test
-    @DisplayName("a record domain with a non-record wire is rejected")
+    @DisplayName("a record domain with a wire that is neither record nor usable bean is rejected")
     void recordWithNonRecordWireRejected() {
+      // String is a concrete class (a candidate bean) but exposes no getter/setter property pair.
       Compilation compilation =
           compile(
               PLAIN,
@@ -2716,7 +2717,9 @@ class MappingProcessorTest {
                   "HalfMapping",
                   "public interface HalfMapping extends MappingSpec<Records.D, String> {}"));
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("must both be records, or both sealed interfaces");
+      assertThat(compilation).hadErrorContaining("'String' is not a usable bean-shaped wire");
+      assertThat(compilation)
+          .hadErrorContaining("public no-args constructor and at least one getter/setter property");
     }
 
     @Test
@@ -3550,7 +3553,7 @@ class MappingProcessorTest {
     }
 
     @Test
-    @DisplayName("rejects non-record type arguments")
+    @DisplayName("rejects a bean-shaped domain type argument")
     void rejectsNonRecordArguments() {
       JavaFileObject spec =
           JavaFileObjects.forSourceString(
@@ -3567,7 +3570,10 @@ class MappingProcessorTest {
 
       Compilation compilation = compile(WIRE, spec);
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("must both be records");
+      assertThat(compilation)
+          .hadErrorContaining(
+              "is a bean-shaped class, which this mapper does not support on the domain side");
+      assertThat(compilation).hadErrorContaining("the domain must be a record");
     }
   }
 


### PR DESCRIPTION
Closes #628.

Adds **bean-shaped wire targets** to `@GenerateMapping`: a record domain can now map to a bean (getter/setter DTO or builder-based immutable), not only a record. This is the one un-owned wire shape the mapper couldn't reach, and it dominates generated DTOs (JAXB, protobuf-lite, many OpenAPI generators). Design decisions were locked in the [#628 review comment](https://github.com/higher-kinded-j/higher-kinded-j/issues/628#issuecomment-5012882508); the plan lives at `docs/plans/IMPL-PLAN-bean-mapper.md`.

Zero new public API — the same empty spec interface, with the wire shape detected:

```java
public record User(String name, EmailAddress email) {}
public class UserDto { String getName(); void setName(String); String getEmail(); void setEmail(String); }

@GenerateMapping
public interface UserMapping extends MappingSpec<User, UserDto> {
  default ValidatedPrism<String, EmailAddress> email() { return EmailCodecs.EMAIL; }
}
// build(User)    -> new UserDto(); setName(...); setEmail(...)
// parse(UserDto) -> reads getName()/getEmail(), null-guarded, located + accumulating
```

## What's included

- **Construction ladder** (detected from the bean's shape): a no-args constructor with `setX` setters (and, for a getter-only `List`, the JAXB convention `getItems().addAll(...)`); then a static `builder()`/`newBuilder()` whose setters fill it and whose `build()` yields the wire. Fluent setters (returning the bean) are accepted.
- **Null is located, never thrown.** An unset bean property is `null` and `ValidatedPrism.parse` rejects `null`, so every reference-typed read is null-guarded into a located `FieldError`; `parse` stays total and accumulating, and a `null` never reaches a leaf. Primitive reads are unguarded.
- **Honest tiers, for free.** Those guards make reference components fallible, so `asIso()` is withheld automatically — an all-primitive bean still earns it. Bean mappings expose `asValidatedPrism()`, so record specs nest them and containers lift them.
- **Optional bridging.** A domain `Optional<T>` maps to a nullable bean property `T` (empty ↔ absent): `build` skips the write when empty (protecting null-hostile setters), `parse` reads `Optional.ofNullable(...)`.
- All existing features carry over: renames, leaves, derived fields, `List`/`Optional`/`Map` lifting, nesting both ways, sealed dispatch.
- What/why/fix diagnostics for: a bean domain, an unusable bean, a getter/setter type mismatch, a non-record/non-bean wire, and a deferred reference-typed bean projection.

## Structure (sequential commits)

- **A** — a `WireShape` abstraction over the wire side (zero behaviour change; byte-identical record output).
- **B** — mutable JavaBean full tier + null-guarded parse.
- **C** — builder and JAXB collection strategies.
- **D** — Optional bridging and the bean-projection safety gate.
- **E** — book section, example, law-check, javadoc, release notes.

## Deferred to follow-ons (documented)

The validated-`patch` projection tier (reference-typed bean projections), read-only (parse-only) and write-only (build-only) bean tiers, and Optional bridging through a nested spec. An all-primitive bean projection maps as a lawful `asLens()` today; a reference-typed one is reported with a pointer to the `patch` tier rather than emitting an unlawful lens. The sparse null-as-absent PATCH follow-up (`Update<Domain>`) is drafted at `docs/plans/DRAFT-ISSUE-bean-sparse-update.md`.

## Gates

`MappingProcessor*` holds at 100% line and branch coverage; the analyser and `WireShape` stay above the package gate; the full project builds clean; book snippets are compile-verified in hkj-examples; every emission tier (including the bean tier) is law-checked through the published `MappingLaws` harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mapping record domains to bean-shaped wire types (mutable getter/setter DTOs and immutable builder-based DTOs), including JavaBeans `isX` properties and common `List` getter/add patterns.
  * Extended `Optional<T>` mappings by bridging to nullable bean properties while keeping `parse` total via located `FieldError`s for unset reference fields.
* **Documentation**
  * Updated mapping docs, release history, and examples to cover bean-shaped DTOs and correct annotation placement.
* **Tests**
  * Added/expanded processor, law, and example tests for multiple bean construction strategies and null/Optional edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->