### PR TITLE
Document the injection and test-double story for generated mappings (#678)

### DIFF
--- a/.claude/skills/hkj-mapping/SKILL.md
+++ b/.claude/skills/hkj-mapping/SKILL.md
@@ -182,12 +182,15 @@ directly. Diagnostics about inherited members name the declaring interface.
 ### Injecting and faking (Spring)
 
 Register the surface you consume as a bean, not the spec or Impl: `ValidatedPrism<Wire, Domain>`
-via `Impl.INSTANCE.asValidatedPrism()` for parse-capable mappings; `Function`/`BiFunction` method
-references for build-only, `patch` and `updateFrom`. `ValidatedPrism` is SEALED: fakes are built
-as values with `ValidatedPrism.of(...)`, never mocked (Mockito rejects sealed types). Spring
-resolves the generic type, so per-pair codecs coexist; same-pair duplicates need `@Qualifier`.
-Injection is optional: an Impl is a stateless pure function, and calling `INSTANCE` directly
-loses nothing but the substitution seam.
+via `Impl.INSTANCE.asValidatedPrism()` (concrete; threaded specs use `instance()`, element-mapped
+specs build the Impl once with `of(prisms)` in the `@Bean` method) for parse-capable mappings;
+`Function`/`BiFunction` method references for build-only, `patch` and `updateFrom`.
+`ValidatedPrism` is SEALED: fakes are built as values with `ValidatedPrism.of(...)`, never mocked
+(Mockito rejects sealed types). Spring resolves the generic type, so per-pair codecs coexist;
+same-pair duplicates need `@Qualifier`. Injection is optional: concrete and threaded Impls are
+stateless pure functions, element-mapped ones immutable values, and calling the Impl directly
+(`INSTANCE`, `instance()`, or one shared `of(...)` instance) loses nothing but the substitution
+seam.
 
 ### Sealed hierarchies dispatch exhaustively
 

--- a/.claude/skills/hkj-mapping/SKILL.md
+++ b/.claude/skills/hkj-mapping/SKILL.md
@@ -179,6 +179,16 @@ naming both interfaces). Interface statics are not inherited. Rejected with diag
 generic specs may extend (non-generic) mix-ins; `@GenerateMerge` specs still declare everything
 directly. Diagnostics about inherited members name the declaring interface.
 
+### Injecting and faking (Spring)
+
+Register the surface you consume as a bean, not the spec or Impl: `ValidatedPrism<Wire, Domain>`
+via `Impl.INSTANCE.asValidatedPrism()` for parse-capable mappings; `Function`/`BiFunction` method
+references for build-only, `patch` and `updateFrom`. `ValidatedPrism` is SEALED: fakes are built
+as values with `ValidatedPrism.of(...)`, never mocked (Mockito rejects sealed types). Spring
+resolves the generic type, so per-pair codecs coexist; same-pair duplicates need `@Qualifier`.
+Injection is optional: an Impl is a stateless pure function, and calling `INSTANCE` directly
+loses nothing but the substitution seam.
+
 ### Sealed hierarchies dispatch exhaustively
 
 A `MappingSpec` may be declared over two **sealed interfaces**, not just two records. Give each

--- a/hkj-book/src/optics/record_mapping.md
+++ b/hkj-book/src/optics/record_mapping.md
@@ -443,7 +443,7 @@ Two verbs keep the two operations distinct: `ErrorEnvelope.withContext(D)` is th
 
 ## Injecting and testing generated mappings
 
-A generated Impl is a stateless pure function reached through statics, and the spec interface deliberately declares nothing (`@Autowired UserMapping` injects nothing useful, by design). When you do want a Spring bean or a test double, register the **surface you consume**, per tier:
+A concrete or threaded Impl is a stateless pure function reached through statics (`INSTANCE`, `instance()`); an element-mapped Impl is an immutable value built by `of(...)`, carrying its element prisms. The spec interface deliberately declares nothing either way (`@Autowired UserMapping` injects nothing useful, by design). When you do want a Spring bean or a test double, register the **surface you consume**, per tier:
 
 | Tier surface | Injectable shape | From |
 |---|---|---|
