### PR TITLE
deploy-mdbook: refresh shared theme when re-deploying a tagged version

### DIFF
--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -78,7 +78,11 @@ jobs:
           # frozen /vX.Y.Z/ snapshot on re-deploy, without rewriting that
           # version's prose. On a fresh tag push HEAD already IS the tag, so the
           # checkout below is a harmless no-op.
-          VERSION="${{ steps.version.outputs.version }}"
+      - name: Restore tagged content for re-deploys (keep current shared theme)
+        env:
+          DEPLOY_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          VERSION="$DEPLOY_VERSION"
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Not a versioned tag ('${VERSION}'); building from current checkout"
             exit 0

--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to deploy (e.g., v0.1.9 for release or "latest" for snapshot)'
+        description: 'Version to deploy (e.g., v0.1.9 to (re)deploy a release, or "latest" for the snapshot). Re-deploying an existing tag rebuilds that version''s content with the current shared theme/scripts.'
         required: true
         default: 'latest'
 
@@ -64,6 +64,31 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "deploy_path=${DEPLOY_PATH}" >> "$GITHUB_OUTPUT"
           echo "version_label=${VERSION_LABEL}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Restore tagged content for re-deploys (keep current shared theme)
+        run: |
+          # When (re)deploying an existing tag whose commit is NOT the one we
+          # checked out - e.g. a manual `workflow_dispatch` from main to refresh
+          # an old release - take that version's documented CONTENT from the tag
+          # but leave theme/, scripts and workflow files at the deploying branch.
+          #
+          # This lets cross-cutting infrastructure fixes (such as the
+          # change-tracking default that must be 'off' outside /latest/) reach a
+          # frozen /vX.Y.Z/ snapshot on re-deploy, without rewriting that
+          # version's prose. On a fresh tag push HEAD already IS the tag, so the
+          # checkout below is a harmless no-op.
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Not a versioned tag ('${VERSION}'); building from current checkout"
+            exit 0
+          fi
+          if ! git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "Tag ${VERSION} not found; building from current checkout"
+            exit 0
+          fi
+          echo "Restoring hkj-book/src from tag ${VERSION} (theme/scripts stay current)"
+          git checkout "refs/tags/${VERSION}" -- hkj-book/src
         shell: bash
 
       - name: Setup mdBook and Rust Environment


### PR DESCRIPTION
Each versioned docs snapshot (/vX.Y.Z/) is frozen at build time, including its own copy of theme/change-tracking.js. The change-tracking default-off fix (#641) landed after v0.4.8 tagged, so /v0.4.8/ still serves the old script that defaults change markers to 'full' everywhere instead of only on /latest/.

Re-deploying an old version could not fix this cleanly: a workflow_dispatch for vX.Y.Z built main's content under that path, and re-pushing the tag just reproduced the stale theme.

When (re)deploying an existing tag whose commit is not the checked-out one, restore only hkj-book/src from the tag and keep theme/, scripts and workflow files from the deploying branch. Cross-cutting infrastructure fixes now reach frozen snapshots on re-deploy without rewriting that version's prose; a fresh tag push is unaffected since HEAD already is the tag.


Claude-Session: https://claude.ai/code/session_01RBUCrUBjrn1rGeJYuueBAB

## Description

Please include a summary of the change and which issue is fixed or feature is added. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue number) / Relates to # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring/Code cleanup
- [ ] Test addition/update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] `./gradlew test` passes locally
- [ ] New unit tests added/updated
- [ ] Relevant examples in `MonadSimulation.java` or `OrderWorkflowRunner.java` updated/tested (if applicable)


## Checklist:

- [ ] My code follows the style guidelines of this project (Standard Google Java Conventions)[**See Google Java Style Guide**](https://google.github.io/styleguide/javaguide.html)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g., README.md, Javadoc)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`./gradlew test`)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)
- [ ] I have checked that the GitHub Actions CI build passes with my changes

## Additional Comments (Optional)

Add any other comments here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved versioned documentation redeployments by restoring the exact tagged book content while keeping the currently shared theme and scripts.
  * Ensured re-deploys for valid `vX.Y.Z` tags correctly source the tagged content; otherwise the workflow safely makes no changes.
* **Documentation**
  * Clarified the manual deployment option text to better explain versioned redeploy behavior and the “latest” snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->