### PR TITLE
@GenerateMapping: sparse PATCH write-back via UpdateSpec (#645)

### DIFF
--- a/.claude/skills/hkj-mapping/SKILL.md
+++ b/.claude/skills/hkj-mapping/SKILL.md
@@ -26,6 +26,7 @@ validated domain type out to the wire cannot fail. Coming from the wire in can, 
 | You have | You want | Use |
 |----------|----------|-----|
 | One domain record + one wire DTO | Convert both ways | **`@GenerateMapping`** |
+| One domain record + a PATCH request bean | Fold the present fields, leave the absent | **`@GenerateMapping`** on **`UpdateSpec`** |
 | N source records | One target record | **`@GenerateMerge`** |
 | One record + independently-validated parts | Construct it, collecting every error | **`@GenerateAssembly`** |
 | A sealed error hierarchy | Codes, timestamps, and a typed context | **`@GenerateErrorEnvelope`** |
@@ -197,6 +198,40 @@ rejected outright: the projection's `asLens()` write-back could never honour a c
 - **`parse` is capped at 16 components**: it is assembled via `Validated.fields()`.
 - **It is law-checked.** Assert `build`/`parse` round-trip with `MappingLaws.assertMappingLaws(...)`
   from `hkj-test`.
+
+### Sparse PATCH write-back: `UpdateSpec`
+
+A REST `PATCH` body sends only the fields to change; every other property arrives `null`, meaning
+*not provided, leave unchanged* - the opposite of a `parse`, where `null` is broken data. Opt into
+that contract by extending **`UpdateSpec`** instead of `MappingSpec`. The wire must be **bean-shaped**
+(a record component is always present, so it cannot signal absence).
+
+<!-- verify -->
+```java
+@GenerateMapping
+public interface UserPatchMapping extends UpdateSpec<User, UserPatchBean> {}
+//                                                   ^domain ^PATCH request bean
+```
+
+The Impl exposes a *single* method, `updateFrom(Wire) : Edits.Accumulated<Domain>` - no
+`build`/`parse`/`as*`. It folds the present (non-null) fields into an update and skips the absent
+ones:
+
+<!-- verify -->
+```java
+UserPatchBean patch = new UserPatchBean();
+patch.setEmail("new@corp.example");                              // name absent -> unchanged
+Edits.Accumulated<User> update = UserPatchMappingImpl.INSTANCE.updateFrom(patch);
+Validated<NonEmptyList<FieldError>, User> updated = update.apply(user);  // or applyPath / toValidated
+```
+
+- **Present + valid** -> set (or parsed through its leaf), folded in. **Present + invalid** -> a
+  located `FieldError`, accumulating. **Absent (null)** -> skipped.
+- A **primitive** or **`Optional`-typed** wire property is rejected (neither can carry the absent
+  signal); use a wrapper type, or a nested record/sentinel for the Optional.
+- Coverage is one-sided: a domain component with no wire property is simply never changed.
+- Law-check it with the sparse overload:
+  `MappingLaws.assertMappingLaws(Impl.INSTANCE::updateFrom, current, absentWire, validWire, invalidWire)`.
 
 ---
 

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateMapping.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateMapping.java
@@ -39,6 +39,10 @@ import java.lang.annotation.Target;
  *   <li>A lossless mapping additionally gets {@code asIso()}; a wire record with fewer components
  *       maps as a projection with {@code asLens()} and no {@code parse} (truthful types); every
  *       parse-capable mapping gets {@code asValidatedPrism()} so it plugs in wherever a leaf does.
+ *   <li>A spec extending {@link UpdateSpec} instead of {@link MappingSpec} (issue #645) opts into
+ *       sparse null-as-absent PATCH: it generates only {@code updateFrom(Wire) :
+ *       Edits.Accumulated<Domain>}, folding the present (non-null) wire properties into an update
+ *       and leaving absent ones unchanged.
  * </ul>
  */
 @Target(ElementType.TYPE)

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/UpdateSpec.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/UpdateSpec.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.annotations;
+
+/**
+ * The specification interface for a generated sparse PATCH write-back — the null-as-absent sibling
+ * of {@link MappingSpec} (issue #645).
+ *
+ * <p>Declare an interface extending {@code UpdateSpec<Domain, Wire>} and annotate it with {@link
+ * GenerateMapping}. Where a {@link MappingSpec} treats a null bean property as broken data (a
+ * located {@code FieldError}), an {@code UpdateSpec} treats it as <em>not provided, leave
+ * unchanged</em> — the contract a REST PATCH request DTO follows, where the client sends only the
+ * fields it wants to change and the generated bean arrives with everything else null. The two
+ * meanings of null are a property of the DTO's contract, not something the mapper may infer, so
+ * sparse semantics are an explicit opt-in at the declaration site — never a silent reinterpretation
+ * of a {@link MappingSpec}.
+ *
+ * <p>The generated {@code <Spec>Impl} exposes a single method and nothing else — no {@code build},
+ * no {@code parse}, no {@code asIso}/{@code asLens}/{@code asValidatedPrism} (a sparse mapping is
+ * not a projection of information, and an all-null wire is <em>valid</em>, not a total parse):
+ *
+ * <pre>{@code
+ * public record User(String name, EmailAddress email, int age) {}
+ * // wire properties are wrappers: a primitive can never be absent (rejected with a diagnostic).
+ * public class UserPatchDto {
+ *   String getName(); void setName(String);
+ *   String getEmail(); void setEmail(String);
+ *   Integer getAge(); void setAge(Integer);
+ * }
+ *
+ * @GenerateMapping
+ * public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {
+ *   default ValidatedPrism<String, EmailAddress> email() { return EmailCodecs.EMAIL; }
+ * }
+ * // generates UserPatchMappingImpl with:
+ * //   Edits.Accumulated<User> updateFrom(UserPatchDto)   (folds the PRESENT fields into an Update)
+ *
+ * Edits.Accumulated<User> u = UserPatchMappingImpl.INSTANCE.updateFrom(dto);
+ * Validated<NonEmptyList<FieldError>, User> patched = u.apply(current); // or applyPath / toValidated
+ * }</pre>
+ *
+ * <ul>
+ *   <li><b>Present and valid</b> — the field is set (or parsed through its leaf) and folded into
+ *       the accumulated {@code Update}, composing with {@code Monoids.update()} and the {@code
+ *       Edits} ecosystem.
+ *   <li><b>Present and invalid</b> — a located {@code FieldError}, accumulating as usual:
+ *       sparseness never weakens validation of what <em>was</em> sent.
+ *   <li><b>Absent (null)</b> — skipped; the domain's current value survives.
+ * </ul>
+ *
+ * <p>The wire type {@code B} must be a bean-shaped class (a record cannot distinguish an absent
+ * component from a null-typed one), and every wire property must be reference-typed — a primitive
+ * property is always present, so it can never carry the null-as-absent signal and is rejected with
+ * a diagnostic pointing at the wrapper type. The domain type {@code A} must be a record. Coverage
+ * is one-sided: every wire property maps to a domain component, but a domain component with no wire
+ * property is simply never changed.
+ *
+ * @param <A> the domain type (a record)
+ * @param <B> the wire type (a bean-shaped PATCH DTO)
+ * @see MappingSpec
+ */
+public interface UpdateSpec<A, B> extends MappingSpec<A, B> {}

--- a/hkj-book/src/glossary/optics.md
+++ b/hkj-book/src/glossary/optics.md
@@ -308,9 +308,9 @@ Validated<NonEmptyList<FieldError>, Person> back =
     PersonMappingImpl.INSTANCE.parse(dto);                        // accumulating, located
 ```
 
-**Truthful emission tiers:** the generated mapper offers only what the shape supports: `asIso` when lossless, `asLens` when total one way, and the accumulating `parse` otherwise. Every tier is law-checked against the published `hkj-test` harness.
+**Truthful emission tiers:** the generated mapper offers only what the shape supports: `asIso` when lossless, `asLens` when total one way, and the accumulating `parse` otherwise. A spec extending [UpdateSpec](#updatespec) instead opts into the sparse PATCH tier (only `updateFrom`). Every tier is law-checked against the published `hkj-test` harness.
 
-**Related:** [Record Mapping](../optics/record_mapping.md), [ValidatedPrism](#validatedprism), [FieldError](#fielderror), [@GenerateMerge](#generatemerge)
+**Related:** [Record Mapping](../optics/record_mapping.md), [ValidatedPrism](#validatedprism), [FieldError](#fielderror), [@GenerateMerge](#generatemerge), [UpdateSpec](#updatespec)
 
 ---
 
@@ -498,6 +498,23 @@ Order discounted = orderItems.modify(
 ```
 
 **Related:** [Traversals Documentation](../optics/traversals.md)
+
+---
+
+## UpdateSpec
+
+**Definition:** The sparse-PATCH sibling of [MappingSpec](#generatemapping). Annotate an interface extending `UpdateSpec<Domain, Wire>` (with `@GenerateMapping`) to opt into the null-as-absent contract: a null bean property means *not provided, leave unchanged* rather than broken data. The processor generates a single method, `updateFrom(Wire) : Edits.Accumulated<Domain>` — no `build`, `parse`, or `as*` tier — folding the present (non-null) properties into an [Update](#edits) and skipping the absent ones. The wire must be bean-shaped; a primitive or `Optional`-typed component is rejected (neither can carry the absent signal). Present-but-invalid fields still fail, located and accumulating.
+
+**Example:**
+```java
+@GenerateMapping
+public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {}
+
+Edits.Accumulated<User> patch = UserPatchMappingImpl.INSTANCE.updateFrom(dto);
+Validated<NonEmptyList<FieldError>, User> updated = patch.apply(current); // absent fields survive
+```
+
+**Related:** [Record Mapping](../optics/record_mapping.md#sparse-patch-write-back-updatespec), [@GenerateMapping](#generatemapping), [Edits](#edits)
 
 ---
 

--- a/hkj-book/src/optics/annotations_at_a_glance.md
+++ b/hkj-book/src/optics/annotations_at_a_glance.md
@@ -61,9 +61,10 @@ External types like `LocalDate`, Jackson's `JsonNode`, JOOQ records, and Protobu
 | Annotation | Apply to | Generates | When to reach for it |
 |---|---|---|---|
 | [`@GenerateMapping`](record_mapping.md) | interface extending `MappingSpec<Domain, Wire>` | `XMappingImpl` with a total `build` and an accumulating, located `parse` | Bidirectional boundary mapping with validation: every bad field reported at once |
+| [`@GenerateMapping`](record_mapping.md#sparse-patch-write-back-updatespec) | interface extending `UpdateSpec<Domain, Wire>` (bean wire) | `XMappingImpl` with only `updateFrom(Wire) : Edits.Accumulated<Domain>` | Sparse PATCH write-back: fold the present (non-null) request fields into an update, leave the absent ones |
 | [`@MapField(to = "...")`](record_mapping.md) | abstract method on the spec, named after the domain component | a rename in both directions | Domain and wire components with different names |
 
-Leaves, nesting, `List`/`Optional` lifting, sealed dispatch and the `asIso()`/`asLens()` tiers are covered in [Record Mapping](record_mapping.md).
+Leaves, nesting, `List`/`Optional` lifting, sealed dispatch, the `asIso()`/`asLens()` tiers, and the sparse `UpdateSpec` tier are covered in [Record Mapping](record_mapping.md).
 
 ---
 
@@ -126,6 +127,7 @@ For compile-time path-type checking, see [Compile-Time Checks](../tooling/compil
 | An external sealed/enum (in a library) | Prisms for its variants | `@ImportOptics` |
 | `JsonNode`, JOOQ records, anything tricky | Custom optics with copy strategy | `@ImportOptics` on an `OpticsSpec` interface + spec-method hints |
 | A domain record and a wire DTO | Map both ways, with validation | `@GenerateMapping` on a `MappingSpec` interface |
+| A domain record and a PATCH request bean | Fold the present fields into an update, leave the absent ones | `@GenerateMapping` on an `UpdateSpec` interface |
 
 ---
 

--- a/hkj-book/src/optics/record_mapping.md
+++ b/hkj-book/src/optics/record_mapping.md
@@ -162,6 +162,7 @@ The field correspondences select what the Impl can lawfully offer; nothing is fa
 | Any fallible leaf, nested spec or derived field | `build`, accumulating `parse`, no `asIso` |
 | Wire record with *fewer* components (lossy projection) | `build` + **`asLens()`** whose `set` writes the projected components back, **no `parse`** (the dropped components cannot be reconstructed) |
 | Every parse-capable mapping | **`asValidatedPrism()`**: the mapping as a leaf, so it nests and lifts |
+| A spec extending **`UpdateSpec`** (opt-in, bean wire) | only **`updateFrom(Wire)`**: a sparse PATCH fold, [below](#sparse-patch-write-back-updatespec) |
 
 ``` java
 {{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:projection_spec}}
@@ -186,6 +187,7 @@ The overloads follow the tiers:
 - **Projection:** pass `asLens()` with a domain value and two wire values.
 - **Fallible tier:** pass `asValidatedPrism()` with a parsing and a non-parsing wire value.
 - **Derived-field (total-parse) mapping:** `build` recomputes what `parse` ignores, so only the non-derived components round-trip. The domain-sample overload `assertMappingLaws(prism, domainValue)` asserts exactly that and nothing stronger.
+- **Sparse-update (`UpdateSpec`) mapping:** pass the `updateFrom` method reference, a domain value, and an all-absent, a valid and an invalid wire to check the identity, idempotence and validation laws ([below](#sparse-patch-write-back-updatespec)).
 
 A spec with a derived field *and* a fallible leaf is better served by the fallible overload, given a parseable wire value whose derived components match what `build` would produce (this keeps the no-parse check). Reserve the domain-sample overload for total-parse mappings, where no wire value can fail.
 
@@ -218,6 +220,44 @@ The design decisions worth knowing:
 ~~~admonish note title="Not yet: bean projections and read-only beans"
 A bean *projection* (a bean with fewer properties than the domain) with a reference property, and read-only (parse-only) or write-only (build-only) beans, are follow-ons. An all-primitive bean projection maps as a lawful `asLens()` today; a reference-typed one is reported with a pointer to the planned validated-`patch` tier rather than emitting an unlawful lens.
 ~~~
+
+---
+
+## Sparse PATCH write-back: `UpdateSpec`
+
+A `parse` reads a null bean property as **broken data** - a located `FieldError`. But a REST `PATCH` body means the opposite: the client sends only the fields it wants to change, and every other property of the bound request arrives `null`, meaning *not provided, leave unchanged*. The two meanings of `null` are a property of the DTO's contract, not something the mapper can infer, so sparse semantics are an **explicit opt-in**: the spec extends `UpdateSpec<Domain, Wire>` instead of `MappingSpec`.
+
+``` java
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:update_spec}}
+```
+
+The Impl exposes a *single* method, `updateFrom(Wire) : Edits.Accumulated<Domain>` - no `build`, `parse`, or `as*` tier (a sparse mapping is not a projection of information, and an all-null wire is *valid*, not a total parse). It folds the present properties into an [`Update<Domain>`](multi_edit.md), leaving the absent ones alone:
+
+``` java
+{{#include ../../../hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java:update_usage}}
+```
+
+- **Present and valid** → the field is set, or parsed through its leaf, and folded in.
+- **Present and invalid** → a located `FieldError`, accumulating as usual: sparseness never weakens validation of what *was* sent. `Edits.Accumulated` also offers `applyPath(current)` to drop straight onto the [validation railway](../effect/path_validation.md), so a controller can answer `400` with the errors instead of persisting a partial write.
+- **Absent (null)** → skipped; the domain's current value survives.
+
+The return type is exactly what a hand-written [`Edits.accumulate(...)`](multi_edit.md) PATCH builder produces, so the two compose and the same consumption story (`apply`, `applyPath`, `toValidated`) carries over.
+
+The rules that keep the contract honest:
+
+- **A primitive wire property is rejected.** A primitive is always present (its default), so it can never carry the null-as-absent signal; use the wrapper type (`Integer`, `Boolean`). This is *forced*, not a style choice: an all-absent body must fold to the identity update, which a primitive would break.
+- **A domain `Optional<T>` component is rejected.** Under null-as-absent, `null` already means "leave unchanged", so "set to empty" has no encoding (and a null-clears rule would be JSON Merge Patch's opposite contract). Model the field as a nested record or a sentinel instead.
+- **A record wire is rejected.** A record component is always present, so absence is inexpressible - sparse PATCH is a bean-only shape.
+- **Coverage is one-sided.** Every wire property maps to a domain component, but a domain component with *no* wire property is simply never changed: a PATCH DTO deliberately covers a subset.
+- **A same-typed nested record, `List` or `Map` replaces wholesale** through identity; a nested record whose wire differs is patched wholesale through its own full mapping spec. Deep merge is out of scope.
+
+The sparse tier is law-checked like every other, through the same `MappingLaws` harness:
+
+``` java
+{{#include ../../../hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/RecordMappingBookLawsTest.java:update_laws}}
+```
+
+Identity (an all-absent wire is the identity update), idempotence (applying the same patch twice equals applying it once - which holds because the generated edits *set* and *parse*, never *modify*), and validation (a present invalid field fails).
 
 ---
 

--- a/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/book/mapping/RecordMappingBook.java
@@ -11,6 +11,8 @@ import org.higherkindedj.optics.annotations.GenerateMapping;
 import org.higherkindedj.optics.annotations.GenerateMerge;
 import org.higherkindedj.optics.annotations.MapField;
 import org.higherkindedj.optics.annotations.MappingSpec;
+import org.higherkindedj.optics.annotations.UpdateSpec;
+import org.higherkindedj.optics.edit.Edits;
 import org.higherkindedj.optics.validated.ValidatedPrism;
 
 /**
@@ -76,6 +78,18 @@ public final class RecordMappingBook {
     // A null bean property parses to a located FieldError, e.g. [email: must not be null].
     // ANCHOR_END: bean_usage
     System.out.println(bean.getName() + " / " + fromBean);
+
+    // ANCHOR: update_usage
+    Customer current = new Customer("Ada", new EmailAddress("ada@corp.example"));
+
+    ContactPatchBean patch = new ContactPatchBean();
+    patch.setName("Ada Lovelace"); // email left null: not provided, keep the current one
+
+    Edits.Accumulated<Customer> update = ContactPatchMappingImpl.INSTANCE.updateFrom(patch);
+    Validated<NonEmptyList<FieldError>, Customer> patched = update.apply(current);
+    // Valid(Customer[name=Ada Lovelace, email=ada@corp.example]) - only the name changed
+    // ANCHOR_END: update_usage
+    System.out.println(patched);
 
     // ANCHOR: merge_usage
     Dashboard dashboard =
@@ -251,6 +265,42 @@ interface ContactMapping extends MappingSpec<Customer, ContactBean> {
 }
 
 // ANCHOR_END: bean_spec
+
+// ANCHOR: update_spec
+// A PATCH request bean. Here null means "not provided, leave unchanged" - the opposite of the bean
+// parse above, where null is broken data. That contract is opted into by extending UpdateSpec.
+class ContactPatchBean {
+  private String name;
+  private String email;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}
+
+@GenerateMapping
+interface ContactPatchMapping extends UpdateSpec<Customer, ContactPatchBean> {
+  // Generates only updateFrom(ContactPatchBean) : Edits.Accumulated<Customer> - no build/parse/as*.
+  // A present field is set (email parsed through its leaf, located on failure); an absent (null)
+  // one is skipped, so the domain's current value survives.
+  default ValidatedPrism<String, EmailAddress> email() {
+    return EmailCodecs.EMAIL;
+  }
+}
+
+// ANCHOR_END: update_spec
 
 // ANCHOR: nested_merge_spec
 record Wrapper(CustomerDto customer) {} // the wire side

--- a/hkj-examples/src/main/java/org/higherkindedj/example/optics/UpdateSpecExample.java
+++ b/hkj-examples/src/main/java/org/higherkindedj/example/optics/UpdateSpecExample.java
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.annotations.GenerateMapping;
+import org.higherkindedj.optics.annotations.UpdateSpec;
+import org.higherkindedj.optics.edit.Edits;
+import org.higherkindedj.optics.validated.ValidatedPrism;
+
+/**
+ * A small end-to-end story for sparse PATCH write-back (issue #645): applying a partial update from
+ * a bean-shaped request DTO to an immutable domain record.
+ *
+ * <p>A REST {@code PATCH} body carries only the fields the client wants to change; every other
+ * property of the bound request object arrives {@code null}, meaning <em>not provided, leave
+ * unchanged</em>. That is the opposite of a {@link
+ * org.higherkindedj.optics.annotations.MappingSpec} bean parse, where a {@code null} required
+ * property is broken data. Because the two meanings of {@code null} are a property of the DTO's
+ * contract, sparseness is an explicit opt-in: the spec extends {@link UpdateSpec} instead of {@code
+ * MappingSpec}.
+ *
+ * <p>The generated {@code UpdateSpecExampleUserPatchMappingImpl} exposes a single method, {@code
+ * updateFrom(UserPatchRequest) : Edits.Accumulated<User>} — no {@code build}, {@code parse} or
+ * {@code as*} tier. It folds the present (non-null) properties into an {@link
+ * org.higherkindedj.hkt.Update}:
+ *
+ * <ul>
+ *   <li><b>Present and valid</b> — the field is set, or parsed through its leaf, and folded in.
+ *   <li><b>Present and invalid</b> — a located {@code FieldError}, accumulating as usual:
+ *       sparseness never weakens validation of what was sent.
+ *   <li><b>Absent (null)</b> — skipped; the domain's current value survives.
+ * </ul>
+ *
+ * <p>{@code age} is a wrapper {@code Integer} on the request so the scalar too can be absent; a
+ * primitive property could never carry the null-as-absent signal and is rejected at compile time.
+ * {@code UpdateSpecExampleTest} law-checks the mapping through the published {@code MappingLaws}
+ * harness ({@code hkj-test} is test-scope, so the laws live in a test, not here).
+ */
+public final class UpdateSpecExample {
+
+  public record EmailAddress(String value) {}
+
+  /** The immutable domain record a PATCH is applied onto. */
+  public record User(String name, EmailAddress email, int age) {}
+
+  /** A PATCH request bean: reference-typed getters/setters, a wrapper {@code Integer} for age. */
+  public static final class UserPatchRequest {
+    private String name;
+    private String email;
+    private Integer age;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public void setEmail(String email) {
+      this.email = email;
+    }
+
+    public Integer getAge() {
+      return age;
+    }
+
+    public void setAge(Integer age) {
+      this.age = age;
+    }
+  }
+
+  @GenerateMapping
+  public interface UserPatchMapping extends UpdateSpec<User, UserPatchRequest> {
+    default ValidatedPrism<String, EmailAddress> email() {
+      return emailPrism();
+    }
+  }
+
+  static ValidatedPrism<String, EmailAddress> emailPrism() {
+    return ValidatedPrism.of(
+        raw ->
+            raw.contains("@")
+                ? Validated.validNel(new EmailAddress(raw))
+                : Validated.invalidNel(FieldError.of("not an email address")),
+        EmailAddress::value);
+  }
+
+  /**
+   * Applies a PATCH request onto the current user: the present fields are folded in and validated,
+   * the absent ones keep their current value. A present-but-invalid field fails the whole patch,
+   * located — the endpoint would answer {@code 400} with the errors rather than persist a partial
+   * write.
+   */
+  public static Validated<NonEmptyList<FieldError>, User> applyPatch(
+      User current, UserPatchRequest request) {
+    Edits.Accumulated<User> patch =
+        UpdateSpecExampleUserPatchMappingImpl.INSTANCE.updateFrom(request);
+    return patch.apply(current);
+  }
+
+  public static void main(String[] args) {
+    User current = new User("Ada", new EmailAddress("ada@corp.example"), 36);
+
+    System.out.println("=== Present fields are applied, absent ones survive ===");
+    UserPatchRequest rename = new UserPatchRequest();
+    rename.setName("Ada Lovelace"); // email and age left unset (null)
+    System.out.println("Rename only:     " + applyPatch(current, rename));
+    System.out.println(
+        "Expected: Valid(User[name=Ada Lovelace, email=ada@corp.example, age=36]) — only the name"
+            + " changed\n");
+
+    System.out.println("=== An all-absent request is the identity update ===");
+    System.out.println("Empty patch:     " + applyPatch(current, new UserPatchRequest()));
+    System.out.println("Expected: Valid(the unchanged user)\n");
+
+    System.out.println("=== A present invalid field fails, located ===");
+    UserPatchRequest bad = new UserPatchRequest();
+    bad.setEmail("not-an-email");
+    System.out.println("Bad email:       " + applyPatch(current, bad));
+    System.out.println("Expected: Invalid([email: not an email address]) — nothing is written");
+  }
+
+  private UpdateSpecExample() {}
+}

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/RecordMappingBookLawsTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/RecordMappingBookLawsTest.java
@@ -25,4 +25,23 @@ class RecordMappingBookLawsTest {
         new CustomerDto("Bob", "not-an-email")); // must not parse
     // ANCHOR_END: laws
   }
+
+  @Test
+  void contactPatchMappingObeysTheSparseLaws() {
+    // ANCHOR: update_laws
+    MappingLaws.assertMappingLaws(
+        ContactPatchMappingImpl.INSTANCE::updateFrom,
+        new Customer("Ada", new EmailAddress("ada@example.org")), // the current value
+        patch(null, null), // all-absent   -> identity
+        patch("Grace", "grace@example.org"), // present valid -> changes the domain
+        patch(null, "not-an-email")); // present invalid -> located failure
+    // ANCHOR_END: update_laws
+  }
+
+  private static ContactPatchBean patch(String name, String email) {
+    ContactPatchBean bean = new ContactPatchBean();
+    bean.setName(name);
+    bean.setEmail(email);
+    return bean;
+  }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/example/optics/UpdateSpecExampleTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/optics/UpdateSpecExampleTest.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.example.optics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.higherkindedj.example.optics.UpdateSpecExample.EmailAddress;
+import org.higherkindedj.example.optics.UpdateSpecExample.User;
+import org.higherkindedj.example.optics.UpdateSpecExample.UserPatchRequest;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.optics.laws.MappingLaws;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link UpdateSpecExample}: the sparse-update mapping is law-checked through {@code
+ * MappingLaws}, and {@code applyPatch} folds present fields, leaves absent ones untouched, and
+ * fails a present invalid field, located.
+ */
+@DisplayName("UpdateSpecExample: sparse PATCH write-back through UpdateSpec")
+class UpdateSpecExampleTest {
+
+  private static UserPatchRequest request(String name, String email, Integer age) {
+    UserPatchRequest request = new UserPatchRequest();
+    request.setName(name);
+    request.setEmail(email);
+    request.setAge(age);
+    return request;
+  }
+
+  @Test
+  @DisplayName("the sparse-update mapping satisfies identity, idempotence and validation")
+  void updateMappingIsLawful() {
+    MappingLaws.assertMappingLaws(
+        UpdateSpecExampleUserPatchMappingImpl.INSTANCE::updateFrom,
+        new User("Ada", new EmailAddress("ada@corp.example"), 36),
+        request(null, null, null),
+        request("Grace", "grace@corp.example", 41),
+        request(null, "not-an-email", null));
+  }
+
+  @Test
+  @DisplayName("present fields are applied, absent ones keep their current value")
+  void appliesPresentLeavesAbsent() {
+    User current = new User("Ada", new EmailAddress("ada@corp.example"), 36);
+
+    var patched = UpdateSpecExample.applyPatch(current, request("Ada Lovelace", null, null));
+
+    assertThat(patched.isValid()).isTrue();
+    assertThat(patched.get())
+        .isEqualTo(new User("Ada Lovelace", new EmailAddress("ada@corp.example"), 36));
+  }
+
+  @Test
+  @DisplayName("an all-absent request is the identity update")
+  void allAbsentIsIdentity() {
+    User current = new User("Ada", new EmailAddress("ada@corp.example"), 36);
+
+    var patched = UpdateSpecExample.applyPatch(current, request(null, null, null));
+
+    assertThat(patched.isValid()).isTrue();
+    assertThat(patched.get()).isEqualTo(current);
+  }
+
+  @Test
+  @DisplayName("a present invalid field fails the patch, located, writing nothing")
+  void presentInvalidFieldFailsLocated() {
+    User current = new User("Ada", new EmailAddress("ada@corp.example"), 36);
+
+    var patched = UpdateSpecExample.applyPatch(current, request("Grace", "not-an-email", null));
+
+    assertThat(patched.isInvalid()).isTrue();
+    assertThat(patched.getError().toJavaList())
+        .containsExactly(new FieldError(List.of("email"), "not an email address"));
+  }
+}

--- a/hkj-examples/src/test/resources/fixtures/hkj_mapping_SKILL.java
+++ b/hkj-examples/src/test/resources/fixtures/hkj_mapping_SKILL.java
@@ -32,6 +32,8 @@ import org.higherkindedj.optics.annotations.GenerateMapping;
 import org.higherkindedj.optics.annotations.GenerateMerge;
 import org.higherkindedj.optics.annotations.MapField;
 import org.higherkindedj.optics.annotations.MappingSpec;
+import org.higherkindedj.optics.annotations.UpdateSpec;
+import org.higherkindedj.optics.edit.Edits;
 import org.higherkindedj.optics.validated.ValidatedPrism;
 import org.jspecify.annotations.Nullable;
 
@@ -81,6 +83,31 @@ record BankDto(String iban) implements PaymentDto {}
 
 // @GenerateMerge: N sources -> one target.
 record User(String name, String email) {}
+
+// UpdateSpec (sparse PATCH): a bean-shaped request where null means "not provided, leave unchanged".
+class UserPatchBean {
+  private String name;
+  private String email;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}
+
+@GenerateMapping
+interface UserPatchMapping extends UpdateSpec<User, UserPatchBean> {}
 
 record Account(String iban, int balance) {}
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -35,6 +35,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -75,6 +76,14 @@ import org.higherkindedj.optics.processing.util.Diagnostics;
  * {@code Optional<T>} bridges to a nullable bean property {@code T}. A reference-typed bean
  * projection is deferred (the validated-patch tier); an all-primitive one keeps the {@code
  * asLens()} projection.
+ *
+ * <p>A spec extending {@code UpdateSpec<Domain, Wire>} (issue #645, {@link
+ * org.higherkindedj.optics.annotations.UpdateSpec}) opts into the opposite null contract: a null
+ * bean property means <em>absent — leave unchanged</em> rather than invalid. Such a spec emits only
+ * {@code updateFrom(Wire) : Edits.Accumulated<Domain>}, folding the present (non-null) properties
+ * into an {@code Update} via {@code Edits.accumulate} — no {@code build}, {@code parse}, or {@code
+ * as*} tier. A primitive wire property (which can never be absent) is rejected with a diagnostic,
+ * and an {@code UpdateSpec} never registers for nesting (it has no {@code parse}).
  */
 @AutoService(Processor.class)
 @SupportedAnnotationTypes("org.higherkindedj.optics.annotations.GenerateMapping")
@@ -82,10 +91,16 @@ public class MappingProcessor extends AbstractProcessor {
 
   private static final String TAG = "@GenerateMapping";
   private static final String MAPPING_SPEC = "org.higherkindedj.optics.annotations.MappingSpec";
+  private static final String UPDATE_SPEC = "org.higherkindedj.optics.annotations.UpdateSpec";
   private static final String VALIDATED_PRISM = "org.higherkindedj.optics.validated.ValidatedPrism";
   private static final String GETTER = "org.higherkindedj.optics.Getter";
   private static final ClassName VALIDATED_PRISM_TYPE =
       ClassName.get("org.higherkindedj.optics.validated", "ValidatedPrism");
+  private static final ClassName EDITS = ClassName.get("org.higherkindedj.optics.edit", "Edits");
+  private static final ClassName EDIT = ClassName.get("org.higherkindedj.optics.edit", "Edit");
+  private static final ClassName ACCUMULATED =
+      ClassName.get("org.higherkindedj.optics.edit", "Edits", "Accumulated");
+  private static final ClassName SETTER = ClassName.get("org.higherkindedj.optics", "Setter");
   private static final ClassName VALIDATED =
       ClassName.get("org.higherkindedj.hkt.validated", "Validated");
   private static final ClassName FIELD_ERROR =
@@ -267,6 +282,15 @@ public class MappingProcessor extends AbstractProcessor {
     }
     TypeElement spec = (TypeElement) element;
 
+    // A spec extending UpdateSpec<Domain, Wire> opts into sparse null-as-absent PATCH (#645): it
+    // emits updateFrom() and nothing else. It never reaches scanRegistry (which matches the direct
+    // MappingSpec supertype only), so an UpdateSpec is never nestable — it has no parse.
+    DeclaredType updateSuper = findUpdateSpec(spec);
+    if (updateSuper != null) {
+      processUpdateSpec(spec, updateSuper);
+      return;
+    }
+
     DeclaredType specSuper = findMappingSpec(spec);
     if (specSuper == null || specSuper.getTypeArguments().size() != 2) {
       Diagnostics.error(
@@ -374,6 +398,385 @@ public class MappingProcessor extends AbstractProcessor {
       return;
     }
     writeImpl(spec, domain, wireShape, correspondences);
+  }
+
+  /**
+   * Processes a sparse-update spec (issue #645, {@code extends UpdateSpec<Domain, Wire>}). The wire
+   * must be a bean-shaped class (a record cannot signal absence) and the domain a record; sealed
+   * pairs are deferred. Every present (non-null) wire property folds into an {@code Update} via
+   * {@code Edits.accumulate}; absent properties leave the domain unchanged. Only {@code updateFrom}
+   * is emitted — no {@code build}, {@code parse}, or {@code as*} tier.
+   */
+  private void processUpdateSpec(TypeElement spec, DeclaredType updateSuper) {
+    if (updateSuper.getTypeArguments().size() != 2) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          spec,
+          TAG,
+          "'" + spec.getSimpleName() + "' does not extend UpdateSpec<Domain, Wire>.",
+          "The two type arguments name the domain record and the bean-shaped PATCH wire.",
+          "Add 'extends UpdateSpec<Domain, Wire>' with both type arguments.");
+      return;
+    }
+    if (spec.getInterfaces().size() != 1) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          spec,
+          TAG,
+          "'" + spec.getSimpleName() + "' extends interfaces besides UpdateSpec.",
+          "Renames and leaves declared on other supertypes are invisible to this slice's"
+              + " classification, so the generated Impl could silently miss inherited members.",
+          "Declare every rename and leaf directly on the spec.");
+      return;
+    }
+
+    TypeMirror domainArg = updateSuper.getTypeArguments().get(0);
+    TypeMirror wireArg = updateSuper.getTypeArguments().get(1);
+
+    if (asSealed(domainArg) != null || asSealed(wireArg) != null) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          spec,
+          TAG,
+          "a sparse UpdateSpec cannot map a sealed hierarchy.",
+          "A sparse update edits the fields of one record; a sealed mapping dispatches over whole"
+              + " values, and a wire subtype cannot choose the domain variant to patch at fold"
+              + " time.",
+          "Declare one UpdateSpec per concrete record pair.");
+      return;
+    }
+
+    if (!validateSpecMethods(spec, false)) {
+      return;
+    }
+
+    TypeElement domain = asRecord(domainArg);
+    if (domain == null) {
+      reportUnsupportedDomain(spec, domainArg);
+      return;
+    }
+
+    // A record wire cannot express "absent" (every component is always present), so sparse PATCH is
+    // a bean-only shape; a non-bean, non-record wire is unsupported as for the full mapper.
+    if (asRecord(wireArg) != null) {
+      reportRecordWireOnUpdate(spec, domain, asRecord(wireArg));
+      return;
+    }
+    TypeElement wireBean = asBean(wireArg);
+    if (wireBean == null) {
+      reportUnsupportedWire(spec, wireArg);
+      return;
+    }
+    if (!checkNotGeneric(spec, domain, wireBean)) {
+      return;
+    }
+
+    WireShape wireShape = new BeanPropertyAnalyser(processingEnv).analyse(spec, wireBean, TAG);
+    if (wireShape == null) {
+      return;
+    }
+
+    Map<String, String> renames = collectRenames(spec, domain, wireShape);
+    if (renames == null) {
+      return;
+    }
+
+    List<UpdateEdit> edits = classifyUpdate(spec, domain, wireShape, renames);
+    if (edits == null) {
+      return;
+    }
+    writeUpdateImpl(spec, domain, wireShape, edits);
+  }
+
+  /**
+   * One folded edit of a sparse update: the domain component it writes, the wire property it reads,
+   * and — for a validated leaf — the leaf accessor to parse the present value through. A pure
+   * (identity) edit carries no leaf and folds as {@code Edit.setIfPresent}; a leaf edit folds as
+   * {@code Edit.parseIfPresent(...).at(name)}.
+   */
+  private record UpdateEdit(String domainName, String wireName, CodeBlock leaf) {
+    boolean parsed() {
+      return leaf != null;
+    }
+  }
+
+  /**
+   * Classifies each wire property against the domain for a sparse update. Coverage is one-sided:
+   * every wire property must map to a domain component (a dangling wire property is an error), but
+   * a domain component with no wire property is simply never edited. Each property matches by an
+   * explicit leaf (named after the domain component), or by identity — the same type, or a wrapper
+   * of a primitive domain component (so an {@code Integer} property can patch an {@code int}
+   * field). A primitive wire property can never be absent and is rejected. Returns null after
+   * reporting.
+   */
+  private List<UpdateEdit> classifyUpdate(
+      TypeElement spec, TypeElement domain, WireShape wire, Map<String, String> renames) {
+    Map<String, String> wireToDomain = new LinkedHashMap<>();
+    renames.forEach((domainName, wireName) -> wireToDomain.put(wireName, domainName));
+
+    List<UpdateEdit> edits = new ArrayList<>();
+    Map<String, String> claimedBy = new LinkedHashMap<>();
+    for (WireShape.WireComponent property : wire.components()) {
+      String domainName = wireToDomain.getOrDefault(property.name(), property.name());
+      RecordComponentElement domainComp =
+          domain.getRecordComponents().stream()
+              .filter(c -> c.getSimpleName().contentEquals(domainName))
+              .findFirst()
+              .orElse(null);
+      if (domainComp == null) {
+        reportDanglingWireProperty(spec, domain, property);
+        return null;
+      }
+      // One wire property per domain component: a same-named property and a rename can otherwise
+      // both land on one component, silently emitting two writes to the same slot.
+      if (claimedBy.containsKey(domainName)) {
+        reportDuplicateDomainTarget(
+            spec, domain, domainName, claimedBy.get(domainName), property.name());
+        return null;
+      }
+      claimedBy.put(domainName, property.name());
+      if (property.type().getKind().isPrimitive()) {
+        reportPrimitiveProperty(spec, property);
+        return null;
+      }
+      ExecutableElement leaf = findLeaf(spec, domainName, property.type(), domainComp.asType());
+      if (leaf != null) {
+        edits.add(
+            new UpdateEdit(
+                domainName, property.name(), CodeBlock.of("$L()", leaf.getSimpleName())));
+        continue;
+      }
+      if (identityMatch(property.type(), domainComp.asType())) {
+        edits.add(new UpdateEdit(domainName, property.name(), null));
+        continue;
+      }
+      reportNoUpdateSource(spec, domain, property, domainComp);
+      return null;
+    }
+    return edits;
+  }
+
+  /**
+   * Whether a present wire value can be written straight into the domain component: the same type,
+   * or a wrapper of a primitive domain component (unboxing identity). The wire property is never a
+   * primitive here — a primitive property is rejected before this by {@link #classifyUpdate}.
+   */
+  private boolean identityMatch(TypeMirror wireType, TypeMirror domainType) {
+    if (processingEnv.getTypeUtils().isSameType(wireType, domainType)) {
+      return true;
+    }
+    if (domainType.getKind().isPrimitive()) {
+      TypeMirror boxed =
+          processingEnv.getTypeUtils().boxedClass((PrimitiveType) domainType).asType();
+      return processingEnv.getTypeUtils().isSameType(wireType, boxed);
+    }
+    return false;
+  }
+
+  /**
+   * A record wire on an UpdateSpec: records cannot express an absent (null-as-not-provided) field.
+   */
+  private void reportRecordWireOnUpdate(TypeElement spec, TypeElement domain, TypeElement wire) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire '"
+            + wire.getSimpleName()
+            + "' is a record, which a sparse UpdateSpec cannot map.",
+        "Sparse PATCH reads null as 'not provided, leave unchanged', but a record component is"
+            + " always present, so absence is inexpressible.",
+        "Use a bean-shaped PATCH DTO (wrapper-typed getters/setters), or a full MappingSpec<"
+            + domain.getSimpleName()
+            + ", "
+            + wire.getSimpleName()
+            + "> if you meant a total mapping.");
+  }
+
+  /**
+   * A primitive wire property is always present, so it can never carry the null-as-absent signal.
+   */
+  private void reportPrimitiveProperty(TypeElement spec, WireShape.WireComponent property) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire property '" + property.name() + "' is primitive and can never be absent.",
+        "An all-absent PATCH body must fold to the identity update, but a primitive property always"
+            + " carries a value (its default), so its 'absent' state cannot be distinguished.",
+        "Use the wrapper type for '"
+            + property.name()
+            + "' on the PATCH DTO (e.g. Integer, Boolean).");
+  }
+
+  /**
+   * A wire property with no domain component to write into (one-sided coverage still requires one).
+   */
+  private void reportDanglingWireProperty(
+      TypeElement spec, TypeElement domain, WireShape.WireComponent property) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire property '"
+            + property.name()
+            + "' names no component of "
+            + domain.getSimpleName()
+            + ".",
+        "A sparse update writes each present wire property into a domain component; there is no"
+            + " build step for a derived field to feed. Found on "
+            + domain.getSimpleName()
+            + ": "
+            + wireNames(domain.getRecordComponents())
+            + ".",
+        "Add a @MapField rename to a domain component, or remove the property.");
+  }
+
+  /** Two wire properties resolve to the same domain component (a same-named one and a rename). */
+  private void reportDuplicateDomainTarget(
+      TypeElement spec, TypeElement domain, String domainName, String first, String second) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire properties '"
+            + first
+            + "' and '"
+            + second
+            + "' both write "
+            + domain.getSimpleName()
+            + "."
+            + domainName
+            + ".",
+        "Each domain component takes at most one wire source, or the update would write the slot"
+            + " twice (last write wins).",
+        "Point the @MapField rename at a distinct component, or drop one of the properties.");
+  }
+
+  /** A wire property matches a domain component by name but neither by type nor through a leaf. */
+  private void reportNoUpdateSource(
+      TypeElement spec,
+      TypeElement domain,
+      WireShape.WireComponent property,
+      RecordComponentElement domainComp) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire property '"
+            + property.name()
+            + "' ("
+            + property.type()
+            + ") cannot be written into "
+            + domain.getSimpleName()
+            + "."
+            + domainComp.getSimpleName()
+            + " ("
+            + domainComp.asType()
+            + ").",
+        "A sparse update writes a present property by identity (same type, or a wrapper of a"
+            + " primitive component) or through a leaf named after the domain component."
+            + leafNearMissHint(spec, domainComp.getSimpleName().toString()),
+        "Declare a leaf 'default ValidatedPrism<"
+            + property.type()
+            + ", "
+            + domainComp.asType()
+            + "> "
+            + domainComp.getSimpleName()
+            + "()', or align the types.");
+  }
+
+  /**
+   * Emits the sparse-update Impl: a single {@code updateFrom(Wire) : Edits.Accumulated<Domain>}
+   * that folds each present wire property into an {@code Update}. Identity edits use {@code
+   * Edit.setIfPresent} against an inline {@code Setter} that rebuilds the record; leaf edits use
+   * {@code Edit.parseIfPresent(...).at(name)}, so a present-but-invalid value accumulates a located
+   * {@code FieldError}. No {@code build}/{@code parse}/{@code as*} tier is emitted.
+   */
+  private void writeUpdateImpl(
+      TypeElement spec, TypeElement domain, WireShape wire, List<UpdateEdit> edits) {
+    ClassName specName = ClassName.get(spec);
+    ClassName implName = implClassName(spec);
+    ClassName domainClass = ClassName.get(domain);
+    TypeName wireName = TypeName.get(wire.element().asType());
+    TypeName accumulatedReturn =
+        ParameterizedTypeName.get(ACCUMULATED, TypeName.get(domain.asType()));
+
+    CodeBlock.Builder call = CodeBlock.builder().add("return $T.accumulate(", EDITS);
+    boolean first = true;
+    for (UpdateEdit edit : edits) {
+      call.add(first ? "\n" : ",\n");
+      first = false;
+      CodeBlock setter = setterExpr(domainClass, domain, edit.domainName());
+      CodeBlock read = wireRead(wire, edit.wireName());
+      if (edit.parsed()) {
+        call.add(
+            "    $T.parseIfPresent($L, $L, $L::parse).at($S)",
+            EDIT,
+            setter,
+            read,
+            edit.leaf(),
+            edit.domainName());
+      } else {
+        call.add("    $T.setIfPresent($L, $L)", EDIT, setter, read);
+      }
+    }
+    call.add(")");
+
+    MethodSpec updateFrom =
+        MethodSpec.methodBuilder("updateFrom")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(accumulatedReturn)
+            .addParameter(wireName, "wire")
+            .addJavadoc(
+                "Folds the present (non-null) properties of {@code wire} into an update: an absent"
+                    + " property leaves the domain unchanged, a present one is set (or parsed"
+                    + " through its leaf) and located on failure.\n")
+            .addStatement("$T.requireNonNull(wire, $S)", OBJECTS, "wire must not be null")
+            .addStatement("$L", call.build())
+            .build();
+
+    TypeSpec.Builder implBuilder =
+        implSkeleton(
+                spec,
+                implName,
+                specName,
+                "Generated sparse PATCH write-back for {@link $T}: folds the present wire fields into"
+                    + " an {@code Edits.Accumulated<Domain>} (issue #645).\n")
+            .addMethod(updateFrom);
+    addRenameStubs(implBuilder, spec);
+    writeFile(spec, specName.packageName(), implBuilder.build());
+  }
+
+  /**
+   * An inline {@code Setter.fromGetSet(Domain::comp, (d, v) -> new Domain(...))} focusing one
+   * domain component: the getter is the component accessor, and the writer rebuilds the record
+   * positionally with the focused slot taken from {@code v}. Type inference fixes the focus type,
+   * so no explicit generics are needed (a wrapper {@code v} auto-unboxes into a primitive slot).
+   */
+  private static CodeBlock setterExpr(
+      ClassName domainClass, TypeElement domain, String focusedName) {
+    CodeBlock.Builder args = CodeBlock.builder();
+    boolean first = true;
+    for (RecordComponentElement component : domain.getRecordComponents()) {
+      if (!first) {
+        args.add(", ");
+      }
+      first = false;
+      String name = component.getSimpleName().toString();
+      if (name.equals(focusedName)) {
+        args.add("v");
+      } else {
+        args.add("d.$L()", name);
+      }
+    }
+    return CodeBlock.of(
+        "$T.fromGetSet($T::$L, (d, v) -> new $T($L))",
+        SETTER,
+        domainClass,
+        focusedName,
+        domainClass,
+        args.build());
   }
 
   /**
@@ -1772,6 +2175,17 @@ public class MappingProcessor extends AbstractProcessor {
       // Superinterface mirrors are always declared (or error) types, both DeclaredType.
       DeclaredType declared = (DeclaredType) iface;
       if (((TypeElement) declared.asElement()).getQualifiedName().contentEquals(MAPPING_SPEC)) {
+        return declared;
+      }
+    }
+    return null;
+  }
+
+  /** The direct {@code UpdateSpec<Domain, Wire>} supertype (issue #645), or null if none. */
+  private static DeclaredType findUpdateSpec(TypeElement spec) {
+    for (TypeMirror iface : spec.getInterfaces()) {
+      DeclaredType declared = (DeclaredType) iface;
+      if (((TypeElement) declared.asElement()).getQualifiedName().contentEquals(UPDATE_SPEC)) {
         return declared;
       }
     }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -287,7 +287,7 @@ public class MappingProcessor extends AbstractProcessor {
     // MappingSpec supertype only), so an UpdateSpec is never nestable — it has no parse.
     DeclaredType updateSuper = findUpdateSpec(spec);
     if (updateSuper != null) {
-      processUpdateSpec(spec, updateSuper);
+      processUpdateSpec(spec, updateSuper, registry);
       return;
     }
 
@@ -407,7 +407,8 @@ public class MappingProcessor extends AbstractProcessor {
    * {@code Edits.accumulate}; absent properties leave the domain unchanged. Only {@code updateFrom}
    * is emitted — no {@code build}, {@code parse}, or {@code as*} tier.
    */
-  private void processUpdateSpec(TypeElement spec, DeclaredType updateSuper) {
+  private void processUpdateSpec(
+      TypeElement spec, DeclaredType updateSuper, List<RegisteredSpec> registry) {
     if (updateSuper.getTypeArguments().size() != 2) {
       Diagnostics.error(
           processingEnv.getMessager(),
@@ -449,6 +450,9 @@ public class MappingProcessor extends AbstractProcessor {
     if (!validateSpecMethods(spec, false)) {
       return;
     }
+    if (!checkNoDerivedFields(spec)) {
+      return;
+    }
 
     TypeElement domain = asRecord(domainArg);
     if (domain == null) {
@@ -481,7 +485,7 @@ public class MappingProcessor extends AbstractProcessor {
       return;
     }
 
-    List<UpdateEdit> edits = classifyUpdate(spec, domain, wireShape, renames);
+    List<UpdateEdit> edits = classifyUpdate(spec, domain, wireShape, renames, registry);
     if (edits == null) {
       return;
     }
@@ -490,13 +494,26 @@ public class MappingProcessor extends AbstractProcessor {
 
   /**
    * One folded edit of a sparse update: the domain component it writes, the wire property it reads,
-   * and — for a validated leaf — the leaf accessor to parse the present value through. A pure
-   * (identity) edit carries no leaf and folds as {@code Edit.setIfPresent}; a leaf edit folds as
-   * {@code Edit.parseIfPresent(...).at(name)}.
+   * and — when the present value must be validated — the prism expression to parse through and the
+   * {@code ValidatedPrism} method to call ({@code parse} for a whole value or nested spec, {@code
+   * parseAll} for a {@code List}, {@code parseValues} for a {@code Map}). A pure (identity) edit
+   * carries no prism and folds as {@code Edit.setIfPresent}; a validated edit folds as {@code
+   * Edit.parseIfPresent(...).at(name)}.
    */
-  private record UpdateEdit(String domainName, String wireName, CodeBlock leaf) {
+  private record UpdateEdit(
+      String domainName, String wireName, CodeBlock prism, String parseMethod) {
+
+    static UpdateEdit identity(String domainName, String wireName) {
+      return new UpdateEdit(domainName, wireName, null, null);
+    }
+
+    static UpdateEdit validated(
+        String domainName, String wireName, CodeBlock prism, String parseMethod) {
+      return new UpdateEdit(domainName, wireName, prism, parseMethod);
+    }
+
     boolean parsed() {
-      return leaf != null;
+      return prism != null;
     }
   }
 
@@ -510,7 +527,11 @@ public class MappingProcessor extends AbstractProcessor {
    * reporting.
    */
   private List<UpdateEdit> classifyUpdate(
-      TypeElement spec, TypeElement domain, WireShape wire, Map<String, String> renames) {
+      TypeElement spec,
+      TypeElement domain,
+      WireShape wire,
+      Map<String, String> renames,
+      List<RegisteredSpec> registry) {
     Map<String, String> wireToDomain = new LinkedHashMap<>();
     renames.forEach((domainName, wireName) -> wireToDomain.put(wireName, domainName));
 
@@ -539,21 +560,70 @@ public class MappingProcessor extends AbstractProcessor {
         reportPrimitiveProperty(spec, property);
         return null;
       }
-      ExecutableElement leaf = findLeaf(spec, domainName, property.type(), domainComp.asType());
+      TypeMirror wireType = property.type();
+      TypeMirror domainType = domainComp.asType();
+
+      // An explicit whole-component leaf wins even over a same-typed match, so it can validate or
+      // normalise a copied field.
+      ExecutableElement leaf = findLeaf(spec, domainName, wireType, domainType);
       if (leaf != null) {
         edits.add(
-            new UpdateEdit(
-                domainName, property.name(), CodeBlock.of("$L()", leaf.getSimpleName())));
+            UpdateEdit.validated(
+                domainName, property.name(), CodeBlock.of("$L()", leaf.getSimpleName()), "parse"));
         continue;
       }
-      if (identityMatch(property.type(), domainComp.asType())) {
-        edits.add(new UpdateEdit(domainName, property.name(), null));
+
+      // Same type (or a wrapper of a primitive component) — including a same-typed List, Map or
+      // nested record — writes the present value straight in (wholesale replacement).
+      if (identityMatch(wireType, domainType)) {
+        edits.add(UpdateEdit.identity(domainName, property.name()));
         continue;
       }
+
+      // A domain Optional<T> component is the null-as-absent bridge shape (a same-typed Optional
+      // wire was already matched by identity above), which sparseness cannot express: null already
+      // means "leave unchanged", so "set to empty" has no encoding.
+      if (containerElement(domainType, "java.util.Optional") != null) {
+        reportOptionalBridge(spec, domain, property, domainComp);
+        return null;
+      }
+
+      // A nested record patched wholesale through its own full mapping spec's asValidatedPrism().
+      PrismResolution nested = resolveNestedSpec(spec, registry, domainName, wireType, domainType);
+      if (nested.ambiguous()) {
+        return null;
+      }
+      if (nested.accessor() != null) {
+        edits.add(UpdateEdit.validated(domainName, property.name(), nested.accessor(), "parse"));
+        continue;
+      }
+
       reportNoUpdateSource(spec, domain, property, domainComp);
       return null;
     }
     return edits;
+  }
+
+  /**
+   * A spec {@code default} method returning {@code Getter} (a derived field) has no sparse meaning.
+   */
+  private boolean checkNoDerivedFields(TypeElement spec) {
+    for (ExecutableElement method : ElementFilter.methodsIn(spec.getEnclosedElements())) {
+      if (isDerivedCandidate(method)) {
+        Diagnostics.error(
+            processingEnv.getMessager(),
+            method,
+            TAG,
+            "the derived-field method '"
+                + method.getSimpleName()
+                + "' has no meaning on a sparse UpdateSpec.",
+            "A derived field feeds build(); a sparse update only writes present wire properties into"
+                + " the domain, so there is nothing to derive.",
+            "Remove the method, or use a full MappingSpec if you need a total build().");
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -630,6 +700,34 @@ public class MappingProcessor extends AbstractProcessor {
             + wireNames(domain.getRecordComponents())
             + ".",
         "Add a @MapField rename to a domain component, or remove the property.");
+  }
+
+  /**
+   * A domain {@code Optional<T>} component under sparseness: null already means absent, so "set to
+   * empty" is inexpressible (and null-clears would be JSON Merge Patch's opposite contract).
+   */
+  private void reportOptionalBridge(
+      TypeElement spec,
+      TypeElement domain,
+      WireShape.WireComponent property,
+      RecordComponentElement domainComp) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the wire property '"
+            + property.name()
+            + "' bridges the domain Optional component "
+            + domain.getSimpleName()
+            + "."
+            + domainComp.getSimpleName()
+            + " ("
+            + domainComp.asType()
+            + "), which a sparse update cannot express.",
+        "Under null-as-absent a null property means 'leave unchanged', so setting the component to"
+            + " an empty Optional has no encoding; a null-clears rule would be the opposite contract"
+            + " (JSON Merge Patch).",
+        "Model the field as a nested record or a sentinel value instead of Optional.");
   }
 
   /** Two wire properties resolve to the same domain component (a same-named one and a rename). */
@@ -711,11 +809,12 @@ public class MappingProcessor extends AbstractProcessor {
       CodeBlock read = wireRead(wire, edit.wireName());
       if (edit.parsed()) {
         call.add(
-            "    $T.parseIfPresent($L, $L, $L::parse).at($S)",
+            "    $T.parseIfPresent($L, $L, $L::$L).at($S)",
             EDIT,
             setter,
             read,
-            edit.leaf(),
+            edit.prism(),
+            edit.parseMethod(),
             edit.domainName());
       } else {
         call.add("    $T.setIfPresent($L, $L)", EDIT, setter, read);

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -456,19 +456,19 @@ public class MappingProcessor extends AbstractProcessor {
 
     TypeElement domain = asRecord(domainArg);
     if (domain == null) {
-      reportUnsupportedDomain(spec, domainArg);
+      reportUpdateDomainNotRecord(spec, domainArg);
       return;
     }
 
     // A record wire cannot express "absent" (every component is always present), so sparse PATCH is
-    // a bean-only shape; a non-bean, non-record wire is unsupported as for the full mapper.
+    // a bean-only shape; a non-bean, non-record wire is rejected with a sparse-specific message.
     if (asRecord(wireArg) != null) {
       reportRecordWireOnUpdate(spec, domain, asRecord(wireArg));
       return;
     }
     TypeElement wireBean = asBean(wireArg);
     if (wireBean == null) {
-      reportUnsupportedWire(spec, wireArg);
+      reportUpdateWireNotBean(spec, wireArg);
       return;
     }
     if (!checkNotGeneric(spec, domain, wireBean)) {
@@ -494,22 +494,21 @@ public class MappingProcessor extends AbstractProcessor {
 
   /**
    * One folded edit of a sparse update: the domain component it writes, the wire property it reads,
-   * and — when the present value must be validated — the prism expression to parse through and the
-   * {@code ValidatedPrism} method to call ({@code parse} for a whole value or nested spec, {@code
-   * parseAll} for a {@code List}, {@code parseValues} for a {@code Map}). A pure (identity) edit
-   * carries no prism and folds as {@code Edit.setIfPresent}; a validated edit folds as {@code
-   * Edit.parseIfPresent(...).at(name)}.
+   * and — when the present value must be validated — the {@code ValidatedPrism} expression to parse
+   * it through (a whole-component leaf, or a nested spec's {@code asValidatedPrism()}). A pure
+   * (identity) edit carries no prism and folds as {@code Edit.setIfPresent}; a validated edit folds
+   * as {@code Edit.parseIfPresent(...).at(name)}. (Container element-lifting — {@code
+   * parseAll}/{@code parseValues} — is deferred; when it lands, the parse method is selected from
+   * the container shape, as {@link Correspondence} does with its {@code Kind}.)
    */
-  private record UpdateEdit(
-      String domainName, String wireName, CodeBlock prism, String parseMethod) {
+  private record UpdateEdit(String domainName, String wireName, CodeBlock prism) {
 
     static UpdateEdit identity(String domainName, String wireName) {
-      return new UpdateEdit(domainName, wireName, null, null);
+      return new UpdateEdit(domainName, wireName, null);
     }
 
-    static UpdateEdit validated(
-        String domainName, String wireName, CodeBlock prism, String parseMethod) {
-      return new UpdateEdit(domainName, wireName, prism, parseMethod);
+    static UpdateEdit validated(String domainName, String wireName, CodeBlock prism) {
+      return new UpdateEdit(domainName, wireName, prism);
     }
 
     boolean parsed() {
@@ -569,7 +568,7 @@ public class MappingProcessor extends AbstractProcessor {
       if (leaf != null) {
         edits.add(
             UpdateEdit.validated(
-                domainName, property.name(), CodeBlock.of("$L()", leaf.getSimpleName()), "parse"));
+                domainName, property.name(), CodeBlock.of("$L()", leaf.getSimpleName())));
         continue;
       }
 
@@ -594,7 +593,7 @@ public class MappingProcessor extends AbstractProcessor {
         return null;
       }
       if (nested.accessor() != null) {
-        edits.add(UpdateEdit.validated(domainName, property.name(), nested.accessor(), "parse"));
+        edits.add(UpdateEdit.validated(domainName, property.name(), nested.accessor()));
         continue;
       }
 
@@ -641,6 +640,39 @@ public class MappingProcessor extends AbstractProcessor {
       return processingEnv.getTypeUtils().isSameType(wireType, boxed);
     }
     return false;
+  }
+
+  /**
+   * The domain of a sparse UpdateSpec is not a record (a sealed one was rejected earlier). Unlike
+   * the full mapper's domain diagnostic, this references the positional record rebuild (there is no
+   * {@code parse}), and does not offer a sealed hierarchy (the sparse tier rejects those).
+   */
+  private void reportUpdateDomainNotRecord(TypeElement spec, TypeMirror domainArg) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the UpdateSpec domain type argument '" + domainArg + "' is not a record.",
+        "A sparse update rebuilds the domain positionally through its canonical constructor, so the"
+            + " domain must be a record; only the wire may be bean-shaped.",
+        "Use a record for the domain, mapping the bean as the wire.");
+  }
+
+  /**
+   * The wire of a sparse UpdateSpec is neither a record (rejected earlier) nor a bean. Unlike the
+   * full mapper's wire diagnostic, the fix names only the bean-shaped PATCH DTO — a record wire is
+   * rejected here, so offering one (as the full mapper does) would send the user in a circle.
+   */
+  private void reportUpdateWireNotBean(TypeElement spec, TypeMirror wireArg) {
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        spec,
+        TAG,
+        "the UpdateSpec wire type argument '" + wireArg + "' is not a bean-shaped class.",
+        "A sparse update reads the present properties through the wire's getters, so the wire must"
+            + " be a bean (a class with getters and setters or a builder); a record component is"
+            + " always present, so a record cannot express an absent field.",
+        "Use a bean-shaped PATCH DTO (wrapper-typed getters/setters).");
   }
 
   /**
@@ -775,13 +807,21 @@ public class MappingProcessor extends AbstractProcessor {
         "A sparse update writes a present property by identity (same type, or a wrapper of a"
             + " primitive component) or through a leaf named after the domain component."
             + leafNearMissHint(spec, domainComp.getSimpleName().toString()),
-        "Declare a leaf 'default ValidatedPrism<"
-            + property.type()
-            + ", "
-            + domainComp.asType()
-            + "> "
-            + domainComp.getSimpleName()
-            + "()', or align the types.");
+        // A leaf cannot target a primitive component: a ValidatedPrism's domain arg is a reference
+        // type, so findLeaf's isSameType(wrapper, primitive) can never match. Steer to alignment.
+        domainComp.asType().getKind().isPrimitive()
+            ? "Align the types: make '"
+                + domainComp.getSimpleName()
+                + "' a wrapper type, or match the wire property to "
+                + domainComp.asType()
+                + "."
+            : "Declare a leaf 'default ValidatedPrism<"
+                + property.type()
+                + ", "
+                + domainComp.asType()
+                + "> "
+                + domainComp.getSimpleName()
+                + "()', or align the types.");
   }
 
   /**
@@ -809,12 +849,11 @@ public class MappingProcessor extends AbstractProcessor {
       CodeBlock read = wireRead(wire, edit.wireName());
       if (edit.parsed()) {
         call.add(
-            "    $T.parseIfPresent($L, $L, $L::$L).at($S)",
+            "    $T.parseIfPresent($L, $L, $L::parse).at($S)",
             EDIT,
             setter,
             read,
             edit.prism(),
-            edit.parseMethod(),
             edit.domainName());
       } else {
         call.add("    $T.setIfPresent($L, $L)", EDIT, setter, read);

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedMappingLawsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedMappingLawsTest.java
@@ -11,9 +11,11 @@ import com.google.testing.compile.JavaFileObjects;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import javax.tools.JavaFileObject;
 import org.higherkindedj.optics.Iso;
 import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.edit.Edits;
 import org.higherkindedj.optics.laws.MappingLaws;
 import org.higherkindedj.optics.validated.ValidatedPrism;
 import org.junit.jupiter.api.DisplayName;
@@ -649,5 +651,98 @@ class GeneratedMappingLawsTest {
             "Grace",
             result.newInstance("com.example.EmailAddress", "grace@example.org"),
             Optional.empty()));
+  }
+
+  @Test
+  @DisplayName(
+      "sparse-update tier: a generated updateFrom satisfies identity, idempotence and validation")
+  void updateTierIsLawful() throws ReflectiveOperationException {
+    JavaFileObject domain =
+        JavaFileObjects.forSourceString(
+            "com.example.User",
+            """
+            package com.example;
+
+            public record User(String name, EmailAddress email, int age) {}
+            """);
+    // A PATCH DTO: reference-typed getters/setters, a wrapper Integer for the scalar so it too can
+    // be absent (null).
+    JavaFileObject wire =
+        JavaFileObjects.forSourceString(
+            "com.example.UserPatchDto",
+            """
+            package com.example;
+
+            public class UserPatchDto {
+              private String name;
+              private String email;
+              private Integer age;
+
+              public String getName() { return name; }
+              public void setName(String name) { this.name = name; }
+              public String getEmail() { return email; }
+              public void setEmail(String email) { this.email = email; }
+              public Integer getAge() { return age; }
+              public void setAge(Integer age) { this.age = age; }
+            }
+            """);
+    JavaFileObject spec =
+        JavaFileObjects.forSourceString(
+            "com.example.UserPatchMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.hkt.validated.FieldError;
+            import org.higherkindedj.hkt.validated.Validated;
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.UpdateSpec;
+            import org.higherkindedj.optics.validated.ValidatedPrism;
+
+            @GenerateMapping
+            public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {
+              default ValidatedPrism<String, EmailAddress> email() {
+                return emailPrism();
+              }
+
+            """
+                + EMAIL_PRISM
+                + """
+            }
+            """);
+
+    var result = compileMapping(EMAIL, domain, wire, spec);
+    Object impl = implInstance(result, "com.example.UserPatchMappingImpl");
+
+    Function<Object, Edits.Accumulated<Object>> updateFrom =
+        w -> asAccumulated(invoke(impl, "updateFrom", w));
+
+    // Absent -> identity; a present valid patch changes name/email/age (Integer unboxing into int)
+    // and is idempotent; a present invalid email fails, all through the published harness.
+    MappingLaws.assertMappingLaws(
+        updateFrom,
+        result.newInstance(
+            "com.example.User",
+            "Ada",
+            result.newInstance("com.example.EmailAddress", "ada@example.org"),
+            36),
+        patchDto(result, null, null, null),
+        patchDto(result, "Grace", "grace@example.org", 41),
+        patchDto(result, null, "not-an-email", null));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Edits.Accumulated<Object> asAccumulated(Object accumulated) {
+    return (Edits.Accumulated<Object>) accumulated;
+  }
+
+  private static Object patchDto(
+      RuntimeCompilationHelper.CompiledResult result, String name, String email, Integer age)
+      throws ReflectiveOperationException {
+    Object dto =
+        result.loadClass("com.example.UserPatchDto").getDeclaredConstructor().newInstance();
+    invoke(dto, "setName", name);
+    invoke(dto, "setEmail", email);
+    invoke(dto, "setAge", age);
+    return dto;
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
@@ -310,6 +310,188 @@ class MappingProcessorUpdateTest {
   }
 
   @Nested
+  @DisplayName("Nesting")
+  class Nesting {
+
+    private static final JavaFileObject ADDRESS =
+        JavaFileObjects.forSourceString(
+            "com.example.Address",
+            """
+            package com.example;
+
+            public record Address(String city) {}
+            """);
+
+    private static final JavaFileObject ADDRESS_DTO =
+        JavaFileObjects.forSourceString(
+            "com.example.AddressDto",
+            """
+            package com.example;
+
+            public class AddressDto {
+              private String city;
+              public String getCity() { return city; }
+              public void setCity(String city) { this.city = city; }
+            }
+            """);
+
+    private static final JavaFileObject CUSTOMER =
+        JavaFileObjects.forSourceString(
+            "com.example.Customer",
+            """
+            package com.example;
+
+            public record Customer(Address address) {}
+            """);
+
+    private static final JavaFileObject CUSTOMER_PATCH_DTO =
+        JavaFileObjects.forSourceString(
+            "com.example.CustomerPatchDto",
+            """
+            package com.example;
+
+            public class CustomerPatchDto {
+              private AddressDto address;
+              public AddressDto getAddress() { return address; }
+              public void setAddress(AddressDto address) { this.address = address; }
+            }
+            """);
+
+    private static final JavaFileObject ADDRESS_MAPPING =
+        JavaFileObjects.forSourceString(
+            "com.example.AddressMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface AddressMapping extends MappingSpec<Address, AddressDto> {}
+            """);
+
+    private static final JavaFileObject CUSTOMER_PATCH_MAPPING =
+        JavaFileObjects.forSourceString(
+            "com.example.CustomerPatchMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.UpdateSpec;
+
+            @GenerateMapping
+            public interface CustomerPatchMapping extends UpdateSpec<Customer, CustomerPatchDto> {}
+            """);
+
+    @Test
+    @DisplayName("a nested record is patched wholesale through its own full mapping spec")
+    void nestedThroughFullSpec() {
+      Compilation compilation =
+          compile(
+              ADDRESS,
+              ADDRESS_DTO,
+              CUSTOMER,
+              CUSTOMER_PATCH_DTO,
+              ADDRESS_MAPPING,
+              CUSTOMER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.CustomerPatchMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("Edit.parseIfPresent(")
+          .contains("AddressMappingImpl.INSTANCE.asValidatedPrism()::parse")
+          .contains("wire.getAddress()")
+          .contains(".at(\"address\")");
+
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.CustomerPatchMappingImpl").getField("INSTANCE").get(null);
+        Object oldAddress = result.newInstance("com.example.Address", "OldCity");
+        Object current = result.newInstance("com.example.Customer", oldAddress);
+
+        Object addressDto =
+            result.loadClass("com.example.AddressDto").getDeclaredConstructor().newInstance();
+        invoke(addressDto, "setCity", "NewCity");
+        Object patch =
+            result.loadClass("com.example.CustomerPatchDto").getDeclaredConstructor().newInstance();
+        invoke(patch, "setAddress", addressDto);
+
+        Object accumulated = invoke(impl, "updateFrom", patch);
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(accumulated, "apply", current);
+        Assertions.assertThat(patched.isValid()).isTrue();
+        Object newAddress = result.newInstance("com.example.Address", "NewCity");
+        Assertions.assertThat(invoke(patched.get(), "address")).isEqualTo(newAddress);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("an absent nested record leaves the domain component unchanged")
+    void absentNestedUnchanged() {
+      Compilation compilation =
+          compile(
+              ADDRESS,
+              ADDRESS_DTO,
+              CUSTOMER,
+              CUSTOMER_PATCH_DTO,
+              ADDRESS_MAPPING,
+              CUSTOMER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.CustomerPatchMappingImpl").getField("INSTANCE").get(null);
+        Object oldAddress = result.newInstance("com.example.Address", "OldCity");
+        Object current = result.newInstance("com.example.Customer", oldAddress);
+        Object patch =
+            result
+                .loadClass("com.example.CustomerPatchDto")
+                .getDeclaredConstructor()
+                .newInstance(); // address left null
+
+        Object accumulated = invoke(impl, "updateFrom", patch);
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(accumulated, "apply", current);
+        Assertions.assertThat(patched.get()).isEqualTo(current);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("two full specs mapping the same nested pair are ambiguous")
+    void ambiguousNestedSpec() {
+      JavaFileObject addressMapping2 =
+          JavaFileObjects.forSourceString(
+              "com.example.AddressMapping2",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface AddressMapping2 extends MappingSpec<Address, AddressDto> {}
+              """);
+      Compilation compilation =
+          compile(
+              ADDRESS,
+              ADDRESS_DTO,
+              CUSTOMER,
+              CUSTOMER_PATCH_DTO,
+              ADDRESS_MAPPING,
+              addressMapping2,
+              CUSTOMER_PATCH_MAPPING);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("matches more than one mapping spec");
+    }
+  }
+
+  @Nested
   @DisplayName("Shape diagnostics")
   class ShapeDiagnostics {
 
@@ -805,6 +987,73 @@ class MappingProcessorUpdateTest {
       Compilation compilation = compile(domain, dto, spec);
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("both write Acct.owner");
+    }
+
+    @Test
+    @DisplayName("a domain Optional component (null-as-absent bridge) is rejected")
+    void optionalBridgeRejected() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.ProfilePatchDto",
+              """
+              package com.example;
+
+              public class ProfilePatchDto {
+                private String nickname;
+                public String getNickname() { return nickname; }
+                public void setNickname(String nickname) { this.nickname = nickname; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Profile",
+              """
+              package com.example;
+
+              import java.util.Optional;
+
+              public record Profile(Optional<String> nickname) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ProfilePatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface ProfilePatchMapping extends UpdateSpec<Profile, ProfilePatchDto> {}
+              """);
+      Compilation compilation = compile(domain, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("which a sparse update cannot express");
+    }
+
+    @Test
+    @DisplayName("a derived-field default method has no meaning on an UpdateSpec")
+    void derivedFieldRejected() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.DerivedPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.Getter;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface DerivedPatchMapping extends UpdateSpec<User, UserPatchDto> {
+                default Getter<User, String> summary() {
+                  return User::name;
+                }
+              }
+              """);
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("has no meaning on a sparse UpdateSpec");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
@@ -655,7 +655,8 @@ class MappingProcessorUpdateTest {
               """);
       Compilation compilation = compile(EMAIL, USER_PATCH_DTO, domainBean, spec);
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("does not support on the domain side");
+      assertThat(compilation).hadErrorContaining("UpdateSpec domain type argument");
+      assertThat(compilation).hadErrorContaining("is not a record");
     }
 
     @Test
@@ -712,7 +713,8 @@ class MappingProcessorUpdateTest {
               """);
       Compilation compilation = compile(EMAIL, USER, wire, spec);
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("neither a record nor a bean-shaped class");
+      assertThat(compilation).hadErrorContaining("UpdateSpec wire type argument");
+      assertThat(compilation).hadErrorContaining("is not a bean-shaped class");
     }
 
     @Test
@@ -939,6 +941,9 @@ class MappingProcessorUpdateTest {
       Compilation compilation = compile(domain, dto, spec);
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("cannot be written into");
+      // A leaf can never target a primitive component, so the fix steers to type alignment only.
+      assertThat(compilation).hadErrorContaining("Align the types");
+      assertThat(compilation).hadErrorContaining("make 'count' a wrapper type");
     }
 
     @Test
@@ -1094,6 +1099,8 @@ class MappingProcessorUpdateTest {
       Compilation compilation = compile(EMAIL, domain, dto, spec);
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("cannot be written into");
+      // A reference-typed component CAN take a leaf, so the fix offers one.
+      assertThat(compilation).hadErrorContaining("Declare a leaf 'default ValidatedPrism<");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
@@ -1,0 +1,865 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.RuntimeCompilationHelper.invoke;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
+import javax.tools.JavaFileObject;
+import org.assertj.core.api.Assertions;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MappingProcessor - sparse PATCH write-back via UpdateSpec (#645)")
+class MappingProcessorUpdateTest {
+
+  private static final JavaFileObject EMAIL =
+      JavaFileObjects.forSourceString(
+          "com.example.EmailAddress",
+          """
+          package com.example;
+
+          public record EmailAddress(String value) {}
+          """);
+
+  private static final JavaFileObject USER =
+      JavaFileObjects.forSourceString(
+          "com.example.User",
+          """
+          package com.example;
+
+          public record User(String name, EmailAddress email, int age) {}
+          """);
+
+  // A PATCH DTO: reference-typed getters/setters throughout — a wrapper Integer for age, so the
+  // scalar can be absent (null) as well as present.
+  private static final JavaFileObject USER_PATCH_DTO =
+      JavaFileObjects.forSourceString(
+          "com.example.UserPatchDto",
+          """
+          package com.example;
+
+          public class UserPatchDto {
+            private String name;
+            private String email;
+            private Integer age;
+
+            public String getName() { return name; }
+            public void setName(String name) { this.name = name; }
+            public String getEmail() { return email; }
+            public void setEmail(String email) { this.email = email; }
+            public Integer getAge() { return age; }
+            public void setAge(Integer age) { this.age = age; }
+          }
+          """);
+
+  private static final JavaFileObject USER_PATCH_MAPPING =
+      JavaFileObjects.forSourceString(
+          "com.example.UserPatchMapping",
+          """
+          package com.example;
+
+          import org.higherkindedj.hkt.validated.FieldError;
+          import org.higherkindedj.hkt.validated.Validated;
+          import org.higherkindedj.optics.annotations.GenerateMapping;
+          import org.higherkindedj.optics.annotations.UpdateSpec;
+          import org.higherkindedj.optics.validated.ValidatedPrism;
+
+          @GenerateMapping
+          public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {
+            default ValidatedPrism<String, EmailAddress> email() {
+              return ValidatedPrism.of(
+                  raw ->
+                      raw.contains("@")
+                          ? Validated.validNel(new EmailAddress(raw))
+                          : Validated.invalidNel(FieldError.of("not an email address")),
+                  EmailAddress::value);
+            }
+          }
+          """);
+
+  private Compilation compile(JavaFileObject... sources) {
+    return javac().withProcessors(new MappingProcessor()).compile(sources);
+  }
+
+  @Nested
+  @DisplayName("Emission")
+  class Emission {
+
+    @Test
+    @DisplayName("emits only updateFrom - no build, parse, or as* tier")
+    void emitsOnlyUpdateFrom() {
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, USER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.UserPatchMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("updateFrom(UserPatchDto wire)")
+          .contains("Edits.accumulate(")
+          .contains("Edit.setIfPresent(")
+          .contains("Setter.fromGetSet(User::name, (d, v) -> new User(v, d.email(), d.age()))")
+          .contains("wire.getName()")
+          .contains("Edit.parseIfPresent(")
+          .contains("Setter.fromGetSet(User::email, (d, v) -> new User(d.name(), v, d.age()))")
+          .contains("wire.getEmail()")
+          .contains("email()::parse")
+          .contains(".at(\"email\")")
+          .contains("Setter.fromGetSet(User::age, (d, v) -> new User(d.name(), d.email(), v))")
+          .contains("wire.getAge()")
+          .doesNotContain("asIso")
+          .doesNotContain("asValidatedPrism")
+          .doesNotContain("asLens")
+          .doesNotContain("build(User domain)")
+          .doesNotContain("parse(UserPatchDto");
+    }
+  }
+
+  @Nested
+  @DisplayName("Runtime")
+  class Runtime {
+
+    private Object impl(RuntimeCompilationHelper.CompiledResult result)
+        throws ReflectiveOperationException {
+      return result.loadClass("com.example.UserPatchMappingImpl").getField("INSTANCE").get(null);
+    }
+
+    private Object patchDto(
+        RuntimeCompilationHelper.CompiledResult result, String name, String email, Integer age)
+        throws ReflectiveOperationException {
+      Object dto =
+          result.loadClass("com.example.UserPatchDto").getDeclaredConstructor().newInstance();
+      invoke(dto, "setName", name);
+      invoke(dto, "setEmail", email);
+      invoke(dto, "setAge", age);
+      return dto;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Validated<NonEmptyList<FieldError>, Object> apply(
+        Object impl, Object dto, Object current) throws ReflectiveOperationException {
+      Object accumulated = invoke(impl, "updateFrom", dto);
+      return (Validated<NonEmptyList<FieldError>, Object>) invoke(accumulated, "apply", current);
+    }
+
+    @Test
+    @DisplayName("an all-absent DTO folds to the identity update")
+    void allAbsentIsIdentity() {
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, USER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object email = result.newInstance("com.example.EmailAddress", "ada@corp.example");
+        Object current = result.newInstance("com.example.User", "Ada", email, 42);
+
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            apply(impl(result), patchDto(result, null, null, null), current);
+
+        Assertions.assertThat(patched.isValid()).isTrue();
+        Assertions.assertThat(patched.get()).isEqualTo(current);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("present fields are applied; absent ones keep their value (identity + unboxing)")
+    void presentFieldsApplied() {
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, USER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object email = result.newInstance("com.example.EmailAddress", "ada@corp.example");
+        Object current = result.newInstance("com.example.User", "Ada", email, 42);
+
+        // Change only name and age (a wrapper Integer that unboxes into the int field); email
+        // stays.
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            apply(impl(result), patchDto(result, "Grace", null, 50), current);
+
+        Assertions.assertThat(patched.isValid()).isTrue();
+        Object updated = patched.get();
+        Assertions.assertThat(invoke(updated, "name")).isEqualTo("Grace");
+        Assertions.assertThat(invoke(updated, "age")).isEqualTo(50);
+        Assertions.assertThat(invoke(updated, "email")).isEqualTo(email);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("a present valid leaf is parsed and applied")
+    void presentValidLeafParsed() {
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, USER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object email = result.newInstance("com.example.EmailAddress", "ada@corp.example");
+        Object current = result.newInstance("com.example.User", "Ada", email, 42);
+
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            apply(impl(result), patchDto(result, null, "grace@corp.example", null), current);
+
+        Assertions.assertThat(patched.isValid()).isTrue();
+        Object newEmail = result.newInstance("com.example.EmailAddress", "grace@corp.example");
+        Assertions.assertThat(invoke(patched.get(), "email")).isEqualTo(newEmail);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Test
+    @DisplayName("a present invalid leaf accumulates a located FieldError; pure edits add no error")
+    void presentInvalidLeafLocated() {
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, USER_PATCH_MAPPING);
+      assertThat(compilation).succeeded();
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object email = result.newInstance("com.example.EmailAddress", "ada@corp.example");
+        Object current = result.newInstance("com.example.User", "Ada", email, 42);
+
+        // A valid name (pure edit, no error) and an invalid email (located under "email").
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            apply(impl(result), patchDto(result, "Grace", "not-an-email", null), current);
+
+        Assertions.assertThat(patched.isInvalid()).isTrue();
+        Assertions.assertThat(patched.getError().toJavaList())
+            .containsExactly(new FieldError(List.of("email"), "not an email address"));
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("Renames")
+  class Renames {
+
+    @Test
+    @DisplayName("@MapField renames a domain component to a differently-named wire property")
+    void renameThroughMapField() {
+      JavaFileObject account =
+          JavaFileObjects.forSourceString(
+              "com.example.Account",
+              """
+              package com.example;
+
+              public record Account(String owner) {}
+              """);
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.AccountPatchDto",
+              """
+              package com.example;
+
+              public class AccountPatchDto {
+                private String holder;
+                public String getHolder() { return holder; }
+                public void setHolder(String holder) { this.holder = holder; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.AccountPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MapField;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface AccountPatchMapping extends UpdateSpec<Account, AccountPatchDto> {
+                @MapField(to = "holder")
+                String owner();
+              }
+              """);
+
+      Compilation compilation = compile(account, dto, spec);
+      assertThat(compilation).succeeded();
+      String generated = generatedSource(compilation, "com.example.AccountPatchMappingImpl");
+      Assertions.assertThat(generated)
+          .contains("Setter.fromGetSet(Account::owner, (d, v) -> new Account(v))")
+          .contains("wire.getHolder()")
+          .contains("public String owner()");
+
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.AccountPatchMappingImpl").getField("INSTANCE").get(null);
+        Object current = result.newInstance("com.example.Account", "Ada");
+        Object patch =
+            result.loadClass("com.example.AccountPatchDto").getDeclaredConstructor().newInstance();
+        invoke(patch, "setHolder", "Grace");
+
+        Object accumulated = invoke(impl, "updateFrom", patch);
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(accumulated, "apply", current);
+        Assertions.assertThat(invoke(patched.get(), "owner")).isEqualTo("Grace");
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("Shape diagnostics")
+  class ShapeDiagnostics {
+
+    @Test
+    @DisplayName("a raw UpdateSpec (no type arguments) is rejected")
+    void rawUpdateSpec() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.RawMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              @SuppressWarnings("rawtypes")
+              public interface RawMapping extends UpdateSpec {}
+              """);
+      Compilation compilation = compile(spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("does not extend UpdateSpec<Domain, Wire>");
+    }
+
+    @Test
+    @DisplayName("a spec extending another interface besides UpdateSpec is rejected")
+    void extraSuperinterface() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ExtraMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              interface Marker {}
+
+              @GenerateMapping
+              public interface ExtraMapping extends UpdateSpec<User, UserPatchDto>, Marker {}
+              """);
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("extends interfaces besides UpdateSpec");
+    }
+
+    @Test
+    @DisplayName("a sealed domain is rejected (dispatch has no sparse meaning)")
+    void sealedDomain() {
+      JavaFileObject shape =
+          JavaFileObjects.forSourceString(
+              "com.example.Shape",
+              """
+              package com.example;
+
+              public sealed interface Shape permits Circle {}
+              """);
+      JavaFileObject circle =
+          JavaFileObjects.forSourceString(
+              "com.example.Circle",
+              """
+              package com.example;
+
+              public record Circle(double radius) implements Shape {}
+              """);
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.ShapeDto",
+              """
+              package com.example;
+
+              public sealed interface ShapeDto permits CircleDto {}
+              """);
+      JavaFileObject circleDto =
+          JavaFileObjects.forSourceString(
+              "com.example.CircleDto",
+              """
+              package com.example;
+
+              public record CircleDto(double radius) implements ShapeDto {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ShapeMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface ShapeMapping extends UpdateSpec<Shape, ShapeDto> {}
+              """);
+      Compilation compilation = compile(shape, circle, dto, circleDto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("cannot map a sealed hierarchy");
+    }
+
+    @Test
+    @DisplayName("a sealed wire (record domain) is rejected too")
+    void sealedWire() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.ShapeDto",
+              """
+              package com.example;
+
+              public sealed interface ShapeDto permits CircleDto {}
+              """);
+      JavaFileObject circleDto =
+          JavaFileObjects.forSourceString(
+              "com.example.CircleDto",
+              """
+              package com.example;
+
+              public record CircleDto(double radius) implements ShapeDto {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.WireMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface WireMapping extends UpdateSpec<User, ShapeDto> {}
+              """);
+      Compilation compilation = compile(EMAIL, USER, dto, circleDto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("cannot map a sealed hierarchy");
+    }
+
+    @Test
+    @DisplayName("a bean-shaped domain is rejected (parse assembles a record)")
+    void beanDomain() {
+      JavaFileObject domainBean =
+          JavaFileObjects.forSourceString(
+              "com.example.UserBean",
+              """
+              package com.example;
+
+              public class UserBean {
+                private String name;
+                public String getName() { return name; }
+                public void setName(String name) { this.name = name; }
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.BeanDomainMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface BeanDomainMapping extends UpdateSpec<UserBean, UserPatchDto> {}
+              """);
+      Compilation compilation = compile(EMAIL, USER_PATCH_DTO, domainBean, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("does not support on the domain side");
+    }
+
+    @Test
+    @DisplayName("a record wire is rejected (a record cannot express absence)")
+    void recordWire() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.UserRecordDto",
+              """
+              package com.example;
+
+              public record UserRecordDto(String name) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.RecordWireMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface RecordWireMapping extends UpdateSpec<User, UserRecordDto> {}
+              """);
+      Compilation compilation = compile(EMAIL, USER, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("is a record, which a sparse UpdateSpec cannot map");
+    }
+
+    @Test
+    @DisplayName("a wire that is neither a record nor a bean is rejected")
+    void nonBeanNonRecordWire() {
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.WireIface",
+              """
+              package com.example;
+
+              public interface WireIface {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.IfaceWireMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface IfaceWireMapping extends UpdateSpec<User, WireIface> {}
+              """);
+      Compilation compilation = compile(EMAIL, USER, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("neither a record nor a bean-shaped class");
+    }
+
+    @Test
+    @DisplayName("a generic spec is rejected")
+    void genericSpec() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.GenericMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface GenericMapping<T> extends UpdateSpec<User, UserPatchDto> {}
+              """);
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("is generic");
+    }
+
+    @Test
+    @DisplayName("an unusable bean wire (no getters/setters) is rejected")
+    void unusableBean() {
+      JavaFileObject wire =
+          JavaFileObjects.forSourceString(
+              "com.example.OpaqueDto",
+              """
+              package com.example;
+
+              public class OpaqueDto {
+                private String name;
+              }
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.OpaqueMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface OpaqueMapping extends UpdateSpec<User, OpaqueDto> {}
+              """);
+      Compilation compilation = compile(EMAIL, USER, wire, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("is not a usable bean-shaped wire");
+    }
+
+    @Test
+    @DisplayName("a malformed @MapField (with a body) is rejected on the update path")
+    void malformedMapField() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.BadRenameMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MapField;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface BadRenameMapping extends UpdateSpec<User, UserPatchDto> {
+                @MapField(to = "name")
+                default String name() { return ""; }
+              }
+              """);
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("must be abstract");
+    }
+
+    @Test
+    @DisplayName("a @MapField naming no domain component is rejected on the update path")
+    void renameNamesNoDomainComponent() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.StrayRenameMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MapField;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface StrayRenameMapping extends UpdateSpec<User, UserPatchDto> {
+                @MapField(to = "name")
+                String nickname();
+              }
+              """);
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("does not name a component of User");
+    }
+  }
+
+  @Nested
+  @DisplayName("Classification diagnostics")
+  class ClassificationDiagnostics {
+
+    @Test
+    @DisplayName("a primitive wire property is rejected (it can never be absent)")
+    void primitiveProperty() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.CountPatchDto",
+              """
+              package com.example;
+
+              public class CountPatchDto {
+                private int count;
+                public int getCount() { return count; }
+                public void setCount(int count) { this.count = count; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Counter",
+              """
+              package com.example;
+
+              public record Counter(int count) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.CounterPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface CounterPatchMapping extends UpdateSpec<Counter, CountPatchDto> {}
+              """);
+      Compilation compilation = compile(domain, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("is primitive and can never be absent");
+    }
+
+    @Test
+    @DisplayName("a wire property with no domain component is rejected")
+    void danglingWireProperty() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.StrayPatchDto",
+              """
+              package com.example;
+
+              public class StrayPatchDto {
+                private String owner;
+                private String extra;
+                public String getOwner() { return owner; }
+                public void setOwner(String owner) { this.owner = owner; }
+                public String getExtra() { return extra; }
+                public void setExtra(String extra) { this.extra = extra; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Owned",
+              """
+              package com.example;
+
+              public record Owned(String owner) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.OwnedPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface OwnedPatchMapping extends UpdateSpec<Owned, StrayPatchDto> {}
+              """);
+      Compilation compilation = compile(domain, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("names no component of Owned");
+    }
+
+    @Test
+    @DisplayName("a type mismatch against a primitive component with no leaf is rejected")
+    void mismatchPrimitiveComponentNoLeaf() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.TextCountDto",
+              """
+              package com.example;
+
+              public class TextCountDto {
+                private String count;
+                public String getCount() { return count; }
+                public void setCount(String count) { this.count = count; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Counter2",
+              """
+              package com.example;
+
+              public record Counter2(int count) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.Counter2PatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface Counter2PatchMapping extends UpdateSpec<Counter2, TextCountDto> {}
+              """);
+      Compilation compilation = compile(domain, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("cannot be written into");
+    }
+
+    @Test
+    @DisplayName("two wire properties resolving to one domain component are rejected")
+    void duplicateDomainTarget() {
+      // A rename (owner -> holder) plus a same-named 'owner' getter both land on Account.owner.
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.DupPatchDto",
+              """
+              package com.example;
+
+              public class DupPatchDto {
+                private String owner;
+                private String holder;
+                public String getOwner() { return owner; }
+                public void setOwner(String owner) { this.owner = owner; }
+                public String getHolder() { return holder; }
+                public void setHolder(String holder) { this.holder = holder; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Acct",
+              """
+              package com.example;
+
+              public record Acct(String owner) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.DupPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MapField;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface DupPatchMapping extends UpdateSpec<Acct, DupPatchDto> {
+                @MapField(to = "holder")
+                String owner();
+              }
+              """);
+      Compilation compilation = compile(domain, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("both write Acct.owner");
+    }
+
+    @Test
+    @DisplayName("a type mismatch against a reference component with no leaf is rejected")
+    void mismatchReferenceComponentNoLeaf() {
+      JavaFileObject dto =
+          JavaFileObjects.forSourceString(
+              "com.example.NumEmailDto",
+              """
+              package com.example;
+
+              public class NumEmailDto {
+                private Integer email;
+                public Integer getEmail() { return email; }
+                public void setEmail(Integer email) { this.email = email; }
+              }
+              """);
+      JavaFileObject domain =
+          JavaFileObjects.forSourceString(
+              "com.example.Contact",
+              """
+              package com.example;
+
+              public record Contact(EmailAddress email) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.ContactPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+
+              @GenerateMapping
+              public interface ContactPatchMapping extends UpdateSpec<Contact, NumEmailDto> {}
+              """);
+      Compilation compilation = compile(EMAIL, domain, dto, spec);
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("cannot be written into");
+    }
+  }
+
+  private static String generatedSource(Compilation compilation, String qualifiedName) {
+    return compilation.generatedSourceFiles().stream()
+        .filter(f -> f.getName().contains(qualifiedName.replace('.', '/')))
+        .findFirst()
+        .map(
+            f -> {
+              try {
+                return f.getCharContent(true).toString();
+              } catch (java.io.IOException e) {
+                throw new java.io.UncheckedIOException(e);
+              }
+            })
+        .orElseThrow(() -> new AssertionError("generated source not found: " + qualifiedName));
+  }
+}

--- a/hkj-test/src/main/java/org/higherkindedj/optics/laws/MappingLaws.java
+++ b/hkj-test/src/main/java/org/higherkindedj/optics/laws/MappingLaws.java
@@ -4,11 +4,13 @@ package org.higherkindedj.optics.laws;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.Function;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
 import org.higherkindedj.optics.Iso;
 import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.edit.Edits;
 import org.higherkindedj.optics.validated.ValidatedPrism;
 
 /**
@@ -28,6 +30,9 @@ import org.higherkindedj.optics.validated.ValidatedPrism;
  *       value - both validated round-trip laws plus the no-parse sanity check;
  *   <li>total-parse mappings (no wire value can fail, e.g. derived wire fields over identity
  *       components): pass a domain sample - the round trip through {@code build}.
+ *   <li>sparse-update tier ({@code updateFrom()} only, from an {@code UpdateSpec}): pass the {@code
+ *       updateFrom} method reference, a domain sample, and an all-absent, a valid and an invalid
+ *       wire - the identity, idempotence and validation laws.
  * </ul>
  *
  * <p>The derived-field reality: {@code build} recomputes a derived wire component and {@code parse}
@@ -141,5 +146,103 @@ public final class MappingLaws {
    */
   public static <W, D> void assertMappingLaws(ValidatedPrism<W, D> mapping, D domainSample) {
     ValidatedPrismLaws.assertParseBuild(mapping, domainSample);
+  }
+
+  /**
+   * All laws of the sparse-update tier ({@code updateFrom(Wire) : Edits.Accumulated<Domain>}, issue
+   * #645): the identity, idempotence and validation laws that make a null-as-absent PATCH lawful.
+   *
+   * <ul>
+   *   <li><b>Identity</b> — {@code updateFrom(allAbsentWire).apply(d) == Valid(d)}: an all-absent
+   *       wire folds to the identity update, leaving the domain untouched.
+   *   <li><b>Idempotence</b> — applying a valid patch twice equals applying it once. This holds
+   *       because generated edits <em>set</em> or <em>parse</em> (overwrite), never
+   *       <em>modify</em>; a modify-shaped edit (e.g. increment) is deliberately not idempotent and
+   *       would fail here.
+   *   <li><b>Validation</b> — {@code updateFrom(invalidWire).apply(d)} is {@code Invalid}: a
+   *       present but invalid field fails, so sparseness never weakens validation of what was sent.
+   * </ul>
+   *
+   * <p>Monoidal composition of the folded {@code Update} is {@code Monoids.update()}'s own law
+   * suite (verified there); this helper checks only the laws specific to {@code updateFrom}.
+   *
+   * <p>Guards against vacuous fixtures: {@code validWire} must parse and must actually change
+   * {@code domainSample} (otherwise idempotence is trivially true), and {@code invalidWire} must
+   * fail (otherwise the validation law is not exercised).
+   *
+   * @param updateFrom the generated {@code Impl.INSTANCE::updateFrom}
+   * @param domainSample the current domain value a patch is applied onto
+   * @param allAbsentWire a wire with every property absent (null)
+   * @param validWire a wire with at least one present, valid property that changes the domain
+   * @param invalidWire a wire with a present but invalid property
+   */
+  public static <W, D> void assertMappingLaws(
+      Function<? super W, Edits.Accumulated<D>> updateFrom,
+      D domainSample,
+      W allAbsentWire,
+      W validWire,
+      W invalidWire) {
+    assertSparseIdentity(updateFrom, domainSample, allAbsentWire);
+    assertSparseIdempotent(updateFrom, domainSample, validWire);
+    assertSparseValidationFails(updateFrom, domainSample, invalidWire);
+  }
+
+  /**
+   * Sparse identity law: an all-absent wire folds to the identity update, so {@code
+   * updateFrom(allAbsentWire).apply(domainSample) == Valid(domainSample)}.
+   */
+  public static <W, D> void assertSparseIdentity(
+      Function<? super W, Edits.Accumulated<D>> updateFrom, D domainSample, W allAbsentWire) {
+    Validated<NonEmptyList<FieldError>, D> result =
+        updateFrom.apply(allAbsentWire).apply(domainSample);
+    assertThat(result)
+        .as(
+            "Sparse identity law: updateFrom(allAbsentWire).apply(%s) == Valid(it); got %s",
+            domainSample, result)
+        .isEqualTo(Validated.validNel(domainSample));
+  }
+
+  /**
+   * Sparse idempotence law: applying the same valid patch twice equals applying it once. Guards
+   * that {@code validWire} parses and genuinely changes the domain, so the law is not vacuously
+   * true.
+   */
+  public static <W, D> void assertSparseIdempotent(
+      Function<? super W, Edits.Accumulated<D>> updateFrom, D domainSample, W validWire) {
+    Validated<NonEmptyList<FieldError>, D> once = updateFrom.apply(validWire).apply(domainSample);
+    assertThat(once.isValid())
+        .as(
+            "Sparse idempotence needs a validWire that PARSES; updateFrom(validWire).apply(%s) was"
+                + " %s",
+            domainSample, once)
+        .isTrue();
+    D patched = once.get();
+    assertThat(patched)
+        .as(
+            "Sparse idempotence needs a validWire that CHANGES the domain; %s left %s unchanged",
+            validWire, domainSample)
+        .isNotEqualTo(domainSample);
+    Validated<NonEmptyList<FieldError>, D> twice = updateFrom.apply(validWire).apply(patched);
+    assertThat(twice)
+        .as(
+            "Sparse idempotence law: applying the same patch twice equals applying it once; got %s",
+            twice)
+        .isEqualTo(Validated.validNel(patched));
+  }
+
+  /**
+   * Sparse validation law: a present but invalid field fails, so {@code
+   * updateFrom(invalidWire).apply(domainSample)} is {@code Invalid}.
+   */
+  public static <W, D> void assertSparseValidationFails(
+      Function<? super W, Edits.Accumulated<D>> updateFrom, D domainSample, W invalidWire) {
+    Validated<NonEmptyList<FieldError>, D> result =
+        updateFrom.apply(invalidWire).apply(domainSample);
+    assertThat(result.isInvalid())
+        .as(
+            "Sparse validation law: a present invalid field must fail;"
+                + " updateFrom(invalidWire).apply(%s) was %s",
+            domainSample, result)
+        .isTrue();
   }
 }

--- a/hkj-test/src/test/java/org/higherkindedj/optics/laws/MappingLawsTest.java
+++ b/hkj-test/src/test/java/org/higherkindedj/optics/laws/MappingLawsTest.java
@@ -5,10 +5,14 @@ package org.higherkindedj.optics.laws;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Locale;
+import java.util.function.Function;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
 import org.higherkindedj.optics.Iso;
 import org.higherkindedj.optics.Lens;
+import org.higherkindedj.optics.Setter;
+import org.higherkindedj.optics.edit.Edit;
+import org.higherkindedj.optics.edit.Edits;
 import org.higherkindedj.optics.validated.ValidatedPrism;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -66,6 +70,31 @@ class MappingLawsTest {
           w -> Validated.validNel(new FullName(w.first(), w.last())),
           d -> new FullNameDto(d.first(), d.last(), d.first() + " " + d.last()));
 
+  // Sparse-update tier: a hand-written updateFrom over an owner (identity) and a validated contact
+  // (leaf), mirroring what an UpdateSpec Impl emits (issue #645).
+  record Account(String owner, EmailAddress contact) {}
+
+  record AccountPatch(String owner, String contact) {}
+
+  private static final Setter<Account, String> ACCOUNT_OWNER =
+      Setter.fromGetSet(Account::owner, (a, v) -> new Account(v, a.contact()));
+
+  private static final Setter<Account, EmailAddress> ACCOUNT_CONTACT =
+      Setter.fromGetSet(Account::contact, (a, v) -> new Account(a.owner(), v));
+
+  private static final Account ACCOUNT = new Account("Ada", new EmailAddress("ada@example.org"));
+
+  // Lawful: absent -> no-op, present owner -> set, present contact -> parsed and located.
+  private static final Function<AccountPatch, Edits.Accumulated<Account>> LAWFUL_UPDATE =
+      p ->
+          Edits.accumulate(
+              Edit.setIfPresent(ACCOUNT_OWNER, p.owner()),
+              Edit.parseIfPresent(ACCOUNT_CONTACT, p.contact(), EMAIL::parse).at("contact"));
+
+  private static final AccountPatch ABSENT_PATCH = new AccountPatch(null, null);
+  private static final AccountPatch VALID_PATCH = new AccountPatch("Grace", "grace@example.org");
+  private static final AccountPatch INVALID_PATCH = new AccountPatch(null, "not-an-email");
+
   @Nested
   @DisplayName("Lawful mappings pass every tier's laws")
   class LawfulMappings {
@@ -96,6 +125,13 @@ class MappingLawsTest {
     @DisplayName("a total-parse mapping with a derived field round-trips its domain sample")
     void totalParseTierPasses() {
       MappingLaws.assertMappingLaws(DERIVED_MAPPING, new FullName("Ada", "Lovelace"));
+    }
+
+    @Test
+    @DisplayName("the sparse-update tier passes identity, idempotence and validation")
+    void sparseUpdateTierPasses() {
+      MappingLaws.assertMappingLaws(
+          LAWFUL_UPDATE, ACCOUNT, ABSENT_PATCH, VALID_PATCH, INVALID_PATCH);
     }
 
     @Test
@@ -161,6 +197,44 @@ class MappingLawsTest {
           .isInstanceOf(AssertionError.class)
           .hasMessageContaining("parse-build");
     }
+
+    @Test
+    @DisplayName("a sparse update that ignores the absent contract fails the identity law")
+    void sparseNonIdentityFails() {
+      // Always sets owner, even for an all-absent wire, so the domain never survives untouched.
+      Function<AccountPatch, Edits.Accumulated<Account>> alwaysSets =
+          p -> Edits.accumulate(Edit.set(ACCOUNT_OWNER, "CONSTANT"));
+
+      assertThatThrownBy(() -> MappingLaws.assertSparseIdentity(alwaysSets, ACCOUNT, ABSENT_PATCH))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("identity law");
+    }
+
+    @Test
+    @DisplayName("a modify-shaped sparse update fails the idempotence law")
+    void sparseNonIdempotentFails() {
+      // Appends the present owner to the current one, so applying twice differs from applying once.
+      Function<AccountPatch, Edits.Accumulated<Account>> appending =
+          p ->
+              Edits.accumulate(Edit.modifyIfPresent(ACCOUNT_OWNER, p.owner(), (v, cur) -> cur + v));
+
+      assertThatThrownBy(() -> MappingLaws.assertSparseIdempotent(appending, ACCOUNT, VALID_PATCH))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("idempotence law");
+    }
+
+    @Test
+    @DisplayName("a sparse update that ignores a present invalid field fails the validation law")
+    void sparseValidationDoesNotFail() {
+      // Never parses contact, so an invalid contact still yields a Valid result.
+      Function<AccountPatch, Edits.Accumulated<Account>> ignoresContact =
+          p -> Edits.accumulate(Edit.setIfPresent(ACCOUNT_OWNER, p.owner()));
+
+      assertThatThrownBy(
+              () -> MappingLaws.assertSparseValidationFails(ignoresContact, ACCOUNT, INVALID_PATCH))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("must fail");
+    }
   }
 
   @Nested
@@ -219,6 +293,26 @@ class MappingLawsTest {
       assertThatThrownBy(() -> MappingLaws.assertMappingLaws(EMAIL, "nope", "also-nope"))
           .isInstanceOf(AssertionError.class)
           .hasMessageContaining("PARSING");
+    }
+
+    @Test
+    @DisplayName("the sparse tier rejects a validWire that does not change the domain")
+    void sparseTierRejectsVacuousValidWire() {
+      // A patch equal to the current values changes nothing, making idempotence vacuously true.
+      AccountPatch vacuous = new AccountPatch("Ada", "ada@example.org");
+
+      assertThatThrownBy(() -> MappingLaws.assertSparseIdempotent(LAWFUL_UPDATE, ACCOUNT, vacuous))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("CHANGES");
+    }
+
+    @Test
+    @DisplayName("the sparse tier rejects a validWire that does not parse")
+    void sparseTierRejectsNonParsingValidWire() {
+      assertThatThrownBy(
+              () -> MappingLaws.assertSparseIdempotent(LAWFUL_UPDATE, ACCOUNT, INVALID_PATCH))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("PARSES");
     }
   }
 }


### PR DESCRIPTION
Closes #645. Follow-on to #628/#644 (bean-shaped `@GenerateMapping` wire targets); the deliberate opt-in for the **opposite** null contract.

## What this adds

A spec extending **`UpdateSpec<Domain, Wire>`** (instead of `MappingSpec`) opts into sparse null-as-absent PATCH: a `null` bean property means *not provided, leave unchanged* rather than broken data. The generated `<Spec>Impl` exposes a single method — no `build`/`parse`/`as*` tier:

```java
public record User(String name, EmailAddress email, int age) {}
// wire is a bean; a wrapper Integer so the scalar can be absent too
public class UserPatchDto { String getName(); void setName(String); Integer getAge(); ... }

@GenerateMapping
public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {
  default ValidatedPrism<String, EmailAddress> email() { return EmailCodecs.EMAIL; }
}

Edits.Accumulated<User> u = UserPatchMappingImpl.INSTANCE.updateFrom(dto);
Validated<NonEmptyList<FieldError>, User> patched = u.apply(current); // or applyPath / toValidated
```

- **Present + valid** → set (or parsed through its leaf), folded into an `Update<Domain>`.
- **Present + invalid** → a located `FieldError`, accumulating.
- **Absent (null)** → skipped; the current value survives.

The runtime already existed (`Edits.accumulate` / `Edit.setIfPresent` / `Edit.parseIfPresent` from #582, `Setter`/`Update`), so this is **codegen over the #628 bean property model — zero `hkj-core` changes**.

## Design (locked in the [#645 review comment](https://github.com/higher-kinded-j/higher-kinded-j/issues/645#issuecomment-5016699230))

- **Opt-in surface** = a `UpdateSpec<A,B> extends MappingSpec<A,B>` marker type; the contract is visible in the type at the declaration site, and `@GenerateMapping` stays attribute-free.
- **Method** = `updateFrom`; **return** = `Edits.Accumulated<Domain>`, identical to a hand-written `Edits.accumulate(...)` PATCH builder, so the REST-PATCH consumption story (`apply`/`applyPath`/`toValidated`) carries over.
- **Rejections (what/why/fix diagnostics):** a primitive wire property (the identity law forces it — an all-absent body must be `Update.identity()`); a domain `Optional<T>` component ("set to empty" is inexpressible under null-as-absent); a record wire (can't express absence); a sealed domain/wire. Coverage is one-sided (a domain component with no wire property is simply never changed).
- **Present = wholesale replacement, top-level only.** Same-typed `List`/`Map`/nested record replace wholesale via identity; a differently-typed nested record is patched through its own full mapping spec.

## Slices (each an independent commit)

| | |
|---|---|
| A | marker + detection + core emission (identity/unboxing/leaf) |
| B | nested-spec resolution + Optional-bridge/derived-field diagnostics |
| C | `MappingLaws` sparse tier — identity / idempotence / validation laws |
| D | in-repo generated-law guarantee (`GeneratedMappingLawsTest`) + a runnable `UpdateSpecExample` |
| E | book page (`record_mapping.md`), at-a-glance + glossary, and the hkj-mapping skill |
| — | pre-PR expert-panel review fixes (sparse-specific diagnostics; dropped a dead `UpdateEdit` seam) |

## Verification

- Full `gradle build` green; `MappingProcessor*` held at **100% line+branch**, hkj-test at **100% BUNDLE**.
- The `bookVerify` gate compiles every book `{{#include}}` anchor and skill `<!-- verify -->` snippet against the fixtures, so the docs can't drift from the API.
- A six-lens expert panel (correctness, type-safety, immutability, ergonomics, modern-Java, HKJ patterns) with each finding adversarially verified: 5 low-severity findings, 0 refuted, all fixed; type-safety and immutability came back clean.

## Out of scope (gated follow-up)

Element-*lifted* containers (`List<Dto>` → `List<Domain>` through a leaf/nested spec, emitting `parseAll`/`parseValues`) — rare in PATCH DTOs, and same-typed containers already replace wholesale. Tracked as **B2**; today such a container gets a clean type-mismatch diagnostic, never miscompiled code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `UpdateSpec` support for generating sparse PATCH mappings.
  * PATCH requests now update only provided fields; null fields remain unchanged.
  * Invalid provided values produce localized validation errors.
  * Added law-checking support for identity, idempotence, and validation behavior.

* **Documentation**
  * Added guides, glossary entries, decision guidance, and examples for sparse PATCH mappings.

* **Tests**
  * Added comprehensive coverage for generated mappings, nested updates, validation, and unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->