### PR TITLE
@GenerateFocus: reject a container the widening cannot be written for (#718)

### DIFF
--- a/.claude/skills/hkj-optics/reference/container-types.md
+++ b/.claude/skills/hkj-optics/reference/container-types.md
@@ -117,6 +117,26 @@ public static TraversalPath<Employee, Integer> scores() {
 
 Patterns like `Optional<List<String>>` or `Either<E, Map<K, V>>` are detected automatically. The processor generates composed widening chains (e.g., `.some().each()`).
 
+## Raw and Wildcard Container Type Arguments
+
+An SPI container widens by receiving an optic instance — `.some(Affines.eitherRight())`, `.each(EachInstances.mapValuesEach())` — whose own type arguments javac infers from the field type. A raw container offers none to infer from, and a wildcard has no ground instantiation, so `@GenerateFocus` rejects the component rather than emitting a call that cannot compile.
+
+```java
+// Rejected: no Affine can be denoted for a wildcard type argument
+@GenerateFocus
+record Holder(Either<String, ? extends Leaf> boundedEither) {}
+
+// Accepted
+@GenerateFocus
+record Holder(Either<String, Leaf> either) {}
+```
+
+- Both of the container's own type arguments count, focused or not: `Either<?, Leaf>` is rejected too.
+- A wildcard nested *inside* an argument is fine: `Either<String, List<? extends Leaf>>` has a ground instantiation and widens to `.some(Affines.eitherRight()).each()`.
+- The built-in `Optional`, `List` and `Set` widenings take a wildcard without complaint, because `.some()` and `.each()` are methods with a free type variable and no optic argument to unify.
+- A `ZERO_OR_MORE` SPI container is rejected only when something actually widens it: `widenCollections = true`, or a navigator taking it. At the default settings it stays a `FocusPath`, and so does everything beneath it — `Map<String, Either<String, ? extends Leaf>>` compiles by default, because the un-widened `Map` means the `Either` is never asked for an optic.
+- A custom generator that names no optic expression is exempt: it widens through `.nullable()` or `.each()`, whose free type variable takes a raw or wildcard argument without complaint. Every generator shipped with HKJ names one.
+
 ## ZERO_OR_MORE Manual Widening
 
 For SPI `ZERO_OR_MORE` types, static Focus methods return `FocusPath`. Widen manually:

--- a/hkj-book/src/optics/focus_containers.md
+++ b/hkj-book/src/optics/focus_containers.md
@@ -134,6 +134,28 @@ AssetClass rebalanced =
         .modifyAll(w -> w * 1.05, assetClass);
 ```
 
+~~~admonish warning title="Raw and wildcard container type arguments"
+An SPI container widens by receiving an optic **instance** — `.some(Affines.eitherRight())`, `.each(EachInstances.mapValuesEach())` — whose own type arguments javac infers from the field type. A raw container offers none to infer from, and a wildcard has no ground instantiation, so `@GenerateFocus` rejects the component rather than emitting a call that cannot compile:
+
+```java
+// Rejected: no Affine can be denoted for a wildcard type argument
+@GenerateFocus
+public record Holder(Either<String, ? extends Leaf> boundedEither) {}
+
+// Accepted
+@GenerateFocus
+public record Holder(Either<String, Leaf> either) {}
+```
+
+Both of the container's own type arguments count, focused or not, so `Either<?, Leaf>` is rejected too. A wildcard nested *inside* an argument is fine: `Either<String, List<? extends Leaf>>` still has a ground instantiation and widens to `.some(Affines.eitherRight()).each()`.
+
+The built-in `Optional`, `List` and `Set` widenings take a wildcard without complaint, because `.some()` and `.each()` are methods with a free type variable and no optic argument to unify. `List<? extends Leaf>` widens to `TraversalPath<Holder, Leaf>` as usual.
+
+A `ZERO_OR_MORE` SPI container is rejected only when something actually widens it — `widenCollections = true`, or a navigator taking it. At the default settings it stays a `FocusPath`, and the wildcard costs it nothing. Nor does one beneath it: `Map<String, Either<String, ? extends Leaf>>` compiles at the default settings, because the `Map` is never widened and so the `Either` inside it is never asked for an optic.
+
+A generator that names no optic expression is exempt: it widens through `.nullable()` or `.each()`, whose free type variable takes a raw or wildcard argument without complaint. Every generator shipped with HKJ names one.
+~~~
+
 ### Cross-Ecosystem Navigation
 
 Real projects mix collection libraries: JDK collections for ordinary code, Eclipse Collections for high-performance immutable data, HKJ types for typed error handling. Focus navigates all of them from one annotation, composing chains that cross ecosystem boundaries without ceremony. For a full walkthrough on a financial portfolio model, see [Portfolio Risk Analysis](../examples/examples_portfolio_risk.md).

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
@@ -243,6 +244,7 @@ public class FocusProcessor extends AbstractProcessor {
 
     // Generate FocusPath methods for each component
     for (RecordComponentElement component : components) {
+      reportUndenotableSpiWidening(component, widenCollections, navigatorGenerator);
       MethodSpec method = null;
 
       // Try to create a navigator method if navigators are enabled
@@ -709,7 +711,7 @@ public class FocusProcessor extends AbstractProcessor {
     // otherwise they remain FocusPath for backwards compatibility.
     // Generators are pre-sorted by priority descending; highest-priority match wins.
     // Only equal-priority conflicts emit a warning.
-    TraversableGenerator matchedGenerator = findSpiGenerator(type, component);
+    TraversableGenerator matchedGenerator = wideningGenerator(type, component);
     if (matchedGenerator != null && matchedGenerator.getCardinality() == Cardinality.ZERO_OR_ONE) {
       int typeArgIndex = matchedGenerator.getFocusTypeArgumentIndex();
       TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, typeArgIndex);
@@ -755,6 +757,138 @@ public class FocusProcessor extends AbstractProcessor {
   }
 
   /**
+   * Rejects a component whose SPI container is raw or carries a wildcard type argument, where the
+   * widening that container would otherwise receive cannot be written.
+   *
+   * <p>The walk mirrors the one {@link #analyseNestedType} makes, so it reaches the same containers
+   * and stops where that one stops. A layer the current settings do not widen ends it: a {@code
+   * ZERO_OR_MORE} SPI field is left a plain {@code FocusPath} unless collections are widened or a
+   * navigator takes it, and the analysis then neither widens it nor looks inside it, so neither
+   * that layer nor anything under it can be reported.
+   *
+   * @param component the record component to inspect
+   * @param widenCollections whether ZERO_OR_MORE SPI types widen
+   * @param navigatorGenerator the navigator generator, or null when navigators are off
+   */
+  private void reportUndenotableSpiWidening(
+      RecordComponentElement component,
+      boolean widenCollections,
+      NavigatorClassGenerator navigatorGenerator) {
+
+    // A navigator only ever reads the component's own type, and the walk reaches a nested
+    // container only when that type denotes its own arguments, so this answer belongs to the
+    // first layer alone.
+    boolean navigatorWidens =
+        navigatorGenerator != null && navigatorGenerator.widensUndenotableSpiContainer(component);
+
+    TypeMirror current = component.asType();
+    for (int depth = 0; depth < MAX_NESTING_DEPTH; depth++) {
+      if (current.getKind() != TypeKind.DECLARED) {
+        return;
+      }
+      DeclaredType declaredType = (DeclaredType) current;
+      TypeElement typeElement = (TypeElement) declaredType.asElement();
+      String qualifiedName = typeElement.getQualifiedName().toString();
+      boolean hardcoded =
+          OPTIONAL_TYPES.contains(qualifiedName) || COLLECTION_TYPES.contains(qualifiedName);
+
+      // Optional and the collections widen through .some()/.each(), whose free type variable
+      // takes an undenotable argument without complaint. Only a generator's container, which
+      // widens through an inferred optic instance, is at risk.
+      TraversableGenerator generator = hardcoded ? null : findSpiGenerator(current, null);
+      if (!hardcoded && generator == null) {
+        return;
+      }
+      if (!widensHere(generator, widenCollections, navigatorWidens)) {
+        return;
+      }
+      if (generator != null && widensUndenotably(generator, declaredType)) {
+        reportUndenotableContainer(component, declaredType);
+        return;
+      }
+      int typeArgIndex = generator == null ? 0 : generator.getFocusTypeArgumentIndex();
+      current = getTypeArgumentAt(declaredType, typeArgIndex);
+      if (current == null) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Whether the analysis widens this layer, and so goes on to look inside it.
+   *
+   * <p>Optional and the collections always do, and so does a {@code ZERO_OR_ONE} generator. A
+   * {@code ZERO_OR_MORE} generator only does when collections are widened or a navigator takes the
+   * field; left alone it stays a plain {@code FocusPath}, and the type arguments of everything
+   * beneath it are never asked for an optic.
+   *
+   * @param generator the generator for this layer, or null when Optional or a collection widens it
+   * @param widenCollections whether ZERO_OR_MORE SPI types widen
+   * @param navigatorWidens whether a navigator widens the component's own type
+   */
+  private static boolean widensHere(
+      TraversableGenerator generator, boolean widenCollections, boolean navigatorWidens) {
+    return generator == null
+        || generator.getCardinality() == Cardinality.ZERO_OR_ONE
+        || widenCollections
+        || navigatorWidens;
+  }
+
+  /**
+   * Reports the container the widening cannot be written for, in the terms it went wrong in: a raw
+   * container has no type arguments to infer from, a parameterised one has a wildcard among them.
+   */
+  private void reportUndenotableContainer(
+      RecordComponentElement component, DeclaredType declaredType) {
+    boolean raw = declaredType.getTypeArguments().isEmpty();
+    String qualifiedComponent =
+        component.getEnclosingElement().getSimpleName() + "." + component.getSimpleName();
+    Diagnostics.error(
+        processingEnv.getMessager(),
+        component,
+        "@GenerateFocus",
+        raw
+            ? "record component '"
+                + qualifiedComponent
+                + "' has a raw "
+                + declaredType.asElement().getSimpleName()
+                + "."
+            : "record component '"
+                + qualifiedComponent
+                + "' has a wildcard type argument in "
+                + simpleTypeName(declaredType)
+                + ".",
+        "The optic instance that widens that container is inferred from the field type, and "
+            + (raw
+                ? "a raw type offers no type arguments to infer it from."
+                : "a wildcard has no ground instantiation to infer it from."),
+        "Declare the component with concrete type arguments, such as "
+            + concreteAlternative(declaredType)
+            + ".");
+  }
+
+  /**
+   * The container written with concrete type arguments: each wildcard replaced by the type it
+   * resolves to, and a raw container filled in from the bounds its type parameters declare.
+   */
+  private static String concreteAlternative(DeclaredType declaredType) {
+    TypeElement element = (TypeElement) declaredType.asElement();
+    Stream<String> arguments =
+        declaredType.getTypeArguments().isEmpty()
+            ? element.getTypeParameters().stream()
+                .map(parameter -> simpleTypeName(parameter.getBounds().getFirst()))
+            : declaredType.getTypeArguments().stream()
+                .map(ProcessorUtils::resolveWildcard)
+                .map(resolved -> resolved == null ? "Object" : simpleTypeName(resolved));
+    return element.getSimpleName() + "<" + arguments.collect(Collectors.joining(", ")) + ">";
+  }
+
+  /** Renders a type for a diagnostic, with package qualifiers dropped and type arguments spaced. */
+  private static String simpleTypeName(TypeMirror type) {
+    return type.toString().replaceAll("\\b(?:[a-z][\\p{Alnum}_]*\\.)+", "").replace(",", ", ");
+  }
+
+  /**
    * Finds the highest-priority SPI generator that supports the given type.
    *
    * @param type the type to check
@@ -788,6 +922,37 @@ public class FocusProcessor extends AbstractProcessor {
       }
     }
     return matchedGenerator;
+  }
+
+  /**
+   * The generator that widens {@code type}, or {@code null} when none matches or the widening it
+   * would emit cannot be written.
+   *
+   * @param type the type to widen
+   * @param component the record component for diagnostic messages (may be null)
+   * @return the generator to widen with, or null
+   */
+  private TraversableGenerator wideningGenerator(TypeMirror type, Element component) {
+    TraversableGenerator matched = findSpiGenerator(type, component);
+    return matched != null && widensUndenotably(matched, type) ? null : matched;
+  }
+
+  /**
+   * Whether {@code generator} cannot write the widening it would emit for {@code type}.
+   *
+   * <p>A generator that names an optic instance — {@code .some(Affines.eitherRight())}, {@code
+   * .each(EachInstances.mapValuesEach())} — has that instance's type arguments inferred from the
+   * field type, which a raw or wildcard-carrying container gives javac no way to do. A generator
+   * with no optic expression widens through {@code .nullable()} or {@code .each()} instead, whose
+   * free type variable takes either without complaint.
+   *
+   * <p>Such a container is left un-widened, and its declaration is rejected by {@link
+   * #reportUndenotableSpiWidening} so that the mistake is reported where it is written rather than
+   * inside generated source.
+   */
+  private static boolean widensUndenotably(TraversableGenerator generator, TypeMirror type) {
+    return !generator.generateOpticExpression().isEmpty()
+        && ProcessorUtils.hasUndenotableTypeArguments(type);
   }
 
   /**
@@ -858,7 +1023,7 @@ public class FocusProcessor extends AbstractProcessor {
     }
 
     // Check for SPI types
-    TraversableGenerator gen = findSpiGenerator(type, null);
+    TraversableGenerator gen = wideningGenerator(type, null);
     if (gen != null && gen.getCardinality() == Cardinality.ZERO_OR_ONE) {
       List<WideningStep> steps = new ArrayList<>();
       TypeMirror innerTypeMirror = getTypeArgumentAt(declaredType, gen.getFocusTypeArgumentIndex());

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -194,7 +194,7 @@ public class NavigatorClassGenerator {
     }
 
     // Consult TraversableGenerator SPI for additional container types.
-    TraversableGenerator matched = findSpiGenerator(type);
+    TraversableGenerator matched = wideningGenerator(type);
     if (matched != null) {
       PathKind spiKind =
           switch (matched.getCardinality()) {
@@ -882,7 +882,17 @@ public class NavigatorClassGenerator {
     if (fieldType.getKind() != TypeKind.DECLARED || isHardcodedWideningType(fieldType)) {
       return null;
     }
-    TraversableGenerator generator = findSpiGenerator(fieldType);
+    return spiNavigableUnder(fieldType, wideningGenerator(fieldType));
+  }
+
+  /**
+   * The navigable element a declared, non-hardcoded container focuses on under {@code generator},
+   * or {@code null} when there is none.
+   *
+   * <p>Split from {@link #spiNavigable} so that {@link #widensUndenotableSpiContainer} can ask the
+   * same question of a generator the widening guard has already turned away.
+   */
+  private SpiNavigable spiNavigableUnder(TypeMirror fieldType, TraversableGenerator generator) {
     if (generator == null) {
       // A Collection subtype such as ArrayList is widened by the interface walk rather than by a
       // generator, so there is no focus type argument to read.
@@ -997,6 +1007,62 @@ public class NavigatorClassGenerator {
       }
     }
     return matched;
+  }
+
+  /**
+   * The generator that widens {@code type}, or {@code null} when none matches or the widening it
+   * would emit cannot be written.
+   *
+   * <p>Every widening site reads its generator from here, so the path kind, the navigator class and
+   * the composition call cannot disagree about which containers widen.
+   */
+  private TraversableGenerator wideningGenerator(TypeMirror type) {
+    TraversableGenerator matched = findSpiGenerator(type);
+    return matched != null && widensUndenotably(matched, type) ? null : matched;
+  }
+
+  /**
+   * Whether {@code generator} cannot write the widening it would emit for {@code type}.
+   *
+   * <p>A generator that names an optic instance — {@code .some(Affines.eitherRight())}, {@code
+   * .each(EachInstances.mapValuesEach())} — has that instance's type arguments inferred from the
+   * field type, which a raw or wildcard-carrying container gives javac no way to do. A generator
+   * with no optic expression widens through {@code .nullable()} or {@code .each()} instead, whose
+   * free type variable takes either without complaint.
+   *
+   * <p>Such a container is left un-widened here, and the declaration is rejected by {@code
+   * FocusProcessor}, which sees the component it is written on.
+   */
+  private static boolean widensUndenotably(TraversableGenerator generator, TypeMirror type) {
+    return !generator.generateOpticExpression().isEmpty()
+        && ProcessorUtils.hasUndenotableTypeArguments(type);
+  }
+
+  /**
+   * Whether a navigator for {@code component} would widen through an SPI container whose type
+   * arguments leave the optic instance undenotable.
+   *
+   * <p>Answered here because the navigator generator decides which fields get a navigator; the
+   * diagnostic is reported by {@code FocusProcessor}, which sees each component once.
+   *
+   * @param component the record component to inspect
+   * @return true when only the type arguments stand between this component and a navigator
+   */
+  boolean widensUndenotableSpiContainer(RecordComponentElement component) {
+    TypeMirror fieldType = component.asType();
+    // The guards run in the order the navigator itself decides: a filtered-out or directly
+    // navigable field never reaches the SPI question, and Optional and the collections widen
+    // through their own path.
+    if (!shouldGenerateNavigator(component)
+        || fieldType.getKind() != TypeKind.DECLARED
+        || navigableTypeElement(fieldType) != null
+        || isHardcodedWideningType(fieldType)) {
+      return false;
+    }
+    TraversableGenerator generator = findSpiGenerator(fieldType);
+    return generator != null
+        && widensUndenotably(generator, fieldType)
+        && spiNavigableUnder(fieldType, generator) != null;
   }
 
   /**
@@ -1214,7 +1280,7 @@ public class NavigatorClassGenerator {
       return new Layer(".each()", PathKind.TRAVERSAL, typeArgument(declaredType, 0));
     }
 
-    TraversableGenerator generator = findSpiGenerator(type);
+    TraversableGenerator generator = wideningGenerator(type);
     if (generator == null) {
       // No generator, so the analysis recognised this layer through the Collection-subtype walk.
       return new Layer(".each()", PathKind.TRAVERSAL, typeArgument(declaredType, 0));

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -2,7 +2,11 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.processing.util;
 
+import java.util.List;
 import java.util.Locale;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.WildcardType;
 
@@ -42,6 +46,37 @@ public final class ProcessorUtils {
       return null;
     }
     return type;
+  }
+
+  /**
+   * Whether a container's type arguments leave an optic instance composed over it undenotable.
+   *
+   * <p>An optic handed to a Focus path — {@code .some(Affines.eitherRight())}, {@code
+   * .each(EachInstances.mapValuesEach())} — has its own type arguments inferred from the field
+   * type. A raw container offers none to infer them from and a wildcard has no ground
+   * instantiation, so in either case javac cannot instantiate the optic's own type variables and
+   * the composition call does not apply to the path.
+   *
+   * <p>Only the container's own arguments count: {@code Either<String, ? extends Leaf>} is
+   * undenotable, {@code Either<String, List<? extends Leaf>>} is not, because the wildcard there
+   * belongs to the {@code List} and {@code Either} still has a ground instantiation.
+   *
+   * @param type the type to inspect
+   * @return true when {@code type} is a declared generic type that is raw or carries a wildcard
+   *     type argument
+   * @since 0.4.10
+   */
+  public static boolean hasUndenotableTypeArguments(TypeMirror type) {
+    if (type.getKind() != TypeKind.DECLARED) {
+      return false;
+    }
+    DeclaredType declaredType = (DeclaredType) type;
+    List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
+    if (typeArguments.isEmpty()) {
+      // A generic element with no arguments is raw; a non-generic one simply has none to give.
+      return !((TypeElement) declaredType.asElement()).getTypeParameters().isEmpty();
+    }
+    return typeArguments.stream().anyMatch(arg -> arg.getKind() == TypeKind.WILDCARD);
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/architecture/ProcessorArchitectureRules.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/architecture/ProcessorArchitectureRules.java
@@ -13,6 +13,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +35,14 @@ import org.junit.jupiter.api.Test;
 class ProcessorArchitectureRules {
 
   private static final String BASE_PACKAGE = "org.higherkindedj";
+
+  /** The SPI generator lookup that every widening site must reach through the guard. */
+  private static final String SPI_LOOKUP = "findSpiGenerator";
+
+  /** The methods that may reach the lookup directly: the guard itself, and the diagnostic walk. */
+  private static final Set<String> SPI_LOOKUP_CALLERS =
+      Set.of("wideningGenerator", "reportUndenotableSpiWidening", "widensUndenotableSpiContainer");
+
   private static JavaClasses classes;
 
   @BeforeAll
@@ -204,6 +213,26 @@ class ProcessorArchitectureRules {
   }
 
   /**
+   * Every widening site must read its SPI generator through the guard.
+   *
+   * <p>A generator widens by handing the path an optic instance whose type arguments javac infers
+   * from the field type, which a raw or wildcard-carrying container gives it no way to do (#718).
+   * {@code wideningGenerator} is the one place such a container is turned away, so a site that
+   * looks a generator up itself would widen it anyway and emit source that cannot compile. The
+   * diagnostic walk is exempt: it exists to report the container the guard turned away.
+   */
+  @Test
+  @DisplayName("SPI generator lookups should go through the widening guard")
+  void spi_generator_lookups_should_go_through_the_widening_guard() {
+    classes()
+        .that()
+        .resideInAPackage("..processing..")
+        .should(lookUpSpiGeneratorsOnlyFrom(SPI_LOOKUP_CALLERS))
+        .allowEmptyShould(true)
+        .check(classes);
+  }
+
+  /**
    * Custom condition checking for final or static fields only.
    *
    * @return the arch condition
@@ -224,6 +253,36 @@ class ProcessorArchitectureRules {
                             String.format(
                                 "Processor %s has mutable instance field '%s'",
                                 javaClass.getName(), field.getName()))));
+      }
+    };
+  }
+
+  /**
+   * Custom condition that no method outside {@code allowed} looks an SPI generator up directly.
+   *
+   * @param allowed the names of the methods that may call the lookup
+   * @return the arch condition
+   */
+  private static ArchCondition<JavaClass> lookUpSpiGeneratorsOnlyFrom(Set<String> allowed) {
+    return new ArchCondition<>("look SPI generators up only from " + allowed) {
+      @Override
+      public void check(JavaClass javaClass, ConditionEvents events) {
+        javaClass.getMethodCallsFromSelf().stream()
+            .filter(call -> call.getTarget().getName().equals(SPI_LOOKUP))
+            .filter(call -> !allowed.contains(call.getOrigin().getName()))
+            .forEach(
+                call ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            javaClass,
+                            String.format(
+                                "%s.%s calls %s directly. Read the generator from"
+                                    + " wideningGenerator instead, so that a raw or"
+                                    + " wildcard-carrying container is turned away rather than"
+                                    + " widened into source that cannot compile.",
+                                javaClass.getSimpleName(),
+                                call.getOrigin().getName(),
+                                SPI_LOOKUP))));
       }
     };
   }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorSpiEnhancementsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorSpiEnhancementsTest.java
@@ -11,10 +11,19 @@ import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.JavaFileObject;
+import org.higherkindedj.optics.annotations.GenerateFocus;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
 import org.higherkindedj.optics.processing.util.ProcessorUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -437,6 +446,250 @@ public class FocusProcessorSpiEnhancementsTest {
   }
 
   @Nested
+  @DisplayName("Raw and wildcard type arguments in SPI containers")
+  class SpiContainerTypeArguments {
+
+    /**
+     * The type these records' containers focus on, navigable so that a navigator is generated for
+     * the ones a wildcard bounds by it.
+     */
+    private static final JavaFileObject LEAF =
+        JavaFileObjects.forSourceString(
+            "com.example.Leaf",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateFocus;
+
+            @GenerateFocus
+            public record Leaf(String name) {}
+            """);
+
+    private static JavaFileObject holder(String attributes, String component) {
+      return JavaFileObjects.forSourceString(
+          "com.example.Holder",
+          """
+          package com.example;
+
+          import org.higherkindedj.optics.annotations.GenerateFocus;
+          import org.higherkindedj.hkt.either.Either;
+          import java.util.List;
+          import java.util.Map;
+          import java.util.Optional;
+
+          @GenerateFocus(%s)
+          public record Holder(%s) {}
+          """
+              .formatted(attributes, component));
+    }
+
+    private static Compilation compile(String attributes, String component) {
+      return javac()
+          .withProcessors(new FocusProcessor())
+          .compile(holder(attributes, component), LEAF);
+    }
+
+    @Test
+    @DisplayName("should reject a wildcard in the focused type argument")
+    void shouldRejectWildcardInFocusedTypeArgument() {
+      Compilation compilation = compile("", "Either<String, ? extends Leaf> boundedEither");
+
+      assertThat(compilation)
+          .hadErrorContaining(
+              "@GenerateFocus: record component 'Holder.boundedEither' has a wildcard type"
+                  + " argument in Either<String, ? extends Leaf>.");
+      assertThat(compilation)
+          .hadErrorContaining(
+              "Declare the component with concrete type arguments, such as"
+                  + " Either<String, Leaf>.");
+    }
+
+    @Test
+    @DisplayName("should reject a wildcard in a type argument the generator does not focus on")
+    void shouldRejectWildcardInUnfocusedTypeArgument() {
+      // Affines.eitherRight() infers both of Either's type arguments, so a wildcard on the left
+      // leaves the optic just as undenotable as one on the right.
+      Compilation compilation = compile("", "Either<?, Leaf> unfocusedWildcard");
+
+      assertThat(compilation)
+          .hadErrorContaining("has a wildcard type argument in Either<?, Leaf>.");
+      assertThat(compilation).hadErrorContaining("such as Either<Object, Leaf>.");
+    }
+
+    @Test
+    @DisplayName("should name Object as the alternative for an unbounded wildcard")
+    void shouldNameObjectForUnboundedWildcard() {
+      Compilation compilation = compile("", "Either<String, ?> unbounded");
+
+      assertThat(compilation).hadErrorContaining("such as Either<String, Object>.");
+    }
+
+    @Test
+    @DisplayName("should reject a wildcard container nested inside a widening chain")
+    void shouldRejectWildcardContainerNestedInChain() {
+      Compilation compilation = compile("", "Optional<Either<String, ? extends Leaf>> nested");
+
+      assertThat(compilation)
+          .hadErrorContaining(
+              "record component 'Holder.nested' has a wildcard type argument in Either<String, ?"
+                  + " extends Leaf>.");
+    }
+
+    @Test
+    @DisplayName("should accept a wildcard nested inside a type argument")
+    void shouldAcceptWildcardNestedInsideTypeArgument() {
+      // Either<String, List<? extends Leaf>> has a ground instantiation: the wildcard belongs to
+      // the List, which widens through the free type variable of .each().
+      Compilation compilation = compile("", "Either<String, List<? extends Leaf>> groundEither");
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.HolderFocus", ".some(Affines.eitherRight()).each()");
+    }
+
+    @Test
+    @DisplayName("should leave a ZERO_OR_MORE container alone when it is not widened anyway")
+    void shouldLeaveUnwidenedZeroOrMoreContainerAlone() {
+      // The static method leaves every ZERO_OR_MORE SPI field a plain FocusPath, so the wildcard
+      // costs this record nothing and there is nothing to report.
+      Compilation compilation = compile("", "Map<String, ? extends Leaf> values");
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.HolderFocus",
+          "public static FocusPath<Holder, Map<String, ? extends Leaf>> values()");
+    }
+
+    @Test
+    @DisplayName("should reject a ZERO_OR_MORE container once widenCollections asks for it")
+    void shouldRejectZeroOrMoreContainerWhenCollectionsWiden() {
+      Compilation compilation =
+          compile("widenCollections = true", "Map<String, ? extends Leaf> values");
+
+      assertThat(compilation)
+          .hadErrorContaining("has a wildcard type argument in Map<String, ? extends Leaf>.");
+      assertThat(compilation).hadErrorContaining("such as Map<String, Leaf>.");
+    }
+
+    @Test
+    @DisplayName("should reject a ZERO_OR_MORE container once a navigator takes it")
+    void shouldRejectZeroOrMoreContainerWhenNavigatorTakesIt() {
+      Compilation compilation =
+          compile("generateNavigators = true", "Map<String, ? extends Leaf> values");
+
+      assertThat(compilation)
+          .hadErrorContaining("has a wildcard type argument in Map<String, ? extends Leaf>.");
+    }
+
+    @Test
+    @DisplayName("should accept a navigator record whose wildcard container has no navigable inner")
+    void shouldAcceptNavigatorRecordWithoutNavigableInner() {
+      // No navigator is generated for Map<String, ? extends String>, so nothing widens it and the
+      // wildcard is harmless.
+      Compilation compilation =
+          compile("generateNavigators = true", "Map<String, ? extends String> labels");
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.HolderFocus",
+          "public static FocusPath<Holder, Map<String, ? extends String>> labels()");
+    }
+
+    @Test
+    @DisplayName("should accept a nested ZERO_OR_MORE container a navigator does not reach")
+    void shouldAcceptNestedZeroOrMoreContainerNavigatorDoesNotReach() {
+      // A navigator only reads the component's own type, and the chain leaves a nested
+      // ZERO_OR_MORE SPI container un-widened, so the Map is never asked for an optic.
+      Compilation compilation =
+          compile("generateNavigators = true", "Optional<Map<String, ? extends Leaf>> nested");
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.HolderFocus",
+          "public static AffinePath<Holder, Map<String, ? extends Leaf>> nested()");
+    }
+
+    @Test
+    @DisplayName("should accept a wildcard container a filter excludes from navigation")
+    void shouldAcceptWildcardContainerExcludedFromNavigation() {
+      Compilation compilation =
+          compile(
+              "generateNavigators = true, excludeFields = \"values\"",
+              "Map<String, ? extends Leaf> values");
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should reject a raw SPI container")
+    void shouldRejectRawSpiContainer() {
+      // A raw container offers no type arguments at all, which leaves the optic just as
+      // undenotable as a wildcard does.
+      Compilation compilation = compile("", "Either raw");
+
+      assertThat(compilation).hadErrorContaining("record component 'Holder.raw' has a raw Either.");
+      assertThat(compilation)
+          .hadErrorContaining("a raw type offers no type arguments to infer it from.");
+      assertThat(compilation).hadErrorContaining("such as Either<Object, Object>.");
+    }
+
+    @Test
+    @DisplayName("should leave a raw ZERO_OR_MORE container alone when it is not widened anyway")
+    void shouldLeaveUnwidenedRawZeroOrMoreContainerAlone() {
+      Compilation compilation = compile("", "Map values");
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should accept a wildcard container deeper than the analysis descends")
+    void shouldAcceptWildcardContainerBelowMaxDepth() {
+      // The widening analysis stops at three layers, so the Either is never widened and its
+      // wildcard is never asked for an optic.
+      Compilation compilation =
+          compile("", "Optional<Optional<Optional<Either<String, ? extends Leaf>>>> deep");
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should accept a primitive component in a navigator record")
+    void shouldAcceptPrimitiveComponentInNavigatorRecord() {
+      // A primitive is not a declared type, so it never reaches the container question at all.
+      Compilation compilation = compile("generateNavigators = true", "int count");
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should accept a wildcard container no generator claims")
+    void shouldAcceptWildcardContainerNoGeneratorClaims() {
+      // Nothing widens a Function, so its wildcard is never asked for an optic.
+      Compilation compilation =
+          compile(
+              "generateNavigators = true",
+              "java.util.function.Function<String, ? extends Leaf> lookup");
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("should still widen an SPI container with concrete type arguments")
+    void shouldStillWidenConcreteSpiContainer() {
+      Compilation compilation = compile("", "Either<String, Leaf> concrete");
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.HolderFocus",
+          "public static AffinePath<Holder, Leaf> concrete()");
+    }
+  }
+
+  @Nested
   @DisplayName("ProcessorUtils.resolveWildcard")
   class ResolveWildcardUnit {
 
@@ -447,6 +700,79 @@ public class FocusProcessorSpiEnhancementsTest {
       // by verifying the compile tests produce correct results (no unit test for TypeMirror
       // without a processing environment).
       assertNotNull(ProcessorUtils.class, "ProcessorUtils should be accessible");
+    }
+  }
+
+  @Nested
+  @DisplayName("ProcessorUtils.hasUndenotableTypeArguments")
+  class UndenotableTypeArguments {
+
+    @Test
+    @DisplayName("should answer for every shape a record component's type can take")
+    void shouldAnswerForEveryComponentShape() {
+      // A raw List and a List<?> differ in ways only javac can produce, so the predicate is put
+      // to real type mirrors rather than to stand-ins.
+      assertEquals(
+          Map.of(
+              "primitive", false, // not a declared type at all
+              "plain", false, // declared, but with no type parameters to leave unfilled
+              "concrete", false,
+              "wildcard", true,
+              "raw", true),
+          answers(
+              "int primitive, String plain, List<String> concrete, List<?> wildcard, List raw"));
+    }
+
+    /** What the predicate answers for each component of a record, keyed by component name. */
+    private Map<String, Boolean> answers(String components) {
+      ComponentTypeProbe probe = new ComponentTypeProbe();
+      Compilation compilation =
+          javac()
+              .withProcessors(probe)
+              .compile(
+                  JavaFileObjects.forSourceString(
+                      "com.example.Probe",
+                      """
+                      package com.example;
+
+                      import org.higherkindedj.optics.annotations.GenerateFocus;
+                      import java.util.List;
+
+                      @GenerateFocus
+                      @SuppressWarnings("rawtypes")
+                      public record Probe(%s) {}
+                      """
+                          .formatted(components)));
+      assertThat(compilation).succeeded();
+      return probe.answers;
+    }
+  }
+
+  /** Puts {@link ProcessorUtils#hasUndenotableTypeArguments} to each component of a record. */
+  private static final class ComponentTypeProbe extends AbstractProcessor {
+
+    private final Map<String, Boolean> answers = new LinkedHashMap<>();
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+      return Set.of("org.higherkindedj.optics.annotations.GenerateFocus");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      for (Element element : roundEnv.getElementsAnnotatedWith(GenerateFocus.class)) {
+        for (RecordComponentElement component : ((TypeElement) element).getRecordComponents()) {
+          answers.put(
+              component.getSimpleName().toString(),
+              ProcessorUtils.hasUndenotableTypeArguments(component.asType()));
+        }
+      }
+      return true;
     }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedFocusSourceCompilesTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedFocusSourceCompilesTest.java
@@ -1,0 +1,279 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.Compiler.javac;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * {@code @GenerateFocus} never emits Focus source that fails to compile.
+ *
+ * <p>This is a guard on the shape of a failure rather than on any one cause. Issue #718 was a
+ * widening call javac could not apply to the path, and it surfaced as an error inside the generated
+ * file instead of at the declaration that caused it; the tests of the day missed it because every
+ * SPI container they wrote was parameterised with a concrete type.
+ *
+ * <p>So every container shape is compiled under every widening setting, and two things are asserted
+ * of whatever comes back: no error is located in generated output, and every error carries the
+ * {@code @GenerateFocus} tag, which only a diagnostic reported against a declaration does. A new
+ * container shape, a new setting, or a widening site that skips the guard fails here without anyone
+ * having to predict the mechanism first.
+ *
+ * <p>Rejecting everything would satisfy that on its own, so the corpus below pins the other half:
+ * every record in it compiles today, and a guard that grows too eager fails on it.
+ */
+@DisplayName("Generated Focus source always compiles")
+class GeneratedFocusSourceCompilesTest {
+
+  /** Marks a generated file in the compile-testing filer's output. */
+  private static final String GENERATED_OUTPUT = "SOURCE_OUTPUT";
+
+  /** The type every container below focuses on, navigable so that navigators reach into it. */
+  private static final JavaFileObject LEAF =
+      JavaFileObjects.forSourceString(
+          "com.example.Leaf",
+          """
+          package com.example;
+
+          import org.higherkindedj.optics.annotations.GenerateFocus;
+
+          @GenerateFocus
+          public record Leaf(String name) {}
+          """);
+
+  /** A container shape, written out for every container whose arity admits it. */
+  private record Shape(String label, List<String> types) {}
+
+  private static final List<Shape> SHAPES =
+      List.of(
+          new Shape(
+              "concrete",
+              List.of(
+                  "Either<String, Leaf>",
+                  "Try<Leaf>",
+                  "Validated<String, Leaf>",
+                  "Maybe<Leaf>",
+                  "Optional<Leaf>",
+                  "Map<String, Leaf>",
+                  "List<Leaf>",
+                  "Set<Leaf>",
+                  "Leaf[]")),
+          new Shape(
+              "wildcard in the focused type argument",
+              List.of(
+                  "Either<String, ? extends Leaf>",
+                  "Try<? extends Leaf>",
+                  "Validated<String, ? extends Leaf>",
+                  "Maybe<? extends Leaf>",
+                  "Optional<? extends Leaf>",
+                  "Map<String, ? extends Leaf>",
+                  "List<? extends Leaf>",
+                  "Set<? extends Leaf>")),
+          new Shape(
+              "wildcard in a type argument the generator does not focus on",
+              List.of("Either<?, Leaf>", "Validated<?, Leaf>", "Map<?, Leaf>")),
+          new Shape(
+              "unbounded wildcard",
+              List.of(
+                  "Either<String, ?>",
+                  "Try<?>",
+                  "Validated<String, ?>",
+                  "Maybe<?>",
+                  "Optional<?>",
+                  "Map<String, ?>",
+                  "List<?>",
+                  "Set<?>")),
+          new Shape(
+              "super-bounded wildcard",
+              List.of(
+                  "Either<String, ? super Leaf>",
+                  "Map<String, ? super Leaf>",
+                  "List<? super Leaf>",
+                  "Optional<? super Leaf>")),
+          new Shape(
+              "raw container",
+              List.of("Either", "Try", "Validated", "Maybe", "Optional", "Map", "List", "Set")),
+          new Shape(
+              "wildcard nested inside a type argument",
+              List.of(
+                  "Either<String, List<? extends Leaf>>",
+                  "Optional<Map<String, ? extends Leaf>>",
+                  "Map<String, List<? extends Leaf>>",
+                  "List<Optional<? extends Leaf>>")));
+
+  /** The widening settings a container can be read under. */
+  private static final List<String> SETTINGS =
+      List.of(
+          "",
+          "widenCollections = true",
+          "generateNavigators = true",
+          "generateNavigators = true, widenCollections = true");
+
+  static Stream<Arguments> shapesUnderEverySetting() {
+    return SHAPES.stream()
+        .flatMap(
+            shape ->
+                SETTINGS.stream()
+                    .map(
+                        setting ->
+                            Arguments.of(
+                                shape.label() + " / " + (setting.isEmpty() ? "defaults" : setting),
+                                shape,
+                                setting)));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("shapesUnderEverySetting")
+  @DisplayName("should report at the declaration and never from generated output")
+  void shouldNeverEmitUncompilableSource(String label, Shape shape, String setting) {
+    Compilation compilation =
+        javac().withProcessors(new FocusProcessor()).compile(holder(shape, setting), LEAF);
+
+    assertThat(errorsFrom(compilation, GENERATED_OUTPUT))
+        .as(
+            "%s: the processor emitted generated source that does not compile. Reject the"
+                + " declaration instead, so the error names the component that caused it",
+            label)
+        .isEmpty();
+
+    assertThat(errorsNotTagged(compilation))
+        .as("%s: an error was reported that no @GenerateFocus diagnostic explains", label)
+        .isEmpty();
+  }
+
+  /**
+   * A component and the settings it is read under, which together must keep compiling.
+   *
+   * <p>Every entry compiles before the undenotable-container rule exists, so each one is a record
+   * the rule must leave alone. A container the analysis never widens is the subtle half: it stays a
+   * plain {@code FocusPath}, nothing beneath it is ever asked for an optic, and an undenotable type
+   * argument down there costs it nothing.
+   */
+  private record StillCompiles(String component, String setting) {}
+
+  private static final List<StillCompiles> CORPUS =
+      List.of(
+          // The built-in widenings take a wildcard: .some() and .each() unify nothing.
+          new StillCompiles("List<? extends Leaf> f", ""),
+          new StillCompiles("Set<? extends Leaf> f", ""),
+          new StillCompiles("Optional<? extends Leaf> f", ""),
+          new StillCompiles("Optional<? super Leaf> f", ""),
+          // A ZERO_OR_MORE SPI container is not widened by the static method on its own. With
+          // navigators it is, which is why that setting is absent here and rejected instead.
+          new StillCompiles("Map<String, ? extends Leaf> f", ""),
+          // Nothing beneath an un-widened container is asked for an optic either.
+          new StillCompiles("Map<String, Either<String, ? extends Leaf>> f", ""),
+          new StillCompiles(
+              "Map<String, Either<String, ? extends Leaf>> f", "generateNavigators = true"),
+          new StillCompiles("Optional<Map<String, ? extends Leaf>> f", "generateNavigators = true"),
+          // A wildcard inside a type argument still leaves the container itself ground.
+          new StillCompiles("Either<String, List<? extends Leaf>> f", ""),
+          new StillCompiles("Optional<Map<String, ? extends Leaf>> f", ""),
+          // Deeper than the analysis descends, so the Either is never widened.
+          new StillCompiles("Optional<Optional<Optional<Either<String, ? extends Leaf>>>> f", ""),
+          // Concrete containers widen exactly as they always did.
+          new StillCompiles("Either<String, Leaf> f", ""),
+          new StillCompiles("Map<String, Leaf> f", "widenCollections = true"),
+          new StillCompiles("Map<String, Leaf> f", "generateNavigators = true"));
+
+  static Stream<Arguments> corpus() {
+    return CORPUS.stream()
+        .map(
+            entry ->
+                Arguments.of(
+                    entry.component()
+                        + " / "
+                        + (entry.setting().isEmpty() ? "defaults" : entry.setting()),
+                    entry));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("corpus")
+  @DisplayName("should leave a record the analysis never widens alone")
+  void shouldKeepCompilingWhatAlreadyCompiled(String label, StillCompiles entry) {
+    Compilation compilation =
+        javac()
+            .withProcessors(new FocusProcessor())
+            .compile(holder(new Shape(label, List.of()), entry.setting(), entry.component()), LEAF);
+
+    assertThat(
+            compilation.errors().stream().map(GeneratedFocusSourceCompilesTest::describe).toList())
+        .as(
+            "%s compiles without the undenotable-container rule, so the rule must leave it alone",
+            label)
+        .isEmpty();
+  }
+
+  /** A record carrying one component per type in the shape, read under the given settings. */
+  private static JavaFileObject holder(Shape shape, String setting) {
+    return holder(
+        shape,
+        setting,
+        IntStream.range(0, shape.types().size())
+            .mapToObj(index -> shape.types().get(index) + " f" + index)
+            .reduce((left, right) -> left + ", " + right)
+            .orElseThrow());
+  }
+
+  /** A record carrying the given components, read under the given settings. */
+  private static JavaFileObject holder(Shape shape, String setting, String components) {
+    return JavaFileObjects.forSourceString(
+        "com.example.Holder",
+        """
+        package com.example;
+
+        import org.higherkindedj.hkt.either.Either;
+        import org.higherkindedj.hkt.maybe.Maybe;
+        import org.higherkindedj.hkt.trymonad.Try;
+        import org.higherkindedj.hkt.validated.Validated;
+        import org.higherkindedj.optics.annotations.GenerateFocus;
+        import java.util.List;
+        import java.util.Map;
+        import java.util.Optional;
+        import java.util.Set;
+
+        @GenerateFocus(%s)
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        public record Holder(%s) {}
+        """
+            .formatted(setting, components));
+  }
+
+  /** The errors javac located in a file whose name contains {@code marker}. */
+  private static List<String> errorsFrom(Compilation compilation, String marker) {
+    return compilation.errors().stream()
+        .filter(error -> error.getSource() != null)
+        .filter(error -> error.getSource().getName().contains(marker))
+        .map(GeneratedFocusSourceCompilesTest::describe)
+        .toList();
+  }
+
+  /** The errors that carry no {@code @GenerateFocus} tag, so no declaration diagnostic explains. */
+  private static List<String> errorsNotTagged(Compilation compilation) {
+    return compilation.errors().stream()
+        .filter(error -> !String.valueOf(error.getMessage(null)).contains("@GenerateFocus"))
+        .map(GeneratedFocusSourceCompilesTest::describe)
+        .toList();
+  }
+
+  private static String describe(Diagnostic<? extends JavaFileObject> error) {
+    String source = error.getSource() == null ? "<no source>" : error.getSource().getName();
+    return source
+        + ":"
+        + error.getLineNumber()
+        + " "
+        + String.valueOf(error.getMessage(null)).lines().findFirst().orElse("");
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpiGeneratorConflictTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpiGeneratorConflictTest.java
@@ -177,6 +177,39 @@ class SpiGeneratorConflictTest {
     }
 
     @Test
+    @DisplayName("should widen wildcard containers whose generator names no optic")
+    void shouldWidenWildcardContainersWithoutOpticExpression() {
+      // Solo and Dup widen through .nullable() and .each(), whose free type variable takes a
+      // wildcard without complaint, so neither needs a denotable instantiation.
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.WildcardSpiInner",
+              """
+              package com.example;
+
+              import com.example.hkjtest.Dup;
+              import com.example.hkjtest.Solo;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(widenCollections = true)
+              public record WildcardSpiInner(Solo<? extends String> s, Dup<? extends String> d) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(DUP_MARKER, SOLO_MARKER, source);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.WildcardSpiInnerFocus",
+          "AffinePath<WildcardSpiInner, String> s()");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.WildcardSpiInnerFocus",
+          "TraversalPath<WildcardSpiInner, String> d()");
+    }
+
+    @Test
     @DisplayName("should widen Box fields to Object when the focus index has no type argument")
     void shouldWidenBoxFieldsToObjectWhenFocusIndexOutOfRange() {
       // BoxIndexOneGenerator focuses on type argument 1, which Box<T> never has, so the focus


### PR DESCRIPTION
Fixes #718.

## What was broken

An SPI container widens by receiving an optic **instance** — `.some(Affines.eitherRight())`, `.each(EachInstances.mapValuesEach())` — whose own type arguments javac infers from the field type. A wildcard has no ground instantiation to infer them from, so the call did not apply to the path and the failure surfaced *inside generated source* rather than at the declaration that caused it:

```
error: no suitable method found for some(Affine<Either<Object,Object>,Object>)
```

Measured with the real processor, one field per compilation. Two rows the issue did not record:

| field | before | note |
|---|---|---|
| `Either<String, ? extends Leaf>` | uncompilable | the issue's reproduction |
| `Either<?, Leaf>` | uncompilable | **wildcard in the type argument the generator does not focus on** — `Affines.eitherRight()` must infer `L` as well as `R` |
| `Either raw` | uncompilable | **raw containers fail identically**; pre-existing, same root cause |
| `Map<String, ? extends Leaf>`, `generateNavigators = true` | uncompilable | |
| `Either<String, List<? extends Leaf>>` | compiles | the wildcard belongs to the `List`; `Either` is still ground |
| `List<? extends Leaf>`, `Optional<? extends Leaf>` | compiles | `.some()`/`.each()` are free type variables with no optic to unify |

## The mechanism

```mermaid
flowchart TD
    F["a container-typed record component"] --> H{"hardcoded container?<br/>Optional, List, Set, Collection"}
    H -->|yes| B[".some() / .each()<br/>free type variable, nothing to unify"]
    H -->|"no: SPI generator"| N{"does the generator<br/>name an optic expression?"}
    N -->|no| B
    N -->|yes| W{"are the container's own<br/>type arguments denotable?"}
    W -->|yes| O[".some(optic) / .each(optic)"]
    W -->|"no: raw or wildcard"| G{"would this layer<br/>widen at all?"}
    G -->|no| B
    G -->|yes| E["reject the component<br/>at the declaration"]
    B --> OK["compiles"]
    O --> OK

    classDef wire fill:#8caaee,stroke:#1e66f5,color:#232634
    classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
    classDef error fill:#e78284,stroke:#d20f39,color:#232634
    classDef domain fill:#a6d189,stroke:#40a02b,color:#232634
    class F wire
    class H,N,W,G decision
    class E error
    class B,O,OK domain
```

## The fix

Option 1 of the issue: reject at the declaration, in the shared what/why/fix shape, naming the concrete alternative.

```
error: @GenerateFocus: record component 'Holder.boundedEither' has a wildcard type argument in
Either<String, ? extends Leaf>. The optic instance that widens that container is inferred from the
field type, and a wildcard has no ground instantiation to infer it from. Declare the component with
concrete type arguments, such as Either<String, Leaf>.
```

The container is also left **un-widened**, so the generated file still compiles and the user sees exactly one diagnostic rather than ours plus the cryptic one.

Three conditions keep the rule off code that works today:

- **The generator must name an optic expression.** One with none widens through `.nullable()`/`.each()`, whose free type variable takes a raw or wildcard argument without complaint. Every shipped generator names one; `SpiGeneratorConflictTest`'s `Solo`/`Dup` do not, and regressed until this condition existed.
- **The layer must actually widen.** A `ZERO_OR_MORE` SPI container stays a plain `FocusPath` unless collections are widened or a navigator takes it, so `Map<String, ? extends Leaf>` at the default settings is untouched.
- **…and so must everything beneath it.** The analysis neither widens an un-widened container nor looks inside it, so `Map<String, Either<String, ? extends Leaf>>` compiles by default.

Every widening site reads its generator through one guard (`wideningGenerator`), so the path kind, the navigator class and the composition call cannot disagree about which containers widen.

## How this has been tested

`gradle :hkj-processor:clean build` green, `spotlessCheck` clean, and a forced `--rerun-tasks` recompile of all five modules that run the processor — nothing in the repo's own sources trips the new rejection.

The issue's post-mortem was *"every SPI container in the processor tests is parameterised with a concrete type"*, so the new guards are built on the shape of the failure rather than on its mechanism:

**`GeneratedFocusSourceCompilesTest`** — seven container shapes (concrete, wildcard-focused, wildcard-unfocused, unbounded, `? super`, raw, wildcard-nested) × four settings. Two assertions: no error is ever located in generated output, and every error carries the `@GenerateFocus` tag, which only a diagnostic reported against a declaration does. Because a guard that says only *where* errors land is satisfied by rejecting everything, a second half pins a corpus of records that must keep compiling.

Both halves are non-vacuous, checked against `main`'s sources: 22 of the 28 shape cases fail there, and **zero** corpus cases do.

**An architecture rule** holds the chokepoint: only `wideningGenerator` and the diagnostic walk may call `findSpiGenerator`, so a new widening site cannot silently skip the guard. Verified by pointing one site back at the raw lookup and watching it fail.

## Review

A pre-merge review caught a regression this PR had introduced: the diagnostic walk descended unconditionally, so `Map<String, Either<String, ? extends Leaf>>` — which compiles on `main` — was rejected. Reproduced, fixed (the walk now stops at any layer the analysis does not widen), and the "still compiles" corpus above exists because the shape sweep alone did not catch it.

## Related

#721 — `@GenerateTraversals` is broken by wildcards far more broadly, including `List<? extends Leaf>`. Different root cause (`TraversalProcessor` copies the type argument verbatim into `new Traversal<Holder, ? extends Leaf>() {`, which is illegal as an anonymous class), so it is filed separately rather than folded in.

---

Type of change: bug fix (non-breaking), plus documentation and tests. The container-types reference in `hkj-book` and in the `hkj-optics` skill both gained the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149w8faEHS2icbw48epbUJA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on raw and wildcard container type arguments in Focus DSL usage.
  - Clarified which nested wildcard patterns are supported and when concrete type arguments are required.

- **Bug Fixes**
  - Improved handling of SPI containers with raw or wildcard types during focus generation.
  - Added diagnostics and actionable suggestions for unsupported widening scenarios.
  - Preserved valid non-widened and built-in container cases.

- **Tests**
  - Added comprehensive coverage for wildcard, raw, nested, navigated, and widened containers.
  - Verified generated focus sources compile successfully across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->