### PR TITLE
hkj-book: make mermaid rendering immune to DOM decoration

### DIFF
--- a/hkj-book/mermaid-init.js
+++ b/hkj-book/mermaid-init.js
@@ -20,9 +20,28 @@
 
     const lastThemeWasLight = isLight();
     mermaid.initialize({
-        startOnLoad: true,
+        startOnLoad: false,
         theme: lastThemeWasLight ? 'default' : 'dark',
     });
+
+    // Render ourselves at window load instead of startOnLoad, so we run after
+    // every DOMContentLoaded script has finished with the page. Mermaid reads
+    // each element's markup as diagram source, so first collapse anything
+    // another script injected into a diagram (change-tracking word underlines,
+    // for instance) back to plain text.
+    const renderAll = () => {
+        document.querySelectorAll('pre.mermaid').forEach((el) => {
+            if (el.firstElementChild) {
+                el.textContent = el.textContent;
+            }
+        });
+        mermaid.run().catch((err) => console.error('mermaid render failed', err));
+    };
+    if (document.readyState === 'complete') {
+        renderAll();
+    } else {
+        window.addEventListener('load', renderAll);
+    }
 
     // Mermaid renders once at load. mdBook swaps the <html> theme class both
     // on theme-menu clicks and, in Auto mode, when the system colour scheme


### PR DESCRIPTION
Fixes the published book rendering every mermaid diagram as mermaid's "Syntax error in text" bomb (reported on the circuit-breaker page; all seven diagrams were affected).

## Why neither local builds nor the CI gate caught it

The bug needs the change-tracking pipeline, which is a no-op without a baseline ref, so it only exists on the deployed site:

```mermaid
sequenceDiagram
    participant P as changes preprocessor<br/>(deploy only, baseline set)
    participant CT as change-tracking.js<br/>(DOMContentLoaded)
    participant M as mermaid<br/>(window load)
    P->>P: marks the new diagram block<br/>as modified, with a word list
    CT->>CT: wraps each changed word in the<br/>pre.mermaid in a span
    M->>M: reads the element markup as<br/>diagram source
    M-->>M: first span: syntax error
```

The subtle part: `underlineWords` already skips `pre`/`code`, but its walker guard checks only ancestors strictly *between* the text node and the block root. An ordinary fenced code block is safe because its text sits inside a nested `<code>`; a mermaid `<pre>` has its text as a direct child, so the guard never fires and 57 spans land inside the circuit-breaker diagram.

## The fix: harden the rendering side only

`change-tracking.js` stays untouched. `mermaid-init.js` now renders via `mermaid.run()` from its own window-load handler instead of `startOnLoad`, first collapsing any markup other scripts injected into a `pre.mermaid` back to plain text. Diagram rendering is thereby immune to any DOM decorator, present or future, regardless of script order. The injected underline spans are sacrificed with everything else in the `pre`, which loses nothing: mermaid replaces the element's content with the rendered SVG anyway, and the change-tracking margin bar (which wraps *around* the `pre`) is unaffected.

## Verification

Simulated the full client pipeline under jsdom against a local build with `HKJ_CHANGES_BASE=v0.4.9` (matching the deploy): unmodified change-tracking at DOMContentLoaded, then the init flatten, then mermaid's actual extraction (`innerHTML` + `entityDecode`). The runtime still injects its 57 spans into the circuit-breaker diagram, and all seven diagrams parse regardless. Without the flatten, the production failure reproduces exactly.

Both files are shared theme/scripts, so a redeploy of any version picks the fix up. Merging republishes `/latest/` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThooJemMifmDZcHGT59pLk
