### PR TITLE
hkj-book: mermaid pilots (circuit-breaker state diagram, 422-leg sequence diagram)

### DIFF
--- a/.github/scripts/mermaid-check/check.cjs
+++ b/.github/scripts/mermaid-check/check.cjs
@@ -63,7 +63,10 @@ function markdownFiles(dir) {
   return out;
 }
 
-function mermaidFences(source) {
+function mermaidFences(rawSource) {
+  // Normalise CRLF so a Windows-authored file cannot slip its fences past
+  // the gate; line numbers are unaffected.
+  const source = rawSource.replace(/\r\n/g, "\n");
   const fences = [];
   const re = /^```mermaid[ \t]*\n([\s\S]*?)^```[ \t]*$/gm;
   let match;

--- a/.github/scripts/mermaid-check/check.cjs
+++ b/.github/scripts/mermaid-check/check.cjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/*
+ * Parse-check every ```mermaid fence in hkj-book/src against the pinned
+ * browser-side mermaid library, so a diagram syntax error fails CI instead of
+ * reaching the published book as a render-time error box.
+ *
+ * Mechanics: mermaid.min.js (fetched by ../fetch_mermaid.sh) is evaluated with
+ * vm.runInThisContext under a jsdom window, matching browser script semantics
+ * (a plain eval misses globalThis in strict mode, and state diagrams need a
+ * DOM for DOMPurify). Each fence is then fed to mermaid.parse().
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const { JSDOM } = require("jsdom");
+
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const bookSrc = path.join(repoRoot, "hkj-book", "src");
+const mermaidJs = path.join(repoRoot, "hkj-book", "mermaid.min.js");
+
+if (!fs.existsSync(mermaidJs)) {
+  console.error(
+    `mermaid.min.js not found at ${mermaidJs}; run .github/scripts/fetch_mermaid.sh first`
+  );
+  process.exit(2);
+}
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost/",
+  pretendToBeVisual: true,
+});
+// Some of these exist as getter-only globals on newer Node versions, so
+// assign via defineProperty and tolerate the ones that refuse.
+for (const [name, value] of Object.entries({
+  window: dom.window,
+  document: dom.window.document,
+  navigator: dom.window.navigator,
+  DOMParser: dom.window.DOMParser,
+  XMLSerializer: dom.window.XMLSerializer,
+  SVGElement: dom.window.SVGElement,
+})) {
+  try {
+    Object.defineProperty(globalThis, name, { value, configurable: true });
+  } catch {
+    // keep the platform-provided global
+  }
+}
+
+vm.runInThisContext(fs.readFileSync(mermaidJs, "utf8"), {
+  filename: "mermaid.min.js",
+});
+const mermaid = globalThis.mermaid;
+
+function markdownFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...markdownFiles(p));
+    else if (entry.isFile() && entry.name.endsWith(".md")) out.push(p);
+  }
+  return out;
+}
+
+function mermaidFences(source) {
+  const fences = [];
+  const re = /^```mermaid[ \t]*\n([\s\S]*?)^```[ \t]*$/gm;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    const line = source.slice(0, match.index).split("\n").length;
+    fences.push({ body: match[1], line });
+  }
+  return fences;
+}
+
+(async () => {
+  let diagrams = 0;
+  let failures = 0;
+  for (const file of markdownFiles(bookSrc).sort()) {
+    const rel = path.relative(repoRoot, file);
+    for (const fence of mermaidFences(fs.readFileSync(file, "utf8"))) {
+      diagrams++;
+      try {
+        await mermaid.parse(fence.body);
+        console.log(`OK    ${rel}:${fence.line}`);
+      } catch (e) {
+        failures++;
+        const message = String(e.message || e).split("\n").slice(0, 3).join(" | ");
+        console.log(`FAIL  ${rel}:${fence.line}  ${message}`);
+        console.log(
+          `::error file=${rel},line=${fence.line}::mermaid parse error: ${message}`
+        );
+      }
+    }
+  }
+  console.log(
+    failures
+      ? `${failures} of ${diagrams} mermaid diagrams failed to parse`
+      : `${diagrams} mermaid diagrams parse cleanly`
+  );
+  process.exit(failures ? 1 : 0);
+})();

--- a/.github/scripts/mermaid-check/check.cjs
+++ b/.github/scripts/mermaid-check/check.cjs
@@ -63,19 +63,111 @@ function markdownFiles(dir) {
   return out;
 }
 
+/*
+ * Collect mermaid fences the way the mdbook-mermaid preprocessor's CommonMark
+ * parser sees them: any fence of three or more backticks or tildes, indented
+ * up to three spaces, whose info string names mermaid. A line-based scan also
+ * tracks non-mermaid fences, so a ```mermaid shown INSIDE a wider example
+ * fence is documentation, not a diagram, and is not collected.
+ */
 function mermaidFences(rawSource) {
   // Normalise CRLF so a Windows-authored file cannot slip its fences past
   // the gate; line numbers are unaffected.
-  const source = rawSource.replace(/\r\n/g, "\n");
+  const lines = rawSource.replace(/\r\n/g, "\n").split("\n");
   const fences = [];
-  const re = /^```mermaid[ \t]*\n([\s\S]*?)^```[ \t]*$/gm;
-  let match;
-  while ((match = re.exec(source)) !== null) {
-    const line = source.slice(0, match.index).split("\n").length;
-    fences.push({ body: match[1], line });
+  let open = null; // { char, len, indent, mermaid, line, body }
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (open === null) {
+      const m = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
+      if (!m) continue;
+      const [, indent, marker, rest] = m;
+      const info = rest.trim();
+      // A backtick fence's info string may not contain a backtick (CommonMark).
+      if (marker[0] === "`" && info.includes("`")) continue;
+      open = {
+        char: marker[0],
+        len: marker.length,
+        indent: indent.length,
+        mermaid: /^mermaid(\s|$)/.test(info),
+        line: i + 1,
+        body: [],
+      };
+    } else {
+      const closer = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
+      if (closer && closer[1][0] === open.char && closer[1].length >= open.len) {
+        if (open.mermaid) {
+          fences.push({ body: open.body.join("\n") + "\n", line: open.line });
+        }
+        open = null;
+      } else if (open.mermaid) {
+        // CommonMark strips up to the opening fence's indentation.
+        open.body.push(line.replace(new RegExp(`^ {0,${open.indent}}`), ""));
+      }
+    }
   }
   return fences;
 }
+
+/*
+ * Regression checks for the scanner itself, run on every invocation: a
+ * silently narrowed scanner would wave broken diagrams through, so its
+ * matching rules are pinned here.
+ */
+function selfTest() {
+  const cases = [
+    {
+      name: "plain three-backtick fence",
+      input: "x\n```mermaid\nflowchart TD\n```\ny",
+      expect: ["flowchart TD\n"],
+    },
+    {
+      name: "CRLF fence",
+      input: "x\r\n```mermaid\r\nflowchart TD\r\n```\r\n",
+      expect: ["flowchart TD\n"],
+    },
+    {
+      name: "indented fence (two spaces)",
+      input: "  ```mermaid\n  flowchart TD\n  ```\n",
+      expect: ["flowchart TD\n"],
+    },
+    {
+      name: "four-backtick fence",
+      input: "````mermaid\nflowchart TD\n````\n",
+      expect: ["flowchart TD\n"],
+    },
+    {
+      name: "tilde fence",
+      input: "~~~mermaid\nflowchart TD\n~~~\n",
+      expect: ["flowchart TD\n"],
+    },
+    {
+      name: "mermaid inside a wider example fence is not a diagram",
+      input: "````markdown\n```mermaid\nflowchart TD\n```\n````\n",
+      expect: [],
+    },
+    {
+      name: "non-mermaid fence is ignored",
+      input: "```java\nint x;\n```\n",
+      expect: [],
+    },
+    {
+      name: "four-space indent is an indented code block, not a fence",
+      input: "    ```mermaid\n    flowchart TD\n    ```\n",
+      expect: [],
+    },
+  ];
+  for (const c of cases) {
+    const got = mermaidFences(c.input).map((f) => f.body);
+    if (JSON.stringify(got) !== JSON.stringify(c.expect)) {
+      console.error(
+        `self-test failed: ${c.name}\n  expected ${JSON.stringify(c.expect)}\n  got      ${JSON.stringify(got)}`
+      );
+      process.exit(2);
+    }
+  }
+}
+selfTest();
 
 (async () => {
   let diagrams = 0;

--- a/.github/scripts/mermaid-check/package-lock.json
+++ b/.github/scripts/mermaid-check/package-lock.json
@@ -1,0 +1,515 @@
+{
+  "name": "mermaid-check",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mermaid-check",
+      "dependencies": {
+        "jsdom": "^30.0.1"
+      },
+      "private": true
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/scripts/mermaid-check/package.json
+++ b/.github/scripts/mermaid-check/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mermaid-check",
+  "private": true,
+  "description": "Parse-checks the book mermaid fences against the pinned mermaid library",
+  "type": "commonjs",
+  "dependencies": {
+    "jsdom": "^30.0.1"
+  }
+}

--- a/.github/workflows/book-mermaid-check.yml
+++ b/.github/workflows/book-mermaid-check.yml
@@ -1,0 +1,45 @@
+name: Book Mermaid Parse Check
+
+# Parse-checks every ```mermaid fence in hkj-book/src against the pinned
+# browser-side mermaid library, so a diagram syntax error fails the PR
+# instead of reaching the published book as a render-time error box.
+# No branches filter on pull_request: stacked PRs are checked too.
+on:
+  pull_request:
+    paths:
+      - 'hkj-book/src/**'
+      - '.github/scripts/fetch_mermaid.sh'
+      - '.github/scripts/mermaid-check/**'
+      - '.github/workflows/book-mermaid-check.yml'
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'hkj-book/src/**'
+      - '.github/scripts/fetch_mermaid.sh'
+      - '.github/scripts/mermaid-check/**'
+      - '.github/workflows/book-mermaid-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  parse-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Fetch pinned mermaid library
+        run: .github/scripts/fetch_mermaid.sh
+
+      - name: Install check dependencies
+        working-directory: .github/scripts/mermaid-check
+        run: npm ci --no-audit --no-fund
+
+      - name: Parse-check mermaid diagrams
+        run: node .github/scripts/mermaid-check/check.cjs

--- a/.github/workflows/book-mermaid-check.yml
+++ b/.github/workflows/book-mermaid-check.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -135,6 +135,11 @@ jobs:
         run: |
           .github/scripts/fetch_mermaid.sh
 
+      - name: Parse-check mermaid diagrams
+        run: |
+          npm ci --no-audit --no-fund --prefix .github/scripts/mermaid-check
+          node .github/scripts/mermaid-check/check.cjs
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy-mdbook-versioned.yml
+++ b/.github/workflows/deploy-mdbook-versioned.yml
@@ -135,6 +135,11 @@ jobs:
         run: |
           .github/scripts/fetch_mermaid.sh
 
+      - name: Set up Node for the mermaid parse check
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Parse-check mermaid diagrams
         run: |
           npm ci --no-audit --no-fund --prefix .github/scripts/mermaid-check

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ bin/
 /CLAUDE.md
 
 docs/plans/
+# Repo-local pinned mdbook toolchain installed by hkj-book/serve.sh
+/hkj-book/.tools/
+/.github/scripts/mermaid-check/node_modules/

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -355,6 +355,7 @@ classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
 - Semantics stay consistent across the book: blue = wire/outside data, green = domain/trusted/generated surface, red = errors/rejections, yellow = decision points
 - Never encode meaning in colour alone; every node carries a label that works in monochrome
 - Keep diagrams small (roughly 12 nodes or fewer); a diagram that needs scrolling should be two diagrams
+- The explicit-`classDef` rule applies to flowcharts and state diagrams (states take the same palette via `classDef`/`class`). Sequence diagrams have no per-node `classDef`: their lines, lifelines and typed-participant icons are theme-managed by `mermaid-init.js`'s light/dark switch, which is already theme-safe; merge specific `themeVariables` only when a filled element needs the palette, and never override `theme` per diagram (a fixed theme would break whichever page background it was not designed for)
 
 ## Admonishment Types
 

--- a/hkj-book/preview-changes.sh
+++ b/hkj-book/preview-changes.sh
@@ -27,11 +27,18 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-# Prefer the repo-local pinned toolchain if serve.sh has installed it
-# (mdbook 0.4.51 + mdbook-mermaid 0.14.1; a global mdbook 0.5.x cannot
-# build this book).
+# Prefer the repo-local pinned toolchain if serve.sh has installed it, but
+# only when it is complete and on-pin: mixing one local binary with global
+# preprocessors would produce an inconsistent preview.
+# shellcheck source=toolchain-pins.sh
+source ./toolchain-pins.sh
 if [[ -d .tools/bin ]]; then
-  export PATH="$PWD/.tools/bin:$PATH"
+  if tools_complete "$PWD/.tools/bin"; then
+    export PATH="$PWD/.tools/bin:$PATH"
+  else
+    echo "warning: hkj-book/.tools is incomplete or off-pin; run ./serve.sh once to repair it." >&2
+    echo "         Falling back to the tools on your PATH." >&2
+  fi
 fi
 
 BASE="${1:-}"
@@ -70,7 +77,7 @@ fi
 # still serves, with mermaid fences rendered as plain code blocks.
 if ! command -v mdbook-mermaid >/dev/null 2>&1; then
   echo "warning: mdbook-mermaid not found; mermaid fences will render as plain code blocks." >&2
-  echo "         Install with: cargo install mdbook-mermaid --version 0.14.1 --locked" >&2
+  echo "         Install with: cargo install mdbook-mermaid --version ${MDBOOK_MERMAID_VERSION} --locked" >&2
 fi
 if ! ../.github/scripts/fetch_mermaid.sh >/dev/null 2>&1; then
   if command -v mdbook-mermaid >/dev/null 2>&1; then

--- a/hkj-book/preview-changes.sh
+++ b/hkj-book/preview-changes.sh
@@ -27,6 +27,13 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# Prefer the repo-local pinned toolchain if serve.sh has installed it
+# (mdbook 0.4.51 + mdbook-mermaid 0.14.1; a global mdbook 0.5.x cannot
+# build this book).
+if [[ -d .tools/bin ]]; then
+  export PATH="$PWD/.tools/bin:$PATH"
+fi
+
 BASE="${1:-}"
 PORT="${2:-3000}"
 

--- a/hkj-book/serve.sh
+++ b/hkj-book/serve.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Serve the book locally with the CI-pinned toolchain.
+#
+# This book builds with mdbook 0.4.51 and mdbook-mermaid 0.14.1 (the versions
+# CI pins); a globally installed mdbook 0.5.x cannot build it. Both binaries
+# are kept under hkj-book/.tools (gitignored), so a different global mdbook
+# for other projects is untouched. The first run installs them via cargo;
+# after that startup is instant.
+#
+# Usage:
+#   ./serve.sh [PORT]     # defaults to 3000
+#
+# mdbook-admonish and mdbook-alerts are taken from your PATH: their installed
+# versions speak the 0.4 preprocessor protocol and work here as-is.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PORT="${1:-3000}"
+TOOLS="$PWD/.tools"
+MDBOOK_VERSION="0.4.51"
+MDBOOK_MERMAID_VERSION="0.14.1"
+
+ensure_tool() { # crate version
+  local bin="$TOOLS/bin/$1"
+  if [[ ! -x "$bin" ]] || ! "$bin" --version 2>/dev/null | grep -qF "$2"; then
+    echo "Installing $1 $2 into $TOOLS (one-off)..."
+    cargo install "$1" --version "$2" --locked --root "$TOOLS"
+  fi
+}
+ensure_tool mdbook "$MDBOOK_VERSION"
+ensure_tool mdbook-mermaid "$MDBOOK_MERMAID_VERSION"
+
+export PATH="$TOOLS/bin:$PATH"
+
+# Refresh mdbook-admonish assets if the binary is available (safe to re-run).
+if command -v mdbook-admonish >/dev/null 2>&1; then
+  mdbook-admonish install . >/dev/null 2>&1 || true
+fi
+
+# Pinned browser-side mermaid; fall back to the preprocessor's bundled copy
+# when offline (see preview-changes.sh for the same dance).
+if ! ../.github/scripts/fetch_mermaid.sh >/dev/null 2>&1; then
+  echo "warning: mermaid fetch failed; using mdbook-mermaid's bundled copy." >&2
+  mdbook-mermaid install . >/dev/null 2>&1 || true
+fi
+
+exec mdbook serve --open --port "$PORT"

--- a/hkj-book/serve.sh
+++ b/hkj-book/serve.sh
@@ -2,29 +2,25 @@
 #
 # Serve the book locally with the CI-pinned toolchain.
 #
-# This book builds with mdbook 0.4.51, mdbook-admonish 1.19.0, mdbook-alerts
-# 0.7.0 and mdbook-mermaid 0.14.1 (exactly the versions CI pins); a globally
-# installed mdbook 0.5.x cannot build it, and a newer global mdbook-admonish
-# rewrites book.toml's assets_version, dirtying the working tree. All four
-# binaries are kept under hkj-book/.tools (gitignored), so different global
-# versions for other projects are untouched. The first run installs them via
-# cargo; after that startup is instant.
+# All four book binaries (mdbook, mdbook-admonish, mdbook-alerts,
+# mdbook-mermaid) are kept under hkj-book/.tools (gitignored) at exactly the
+# versions CI pins (see toolchain-pins.sh for the versions and the why), so
+# different global versions for other projects are untouched. The first run
+# installs them via cargo; after that startup is instant.
 #
 # Usage:
 #   ./serve.sh [PORT]     # defaults to 3000
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# shellcheck source=toolchain-pins.sh
+source ./toolchain-pins.sh
+
 PORT="${1:-3000}"
 TOOLS="$PWD/.tools"
-MDBOOK_VERSION="0.4.51"
-MDBOOK_ADMONISH_VERSION="1.19.0"
-MDBOOK_ALERTS_VERSION="0.7.0"
-MDBOOK_MERMAID_VERSION="0.14.1"
 
 ensure_tool() { # crate version
-  local bin="$TOOLS/bin/$1"
-  if [[ ! -x "$bin" ]] || ! "$bin" --version 2>/dev/null | grep -qF "$2"; then
+  if ! tool_matches "$TOOLS/bin/$1" "$2"; then
     echo "Installing $1 $2 into $TOOLS (one-off)..."
     cargo install "$1" --version "$2" --locked --root "$TOOLS"
   fi
@@ -37,14 +33,24 @@ ensure_tool mdbook-mermaid "$MDBOOK_MERMAID_VERSION"
 export PATH="$TOOLS/bin:$PATH"
 
 # Refresh mdbook-admonish assets with the pinned version (safe to re-run;
-# keeps book.toml's assets_version at the value CI expects).
-mdbook-admonish install . >/dev/null 2>&1 || true
+# keeps book.toml's assets_version at the value CI expects). The book cannot
+# render without these assets, so a failure here is fatal.
+if ! admonish_output=$(mdbook-admonish install . 2>&1); then
+  echo "$admonish_output" >&2
+  echo "error: 'mdbook-admonish install .' failed; not serving a book with broken assets." >&2
+  exit 1
+fi
 
 # Pinned browser-side mermaid; fall back to the preprocessor's bundled copy
-# when offline (see preview-changes.sh for the same dance).
+# when offline (see preview-changes.sh for the same dance). If neither route
+# produces mermaid.min.js, serving would 404 a script every page loads.
 if ! ../.github/scripts/fetch_mermaid.sh >/dev/null 2>&1; then
   echo "warning: mermaid fetch failed; using mdbook-mermaid's bundled copy." >&2
   mdbook-mermaid install . >/dev/null 2>&1 || true
+fi
+if [[ ! -f mermaid.min.js ]]; then
+  echo "error: no mermaid.min.js could be obtained (fetch and bundled fallback both failed)." >&2
+  exit 1
 fi
 
 exec mdbook serve --open --port "$PORT"

--- a/hkj-book/serve.sh
+++ b/hkj-book/serve.sh
@@ -2,23 +2,24 @@
 #
 # Serve the book locally with the CI-pinned toolchain.
 #
-# This book builds with mdbook 0.4.51 and mdbook-mermaid 0.14.1 (the versions
-# CI pins); a globally installed mdbook 0.5.x cannot build it. Both binaries
-# are kept under hkj-book/.tools (gitignored), so a different global mdbook
-# for other projects is untouched. The first run installs them via cargo;
-# after that startup is instant.
+# This book builds with mdbook 0.4.51, mdbook-admonish 1.19.0, mdbook-alerts
+# 0.7.0 and mdbook-mermaid 0.14.1 (exactly the versions CI pins); a globally
+# installed mdbook 0.5.x cannot build it, and a newer global mdbook-admonish
+# rewrites book.toml's assets_version, dirtying the working tree. All four
+# binaries are kept under hkj-book/.tools (gitignored), so different global
+# versions for other projects are untouched. The first run installs them via
+# cargo; after that startup is instant.
 #
 # Usage:
 #   ./serve.sh [PORT]     # defaults to 3000
-#
-# mdbook-admonish and mdbook-alerts are taken from your PATH: their installed
-# versions speak the 0.4 preprocessor protocol and work here as-is.
 set -euo pipefail
 cd "$(dirname "$0")"
 
 PORT="${1:-3000}"
 TOOLS="$PWD/.tools"
 MDBOOK_VERSION="0.4.51"
+MDBOOK_ADMONISH_VERSION="1.19.0"
+MDBOOK_ALERTS_VERSION="0.7.0"
 MDBOOK_MERMAID_VERSION="0.14.1"
 
 ensure_tool() { # crate version
@@ -29,14 +30,15 @@ ensure_tool() { # crate version
   fi
 }
 ensure_tool mdbook "$MDBOOK_VERSION"
+ensure_tool mdbook-admonish "$MDBOOK_ADMONISH_VERSION"
+ensure_tool mdbook-alerts "$MDBOOK_ALERTS_VERSION"
 ensure_tool mdbook-mermaid "$MDBOOK_MERMAID_VERSION"
 
 export PATH="$TOOLS/bin:$PATH"
 
-# Refresh mdbook-admonish assets if the binary is available (safe to re-run).
-if command -v mdbook-admonish >/dev/null 2>&1; then
-  mdbook-admonish install . >/dev/null 2>&1 || true
-fi
+# Refresh mdbook-admonish assets with the pinned version (safe to re-run;
+# keeps book.toml's assets_version at the value CI expects).
+mdbook-admonish install . >/dev/null 2>&1 || true
 
 # Pinned browser-side mermaid; fall back to the preprocessor's bundled copy
 # when offline (see preview-changes.sh for the same dance).

--- a/hkj-book/src/resilience/circuit_breaker.md
+++ b/hkj-book/src/resilience/circuit_breaker.md
@@ -17,21 +17,27 @@ A circuit breaker solves this by tracking recent failures and, when enough accum
 
 ## The State Machine
 
-```
-    Normal operation              Service failing              Probing recovery
-    ┌────────────────┐           ┌────────────────┐           ┌────────────────┐
-    │                │  failures │                │  timeout  │                │
-    │     CLOSED     │  reach    │      OPEN      │  expires  │   HALF_OPEN    │
-    │                │  threshold│                │           │                │
-    │  All calls     │──────────▶│  All calls     │──────────▶│  One probe     │
-    │  flow through  │           │  rejected with │           │  call allowed  │
-    │                │           │  CircuitOpen-  │           │                │
-    │  Failures      │           │  Exception     │           │  Success:      │
-    │  counted       │           │                │           │  close circuit │
-    │                │◀──────────│                │◀──────────│                │
-    │  Successes     │  probes   │  No calls      │  probe    │  Failure:      │
-    │  reset count   │  succeed  │  reach service │  fails    │  re-open       │
-    └────────────────┘           └────────────────┘           └────────────────┘
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> CLOSED
+    CLOSED --> OPEN : consecutive failures reach failureThreshold
+    OPEN --> HALF_OPEN : openDuration expires
+    HALF_OPEN --> CLOSED : successThreshold probes succeed
+    HALF_OPEN --> OPEN : any probe fails
+    CLOSED --> CLOSED : a success resets the failure count
+
+    note right of OPEN
+        calls rejected immediately
+        with CircuitOpenException
+    end note
+
+    classDef closed fill:#a6d189,stroke:#40a02b,color:#232634
+    classDef open fill:#e78284,stroke:#d20f39,color:#232634
+    classDef probing fill:#e5c890,stroke:#df8e1d,color:#232634
+    class CLOSED closed
+    class OPEN open
+    class HALF_OPEN probing
 ```
 
 | State | Behaviour | Transitions to |

--- a/hkj-book/src/spring/spring_boot_integration.md
+++ b/hkj-book/src/spring/spring_boot_integration.md
@@ -397,6 +397,28 @@ When an `Invalid` payload consists **entirely** of located `FieldError`s, the ha
 }
 ```
 
+The whole leg, end to end. The switching happens in `ValidationPathReturnValueHandler` (registered by `HkjWebMvcAutoConfiguration`), and the controller never sees it:
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant C@{ "type": "control" } as UserController
+    participant M@{ "type": "boundary" } as UserMappingImpl
+    participant H@{ "type": "control" } as ValidationPathReturnValueHandler
+
+    Client->>C: POST /api/users/parse<br/>(Jackson binds UserDto: strings and nulls)
+    C->>M: parse(dto)
+    M-->>C: Validated#lt;NonEmptyList#lt;FieldError#gt;, User#gt;
+    C->>H: returned as-is
+    alt Valid(user)
+        H-->>Client: 200 OK: the User
+    else Invalid: every error a located FieldError
+        H-->>Client: 422: each error rendered by path
+    else Invalid: mixed or non-FieldError errors
+        H-->>Client: 400: the generic validation leg
+    end
+```
+
 To inject the mapping behind such an endpoint as a bean, or substitute a fake in a `@WebMvcTest` slice, see [Injecting and testing generated mappings](../mapping/testing.md#injecting-and-testing-generated-mappings); the example app's `MappingConfiguration`, `UserController` and `UserParseFakeCodecSliceTest` demonstrate the pattern end to end.
 
 `path` is the dot-joined display key (`FieldError.pathString()`); `segments` is the exact structured location. Paths use **domain** component names: under a `@MapField(to = "fullName")` rename the client that sent `fullName` receives its error at `name`, so a client mapping errors onto its own payload keys must apply the rename in reverse. The distinction matters: a map key containing a dot is indistinguishable from nesting in the rendered `path` (`attributes."a.b".email` vs deeper nesting), so structured consumers should read `segments`, which stays exact. An unlabelled error renders `"path": ""` and `"segments": []`; treat it as object-level.

--- a/hkj-book/toolchain-pins.sh
+++ b/hkj-book/toolchain-pins.sh
@@ -11,9 +11,14 @@ MDBOOK_ADMONISH_VERSION="1.19.0"
 MDBOOK_ALERTS_VERSION="0.7.0"
 MDBOOK_MERMAID_VERSION="0.14.1"
 
-# tool_matches BIN VERSION: BIN exists, is executable, and reports VERSION.
+# tool_matches BIN VERSION: BIN exists, is executable, and its --version
+# reports exactly VERSION as its version token (an optional leading 'v' is
+# tolerated; a substring such as 0.4.510 against a 0.4.51 pin is not).
 tool_matches() {
-  [[ -x "$1" ]] && "$1" --version 2>/dev/null | grep -qF "$2"
+  [[ -x "$1" ]] || return 1
+  local reported
+  reported=$("$1" --version 2>/dev/null | grep -oE 'v?[0-9]+(\.[0-9]+)+' | head -n1) || return 1
+  [[ "${reported#v}" == "$2" ]]
 }
 
 # tools_complete DIR: all four pinned binaries present in DIR at the pins.

--- a/hkj-book/toolchain-pins.sh
+++ b/hkj-book/toolchain-pins.sh
@@ -1,0 +1,25 @@
+# Single source of truth for the CI-pinned book toolchain versions, sourced
+# by serve.sh and preview-changes.sh. Keep in sync with the MDBOOK_* pins in
+# .github/workflows/deploy-mdbook-versioned.yml (and its siblings).
+#
+# This book builds with mdbook 0.4.x: a global mdbook 0.5.x cannot parse the
+# 0.4-protocol preprocessor output, and a newer global mdbook-admonish
+# rewrites book.toml's assets_version, dirtying the working tree.
+
+MDBOOK_VERSION="0.4.51"
+MDBOOK_ADMONISH_VERSION="1.19.0"
+MDBOOK_ALERTS_VERSION="0.7.0"
+MDBOOK_MERMAID_VERSION="0.14.1"
+
+# tool_matches BIN VERSION: BIN exists, is executable, and reports VERSION.
+tool_matches() {
+  [[ -x "$1" ]] && "$1" --version 2>/dev/null | grep -qF "$2"
+}
+
+# tools_complete DIR: all four pinned binaries present in DIR at the pins.
+tools_complete() {
+  tool_matches "$1/mdbook" "$MDBOOK_VERSION" \
+    && tool_matches "$1/mdbook-admonish" "$MDBOOK_ADMONISH_VERSION" \
+    && tool_matches "$1/mdbook-alerts" "$MDBOOK_ALERTS_VERSION" \
+    && tool_matches "$1/mdbook-mermaid" "$MDBOOK_MERMAID_VERSION"
+}


### PR DESCRIPTION
Stacked on #704 (the mermaid toolchain lands there). Two pilot diagrams take the toolchain beyond the mapping chapter, to the two places in the book where the content is most natively diagram-shaped.

## Circuit breaker as a real state diagram

`resilience/circuit_breaker.md`'s ASCII state machine becomes a `stateDiagram-v2`, with transitions verified against `CircuitBreaker.java`: consecutive failures reaching `failureThreshold` open it, `openDuration` expiry half-opens it, `successThreshold` probe successes close it, any probe failure re-opens it, and a success in CLOSED resets the count. States take the house palette (green CLOSED, red OPEN, yellow HALF_OPEN):

```mermaid
stateDiagram-v2
    direction LR
    [*] --> CLOSED
    CLOSED --> OPEN : consecutive failures reach failureThreshold
    OPEN --> HALF_OPEN : openDuration expires
    HALF_OPEN --> CLOSED : successThreshold probes succeed
    HALF_OPEN --> OPEN : any probe fails
    CLOSED --> CLOSED : a success resets the failure count
```

The reference table below the diagram is unchanged.

## The 422 leg as a sequence diagram

`spring/spring_boot_integration.md`'s 422-leg section gains an end-to-end sequence diagram using mermaid 11.11+'s typed participants (`participant X@{ "type": "control" }` / `"boundary"`): Client → `UserController` → `UserMappingImpl` → `ValidationPathReturnValueHandler`, with the three-way shape-based switch as an `alt`: `Valid` → 200, all-`FieldError` `Invalid` → 422, mixed `Invalid` → 400 (the generic validation leg). The participants match the real components (`ValidationPathReturnValueHandler` handles bare `Validated` returns; registered by `HkjWebMvcAutoConfiguration`).

## Style guide

The Diagrams section gains the non-flowchart rule: state diagrams take the palette via `classDef`; sequence-diagram lines, lifelines and typed-participant icons stay theme-managed by `mermaid-init.js`'s light/dark switch, with `themeVariables` merged only when a filled element needs the palette, and the per-diagram `theme` never overridden.

## Syntax findings worth knowing

- Typed sequence participants use the JSON-config syntax (`participant X@{ "type": "boundary" }`), not a `boundary X` keyword.
- Angle brackets in sequence messages must use mermaid's `#lt;`/`#gt;` escapes: HTML entities break the lexer (the `;` splits the statement) and raw brackets risk sanitisation at render.

## The parse check is now a CI gate

`.github/scripts/mermaid-check/check.cjs` loads the pinned `mermaid.min.js` under jsdom and runs `mermaid.parse` over every mermaid fence in `hkj-book/src`, annotating failures with file and line (verified to fail correctly on a deliberately broken diagram). It runs as the `Book Mermaid Parse Check` workflow on pull requests touching the book (no base-branch filter, so stacked PRs like this one are covered) and on pushes to main, and again in the versioned deploy before `mdbook build`. jsdom is the only dependency, lockfile-pinned and installed with `npm ci`.

## Local serving with two mdbook versions

`hkj-book/serve.sh` serves the book with the CI-pinned toolchain (mdbook 0.4.51, admonish 1.19.0, alerts 0.7.0, mermaid 0.14.1) installed under gitignored `hkj-book/.tools`, so a globally installed mdbook 0.5.x for other projects stays untouched. First run installs via cargo; later runs start instantly. `preview-changes.sh` prefers the same toolchain when present.

## Verification

- All **seven** mermaid diagrams now in the book (these two plus the mapping chapter's five) pass the gate against the pinned mermaid 11.17.0.
- `mdbook build` clean under CI's mdbook 0.4.51; both pages render their `<pre class="mermaid">` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThooJemMifmDZcHGT59pLk




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a local book-serving script with automatic setup, pinned documentation tooling, and an optional port.
  - Added detailed Mermaid diagrams for circuit-breaker behavior and Spring Boot validation flows.

- **Documentation**
  - Clarified Mermaid styling guidance for flowcharts, state diagrams, and sequence diagrams.

- **Bug Fixes**
  - Added automated Mermaid diagram validation to catch invalid diagrams before deployment.
  - Improved local previews by consistently using compatible, pinned tool versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->