@@ -475,7 +475,7 @@ ValidatedPrism<UserDto, User> userCodec() {
 }
 ```
 
-The [hkj-spring example app](../spring/spring_boot_integration.md) demonstrates the seam end to end: `MappingConfiguration` registers the codec, `UserController`'s parse endpoint injects it, and `UserParseFakeCodecSliceTest` substitutes the fake above in a `@WebMvcTest` slice and asserts the located 422 it produces. The same controller's PATCH endpoint deliberately calls `UserPatchMappingImpl.INSTANCE` directly: injection buys substitution, not lifecycle, and a team comfortable calling `INSTANCE` loses nothing.
+The [hkj-spring example app](../spring/spring_boot_integration.md) demonstrates the seam end to end: `MappingConfiguration` registers the codec, `UserController`'s parse endpoint injects it, and `UserParseFakeCodecSliceTest` substitutes the fake above in a `@WebMvcTest` slice and asserts the located 422 it produces. The same controller's PATCH endpoint deliberately calls `UserPatchMappingImpl.INSTANCE` directly: injection buys substitution, not lifecycle, and a team comfortable calling the Impl directly (`INSTANCE`, `instance()`, or one shared `of(...)` instance) loses nothing.
 
 ---
 

--- a/hkj-book/src/optics/record_mapping.md
+++ b/hkj-book/src/optics/record_mapping.md
@@ -441,6 +441,44 @@ Two verbs keep the two operations distinct: `ErrorEnvelope.withContext(D)` is th
 
 ---
 
+## Injecting and testing generated mappings
+
+A generated Impl is a stateless pure function reached through statics, and the spec interface deliberately declares nothing (`@Autowired UserMapping` injects nothing useful, by design). When you do want a Spring bean or a test double, register the **surface you consume**, per tier:
+
+| Tier surface | Injectable shape | From |
+|---|---|---|
+| parse-capable mapping | `ValidatedPrism<UserDto, User>` | `UserMappingImpl.INSTANCE.asValidatedPrism()` |
+| build only | `Function<User, UserDto>` | `UserMappingImpl.INSTANCE::build` |
+| validated `patch` | `BiFunction<User, UserCardDto, Validated<NonEmptyList<FieldError>, User>>` | `UserCardMappingImpl.INSTANCE::patch` |
+| sparse `updateFrom` | `Function<UserPatchDto, Edits.Accumulated<User>>` | `UserPatchMappingImpl.INSTANCE::updateFrom` |
+
+```java
+@Configuration
+class MappingConfiguration {
+  @Bean
+  ValidatedPrism<UserDto, User> userCodec() {
+    return UserMappingImpl.INSTANCE.asValidatedPrism();
+  }
+}
+```
+
+Spring resolves the full generic type, so codecs for different pairs coexist without ceremony; only two codecs for the *same* pair need a `@Qualifier`. An element-mapped Impl (`of(...)`) carries its prisms as state: construct it once, in the `@Bean` method.
+
+**Fakes are values, not mocks.** `ValidatedPrism` is sealed, so it cannot be hand-implemented, and a mocking framework cannot mock it either (sealed types are unmockable). That is the design, not a limitation: a test double is two lines of `ValidatedPrism.of(...)`:
+
+```java
+@Bean
+ValidatedPrism<UserDto, User> userCodec() {
+  return ValidatedPrism.of(
+      dto -> Validated.invalidNel(FieldError.of("rejected by the fake codec").at("email")),
+      user -> new UserDto());
+}
+```
+
+The [hkj-spring example app](../spring/spring_boot_integration.md) demonstrates the seam end to end: `MappingConfiguration` registers the codec, `UserController`'s parse endpoint injects it, and `UserParseFakeCodecSliceTest` substitutes the fake above in a `@WebMvcTest` slice and asserts the located 422 it produces. The same controller's PATCH endpoint deliberately calls `UserPatchMappingImpl.INSTANCE` directly: injection buys substitution, not lifecycle, and a team comfortable calling `INSTANCE` loses nothing.
+
+---
+
 ## Diagnostics and limits
 
 Every rejection follows the processor's what/why/fix standard: the message states what is wrong, why the mapper needs it, and the code to write. Current limits, each with its own diagnostic:

--- a/hkj-book/src/spring/spring_boot_integration.md
+++ b/hkj-book/src/spring/spring_boot_integration.md
@@ -397,6 +397,8 @@ When an `Invalid` payload consists **entirely** of located `FieldError`s, the ha
 }
 ```
 
