### PR TITLE
Replace hijacked pcollections.org links with the project's GitHub repository

### DIFF
--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -95,6 +95,19 @@ jobs:
           git checkout "refs/tags/${VERSION}" -- hkj-book/src
         shell: bash
 
+      - name: Sanitise hijacked pcollections.org links (issue 681)
+        run: |
+          # pcollections.org no longer belongs to the PCollections project and
+          # serves spam. Content restored from tags v0.4.4-v0.4.8 still links
+          # to it; rewrite to the project's GitHub repository. No-op for
+          # current sources, which already use the GitHub URL.
+          find "${BOOK_ROOT_DIR}/src" -name '*.md' -exec \
+            sed -i 's#https://pcollections\.org/#https://github.com/hrldcpr/pcollections#g' {} +
+          if grep -rn 'pcollections\.org' "${BOOK_ROOT_DIR}/src"; then
+            echo "::warning::pcollections.org references remain after sanitisation"
+          fi
+        shell: bash
+
       - name: Setup mdBook and Rust Environment
         uses: peaceiris/actions-mdbook@v2
         with:

--- a/hkj-book/src/tooling/pcollections_integration.md
+++ b/hkj-book/src/tooling/pcollections_integration.md
@@ -7,7 +7,7 @@
 - How to add PCollections to your own project as an opt-in dependency
 ~~~
 
-[PCollections](https://pcollections.org/) is a small, lightweight library of persistent immutable
+[PCollections](https://github.com/hrldcpr/pcollections) is a small, lightweight library of persistent immutable
 data structures whose types implement the standard `java.util` interfaces. `PVector` implements
 `List`, `PStack` implements `List`, `PSet` implements `Set`, and so on. That `java.util`
 compatibility makes PCollections a particularly easy fit for Higher-Kinded-J: any `PVector` or

--- a/hkj-book/src/tooling/pcollections_optics.md
+++ b/hkj-book/src/tooling/pcollections_optics.md
@@ -7,7 +7,7 @@
 - Where natural-ordering caveats apply for sorted variants
 ~~~
 
-[PCollections](https://pcollections.org/) persistent collections are first-class citizens of the optics generator system. Annotating a record whose components are `PVector`, `PStack`, `PSet`, `PSortedSet`, `PBag`, `PMap`, or `PSortedMap` produces traversal code that round-trips through the persistent type, with no production-code changes required.
+[PCollections](https://github.com/hrldcpr/pcollections) persistent collections are first-class citizens of the optics generator system. Annotating a record whose components are `PVector`, `PStack`, `PSet`, `PSortedSet`, `PBag`, `PMap`, or `PSortedMap` produces traversal code that round-trips through the persistent type, with no production-code changes required.
 
 This page documents the seven PCollections generator plugins. For the underlying compatibility hypothesis and benchmark numbers, see [PCollections Integration](pcollections_integration.md).
 


### PR DESCRIPTION
## Description

The `pcollections.org` domain no longer belongs to the PCollections project and now serves a hijacked site with casino spam links. This PR removes all references to it:

- `hkj-book/src/tooling/pcollections_integration.md` and `hkj-book/src/tooling/pcollections_optics.md` now link to the official repository, https://github.com/hrldcpr/pcollections (the source of the `org.pcollections:pcollections` Maven artifact this project depends on).
- `deploy-mdbook-versioned.yml` gains a sanitisation step that rewrites `https://pcollections.org/` after restoring tagged book content. Re-deploys restore `hkj-book/src` from the release tag, so without this the fix on main could never reach the frozen `/vX.Y.Z/` snapshots. With it, dispatching the workflow for v0.4.4–v0.4.8 (the deployed versions carrying the bad link — the page did not exist before v0.4.4) republishes each version with only the link changed; all other prose stays exactly as tagged. The step is a no-op for current sources.

Fixes #681

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- Verified `https://github.com/hrldcpr/pcollections` is the official PCollections repository.
- Verified no `pcollections.org` references remain anywhere in the repository.
- Verified the URL appears in the identical form `https://pcollections.org/` in tags v0.4.4 through v0.4.8, so the workflow's targeted `sed` rewrite covers every affected snapshot; the step also emits a warning annotation if any reference survives sanitisation.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (e.g., README.md, Javadoc)

## Additional Comments (Optional)

After merge, run the "Deploy Versioned mdBook" workflow via `workflow_dispatch` from main once per affected version (`v0.4.4`, `v0.4.5`, `v0.4.6`, `v0.4.7`, `v0.4.8`) to purge the spam link from the published snapshots. `/latest/` is republished automatically by the merge itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PCollections references to link to the project’s GitHub repository.
  * Preserved existing guidance about PCollections integration and optics support.

* **Bug Fixes**
  * Improved versioned documentation builds by rewriting outdated PCollections links and warning when any remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->