### PR TITLE
Bump local projectVersion fallback to 0.4.10-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // Global properties for all modules
 group = "io.github.higher-kinded-j"
-version = project.findProperty("projectVersion")?.toString() ?: "0.4.9-SNAPSHOT"
+version = project.findProperty("projectVersion")?.toString() ?: "0.4.10-SNAPSHOT"
 
 
 // Repositories for root project (required for OpenRewrite dependencies)


### PR DESCRIPTION
Post-tag housekeeping, per the #651 precedent after v0.4.8: v0.4.9 is tagged, so local builds without an explicit `projectVersion` now identify as 0.4.10-SNAPSHOT, matching the fresh release-history placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)