### PR TITLE
@GenerateMapping: reject spec methods that collide with generated Impl members (#654)

### DIFF
--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -34,11 +35,13 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Types;
 import org.higherkindedj.optics.annotations.ArityCeilings;
 import org.higherkindedj.optics.annotations.GenerateMapping;
 import org.higherkindedj.optics.annotations.MapField;
@@ -86,6 +89,12 @@ import org.higherkindedj.optics.processing.util.Diagnostics;
  * into an {@code Update} via {@code Edits.accumulate} — no {@code build}, {@code parse}, or {@code
  * as*} tier. A primitive wire property (which can never be absent) is rejected with a diagnostic,
  * and an {@code UpdateSpec} never registers for nesting (it has no {@code parse}).
+ *
+ * <p>A spec method that is override-equivalent to a member the Impl emits for the classified shape
+ * is rejected with a diagnostic at the spec (issue #654): a colliding {@code default} would
+ * otherwise be silently overridden by the generated method, or — with a different return type —
+ * fail javac inside the generated file. Overloads with a different erased signature, and static or
+ * private spec methods (never inherited by the Impl), stay legal.
  */
 @AutoService(Processor.class)
 @SupportedAnnotationTypes("org.higherkindedj.optics.annotations.GenerateMapping")
@@ -866,6 +875,14 @@ public class MappingProcessor extends AbstractProcessor {
     ClassName implName = implClassName(spec);
     ClassName domainClass = ClassName.get(domain);
     TypeName wireName = TypeName.get(wire.element().asType());
+
+    if (!checkNoEmittedCollisions(
+        spec,
+        "a sparse update",
+        List.of(EmittedMember.of("updateFrom", wire.element().asType())))) {
+      return;
+    }
+
     TypeName accumulatedReturn =
         ParameterizedTypeName.get(ACCUMULATED, TypeName.get(domain.asType()));
 
@@ -1927,6 +1944,21 @@ public class MappingProcessor extends AbstractProcessor {
     // lossless (its reads cannot be null).
     boolean lossless = comps.stream().noneMatch(c -> c.fallible() || beanGuard(c, wire));
     boolean needsGuardHelper = comps.stream().anyMatch(c -> beanGuard(c, wire));
+
+    List<EmittedMember> emitted = new ArrayList<>();
+    emitted.add(EmittedMember.of("build", domain.asType()));
+    emitted.add(EmittedMember.of("parse", wire.element().asType()));
+    emitted.add(EmittedMember.of("asValidatedPrism"));
+    if (lossless) {
+      emitted.add(EmittedMember.of("asIso"));
+    }
+    if (needsGuardHelper) {
+      emitted.add(ifPresentMember());
+    }
+    if (!checkNoEmittedCollisions(spec, "a full mapping", emitted)) {
+      return;
+    }
+
     CodeBlock.Builder reverseArgs = CodeBlock.builder();
     boolean firstReverse = true;
     for (Correspondence c : comps) {
@@ -2074,6 +2106,16 @@ public class MappingProcessor extends AbstractProcessor {
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
 
+    if (!checkNoEmittedCollisions(
+        spec,
+        "a leaf-carrying projection",
+        List.of(
+            EmittedMember.of("build", domain.asType()),
+            EmittedMember.of("patch", domain.asType(), wire.element().asType()),
+            ifPresentMember()))) {
+      return;
+    }
+
     CodeBlock buildBody = wire.buildStatements(wireName, wc -> buildValue(wc, comps));
 
     CodeBlock.Builder patchChain = CodeBlock.builder().add("return $T.fields()", VALIDATED);
@@ -2178,6 +2220,13 @@ public class MappingProcessor extends AbstractProcessor {
     ClassName specName = ClassName.get(spec);
     TypeName domainName = TypeName.get(domain.asType());
     TypeName wireName = TypeName.get(wire.element().asType());
+
+    if (!checkNoEmittedCollisions(
+        spec,
+        "an identity projection",
+        List.of(EmittedMember.of("build", domain.asType()), EmittedMember.of("asLens")))) {
+      return;
+    }
 
     CodeBlock buildBody =
         switch (wire) {
@@ -2344,6 +2393,17 @@ public class MappingProcessor extends AbstractProcessor {
     ClassName specName = ClassName.get(spec);
     TypeName domainName = TypeName.get(domain.asType());
     TypeName wireName = TypeName.get(wire.asType());
+
+    if (!checkNoEmittedCollisions(
+        spec,
+        "a sealed dispatch mapping",
+        List.of(
+            EmittedMember.of("build", domain.asType()),
+            EmittedMember.of("parse", wire.asType()),
+            EmittedMember.of("asValidatedPrism")))) {
+      return;
+    }
+
     TypeName parseReturn =
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
@@ -2448,6 +2508,113 @@ public class MappingProcessor extends AbstractProcessor {
                   "@MapField methods declare renames and are not invocable")
               .build());
     }
+  }
+
+  /**
+   * One member the generated Impl will declare, described for the collision sweep (issue #654): its
+   * name and parameter types, compared against spec methods by erased signature.
+   */
+  private record EmittedMember(String name, List<TypeMirror> params) {
+    static EmittedMember of(String name, TypeMirror... params) {
+      return new EmittedMember(name, List.of(params));
+    }
+  }
+
+  /** The {@code ifPresent} guard helper's erased shape: {@code (Object, Function)}. */
+  private EmittedMember ifPresentMember() {
+    return EmittedMember.of(
+        "ifPresent",
+        processingEnv.getElementUtils().getTypeElement("java.lang.Object").asType(),
+        processingEnv
+            .getTypeUtils()
+            .erasure(
+                processingEnv
+                    .getElementUtils()
+                    .getTypeElement("java.util.function.Function")
+                    .asType()));
+  }
+
+  /**
+   * Rejects spec methods that are override-equivalent to a member the Impl emits for this spec
+   * shape (issue #654). Without the check, a colliding {@code default} is silently overridden by
+   * the generated method — the user's logic never runs on {@code INSTANCE} — or, with a different
+   * return type, the generated file fails javac with no diagnostic pointing at the spec. Static and
+   * private spec methods are not inherited by the Impl, so they can never collide; overloads with a
+   * different erased signature stay legal. Each tier passes exactly the members it emits, so a
+   * helper named after another tier's member (say {@code patch} on a full mapping) stays legal too.
+   */
+  private boolean checkNoEmittedCollisions(
+      TypeElement spec, String tier, List<EmittedMember> emitted) {
+    for (ExecutableElement method : ElementFilter.methodsIn(spec.getEnclosedElements())) {
+      if (method.getModifiers().contains(Modifier.STATIC)
+          || method.getModifiers().contains(Modifier.PRIVATE)) {
+        continue;
+      }
+      for (EmittedMember member : emitted) {
+        if (!overrideEquivalent(method, member)) {
+          continue;
+        }
+        Diagnostics.error(
+            processingEnv.getMessager(),
+            method,
+            TAG,
+            "'"
+                + methodSignature(method)
+                + "' collides with the '"
+                + member.name()
+                + "' member the generated "
+                + implClassName(spec).simpleName()
+                + " emits for this spec shape ("
+                + tier
+                + ").",
+            "The generated Impl declares an override-equivalent '"
+                + member.name()
+                + "', so this method is either silently overridden (its logic never runs on"
+                + " INSTANCE) or fails the generated file's compile with a raw javac error.",
+            "Rename the method, or remove it and rely on the generated '" + member.name() + "'.");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Override-equivalence (JLS 8.4.2) against a member that does not exist yet: same name and same
+   * erased parameter types.
+   */
+  private boolean overrideEquivalent(ExecutableElement method, EmittedMember member) {
+    if (!method.getSimpleName().contentEquals(member.name())
+        || method.getParameters().size() != member.params().size()) {
+      return false;
+    }
+    Types types = processingEnv.getTypeUtils();
+    for (int i = 0; i < member.params().size(); i++) {
+      TypeMirror specParam = types.erasure(method.getParameters().get(i).asType());
+      if (!types.isSameType(specParam, types.erasure(member.params().get(i)))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Renders a spec method as {@code name(SimpleParamType, ...)} for the collision diagnostic. */
+  private static String methodSignature(ExecutableElement method) {
+    StringJoiner params = new StringJoiner(", ", "(", ")");
+    for (VariableElement parameter : method.getParameters()) {
+      params.add(simpleTypeName(parameter.asType()));
+    }
+    return method.getSimpleName() + params.toString();
+  }
+
+  /** The compact display name of a parameter type: no package, no type arguments. */
+  private static String simpleTypeName(TypeMirror type) {
+    String name = type.toString();
+    int generics = name.indexOf('<');
+    if (generics >= 0) {
+      name = name.substring(0, generics);
+    }
+    int lastDot = name.lastIndexOf('.');
+    return lastDot >= 0 ? name.substring(lastDot + 1) : name;
   }
 
   void writeFile(TypeElement spec, String packageName, TypeSpec impl) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -90,11 +90,13 @@ import org.higherkindedj.optics.processing.util.Diagnostics;
  * as*} tier. A primitive wire property (which can never be absent) is rejected with a diagnostic,
  * and an {@code UpdateSpec} never registers for nesting (it has no {@code parse}).
  *
- * <p>A spec method that is override-equivalent to a member the Impl emits for the classified shape
- * is rejected with a diagnostic at the spec (issue #654): a colliding {@code default} would
- * otherwise be silently overridden by the generated method, or — with a different return type —
- * fail javac inside the generated file. Overloads with a different erased signature, and static or
- * private spec methods (never inherited by the Impl), stay legal.
+ * <p>A spec method that collides with a member the Impl emits for the classified tier is rejected
+ * with a diagnostic at the spec (issue #654): a colliding {@code default} would otherwise be
+ * silently overridden by the generated method, or — with a different return type — fail javac
+ * inside the generated file. Overloads with a different erased signature, and static or private
+ * spec methods (never inherited by the Impl), stay legal. The private static {@code hkj$ifPresent}
+ * guard sits in the {@code $} namespace JLS 3.8 reserves for generated code, so no ordinary spec
+ * method can collide with it or capture its call sites, and the sweep never reserves it.
  */
 @AutoService(Processor.class)
 @SupportedAnnotationTypes("org.higherkindedj.optics.annotations.GenerateMapping")
@@ -1882,9 +1884,12 @@ public class MappingProcessor extends AbstractProcessor {
   }
 
   /**
-   * The {@code ifPresent} guard emitted into bean-wire impls: a null property read becomes a
+   * The {@code hkj$ifPresent} guard emitted into bean-wire impls: a null property read becomes a
    * located {@code FieldError} (the {@code fields()} ladder attaches the component label), so a
-   * null never reaches a leaf's {@code parse}, which rejects it.
+   * null never reaches a leaf's {@code parse}, which rejects it. The name lives in the {@code $}
+   * namespace, which JLS 3.8 reserves for mechanically generated code, so no ordinary spec method
+   * can collide with the declaration or capture its call sites through overload resolution (issue
+   * #654) — which is why the collision sweep needs no reservation for it.
    */
   private static MethodSpec ifPresentHelper() {
     TypeVariableName s = TypeVariableName.get("S");
@@ -1896,7 +1901,7 @@ public class MappingProcessor extends AbstractProcessor {
             ClassName.get("java.util.function", "Function"),
             WildcardTypeName.supertypeOf(s),
             validatedOfA);
-    return MethodSpec.methodBuilder("ifPresent")
+    return MethodSpec.methodBuilder("hkj$ifPresent")
         .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
         .addTypeVariable(s)
         .addTypeVariable(a)
@@ -1924,20 +1929,6 @@ public class MappingProcessor extends AbstractProcessor {
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
 
-    CodeBlock buildBody =
-        switch (wire) {
-          case WireShape.RecordShape r -> r.buildStatements(wireName, wc -> buildValue(wc, comps));
-          case WireShape.BeanShape b -> beanBuildBody(b, wireName, comps);
-        };
-
-    CodeBlock.Builder parseChain = CodeBlock.builder().add("return $T.fields()", VALIDATED);
-    for (Correspondence c : comps) {
-      // A bean property is null when unset, so its read is guarded before it reaches a leaf (whose
-      // parse rejects null) or the identity copy; the guard locates the null under the field label.
-      parseChain.add(parseLeg(c, wireRead(wire, c.wireName()), beanGuard(c, wire)));
-    }
-    parseChain.add("\n.apply($T::new)", domainName);
-
     // Derived fields are non-identity, so they exclude the Iso tier too: wire -> domain -> wire
     // recomputes the derived component, an identity only for wire values already consistent. A
     // bean's null-guarded reference reads are fallible too, so only an all-primitive bean stays
@@ -1952,12 +1943,23 @@ public class MappingProcessor extends AbstractProcessor {
     if (lossless) {
       emitted.add(EmittedMember.of("asIso"));
     }
-    if (needsGuardHelper) {
-      emitted.add(ifPresentMember());
-    }
     if (!checkNoEmittedCollisions(spec, "a full mapping", emitted)) {
       return;
     }
+
+    CodeBlock buildBody =
+        switch (wire) {
+          case WireShape.RecordShape r -> r.buildStatements(wireName, wc -> buildValue(wc, comps));
+          case WireShape.BeanShape b -> beanBuildBody(b, wireName, comps);
+        };
+
+    CodeBlock.Builder parseChain = CodeBlock.builder().add("return $T.fields()", VALIDATED);
+    for (Correspondence c : comps) {
+      // A bean property is null when unset, so its read is guarded before it reaches a leaf (whose
+      // parse rejects null) or the identity copy; the guard locates the null under the field label.
+      parseChain.add(parseLeg(c, wireRead(wire, c.wireName()), beanGuard(c, wire)));
+    }
+    parseChain.add("\n.apply($T::new)", domainName);
 
     CodeBlock.Builder reverseArgs = CodeBlock.builder();
     boolean firstReverse = true;
@@ -2016,7 +2018,7 @@ public class MappingProcessor extends AbstractProcessor {
   /**
    * One {@code Validated.fields()} leg for a correspondence — shared by the full tier's {@code
    * parse} and the projection tier's {@code patch}. When {@code guard} is set the read is wrapped
-   * in the {@code ifPresent} helper, so a null becomes a located {@code FieldError} instead of
+   * in the {@code hkj$ifPresent} helper, so a null becomes a located {@code FieldError} instead of
    * reaching a leaf (whose parse rejects null) or the identity copy.
    */
   private CodeBlock parseLeg(Correspondence c, CodeBlock read, boolean guard) {
@@ -2024,16 +2026,18 @@ public class MappingProcessor extends AbstractProcessor {
     return switch (c.kind()) {
       case LEAF ->
           guard
-              ? CodeBlock.of("\n.field($S, ifPresent($L, $L::parse))", c.name(), read, c.prism())
+              ? CodeBlock.of(
+                  "\n.field($S, hkj$$ifPresent($L, $L::parse))", c.name(), read, c.prism())
               : CodeBlock.of("\n.field($S, $L.parse($L))", c.name(), c.prism(), read);
       case LIST ->
           guard
-              ? CodeBlock.of("\n.field($S, ifPresent($L, $L::parseAll))", c.name(), read, c.prism())
+              ? CodeBlock.of(
+                  "\n.field($S, hkj$$ifPresent($L, $L::parseAll))", c.name(), read, c.prism())
               : CodeBlock.of("\n.field($S, $L.parseAll($L))", c.name(), c.prism(), read);
       case OPTIONAL ->
           guard
               ? CodeBlock.of(
-                  "\n.field($S, ifPresent($L, o -> o.map(v ->"
+                  "\n.field($S, hkj$$ifPresent($L, o -> o.map(v ->"
                       + " $L.parse(v).map($T::of)).orElseGet(() ->"
                       + " $T.validNel($T.empty()))))",
                   c.name(),
@@ -2054,11 +2058,12 @@ public class MappingProcessor extends AbstractProcessor {
       case MAP ->
           guard
               ? CodeBlock.of(
-                  "\n.field($S, ifPresent($L, $L::parseValues))", c.name(), read, c.prism())
+                  "\n.field($S, hkj$$ifPresent($L, $L::parseValues))", c.name(), read, c.prism())
               : CodeBlock.of("\n.field($S, $L.parseValues($L))", c.name(), c.prism(), read);
       case IDENTITY ->
           guard
-              ? CodeBlock.of("\n.field($S, ifPresent($L, $T::validNel))", c.name(), read, VALIDATED)
+              ? CodeBlock.of(
+                  "\n.field($S, hkj$$ifPresent($L, $T::validNel))", c.name(), read, VALIDATED)
               : CodeBlock.of("\n.field($S, $T.validNel($L))", c.name(), VALIDATED, read);
       // A nullable bean read bridges to the domain Optional: null becomes Optional.empty, so
       // it is never guarded and never fails on absence.
@@ -2100,6 +2105,7 @@ public class MappingProcessor extends AbstractProcessor {
       WireShape.RecordShape wire,
       List<Correspondence> comps) {
     ClassName specName = ClassName.get(spec);
+    ClassName implName = implClassName(spec);
     TypeName domainName = TypeName.get(domain.asType());
     TypeName wireName = TypeName.get(wire.element().asType());
     TypeName patchReturn =
@@ -2111,8 +2117,7 @@ public class MappingProcessor extends AbstractProcessor {
         "a leaf-carrying projection",
         List.of(
             EmittedMember.of("build", domain.asType()),
-            EmittedMember.of("patch", domain.asType(), wire.element().asType()),
-            ifPresentMember()))) {
+            EmittedMember.of("patch", domain.asType(), wire.element().asType())))) {
       return;
     }
 
@@ -2177,7 +2182,7 @@ public class MappingProcessor extends AbstractProcessor {
     TypeSpec.Builder implBuilder =
         implSkeleton(
                 spec,
-                implClassName(spec),
+                implName,
                 specName,
                 "Generated projection mapping for {@link $T}: total {@code build} and a validated"
                     + " {@code patch} write-back. No {@code parse} is emitted — the dropped"
@@ -2223,7 +2228,7 @@ public class MappingProcessor extends AbstractProcessor {
 
     if (!checkNoEmittedCollisions(
         spec,
-        "an identity projection",
+        "a lossy projection",
         List.of(EmittedMember.of("build", domain.asType()), EmittedMember.of("asLens")))) {
       return;
     }
@@ -2520,28 +2525,16 @@ public class MappingProcessor extends AbstractProcessor {
     }
   }
 
-  /** The {@code ifPresent} guard helper's erased shape: {@code (Object, Function)}. */
-  private EmittedMember ifPresentMember() {
-    return EmittedMember.of(
-        "ifPresent",
-        processingEnv.getElementUtils().getTypeElement("java.lang.Object").asType(),
-        processingEnv
-            .getTypeUtils()
-            .erasure(
-                processingEnv
-                    .getElementUtils()
-                    .getTypeElement("java.util.function.Function")
-                    .asType()));
-  }
-
   /**
-   * Rejects spec methods that are override-equivalent to a member the Impl emits for this spec
-   * shape (issue #654). Without the check, a colliding {@code default} is silently overridden by
-   * the generated method — the user's logic never runs on {@code INSTANCE} — or, with a different
-   * return type, the generated file fails javac with no diagnostic pointing at the spec. Static and
-   * private spec methods are not inherited by the Impl, so they can never collide; overloads with a
-   * different erased signature stay legal. Each tier passes exactly the members it emits, so a
-   * helper named after another tier's member (say {@code patch} on a full mapping) stays legal too.
+   * Rejects spec methods that are override-equivalent (JLS 8.4.2: name plus erased parameter types)
+   * to a member the Impl emits for this tier (issue #654). Without the check, a colliding {@code
+   * default} is silently overridden by the generated method — the user's logic never runs on {@code
+   * INSTANCE} — or, with a different return type, the generated file fails javac with no diagnostic
+   * pointing at the spec. Static and private spec methods are not inherited by the Impl, so they
+   * can never collide; overloads with a different erased signature stay legal, and each tier
+   * reserves only the members it emits, so a helper named after another tier's member (say {@code
+   * patch} on a full mapping) stays legal too. The {@code hkj$ifPresent} guard needs no
+   * reservation: its {@code $} name is out of reach of ordinary spec methods.
    */
   private boolean checkNoEmittedCollisions(
       TypeElement spec, String tier, List<EmittedMember> emitted) {
@@ -2564,14 +2557,17 @@ public class MappingProcessor extends AbstractProcessor {
                 + member.name()
                 + "' member the generated "
                 + implClassName(spec).simpleName()
-                + " emits for this spec shape ("
+                + " emits for this tier ("
                 + tier
                 + ").",
             "The generated Impl declares an override-equivalent '"
                 + member.name()
                 + "', so this method is either silently overridden (its logic never runs on"
                 + " INSTANCE) or fails the generated file's compile with a raw javac error.",
-            "Rename the method, or remove it and rely on the generated '" + member.name() + "'.");
+            "Rename the method, or remove it and rely on the generated '"
+                + member.name()
+                + "'; to customise how a component maps, declare a ValidatedPrism leaf default"
+                + " named after it.");
         return false;
       }
     }
@@ -2589,8 +2585,11 @@ public class MappingProcessor extends AbstractProcessor {
     }
     Types types = processingEnv.getTypeUtils();
     for (int i = 0; i < member.params().size(); i++) {
-      TypeMirror specParam = types.erasure(method.getParameters().get(i).asType());
-      if (!types.isSameType(specParam, types.erasure(member.params().get(i)))) {
+      TypeMirror specParam = method.getParameters().get(i).asType();
+      // An unresolved parameter type matches everything under javac's isSameType; treat it as no
+      // collision, so the real cannot-find-symbol diagnostic is not shadowed by a spurious one.
+      if (specParam.getKind() == TypeKind.ERROR
+          || !types.isSameType(types.erasure(specParam), types.erasure(member.params().get(i)))) {
         return false;
       }
     }
@@ -2606,15 +2605,15 @@ public class MappingProcessor extends AbstractProcessor {
     return method.getSimpleName() + params.toString();
   }
 
-  /** The compact display name of a parameter type: no package, no type arguments. */
+  /**
+   * The compact display name of a parameter type: the element's simple name for declared types, so
+   * packages, type arguments and type-use annotations never clutter the diagnostic; a type variable
+   * renders as its own name.
+   */
   private static String simpleTypeName(TypeMirror type) {
-    String name = type.toString();
-    int generics = name.indexOf('<');
-    if (generics >= 0) {
-      name = name.substring(0, generics);
-    }
-    int lastDot = name.lastIndexOf('.');
-    return lastDot >= 0 ? name.substring(lastDot + 1) : name;
+    return type instanceof DeclaredType declared
+        ? declared.asElement().getSimpleName().toString()
+        : type.toString();
   }
 
   void writeFile(TypeElement spec, String packageName, TypeSpec impl) {

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -165,6 +165,52 @@ class MappingProcessorBeanTest {
         throw new AssertionError(e);
       }
     }
+
+    @Test
+    @DisplayName(
+        "a default override-equivalent to the emitted 'ifPresent' guard is rejected" + " (#654)")
+    void ifPresentCollisionOnBeanFullTierIsRejected() {
+      JavaFileObject colliding =
+          JavaFileObjects.forSourceString(
+              "com.example.UserMapping",
+              """
+              package com.example;
+
+              import java.util.function.Function;
+              import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface UserMapping extends MappingSpec<User, UserDto> {
+                default ValidatedPrism<String, EmailAddress> email() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+
+                default <S, A> Validated<NonEmptyList<FieldError>, A> ifPresent(
+                    S value, Function<? super S, Validated<NonEmptyList<FieldError>, A>> parse) {
+                  return parse.apply(value);
+                }
+              }
+              """);
+
+      Compilation compilation = compile(EMAIL, USER, USER_DTO, colliding);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'ifPresent(S, Function)' collides with the 'ifPresent' member the generated"
+                  + " UserMappingImpl emits");
+      assertThat(compilation).hadErrorContaining("a full mapping");
+    }
   }
 
   @Nested

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorBeanTest.java
@@ -105,10 +105,10 @@ class MappingProcessorBeanTest {
           .contains("wire.setEmail(email().build(domain.email()));")
           .contains("wire.setAge(domain.age());")
           .contains("return wire;")
-          .contains(".field(\"name\", ifPresent(wire.getName(), Validated::validNel))")
-          .contains(".field(\"email\", ifPresent(wire.getEmail(), email()::parse))")
+          .contains(".field(\"name\", hkj$ifPresent(wire.getName(), Validated::validNel))")
+          .contains(".field(\"email\", hkj$ifPresent(wire.getEmail(), email()::parse))")
           .contains(".field(\"age\", Validated.validNel(wire.getAge()))")
-          .contains("private static <S, A> Validated<NonEmptyList<FieldError>, A> ifPresent(")
+          .contains("private static <S, A> Validated<NonEmptyList<FieldError>, A> hkj$ifPresent(")
           .doesNotContain("asIso");
     }
 
@@ -168,9 +168,14 @@ class MappingProcessorBeanTest {
 
     @Test
     @DisplayName(
-        "a default override-equivalent to the emitted 'ifPresent' guard is rejected" + " (#654)")
-    void ifPresentCollisionOnBeanFullTierIsRejected() {
-      JavaFileObject colliding =
+        "a user 'ifPresent' helper stays legal beside the $-namespaced guard and never"
+            + " captures its calls (#654)")
+    void ifPresentHelperStaysLegalBesideTheGuard() {
+      // The generic shape mirrors the guard's own; the String one would be more specific than
+      // the guard for every String property read, so it would capture an unqualified call. Both
+      // are booby-trapped: if generated code ever routed through them, the null-name parse
+      // below would not report the guard's located FieldError.
+      JavaFileObject spec =
           JavaFileObjects.forSourceString(
               "com.example.UserMapping",
               """
@@ -197,19 +202,37 @@ class MappingProcessorBeanTest {
 
                 default <S, A> Validated<NonEmptyList<FieldError>, A> ifPresent(
                     S value, Function<? super S, Validated<NonEmptyList<FieldError>, A>> parse) {
-                  return parse.apply(value);
+                  return Validated.invalidNel(FieldError.of("captured by the generic helper"));
+                }
+
+                default Validated<NonEmptyList<FieldError>, String> ifPresent(
+                    String value,
+                    Function<? super String, Validated<NonEmptyList<FieldError>, String>> parse) {
+                  return Validated.invalidNel(FieldError.of("captured by the String helper"));
                 }
               }
               """);
 
-      Compilation compilation = compile(EMAIL, USER, USER_DTO, colliding);
+      Compilation compilation = compile(EMAIL, USER, USER_DTO, spec);
+      assertThat(compilation).succeeded();
 
-      assertThat(compilation).failed();
-      assertThat(compilation)
-          .hadErrorContaining(
-              "'ifPresent(S, Function)' collides with the 'ifPresent' member the generated"
-                  + " UserMappingImpl emits");
-      assertThat(compilation).hadErrorContaining("a full mapping");
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.UserMappingImpl").getField("INSTANCE").get(null);
+        Object dto = result.loadClass("com.example.UserDto").getDeclaredConstructor().newInstance();
+        invoke(dto, "setEmail", "ada@corp.example");
+        invoke(dto, "setAge", 42);
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> parsed =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", dto);
+        Assertions.assertThat(parsed.isInvalid()).isTrue();
+        Assertions.assertThat(parsed.getError().toJavaList())
+            .containsExactly(new FieldError(List.of("name"), "must not be null"));
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
     }
   }
 
@@ -324,8 +347,8 @@ class MappingProcessorBeanTest {
       Assertions.assertThat(generated)
           .contains("wire.setName(domain.name());")
           .contains("wire.setRole(domain.role());")
-          .contains("ifPresent(wire.getName(), Validated::validNel)")
-          .contains("ifPresent(wire.getRole(), Validated::validNel)");
+          .contains("hkj$ifPresent(wire.getName(), Validated::validNel)")
+          .contains("hkj$ifPresent(wire.getRole(), Validated::validNel)");
     }
   }
 
@@ -378,7 +401,7 @@ class MappingProcessorBeanTest {
       String generated = generatedSource(compilation, "com.example.SiteMappingImpl");
       Assertions.assertThat(generated)
           .contains("wire.setURL(domain.link());")
-          .contains(".field(\"link\", ifPresent(wire.getURL(), Validated::validNel))");
+          .contains(".field(\"link\", hkj$ifPresent(wire.getURL(), Validated::validNel))");
     }
 
     @Test
@@ -433,7 +456,7 @@ class MappingProcessorBeanTest {
       String generated = generatedSource(compilation, "com.example.PersonMappingImpl");
       Assertions.assertThat(generated)
           .contains("wire.setDisplayName(displayName().get(domain));")
-          .contains(".field(\"first\", ifPresent(wire.getFirst(), Validated::validNel))")
+          .contains(".field(\"first\", hkj$ifPresent(wire.getFirst(), Validated::validNel))")
           .doesNotContain(".field(\"displayName\"")
           .doesNotContain("asIso");
     }
@@ -514,9 +537,9 @@ class MappingProcessorBeanTest {
           .contains("wire.setAll(all().buildAll(domain.all()));")
           .contains("wire.setTagged(tagged().buildValues(domain.tagged()));")
           .contains("wire.setPrimary(domain.primary().map(primary()::build));")
-          .contains(".field(\"all\", ifPresent(wire.getAll(), all()::parseAll))")
-          .contains(".field(\"tagged\", ifPresent(wire.getTagged(), tagged()::parseValues))")
-          .contains(".field(\"primary\", ifPresent(wire.getPrimary(), o -> o.map(v ->");
+          .contains(".field(\"all\", hkj$ifPresent(wire.getAll(), all()::parseAll))")
+          .contains(".field(\"tagged\", hkj$ifPresent(wire.getTagged(), tagged()::parseValues))")
+          .contains(".field(\"primary\", hkj$ifPresent(wire.getPrimary(), o -> o.map(v ->");
     }
 
     @Test
@@ -669,7 +692,7 @@ class MappingProcessorBeanTest {
           .contains("b.x(domain.x());")
           .contains("b.label(domain.label());")
           .contains("return b.build();")
-          .contains(".field(\"label\", ifPresent(wire.getLabel(), Validated::validNel))");
+          .contains(".field(\"label\", hkj$ifPresent(wire.getLabel(), Validated::validNel))");
 
       var result = new RuntimeCompilationHelper.CompiledResult(compilation);
       try {
@@ -793,7 +816,7 @@ class MappingProcessorBeanTest {
       Assertions.assertThat(generated)
           .contains("wire.setTitle(domain.title());")
           .contains("wire.getTags().addAll(domain.tags());")
-          .contains(".field(\"tags\", ifPresent(wire.getTags(), Validated::validNel))");
+          .contains(".field(\"tags\", hkj$ifPresent(wire.getTags(), Validated::validNel))");
 
       var result = new RuntimeCompilationHelper.CompiledResult(compilation);
       try {

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
@@ -1824,8 +1824,8 @@ class MappingProcessorTest {
           .contains("public Validated<NonEmptyList<FieldError>, Account> patch(")
           .contains("AccountPatchDto wire)")
           // reference reads are guarded into located FieldErrors; the primitive is not
-          .contains(".field(\"email\", ifPresent(wire.email(), email()::parse))")
-          .contains(".field(\"notes\", ifPresent(wire.notes(), Validated::validNel))")
+          .contains(".field(\"email\", hkj$ifPresent(wire.email(), email()::parse))")
+          .contains(".field(\"notes\", hkj$ifPresent(wire.notes(), Validated::validNel))")
           .contains(".field(\"age\", Validated.validNel(wire.age()))")
           // projected components bind by name; unprojected read from the domain argument
           .contains(".apply((email, notes, age) -> new Account(domain.id(), email, notes, age))")
@@ -4448,6 +4448,10 @@ class MappingProcessorTest {
   @DisplayName("Generated-member collision sweep (#654)")
   class GeneratedMemberCollisionSweep {
 
+    // Full-tier and projection-tier collisions live here; the sealed-tier test sits with its
+    // fixtures in SealedDispatch, the bean 'ifPresent' tests in MappingProcessorBeanTest, and
+    // the sparse-update tests in MappingProcessorUpdateTest.
+
     /** The full-tier spec (leaf on email, so not lossless) with one extra member spliced in. */
     private JavaFileObject fullSpecWith(String extraMember) {
       return JavaFileObjects.forSourceString(
@@ -4484,23 +4488,22 @@ class MappingProcessorTest {
     @Test
     @DisplayName("a default with the exact generated 'parse' signature is rejected, not overridden")
     void exactParseSignatureIsRejected() {
-      Compilation compilation =
-          compile(
-              EMAIL,
-              DOMAIN,
-              WIRE,
-              fullSpecWith(
-                  """
-                    default Validated<NonEmptyList<FieldError>, User> parse(UserDto wire) {
-                      return Validated.invalidNel(FieldError.of("never runs"));
-                    }
-                  """));
+      JavaFileObject colliding =
+          fullSpecWith(
+              """
+                default Validated<NonEmptyList<FieldError>, User> parse(UserDto wire) {
+                  return Validated.invalidNel(FieldError.of("never runs"));
+                }
+              """);
+
+      Compilation compilation = compile(EMAIL, DOMAIN, WIRE, colliding);
 
       assertThat(compilation).failed();
       assertThat(compilation)
           .hadErrorContaining(
               "'parse(UserDto)' collides with the 'parse' member the generated UserMappingImpl"
-                  + " emits");
+                  + " emits")
+          .inFile(colliding);
       assertThat(compilation).hadErrorContaining("a full mapping");
       assertThat(compilation).hadErrorContaining("silently overridden");
       assertThat(compilation)
@@ -4550,6 +4553,20 @@ class MappingProcessorTest {
     }
 
     @Test
+    @DisplayName("a bounded generic default whose erasure matches the member is a collision too")
+    void boundedGenericCollisionIsRejected() {
+      Compilation compilation =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith("  default <T extends User> UserDto build(T value) { return null; }"));
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'build(T)' collides with the 'build' member");
+    }
+
+    @Test
     @DisplayName("'asIso' is reserved only when the mapping is lossless (tier-aware sets)")
     void asIsoReservedOnlyWhenLossless() {
       JavaFileObject point =
@@ -4588,19 +4605,19 @@ class MappingProcessorTest {
       assertThat(losslessCollision).hadErrorContaining("'asIso()' collides");
 
       // The leaf makes the User mapping fallible, so no asIso is emitted and the helper is legal.
-      Compilation fallibleSpec =
+      Compilation fallibleCompilation =
           compile(
               EMAIL,
               DOMAIN,
               WIRE,
               fullSpecWith("  default Iso<User, UserDto> asIso() { return null; }"));
-      assertThat(fallibleSpec).succeeded();
+      assertThat(fallibleCompilation).succeeded();
     }
 
     @Test
-    @DisplayName("overloads with a different erased signature stay legal")
+    @DisplayName("overloads with a different erased signature or arity stay legal")
     void overloadsStayLegal() {
-      Compilation overload =
+      Compilation compilation =
           compile(
               EMAIL,
               DOMAIN,
@@ -4610,12 +4627,13 @@ class MappingProcessorTest {
                     default Validated<NonEmptyList<FieldError>, User> parse(String raw) {
                       return Validated.invalidNel(FieldError.of(raw));
                     }
-                  """));
-      assertThat(overload).succeeded();
 
-      Compilation arityMismatch =
-          compile(EMAIL, DOMAIN, WIRE, fullSpecWith("  default UserDto build() { return null; }"));
-      assertThat(arityMismatch).succeeded();
+                    default UserDto build() {
+                      return null;
+                    }
+                  """));
+
+      assertThat(compilation).succeeded();
     }
 
     @Test
@@ -4732,43 +4750,65 @@ class MappingProcessorTest {
     }
 
     @Test
-    @DisplayName("the emitted 'ifPresent' guard is reserved; a concrete overload stays legal")
-    void ifPresentGuardIsSweptOnThePatchTier() {
-      Compilation collision =
+    @DisplayName(
+        "user 'ifPresent' helpers neither collide with nor capture the $-namespaced"
+            + " guard: every shape is legal and the guard still runs")
+    void ifPresentHelpersNeitherCollideNorCaptureTheGuard() {
+      // The generic helper matches the guard's own shape; the String one would be MORE specific
+      // than the guard for every String read, so it would capture an unqualified 'ifPresent'
+      // call. Both booby-trap their bodies: if generated code ever routed through them, patch
+      // would go invalid below.
+      Compilation compilation =
           compile(
               ACCOUNT,
               ACCOUNT_PATCH_DTO,
               patchSpecWith(
                   """
-                    default <T, B> Validated<NonEmptyList<FieldError>, B> ifPresent(
-                        T value, Function<? super T, Validated<NonEmptyList<FieldError>, B>> parse) {
-                      return parse.apply(value);
+                    default <S, A> Validated<NonEmptyList<FieldError>, A> ifPresent(
+                        S value, Function<? super S, Validated<NonEmptyList<FieldError>, A>> parse) {
+                      return Validated.invalidNel(FieldError.of("captured by the generic helper"));
                     }
-                  """));
-      assertThat(collision).failed();
-      assertThat(collision)
-          .hadErrorContaining("'ifPresent(T, Function)' collides with the 'ifPresent' member");
 
-      Compilation overload =
-          compile(
-              ACCOUNT,
-              ACCOUNT_PATCH_DTO,
-              patchSpecWith(
-                  """
                     default Validated<NonEmptyList<FieldError>, String> ifPresent(
                         String value,
                         Function<? super String, Validated<NonEmptyList<FieldError>, String>> parse) {
-                      return parse.apply(value);
+                      return Validated.invalidNel(FieldError.of("captured by the String helper"));
+                    }
+
+                    default boolean ifPresent(String value) {
+                      return value != null;
                     }
                   """));
-      assertThat(overload).succeeded();
+      assertThat(compilation).succeeded();
+
+      var result = new RuntimeCompilationHelper.CompiledResult(compilation);
+      try {
+        Object impl =
+            result.loadClass("com.example.AccountPatchMappingImpl").getField("INSTANCE").get(null);
+        Object domain =
+            result
+                .loadClass("com.example.Account")
+                .getDeclaredConstructor(String.class, String.class, String.class, int.class)
+                .newInstance("7", "ada@example.com", "notes", 30);
+        Object wire =
+            result
+                .loadClass("com.example.AccountPatchDto")
+                .getDeclaredConstructor(String.class, String.class, int.class)
+                .newInstance("grace@example.com", "updated", 31);
+
+        @SuppressWarnings("unchecked")
+        Validated<NonEmptyList<FieldError>, Object> patched =
+            (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "patch", domain, wire);
+        Assertions.assertThat(patched.isValid()).isTrue();
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
     }
 
     @Test
     @DisplayName(
-        "a default with the generated 'asLens' signature is rejected on an identity"
-            + " projection")
-    void asLensCollisionOnIdentityProjectionIsRejected() {
+        "a default with the generated 'asLens' signature is rejected on a lossy" + " projection")
+    void asLensCollisionOnLossyProjectionIsRejected() {
       JavaFileObject person =
           JavaFileObjects.forSourceString(
               "com.example.Person",
@@ -4808,7 +4848,68 @@ class MappingProcessorTest {
           .hadErrorContaining(
               "'asLens()' collides with the 'asLens' member the generated PersonProjectionImpl"
                   + " emits");
-      assertThat(compilation).hadErrorContaining("an identity projection");
+      assertThat(compilation).hadErrorContaining("a lossy projection");
+    }
+
+    @Test
+    @DisplayName("a @MapField rename named after a zero-parameter generated member is rejected")
+    void mapFieldRenameNamedAfterAZeroParamMemberIsRejected() {
+      JavaFileObject doc =
+          JavaFileObjects.forSourceString(
+              "com.example.Doc",
+              """
+              package com.example;
+
+              public record Doc(String asLens, String title, int pages) {}
+              """);
+      JavaFileObject docDto =
+          JavaFileObjects.forSourceString(
+              "com.example.DocDto",
+              """
+              package com.example;
+
+              public record DocDto(String lensField, int pages) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.DocProjection",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MapField;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface DocProjection extends MappingSpec<Doc, DocDto> {
+                @MapField(to = "lensField")
+                String asLens();
+              }
+              """);
+
+      Compilation compilation = compile(doc, docDto, spec);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'asLens()' collides with the 'asLens' member");
+      assertThat(compilation).hadErrorContaining("a lossy projection");
+    }
+
+    @Test
+    @DisplayName(
+        "an unresolved parameter type is never a collision, so the real cannot-find-symbol"
+            + " error is not shadowed")
+    void unresolvedParameterTypesAreNotCollisions() {
+      Compilation compilation =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith("  default UserDto build(Missing missing) { return null; }"));
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("cannot find symbol");
+      Assertions.assertThat(compilation.errors())
+          .noneMatch(diagnostic -> diagnostic.getMessage(null).contains("collides"));
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
@@ -1701,6 +1701,51 @@ class MappingProcessorTest {
           .inFile(PAYMENT_MAPPING);
       assertThat(compilation).hadErrorContaining("is never produced");
     }
+
+    @Test
+    @DisplayName(
+        "a default with the generated 'parse' signature is rejected on a sealed mapping"
+            + " (#654)")
+    void sealedParseCollisionIsRejected() {
+      JavaFileObject colliding =
+          JavaFileObjects.forSourceString(
+              "com.example.PaymentMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface PaymentMapping extends MappingSpec<Payment, PaymentDto> {
+                default Validated<NonEmptyList<FieldError>, Payment> parse(PaymentDto wire) {
+                  return Validated.invalidNel(FieldError.of("never runs"));
+                }
+              }
+              """);
+
+      Compilation compilation =
+          compile(
+              PAYMENT,
+              CARD,
+              BANK,
+              PAYMENT_DTO,
+              CARD_DTO,
+              BANK_DTO,
+              CARD_MAPPING,
+              BANK_MAPPING,
+              colliding);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'parse(PaymentDto)' collides with the 'parse' member the generated"
+                  + " PaymentMappingImpl emits");
+      assertThat(compilation).hadErrorContaining("a sealed dispatch mapping");
+    }
   }
 
   @Nested
@@ -4396,6 +4441,374 @@ class MappingProcessorTest {
           .hadErrorContaining(
               "is a bean-shaped class, which this mapper does not support on the domain side");
       assertThat(compilation).hadErrorContaining("the domain must be a record");
+    }
+  }
+
+  @Nested
+  @DisplayName("Generated-member collision sweep (#654)")
+  class GeneratedMemberCollisionSweep {
+
+    /** The full-tier spec (leaf on email, so not lossless) with one extra member spliced in. */
+    private JavaFileObject fullSpecWith(String extraMember) {
+      return JavaFileObjects.forSourceString(
+          "com.example.UserMapping",
+          """
+          package com.example;
+
+          import java.util.function.Function;
+          import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+          import org.higherkindedj.hkt.validated.FieldError;
+          import org.higherkindedj.hkt.validated.Validated;
+          import org.higherkindedj.optics.Iso;
+          import org.higherkindedj.optics.annotations.GenerateMapping;
+          import org.higherkindedj.optics.annotations.MappingSpec;
+          import org.higherkindedj.optics.validated.ValidatedPrism;
+
+          @GenerateMapping
+          public interface UserMapping extends MappingSpec<User, UserDto> {
+            default ValidatedPrism<String, EmailAddress> email() {
+              return ValidatedPrism.of(
+                  raw ->
+                      raw.contains("@")
+                          ? Validated.validNel(new EmailAddress(raw))
+                          : Validated.invalidNel(FieldError.of("not an email address")),
+                  EmailAddress::value);
+            }
+
+          %s
+          }
+          """
+              .formatted(extraMember));
+    }
+
+    @Test
+    @DisplayName("a default with the exact generated 'parse' signature is rejected, not overridden")
+    void exactParseSignatureIsRejected() {
+      Compilation compilation =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith(
+                  """
+                    default Validated<NonEmptyList<FieldError>, User> parse(UserDto wire) {
+                      return Validated.invalidNel(FieldError.of("never runs"));
+                    }
+                  """));
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'parse(UserDto)' collides with the 'parse' member the generated UserMappingImpl"
+                  + " emits");
+      assertThat(compilation).hadErrorContaining("a full mapping");
+      assertThat(compilation).hadErrorContaining("silently overridden");
+      assertThat(compilation)
+          .hadErrorContaining("Rename the method, or remove it and rely on the generated 'parse'");
+    }
+
+    @Test
+    @DisplayName(
+        "a default with the same signature but another return type gets the same"
+            + " diagnostic, not a raw javac error in generated code")
+    void incompatibleReturnTypeGetsTheDiagnosticNotARawError() {
+      Compilation compilation =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith("  default String parse(UserDto wire) { return \"\"; }"));
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'parse(UserDto)' collides");
+      assertThat(compilation).hadErrorCount(1);
+    }
+
+    @Test
+    @DisplayName("'build' and 'asValidatedPrism' are swept too")
+    void buildAndAsValidatedPrismAreSwept() {
+      Compilation buildCollision =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith("  default UserDto build(User domain) { return null; }"));
+      assertThat(buildCollision).failed();
+      assertThat(buildCollision)
+          .hadErrorContaining("'build(User)' collides with the 'build' member");
+
+      Compilation prismCollision =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith(
+                  "  default ValidatedPrism<UserDto, User> asValidatedPrism() { return null; }"));
+      assertThat(prismCollision).failed();
+      assertThat(prismCollision)
+          .hadErrorContaining("'asValidatedPrism()' collides with the 'asValidatedPrism' member");
+    }
+
+    @Test
+    @DisplayName("'asIso' is reserved only when the mapping is lossless (tier-aware sets)")
+    void asIsoReservedOnlyWhenLossless() {
+      JavaFileObject point =
+          JavaFileObjects.forSourceString(
+              "com.example.Point",
+              """
+              package com.example;
+
+              public record Point(int x, int y) {}
+              """);
+      JavaFileObject pointDto =
+          JavaFileObjects.forSourceString(
+              "com.example.PointDto",
+              """
+              package com.example;
+
+              public record PointDto(int x, int y) {}
+              """);
+      JavaFileObject losslessSpec =
+          JavaFileObjects.forSourceString(
+              "com.example.PointMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.Iso;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface PointMapping extends MappingSpec<Point, PointDto> {
+                default Iso<Point, PointDto> asIso() { return null; }
+              }
+              """);
+      Compilation losslessCollision = compile(point, pointDto, losslessSpec);
+      assertThat(losslessCollision).failed();
+      assertThat(losslessCollision).hadErrorContaining("'asIso()' collides");
+
+      // The leaf makes the User mapping fallible, so no asIso is emitted and the helper is legal.
+      Compilation fallibleSpec =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith("  default Iso<User, UserDto> asIso() { return null; }"));
+      assertThat(fallibleSpec).succeeded();
+    }
+
+    @Test
+    @DisplayName("overloads with a different erased signature stay legal")
+    void overloadsStayLegal() {
+      Compilation overload =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith(
+                  """
+                    default Validated<NonEmptyList<FieldError>, User> parse(String raw) {
+                      return Validated.invalidNel(FieldError.of(raw));
+                    }
+                  """));
+      assertThat(overload).succeeded();
+
+      Compilation arityMismatch =
+          compile(EMAIL, DOMAIN, WIRE, fullSpecWith("  default UserDto build() { return null; }"));
+      assertThat(arityMismatch).succeeded();
+    }
+
+    @Test
+    @DisplayName("static and private spec methods are not inherited by the Impl, so they pass")
+    void staticAndPrivateMethodsPass() {
+      Compilation compilation =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith(
+                  """
+                    static UserDto build(User domain) {
+                      return null;
+                    }
+
+                    private Validated<NonEmptyList<FieldError>, User> parse(UserDto wire) {
+                      return Validated.invalidNel(FieldError.of("a private helper"));
+                    }
+                  """));
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("'patch' is not reserved on a full mapping: the sets are per tier")
+    void patchHelperOnFullMappingStaysLegal() {
+      Compilation compilation =
+          compile(
+              EMAIL,
+              DOMAIN,
+              WIRE,
+              fullSpecWith(
+                  """
+                    default Validated<NonEmptyList<FieldError>, User> patch(User domain, UserDto wire) {
+                      return Validated.invalidNel(FieldError.of("a helper, not a collision"));
+                    }
+                  """));
+
+      assertThat(compilation).succeeded();
+    }
+
+    /** The leaf-carrying projection spec (issue #625's shape) with one extra member spliced in. */
+    private JavaFileObject patchSpecWith(String extraMember) {
+      return JavaFileObjects.forSourceString(
+          "com.example.AccountPatchMapping",
+          """
+          package com.example;
+
+          import java.util.function.Function;
+          import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+          import org.higherkindedj.hkt.validated.FieldError;
+          import org.higherkindedj.hkt.validated.Validated;
+          import org.higherkindedj.optics.annotations.GenerateMapping;
+          import org.higherkindedj.optics.annotations.MappingSpec;
+          import org.higherkindedj.optics.validated.ValidatedPrism;
+
+          @GenerateMapping
+          public interface AccountPatchMapping extends MappingSpec<Account, AccountPatchDto> {
+            default ValidatedPrism<String, String> email() {
+              return ValidatedPrism.of(
+                  raw ->
+                      raw.contains("@")
+                          ? Validated.validNel(raw)
+                          : Validated.invalidNel(FieldError.of("not an email address")),
+                  email -> email);
+            }
+
+          %s
+          }
+          """
+              .formatted(extraMember));
+    }
+
+    private static final JavaFileObject ACCOUNT =
+        JavaFileObjects.forSourceString(
+            "com.example.Account",
+            """
+            package com.example;
+
+            public record Account(String id, String email, String notes, int age) {}
+            """);
+
+    private static final JavaFileObject ACCOUNT_PATCH_DTO =
+        JavaFileObjects.forSourceString(
+            "com.example.AccountPatchDto",
+            """
+            package com.example;
+
+            public record AccountPatchDto(String email, String notes, int age) {}
+            """);
+
+    @Test
+    @DisplayName("a default with the generated 'patch' signature is rejected on the patch tier")
+    void patchCollisionOnLeafCarryingProjectionIsRejected() {
+      Compilation compilation =
+          compile(
+              ACCOUNT,
+              ACCOUNT_PATCH_DTO,
+              patchSpecWith(
+                  """
+                    default Validated<NonEmptyList<FieldError>, Account> patch(
+                        Account domain, AccountPatchDto wire) {
+                      return Validated.invalidNel(FieldError.of("never runs"));
+                    }
+                  """));
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'patch(Account, AccountPatchDto)' collides with the 'patch' member the generated"
+                  + " AccountPatchMappingImpl emits");
+      assertThat(compilation).hadErrorContaining("a leaf-carrying projection");
+    }
+
+    @Test
+    @DisplayName("the emitted 'ifPresent' guard is reserved; a concrete overload stays legal")
+    void ifPresentGuardIsSweptOnThePatchTier() {
+      Compilation collision =
+          compile(
+              ACCOUNT,
+              ACCOUNT_PATCH_DTO,
+              patchSpecWith(
+                  """
+                    default <T, B> Validated<NonEmptyList<FieldError>, B> ifPresent(
+                        T value, Function<? super T, Validated<NonEmptyList<FieldError>, B>> parse) {
+                      return parse.apply(value);
+                    }
+                  """));
+      assertThat(collision).failed();
+      assertThat(collision)
+          .hadErrorContaining("'ifPresent(T, Function)' collides with the 'ifPresent' member");
+
+      Compilation overload =
+          compile(
+              ACCOUNT,
+              ACCOUNT_PATCH_DTO,
+              patchSpecWith(
+                  """
+                    default Validated<NonEmptyList<FieldError>, String> ifPresent(
+                        String value,
+                        Function<? super String, Validated<NonEmptyList<FieldError>, String>> parse) {
+                      return parse.apply(value);
+                    }
+                  """));
+      assertThat(overload).succeeded();
+    }
+
+    @Test
+    @DisplayName(
+        "a default with the generated 'asLens' signature is rejected on an identity"
+            + " projection")
+    void asLensCollisionOnIdentityProjectionIsRejected() {
+      JavaFileObject person =
+          JavaFileObjects.forSourceString(
+              "com.example.Person",
+              """
+              package com.example;
+
+              public record Person(String name, String town, int age) {}
+              """);
+      JavaFileObject personDto =
+          JavaFileObjects.forSourceString(
+              "com.example.PersonDto",
+              """
+              package com.example;
+
+              public record PersonDto(String town, int age) {}
+              """);
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.PersonProjection",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.MappingSpec;
+
+              @GenerateMapping
+              public interface PersonProjection extends MappingSpec<Person, PersonDto> {
+                default Lens<Person, PersonDto> asLens() { return null; }
+              }
+              """);
+
+      Compilation compilation = compile(person, personDto, spec);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'asLens()' collides with the 'asLens' member the generated PersonProjectionImpl"
+                  + " emits");
+      assertThat(compilation).hadErrorContaining("an identity projection");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
@@ -1150,6 +1150,49 @@ class MappingProcessorUpdateTest {
                   + " UserPatchMappingImpl emits");
       assertThat(compilation).hadErrorContaining("a sparse update");
     }
+
+    @Test
+    @DisplayName(
+        "'build' and 'parse' helpers stay legal: a sparse update reserves only" + " 'updateFrom'")
+    void buildAndParseHelpersStayLegal() {
+      JavaFileObject spec =
+          JavaFileObjects.forSourceString(
+              "com.example.UserPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {
+                default ValidatedPrism<String, EmailAddress> email() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+
+                default UserPatchDto build(User domain) {
+                  return new UserPatchDto();
+                }
+
+                default Validated<NonEmptyList<FieldError>, User> parse(UserPatchDto wire) {
+                  return Validated.invalidNel(FieldError.of("a helper, not a collision"));
+                }
+              }
+              """);
+
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, spec);
+
+      assertThat(compilation).succeeded();
+    }
   }
 
   private static String generatedSource(Compilation compilation, String qualifiedName) {

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorUpdateTest.java
@@ -1104,6 +1104,54 @@ class MappingProcessorUpdateTest {
     }
   }
 
+  @Nested
+  @DisplayName("Generated-member collision sweep (#654)")
+  class GeneratedMemberCollisionSweep {
+
+    @Test
+    @DisplayName("a default with the generated 'updateFrom' signature is rejected")
+    void updateFromCollisionIsRejected() {
+      JavaFileObject colliding =
+          JavaFileObjects.forSourceString(
+              "com.example.UserPatchMapping",
+              """
+              package com.example;
+
+              import org.higherkindedj.hkt.validated.FieldError;
+              import org.higherkindedj.hkt.validated.Validated;
+              import org.higherkindedj.optics.annotations.GenerateMapping;
+              import org.higherkindedj.optics.annotations.UpdateSpec;
+              import org.higherkindedj.optics.edit.Edits;
+              import org.higherkindedj.optics.validated.ValidatedPrism;
+
+              @GenerateMapping
+              public interface UserPatchMapping extends UpdateSpec<User, UserPatchDto> {
+                default ValidatedPrism<String, EmailAddress> email() {
+                  return ValidatedPrism.of(
+                      raw ->
+                          raw.contains("@")
+                              ? Validated.validNel(new EmailAddress(raw))
+                              : Validated.invalidNel(FieldError.of("not an email address")),
+                      EmailAddress::value);
+                }
+
+                default Edits.Accumulated<User> updateFrom(UserPatchDto wire) {
+                  return null;
+                }
+              }
+              """);
+
+      Compilation compilation = compile(EMAIL, USER, USER_PATCH_DTO, colliding);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'updateFrom(UserPatchDto)' collides with the 'updateFrom' member the generated"
+                  + " UserPatchMappingImpl emits");
+      assertThat(compilation).hadErrorContaining("a sparse update");
+    }
+  }
+
   private static String generatedSource(Compilation compilation, String qualifiedName) {
     return compilation.generatedSourceFiles().stream()
         .filter(f -> f.getName().contains(qualifiedName.replace('.', '/')))


### PR DESCRIPTION
Closes #654.

## What

`@GenerateMapping` specs are interfaces the generated Impl implements, and until now the generator added members without checking whether the spec already declared an override-equivalent method. A spec `default` with the exact generated signature was silently overridden — the user's "customisation" never ran on `Impl.INSTANCE` — and one with a different return type failed javac *inside the generated file*, with no diagnostic pointing at the spec.

Each `write*Impl` now sweeps the spec's methods against exactly the member set that tier emits, before anything is written, and rejects override-equivalent ones (JLS 8.4.2: name + erased parameter types) with a what/why/fix diagnostic at the offending method:

```
error: [@GenerateMapping] 'patch(Account, AccountPatchDto)' collides with the 'patch' member the
generated AccountPatchMappingImpl emits for this tier (a leaf-carrying projection). The generated
Impl declares an override-equivalent 'patch', so this method is either silently overridden (its
logic never runs on INSTANCE) or fails the generated file's compile with a raw javac error.
Rename the method, or remove it and rely on the generated 'patch'; to customise how a component
maps, declare a ValidatedPrism leaf default named after it.
```

## Design

**Per-writer sweep, not a `validateSpecMethods` extension.** The issue suggested extending `validateSpecMethods`, but that runs before tier classification and cannot know the exact member set (`asIso` losslessness is only computed inside `writeImpl`); the conservative union would falsely ban legal helpers like a `patch(Domain, Wire)` default on a full mapping. Instead each writer passes its own set (recorded on the issue as review finding 3):

| Tier | Reserved members |
|---|---|
| Full mapping | `build(Domain)`, `parse(Wire)`, `asValidatedPrism()`, + `asIso()` when lossless |
| Lossy projection | `build(Domain)`, `asLens()` |
| Leaf-carrying projection | `build(Domain)`, `patch(Domain, Wire)` |
| Sealed dispatch | `build(Domain)`, `parse(Wire)`, `asValidatedPrism()` |
| Sparse update | `updateFrom(Wire)` |

Static and private spec methods are never inherited by the Impl, so they pass; overloads with a different erased signature stay legal; unresolved (error) parameter types are never a collision, so the real cannot-find-symbol diagnostic is not shadowed by a spurious one.

**The `ifPresent` guard moves to the `$` namespace (`hkj$ifPresent`) instead of being reserved.** The review comment proposed reserving the private static null-guard, but implementation showed both available enforcement shapes are wrong: an erasure-based reservation over-rejects (javac only clashes a class static with a signature-*identical* inherited default — same-erasure variants coexist legally), and qualifying the internal calls does not help either (javac resolves `Impl.ifPresent(...)` against inherited instance members too, and errors when a user's more-specific default wins — while *unqualified* calls would be silently captured by such a default). Renaming the private helper into the `$` namespace, which JLS 3.8 reserves for mechanically generated code, kills every mode at once: no ordinary spec method can collide with the declaration or capture the call sites, and the sweep needs no reservation for it. Booby-trapped runtime tests pin capture-immunity on both guarded tiers.

**Diagnostics match the book.** Tier names use the emission-tier vocabulary from `record_mapping.md` ("a lossy projection", "a leaf-carrying projection", …), and the fix sentence routes the customisation-seeking user to the supported mechanism (a `ValidatedPrism` leaf default).

## Tests

Both #654 failure modes are pinned (exact-signature silent override; different-return with `hadErrorCount(1)` proving the raw javac error is replaced, `.inFile` anchoring the diagnostic at the spec). One collision per remaining tier (patch/lens/sealed/update — the sweep never consults return types, so the second mode is exercised once rather than per tier). Negative space: erased-overload and arity overloads, static/private skips, tier-crossing `patch`-on-full-mapping, `asIso` legal when fallible, bounded-generic collision (`<T extends User> build(T)` — erasure match), a `@MapField` rename named after a zero-param member, `build`/`parse` helpers legal on a sparse update, an unresolved-type non-collision, and user `ifPresent` helpers of every shape compiling beside the guard with the guard still running.

`MappingProcessor` remains at 100% instruction and branch coverage; the full multi-module build passes (no existing spec in the repo trips the sweep).

A five-lens panel review (correctness, type safety, ergonomics, architecture, test quality) ran on the initial implementation; every surviving finding is folded in, including the two the panels proved empirically — the `ErrorType` false positive and the guard capture/clash semantics above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile-time detection of naming/signature collisions between generated mapping helpers and user-declared methods, preventing silent overrides and build failures.
  * Enhanced diagnostics to point to the correct generated mapping context across tiers (including sealed dispatch, projections, and sparse update generation).
  * Namespaced the generated null-guard helper so user-defined `ifPresent`-named methods can’t interfere.

* **Tests**
  * Expanded regression coverage for collision sweep scenarios (including `parse`, `build`, `asValidatedPrism`, `patch`, `asLens`, and sparse `updateFrom`) and for null-guard helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->