+To inject the mapping behind such an endpoint as a bean, or substitute a fake in a `@WebMvcTest` slice, see [Injecting and testing generated mappings](../optics/record_mapping.md#injecting-and-testing-generated-mappings); the example app's `MappingConfiguration`, `UserController` and `UserParseFakeCodecSliceTest` demonstrate the pattern end to end.
+
 `path` is the dot-joined display key (`FieldError.pathString()`); `segments` is the exact structured location. Paths use **domain** component names: under a `@MapField(to = "fullName")` rename the client that sent `fullName` receives its error at `name`, so a client mapping errors onto its own payload keys must apply the rename in reverse. The distinction matters: a map key containing a dot is indistinguishable from nesting in the rendered `path` (`attributes."a.b".email` vs deeper nesting), so structured consumers should read `segments`, which stays exact. An unlabelled error renders `"path": ""` and `"segments": []`; treat it as object-level.
 
 The leg is selected purely by payload shape, so **any** all-`FieldError` payload takes it: `Path.fields()` assemblies, `@GenerateAssembly` results and hand-built `NonEmptyList<FieldError>`s included, not just a mapper `parse`. A pre-existing `Path.fields()` endpoint therefore moves from 400 to 422 on upgrade; set `hkj.web.validation-field-error-status: 400` to restore the old status.

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/config/MappingConfiguration.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/config/MappingConfiguration.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example.config;
+
+import org.higherkindedj.optics.validated.ValidatedPrism;
+import org.higherkindedj.spring.example.controller.UserDto;
+import org.higherkindedj.spring.example.controller.UserMappingImpl;
+import org.higherkindedj.spring.example.domain.User;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the generated user mapping as an injectable bean: the surface a consumer depends on is
+ * the {@link ValidatedPrism} the Impl exposes, not the spec interface (which declares nothing) and
+ * not the Impl class (which would pin the dependency to generated code).
+ *
+ * <p>Spring resolves the full generic type, so {@code ValidatedPrism<UserDto, User>} coexists with
+ * codecs for other pairs; only two codecs for the <em>same</em> pair would need a qualifier. A test
+ * slice can substitute a fake built with {@code ValidatedPrism.of(...)} - the interface is sealed,
+ * so a fake is constructed as a value, never mocked.
+ *
+ * <p>Injection is optional, not idiomatically required: a generated mapping is a stateless pure
+ * function, and calling {@code UserMappingImpl.INSTANCE} directly (as this app's PATCH endpoint
+ * does) loses nothing but the substitution seam.
+ */
+@Configuration
+public class MappingConfiguration {
+
+  /**
+   * The user wire codec: parse a {@link UserDto} into the domain, or render a {@link User} back.
+   *
+   * @return the generated mapping's {@link ValidatedPrism} surface
+   */
+  @Bean
+  public ValidatedPrism<UserDto, User> userCodec() {
+    return UserMappingImpl.INSTANCE.asValidatedPrism();
+  }
+}

--- a/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/UserController.java
+++ b/hkj-spring/example/src/main/java/org/higherkindedj/spring/example/controller/UserController.java
@@ -8,6 +8,7 @@ import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.validated.ValidatedPrism;
 import org.higherkindedj.spring.example.domain.DomainError;
 import org.higherkindedj.spring.example.domain.User;
 import org.higherkindedj.spring.example.domain.UserNotFoundError;
@@ -28,6 +29,7 @@ public class UserController {
 
   private final UserService userService;
   private final JsonMapper jsonMapper;
+  private final ValidatedPrism<UserDto, User> userCodec;
 
   /**
    * Constructs a UserController.
@@ -35,10 +37,15 @@ public class UserController {
    * @param userService the user service
    * @param jsonMapper the application's Jackson 3.x mapper, used by the debug endpoint to probe
    *     whether HkjJacksonModule is actually registered
+   * @param userCodec the generated user mapping's injectable surface (see {@code
+   *     MappingConfiguration}); the PATCH endpoint below deliberately calls the Impl directly
+   *     instead, showing the other idiom
    */
-  public UserController(UserService userService, JsonMapper jsonMapper) {
+  public UserController(
+      UserService userService, JsonMapper jsonMapper, ValidatedPrism<UserDto, User> userCodec) {
     this.userService = userService;
     this.jsonMapper = jsonMapper;
+    this.userCodec = userCodec;
   }
 
   /**
@@ -106,7 +113,7 @@ public class UserController {
    */
   @PostMapping("/parse")
   public Validated<NonEmptyList<FieldError>, User> parseUser(@RequestBody UserDto dto) {
-    return UserMappingImpl.INSTANCE.parse(dto);
+    return userCodec.parse(dto);
   }
 
   /**

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerWebMvcSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserControllerWebMvcSliceTest.java
@@ -68,6 +68,8 @@ import org.springframework.test.web.servlet.MockMvc;
   HkjJacksonAutoConfiguration.class,
   HkjWebMvcAutoConfiguration.class
 })
+@org.springframework.context.annotation.Import(
+    org.higherkindedj.spring.example.config.MappingConfiguration.class)
 @DisplayName("UserController @WebMvcTest slice (with hkj-spring auto-config imported)")
 class UserControllerWebMvcSliceTest {
 

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserParseFakeCodecSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserParseFakeCodecSliceTest.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.example.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.higherkindedj.hkt.validated.FieldError;
+import org.higherkindedj.hkt.validated.Validated;
+import org.higherkindedj.optics.validated.ValidatedPrism;
+import org.higherkindedj.spring.autoconfigure.HkjAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjJacksonAutoConfiguration;
+import org.higherkindedj.spring.autoconfigure.HkjWebMvcAutoConfiguration;
+import org.higherkindedj.spring.example.domain.User;
+import org.higherkindedj.spring.example.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * The substitution seam, end to end: the controller depends on {@code ValidatedPrism<UserDto,
+ * User>}, so a test slice swaps the generated codec for a fake built with {@link
+ * ValidatedPrism#of}. The interface is sealed, so a fake is constructed as a value - two lines, no
+ * mocking framework (and no mocking framework could: sealed types cannot be mocked).
+ */
+@WebMvcTest(UserController.class)
+@ImportAutoConfiguration({
+  HkjAutoConfiguration.class,
+  HkjJacksonAutoConfiguration.class,
+  HkjWebMvcAutoConfiguration.class
+})
+@Import({UserService.class, UserParseFakeCodecSliceTest.RejectEverythingCodec.class})
+@DisplayName("UserController parse slice with a fake codec bean substituted")
+class UserParseFakeCodecSliceTest {
+
+  /** A stub codec: every parse fails with one located error; build renders a fixed DTO. */
+  @TestConfiguration
+  static class RejectEverythingCodec {
+    @Bean
+    ValidatedPrism<UserDto, User> userCodec() {
+      return ValidatedPrism.of(
+          dto -> Validated.invalidNel(FieldError.of("rejected by the fake codec").at("email")),
+          user -> new UserDto());
+    }
+  }
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("the endpoint renders whatever the substituted codec decides - a located 422")
+  void fakeCodecDrivesTheResponse() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/users/parse")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"id\":\"1\",\"email\":\"ada@example.org\","
+                        + "\"firstName\":\"Ada\",\"lastName\":\"Lovelace\"}"))
+        .andExpect(status().isUnprocessableContent())
+        .andExpect(jsonPath("$.errors[0].path").value("email"))
+        .andExpect(jsonPath("$.errors[0].message").value("rejected by the fake codec"));
+  }
+}

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserParseWebMvcSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserParseWebMvcSliceTest.java
@@ -33,7 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
   HkjJacksonAutoConfiguration.class,
   HkjWebMvcAutoConfiguration.class
 })
-@Import(UserService.class)
+@Import({UserService.class, org.higherkindedj.spring.example.config.MappingConfiguration.class})
 @DisplayName("UserController parse @WebMvcTest slice - the 422 leg")
 class UserParseWebMvcSliceTest {
 

--- a/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserPatchWebMvcSliceTest.java
+++ b/hkj-spring/example/src/test/java/org/higherkindedj/spring/example/controller/UserPatchWebMvcSliceTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
   HkjJacksonAutoConfiguration.class,
   HkjWebMvcAutoConfiguration.class
 })
-@Import(UserService.class)
+@Import({UserService.class, org.higherkindedj.spring.example.config.MappingConfiguration.class})
 @DisplayName("UserController sparse PATCH @WebMvcTest slice")
 class UserPatchWebMvcSliceTest {
 


### PR DESCRIPTION
Closes the docs half of #678 (Target 0.4.9), with the evaluation half's recommendation posted on the issue.

## What

Documents the injection and test-double story for generated mappings, which existed but was written nowhere, so a Spring-idiom evaluator concluded the capability was absent.

- **New book section, "Injecting and testing generated mappings"**: register the surface you consume, charted per tier — `ValidatedPrism<Wire, Domain>` for parse-capable mappings, `Function`/`BiFunction` method references for build-only, `patch` and `updateFrom` (the review on the issue found the prism-only story covered half the example app's real usage). Includes the Spring generics-resolution note, the same-pair `@Qualifier` caveat, and the element-mapped `of(...)` construct-once pattern.
- **Fakes are values, not mocks**: `ValidatedPrism` is sealed, so it cannot be hand-implemented and Mockito cannot mock it. The docs lead with the two-line `ValidatedPrism.of(...)` fake, turning a likely first-contact failure into the recommended pattern.
- **End-to-end demonstration in the example app**: `MappingConfiguration` registers the codec bean; `UserController`'s parse endpoint now injects it, while the PATCH endpoint deliberately keeps the direct `INSTANCE` call so both idioms sit side by side; a new `UserParseFakeCodecSliceTest` substitutes a rejecting fake in a `@WebMvcTest` slice and asserts the located 422 it produces.
- The Spring integration page cross-links the section; the mapping skill carries the summary.

All 100 example-module tests pass (three existing slice contexts gained the config import); full multi-module build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for injecting and testing generated record mappings with Spring.
  - Documented supported mapping surfaces, fake codec creation, and generic type resolution.
  - Added examples for integrating mappings with parse and PATCH endpoints.

- **New Features**
  - Registered the user mapping as an injectable Spring codec.
  - Updated the user parsing endpoint to use the injected codec.

- **Tests**
  - Added coverage for substituting a fake codec and returning validation errors.
  - Updated MVC slice tests to include the mapping configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->