### PR TITLE
Bump local projectVersion fallback to 0.4.9-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // Global properties for all modules
 group = "io.github.higher-kinded-j"
-version = project.findProperty("projectVersion")?.toString() ?: "0.2.2-SNAPSHOT"
+version = project.findProperty("projectVersion")?.toString() ?: "0.4.9-SNAPSHOT"
 
 
 // Repositories for root project (required for OpenRewrite dependencies)


### PR DESCRIPTION
The hardcoded fallback in `build.gradle.kts` had gone stale at `0.2.2-SNAPSHOT`. CI always injects `-PprojectVersion` (derived from the latest tag by the versioner step in `publish.yml`), but local builds without the property were stamping artifacts with the old version.

Verified locally: `gradle properties` now resolves `version: 0.4.9-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default project version to `0.4.9-SNAPSHOT`.
  * Added support for specifying a custom project version during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->