### PR TITLE
@ImportOptics: reject a spec-interface default method at the declaration (#712)

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/OpticsSpec.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/OpticsSpec.java
@@ -38,9 +38,12 @@ package org.higherkindedj.optics.annotations;
  *   <li>{@link ThroughField} - field-based traversal
  * </ul>
  *
- * <p>Default methods are copied unchanged to the generated class, allowing manual implementations
- * for complex compositions. Note: default method bodies must use explicit class-qualified
- * references (e.g., {@code PersonOptics.name()}) rather than unqualified method calls.
+ * <h2>Composition</h2>
+ *
+ * <p>A spec interface declares primitives only. A {@code default} method is rejected at the
+ * declaration: annotation processing cannot read a method body, so the generated class could only
+ * carry a stub that throws. Composed optics belong in a {@code static} method on the interface, or
+ * in an ordinary utility class; either one calls the generated statics.
  *
  * <p>Example:
  *
@@ -54,8 +57,8 @@ package org.higherkindedj.optics.annotations;
  *     @ViaBuilder
  *     Lens<Person, Integer> age();
  *
- *     // Manual implementation for complex cases
- *     default Lens<Person, String> firstName() {
+ *     // Composition lives in a static method, referring to the generated class by name
+ *     static Lens<Person, String> firstName() {
  *         return PersonOptics.name().andThen(
  *             Lens.of(
  *                 n -> n.split(" ")[0],
@@ -66,7 +69,8 @@ package org.higherkindedj.optics.annotations;
  * }
  * }</pre>
  *
- * <p>The processor generates a static utility class (note: "Spec" suffix removed):
+ * <p>The processor generates a static utility class from the abstract methods (note: "Spec" suffix
+ * removed):
  *
  * <pre>{@code
  * // Generated from PersonOpticsSpec
@@ -74,7 +78,6 @@ package org.higherkindedj.optics.annotations;
  *     private PersonOptics() {}
  *     public static Lens<Person, String> name() { ... }
  *     public static Lens<Person, Integer> age() { ... }
- *     public static Lens<Person, String> firstName() { ... }
  * }
  * }</pre>
  *

--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -49,6 +49,12 @@ This page is for the moment a build fails and you want to know what the message 
 
 **Fix.** Add the appropriate hint based on how the source type is copied. See [Optics for External Types](importing_optics.md) and [Database Records with JOOQ](copy_strategies.md) for the full strategy table.
 
+### "'XOpticsSpec.foo' is a default method"
+
+**Cause.** A spec interface declares a `default` method. A method body cannot be read during annotation processing, so there is nothing for the generated class to carry.
+
+**Fix.** Keep the spec interface to annotated abstract methods. Composed optics belong in a `static` method on the interface, or in an ordinary utility class; either one calls the generated statics by name, for example `JsonNodeOptics.object().andThen(...)`.
+
 ### "@InstanceOf: target subtype not assignable to source type"
 
 **Cause.** The class passed to `@InstanceOf(SubType.class)` is not a subclass of the optic's source type.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecAnalysis.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecAnalysis.java
@@ -15,7 +15,6 @@ import javax.lang.model.type.TypeMirror;
  * <ul>
  *   <li>The source type {@code S} from {@code OpticsSpec<S>}
  *   <li>Abstract methods requiring generation (annotated with copy strategies)
- *   <li>Default methods to copy unchanged
  *   <li>The target package for generated code
  * </ul>
  *
@@ -23,14 +22,12 @@ import javax.lang.model.type.TypeMirror;
  * @param sourceType the source type {@code S} from {@code OpticsSpec<S>}
  * @param sourceTypeElement the source type as a TypeElement (for generating code)
  * @param opticMethods abstract methods that define optics to generate
- * @param defaultMethods default methods to copy into the generated class
  */
 public record SpecAnalysis(
     TypeElement specInterface,
     TypeMirror sourceType,
     TypeElement sourceTypeElement,
-    List<OpticMethodInfo> opticMethods,
-    List<ExecutableElement> defaultMethods) {
+    List<OpticMethodInfo> opticMethods) {
 
   /** The kind of optic defined by a method. */
   public enum OpticKind {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -26,6 +26,7 @@ import org.higherkindedj.optics.processing.external.SpecAnalysis.PrismHintInfo;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.PrismHintKind;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.TraversalHintInfo;
 import org.higherkindedj.optics.processing.external.SpecAnalysis.TraversalHintKind;
+import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
@@ -36,9 +37,12 @@ import org.higherkindedj.optics.processing.util.ProcessorUtils;
  * <ul>
  *   <li>The source type {@code S} from {@code OpticsSpec<S>}
  *   <li>Abstract methods that need optic implementations generated
- *   <li>Default methods that should be copied to the generated class
  *   <li>Annotations and their parsed values for each method
  * </ul>
+ *
+ * <p>A {@code default} method is rejected: its body cannot be read during annotation processing, so
+ * it has no home in the generated class. Composition belongs in a static method or an ordinary
+ * utility class that calls the generated statics.
  */
 public class SpecInterfaceAnalyser {
 
@@ -110,14 +114,26 @@ public class SpecInterfaceAnalyser {
       return Optional.empty();
     }
 
-    // Categorise methods
-    List<OpticMethodInfo> opticMethods = new ArrayList<>();
-    List<ExecutableElement> defaultMethods = new ArrayList<>();
+    List<ExecutableElement> methods = ElementFilter.methodsIn(specInterface.getEnclosedElements());
 
-    for (ExecutableElement method : ElementFilter.methodsIn(specInterface.getEnclosedElements())) {
+    // A default method has no home in the generated class: a body cannot be read during
+    // annotation processing, so reject it here rather than generating a stub that throws.
+    boolean rejected = false;
+    for (ExecutableElement method : methods) {
       if (method.isDefault()) {
-        defaultMethods.add(method);
-      } else if (method.getModifiers().contains(Modifier.ABSTRACT)) {
+        reportDefaultMethod(specInterface, method);
+        rejected = true;
+      }
+    }
+    if (rejected) {
+      return Optional.empty();
+    }
+
+    List<OpticMethodInfo> opticMethods = new ArrayList<>();
+    for (ExecutableElement method : methods) {
+      // Static methods are left alone: they stay on the interface and can call the generated
+      // statics, so they are a home for composition rather than something to generate.
+      if (method.getModifiers().contains(Modifier.ABSTRACT)) {
         Optional<OpticMethodInfo> opticInfo =
             analyseOpticMethod(method, sourceType, sourceTypeElement, specInterface);
         if (opticInfo.isPresent()) {
@@ -127,12 +143,34 @@ public class SpecInterfaceAnalyser {
           return Optional.empty();
         }
       }
-      // Skip static methods, they're not relevant
     }
 
     return Optional.of(
-        new SpecAnalysis(
-            specInterface, sourceType, sourceTypeElement, opticMethods, defaultMethods));
+        new SpecAnalysis(specInterface, sourceType, sourceTypeElement, opticMethods));
+  }
+
+  /**
+   * Reports a {@code default} method on a spec interface, naming the two places composition can
+   * live instead.
+   *
+   * @param specInterface the spec interface declaring the method
+   * @param method the offending default method
+   */
+  private void reportDefaultMethod(TypeElement specInterface, ExecutableElement method) {
+    Diagnostics.error(
+        messager,
+        method,
+        "@ImportOptics",
+        "'"
+            + specInterface.getSimpleName()
+            + "."
+            + method.getSimpleName()
+            + "' is a default method.",
+        "A spec interface declares the optics to generate, and a method body cannot be read during"
+            + " annotation processing, so the generated class could only carry a stub that throws.",
+        "Make it an abstract method carrying a copy strategy or hint annotation, or move the"
+            + " composition to a static method on this interface or to an ordinary utility class"
+            + " that calls the generated statics.");
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
@@ -16,7 +16,6 @@ import java.util.List;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
@@ -38,8 +37,8 @@ import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport
  * defined in the spec interface. For each abstract method, it generates the appropriate optic using
  * the configured copy strategy, prism hint, or traversal hint.
  *
- * <p>Default methods from the spec interface are copied unchanged to the generated class, converted
- * to static methods.
+ * <p>Every method in the analysis is an abstract optic declaration: the analyser rejects {@code
+ * default} methods, whose bodies cannot be read during annotation processing.
  */
 public class SpecInterfaceGenerator {
 
@@ -102,12 +101,6 @@ public class SpecInterfaceGenerator {
       MethodSpec method =
           generateOpticMethod(
               opticMethod, analysis.sourceType(), analysis.sourceTypeElement(), className);
-      classBuilder.addMethod(method);
-    }
-
-    // Copy default methods (converted to static)
-    for (ExecutableElement defaultMethod : analysis.defaultMethods()) {
-      MethodSpec method = copyDefaultMethod(defaultMethod, analysis.sourceType());
       classBuilder.addMethod(method);
     }
 
@@ -258,53 +251,6 @@ public class SpecInterfaceGenerator {
         sourceType,
         focusType,
         className);
-  }
-
-  /**
-   * Copies a default method from the spec interface, converting it to a static method.
-   *
-   * <p>Note: The method body is copied as-is. Users must use explicit class-qualified references
-   * (e.g., {@code PersonOptics.name()}) in their default method implementations.
-   *
-   * @param defaultMethod the default method to copy
-   * @param sourceType the source type
-   * @return the generated static method
-   */
-  private MethodSpec copyDefaultMethod(ExecutableElement defaultMethod, TypeMirror sourceType) {
-    String methodName = defaultMethod.getSimpleName().toString();
-
-    MethodSpec.Builder methodBuilder =
-        MethodSpec.methodBuilder(methodName)
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .returns(TypeName.get(defaultMethod.getReturnType()))
-            .addJavadoc(
-                "Copied from spec interface default method.\n\n" + "@return The optic instance.");
-
-    // Copy type parameters
-    for (TypeParameterElement typeParam : defaultMethod.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
-    }
-
-    // Copy parameters (default methods shouldn't have parameters for optics, but handle anyway)
-    defaultMethod
-        .getParameters()
-        .forEach(
-            param ->
-                methodBuilder.addParameter(
-                    TypeName.get(param.asType()), param.getSimpleName().toString()));
-
-    // For default methods, we cannot easily copy the body in annotation processing
-    // The user is expected to use explicit static references like PersonOptics.name()
-    // We generate a placeholder that throws - in practice, the user should override
-    // or the spec interface compilation will handle this
-    methodBuilder.addCode(
-        "// Default method body cannot be copied during annotation processing.\n"
-            + "// Ensure the spec interface is compiled and this class is regenerated.\n"
-            + "throw new $T(\"Default method '$L' requires manual implementation or spec recompilation\");\n",
-        UnsupportedOperationException.class,
-        methodName);
-
-    return methodBuilder.build();
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceCoverageTest.java
@@ -5,9 +5,11 @@ package org.higherkindedj.optics.processing;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeDoesNotContain;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -295,8 +297,8 @@ class SpecInterfaceCoverageTest {
   class SpecInterfaceGeneratorCoverage {
 
     @Test
-    @DisplayName("should generate optics for spec interface with default method")
-    void shouldHandleDefaultMethodInSpec() {
+    @DisplayName("should generate optics beside a static helper that calls the generated class")
+    void shouldHandleStaticHelperInSpec() {
       final var externalClass =
           JavaFileObjects.forSourceString(
               "com.external.Config",
@@ -334,7 +336,7 @@ class SpecInterfaceCoverageTest {
                   @Wither("withPort")
                   Lens<Config, Integer> port();
 
-                  default Lens<Config, String> defaultHostLens() {
+                  static Lens<Config, String> aliasedHost() {
                       return ConfigOptics.host();
                   }
               }
@@ -344,8 +346,9 @@ class SpecInterfaceCoverageTest {
           javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
 
       assertThat(compilation).succeeded();
-      // Default method should be copied to generated class
-      assertGeneratedCodeContains(compilation, "com.myapp.ConfigOptics", "defaultHostLens");
+      // The static helper stays on the spec interface; only the declared optics are generated.
+      assertGeneratedCodeContains(compilation, "com.myapp.ConfigOptics", "host()");
+      assertGeneratedCodeDoesNotContain(compilation, "com.myapp.ConfigOptics", "aliasedHost");
     }
 
     @Test
@@ -927,28 +930,29 @@ class SpecInterfaceCoverageTest {
   }
 
   @Nested
-  @DisplayName("Spec interface with default methods having parameters")
-  class DefaultMethodsWithParameters {
+  @DisplayName("Default methods on a spec interface")
+  class DefaultMethodRejection {
+
+    /** A wither class the specs below build lenses over. */
+    private static final JavaFileObject CONFIG =
+        JavaFileObjects.forSourceString(
+            "com.external.Config",
+            """
+            package com.external;
+            public class Config {
+                private final String key;
+                private final String value;
+                public Config(String key, String value) { this.key = key; this.value = value; }
+                public String getKey() { return key; }
+                public String getValue() { return value; }
+                public Config withKey(String key) { return new Config(key, this.value); }
+                public Config withValue(String value) { return new Config(this.key, value); }
+            }
+            """);
 
     @Test
-    @DisplayName("should handle spec with default method that has parameters")
-    void shouldHandleDefaultMethodWithParameters() {
-      final var externalRecord =
-          JavaFileObjects.forSourceString(
-              "com.external.Config",
-              """
-              package com.external;
-              public class Config {
-                  private final String key;
-                  private final String value;
-                  public Config(String key, String value) { this.key = key; this.value = value; }
-                  public String getKey() { return key; }
-                  public String getValue() { return value; }
-                  public Config withKey(String key) { return new Config(key, this.value); }
-                  public Config withValue(String value) { return new Config(this.key, value); }
-              }
-              """);
-
+    @DisplayName("a parameterised default method is rejected at the declaration")
+    void shouldRejectParameterisedDefaultMethod() {
       final var specInterface =
           JavaFileObjects.forSourceString(
               "com.myapp.ConfigOpticsSpec",
@@ -967,17 +971,119 @@ class SpecInterfaceCoverageTest {
                   Lens<Config, String> key();
 
                   default Lens<Config, String> keyWithDefault(String prefix) {
-                      return key();
+                      return null;
                   }
               }
               """);
 
       Compilation compilation =
-          javac()
-              .withProcessors(new ImportOpticsProcessor())
-              .compile(externalRecord, specInterface);
+          javac().withProcessors(new ImportOpticsProcessor()).compile(CONFIG, specInterface);
 
-      assertThat(compilation).succeeded();
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("'ConfigOpticsSpec.keyWithDefault' is a default method");
+    }
+
+    @Test
+    @DisplayName("the diagnostic names both homes for the composition")
+    void shouldNameTheAlternatives() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ConfigOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.Wither;
+              import com.external.Config;
+
+              @ImportOptics
+              public interface ConfigOpticsSpec extends OpticsSpec<Config> {
+                  @Wither(value = "withKey", getter = "getKey")
+                  Lens<Config, String> key();
+
+                  default Lens<Config, String> aliasedKey() {
+                      return null;
+                  }
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(CONFIG, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("a method body cannot be read");
+      assertThat(compilation).hadErrorContaining("static method on this interface");
+      assertThat(compilation).hadErrorContaining("ordinary utility class");
+    }
+
+    @Test
+    @DisplayName("every default method is reported, not just the first")
+    void shouldReportEveryDefaultMethod() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ConfigOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.Wither;
+              import com.external.Config;
+
+              @ImportOptics
+              public interface ConfigOpticsSpec extends OpticsSpec<Config> {
+                  @Wither(value = "withKey", getter = "getKey")
+                  Lens<Config, String> key();
+
+                  default Lens<Config, String> first() { return null; }
+
+                  default String describe() { return "config"; }
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(CONFIG, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'ConfigOpticsSpec.first' is a default method");
+      assertThat(compilation).hadErrorContaining("'ConfigOpticsSpec.describe' is a default method");
+    }
+
+    @Test
+    @DisplayName("a generic default method is rejected too")
+    void shouldRejectGenericDefaultMethod() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ConfigOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.Wither;
+              import com.external.Config;
+
+              @ImportOptics
+              public interface ConfigOpticsSpec extends OpticsSpec<Config> {
+                  @Wither(value = "withKey", getter = "getKey")
+                  Lens<Config, String> key();
+
+                  default <T> Lens<Config, T> generic() {
+                      return null;
+                  }
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(CONFIG, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'ConfigOpticsSpec.generic' is a default method");
     }
   }
 
@@ -1052,60 +1158,6 @@ class SpecInterfaceCoverageTest {
       assertThat(compilation).succeeded();
       // Should generate lenses for the record fields
       assertGeneratedCodeContains(compilation, "com.myapp.TeamLenses", "Lens<Team, String> name()");
-    }
-  }
-
-  @Nested
-  @DisplayName("Default method copying")
-  class DefaultMethodCopying {
-
-    @Test
-    @DisplayName("should copy type parameters of a generic default method")
-    void shouldCopyTypeParametersOfGenericDefaultMethod() {
-      final var externalClass =
-          JavaFileObjects.forSourceString(
-              "com.external.Config",
-              """
-              package com.external;
-
-              public class Config {
-                  private final String host;
-                  public Config(String host) { this.host = host; }
-                  public String getHost() { return host; }
-                  public Config withHost(String host) { return new Config(host); }
-              }
-              """);
-
-      final var specInterface =
-          JavaFileObjects.forSourceString(
-              "com.myapp.ConfigOpticsSpec",
-              """
-              package com.myapp;
-
-              import org.higherkindedj.optics.Lens;
-              import org.higherkindedj.optics.annotations.ImportOptics;
-              import org.higherkindedj.optics.annotations.OpticsSpec;
-              import org.higherkindedj.optics.annotations.Wither;
-              import com.external.Config;
-
-              @ImportOptics
-              public interface ConfigOpticsSpec extends OpticsSpec<Config> {
-
-                  @Wither(value = "withHost", getter = "getHost")
-                  Lens<Config, String> host();
-
-                  default <T> Lens<Config, T> generic() {
-                      return null;
-                  }
-              }
-              """);
-
-      Compilation compilation =
-          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
-
-      assertThat(compilation).succeeded();
-      assertGeneratedCodeContains(
-          compilation, "com.myapp.ConfigOptics", "public static <T> Lens<Config, T> generic()");
     }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecMutationKillingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecMutationKillingTest.java
@@ -748,8 +748,8 @@ class SpecMutationKillingTest {
     }
 
     @Test
-    @DisplayName("Default methods are preserved in generated class")
-    void defaultMethodsArePreserved() {
+    @DisplayName("A default method fails the compilation instead of becoming a stub")
+    void defaultMethodsAreRejected() {
       var data =
           JavaFileObjects.forSourceString(
               "com.external.Data",
@@ -781,7 +781,6 @@ class SpecMutationKillingTest {
                   @ViaBuilder
                   Lens<Data, String> value();
 
-                  // Default method should be preserved
                   default String getDescription() {
                       return "Data lens";
                   }
@@ -791,8 +790,8 @@ class SpecMutationKillingTest {
       Compilation compilation =
           javac().withProcessors(new ImportOpticsProcessor()).compile(data, spec);
 
-      assertThat(compilation).succeeded();
-      // Default methods are preserved in the generated implementation
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'DataSpec.getDescription' is a default method");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -346,8 +346,8 @@ class SpecInterfaceAnalyserTest {
     }
 
     @Test
-    @DisplayName("should identify default methods to copy")
-    void shouldIdentifyDefaultMethods() {
+    @DisplayName("should reject a default method rather than analysing the interface")
+    void shouldRejectDefaultMethods() {
       var person =
           JavaFileObjects.forSourceString(
               "com.test.Person",
@@ -376,13 +376,9 @@ class SpecInterfaceAnalyserTest {
               """);
 
       Optional<SpecAnalysis> result =
-          analyseSpec("com.test.PersonOptics", person, spec, VIA_BUILDER);
+          analyseSpecAllowingErrors("com.test.PersonOptics", person, spec, VIA_BUILDER);
 
-      assertThat(result).isPresent();
-      assertThat(result.get().opticMethods()).hasSize(1);
-      assertThat(result.get().defaultMethods()).hasSize(1);
-      assertThat(result.get().defaultMethods().get(0).getSimpleName().toString())
-          .isEqualTo("firstName");
+      assertThat(result).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Closes #712.

## The bug

`SpecInterfaceGenerator.copyDefaultMethod` copied a `default` method on an `@ImportOptics` spec interface into the generated class as a body that throws. The composition compiled, and then failed the first time it ran:

```java
@ImportOptics
public interface JsonNodeOpticsSpec extends OpticsSpec<JsonNode> {

  @InstanceOf(ObjectNode.class)
  Prism<JsonNode, ObjectNode> object();

  default Affine<JsonNode, JsonNode> field(String name) {
    return JsonNodeOptics.object().andThen(Affine.of(...));
  }
}

JsonNodeOptics.field("data");   // UnsupportedOperationException
```

Annotation processing cannot read a method body, so there was never anything to carry across. The interface's own default method is not a route either: the abstract optic methods have no implementation, so there is nothing to instantiate.

## The fix

Option 1 from the issue: reject at the declaration, so a runtime surprise becomes a compile error.

```mermaid
flowchart LR
    S["Spec interface"] --> A["abstract @InstanceOf method"]
    S --> D["default method"]
    S --> T["static method"]
    A --> G["generated static:<br/>real prism"]
    D --> E["compile error naming<br/>where composition goes"]
    T --> K["left on the interface,<br/>calls the generated statics"]

    classDef wire fill:#8caaee,stroke:#1e66f5,color:#232634
    classDef domain fill:#a6d189,stroke:#40a02b,color:#232634
    classDef error fill:#e78284,stroke:#d20f39,color:#232634
    class S wire
    class A,G,T,K domain
    class D,E error
```

`SpecInterfaceAnalyser` reports every default method it finds and abandons the analysis, in the shared what/why/fix shape:

> `@ImportOptics: 'JsonNodeOpticsSpec.field' is a default method. A spec interface declares the optics to generate, and a method body cannot be read during annotation processing, so the generated class could only carry a stub that throws. Make it an abstract method carrying a copy strategy or hint annotation, or move the composition to a static method on this interface or to an ordinary utility class that calls the generated statics.`

Both alternatives the diagnostic names are real. A `static` method on the spec interface can refer to the generated class by name and is left untouched by the processor — a new compile test pins that, since it is the closest in-place replacement for what people were writing.

With the stub gone, `SpecInterfaceGenerator.copyDefaultMethod` and `SpecAnalysis.defaultMethods` are dead code, so both go.

## Tests

The three tests that asserted the old copying behaviour now assert the diagnostic instead, joined by the cases that behaviour had quietly covered:

| Test | Pins |
| --- | --- |
| `shouldRejectParameterisedDefaultMethod` | a `default` taking arguments is rejected, naming the method |
| `shouldNameTheAlternatives` | the why and both fixes reach the user |
| `shouldReportEveryDefaultMethod` | all default methods are reported, not just the first |
| `shouldRejectGenericDefaultMethod` | a generic signature is rejected too |
| `shouldHandleStaticHelperInSpec` | a `static` helper calling the generated class compiles, and is not generated into it |

`gradle build` is green, including `:hkj-processor:jacocoTestCoverageVerification`.

## Docs

`OpticsSpec`'s javadoc and the book's compiler-errors page teach the static/utility-class rule rather than the default-method one.

The `optics/optics_spec_interfaces.md` page on `main` still teaches composition through default methods. That page is rewritten wholesale in #713, which already teaches the `JsonPaths` utility class and carries the warning, so it is deliberately untouched here to avoid a conflict — **#713 should merge first, or alongside this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017X5v3LVarGAMJ4jJaE6QXC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that optics specification interfaces must contain abstract optic declarations only.
  - Added guidance for resolving compiler errors caused by default methods.
  - Documented using static interface helpers or utility methods for composed optics.

- **Bug Fixes**
  - Default methods in optics specifications are now rejected with clear diagnostics.
  - Static helper methods remain available but are not copied into generated optics classes.

- **Tests**
  - Updated coverage to verify default-method rejection, diagnostics, generic methods, and static helper behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->