### PR TITLE
@ImportOptics: report a type variable source type, not a ClassCastException (#728)

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/OpticsSpec.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/OpticsSpec.java
@@ -81,7 +81,14 @@ package org.higherkindedj.optics.annotations;
  * }
  * }</pre>
  *
- * @param <S> the source type to create optics for
+ * <p>{@code S} names one class, record or interface. It is read for its members and rebuilt through
+ * a constructor, wither or setter, so a type parameter of the spec interface itself, {@code
+ * interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S>}, has nothing to generate from and
+ * is rejected. A source type that is itself generic is supported, declared under the same type
+ * parameter names the source type uses: {@code interface BoxOpticsSpec<T> extends
+ * OpticsSpec<Box<T>>}.
+ *
+ * @param <S> the source type to create optics for; one class, record or interface
  * @see ImportOptics
  * @see ViaBuilder
  * @see Wither

--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -57,9 +57,11 @@ This page is for the moment a build fails and you want to know what the message 
 
 ### "'XOpticsSpec' declares OpticsSpec<S>, which is a type variable"
 
-**Cause.** The spec interface is generic, and its own type parameter is the source type: `interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S>`. Optics are generated against one named type, read for its members and rebuilt through its constructor, wither or setter, so a type parameter standing for whatever a caller picks has nothing to generate from. The same diagnostic covers an array source type, `OpticsSpec<String[]>`.
+**Cause.** The spec interface is generic, and its own type parameter is the source type: `interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S>`. Optics are generated against one named type, read for its members and rebuilt through its constructor, wither or setter, so a type parameter standing for whatever a caller picks has nothing to generate from. An array source type produces the same diagnostic with a different opening, `declares OpticsSpec<String[]>, which is an array type`, and the same remedy.
 
-**Fix.** Name the type the optics are for as the type argument: `OpticsSpec<Box>`. A source type that is itself generic is fine: `OpticsSpec<Box<T>>` on a spec interface declaring `<T>` generates optics parameterised the same way. It is only a bare type variable that has no source to read.
+**Fix.** Name the type the optics are for as the type argument: `OpticsSpec<Box>`. Where the bound names a single type, the message suggests it for you.
+
+A source type that is itself generic is supported. Declare the spec's type parameters under the same names, and with the same arity, that the source type uses: `Box<T>` is matched by `interface BoxOpticsSpec<T> extends OpticsSpec<Box<T>>`, which generates `static <T> Lens<Box<T>, String> label()`. The generated signature takes its type parameters from the source type's own declaration, so a spec that renames or drops them is not currently diagnosed — it generates a signature naming a parameter that is not in scope. It is only a bare type variable that has no source to read at all.
 
 ### "@InstanceOf: target subtype not assignable to source type"
 

--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -55,6 +55,12 @@ This page is for the moment a build fails and you want to know what the message 
 
 **Fix.** Keep the spec interface to annotated abstract methods. Composed optics belong in a `static` method on the interface, or in an ordinary utility class; either one calls the generated statics by name, for example `JsonNodeOptics.object().andThen(...)`.
 
+### "'XOpticsSpec' declares OpticsSpec<S>, which is a type variable"
+
+**Cause.** The spec interface is generic, and its own type parameter is the source type: `interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S>`. Optics are generated against one named type, read for its members and rebuilt through its constructor, wither or setter, so a type parameter standing for whatever a caller picks has nothing to generate from. The same diagnostic covers an array source type, `OpticsSpec<String[]>`.
+
+**Fix.** Name the type the optics are for as the type argument: `OpticsSpec<Box>`. A source type that is itself generic is fine: `OpticsSpec<Box<T>>` on a spec interface declaring `<T>` generates optics parameterised the same way. It is only a bare type variable that has no source to read.
+
 ### "@InstanceOf: target subtype not assignable to source type"
 
 **Cause.** The class passed to `@InstanceOf(SubType.class)` is not a subclass of the optic's source type.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -444,7 +444,7 @@ public class FocusProcessor extends AbstractProcessor {
             : "record component '"
                 + qualifiedComponent
                 + "' has a wildcard type argument in "
-                + simpleTypeName(declaredType)
+                + ProcessorUtils.simpleTypeName(declaredType)
                 + ".",
         "The optic instance that widens that container is inferred from the field type, and "
             + (raw
@@ -464,15 +464,12 @@ public class FocusProcessor extends AbstractProcessor {
     Stream<String> arguments =
         declaredType.getTypeArguments().isEmpty()
             ? element.getTypeParameters().stream()
-                .map(parameter -> simpleTypeName(parameter.getBounds().getFirst()))
+                .map(parameter -> ProcessorUtils.simpleTypeName(parameter.getBounds().getFirst()))
             : declaredType.getTypeArguments().stream()
                 .map(ProcessorUtils::resolveWildcard)
-                .map(resolved -> resolved == null ? "Object" : simpleTypeName(resolved));
+                .map(
+                    resolved ->
+                        resolved == null ? "Object" : ProcessorUtils.simpleTypeName(resolved));
     return element.getSimpleName() + "<" + arguments.collect(Collectors.joining(", ")) + ">";
-  }
-
-  /** Renders a type for a diagnostic, with package qualifiers dropped and type arguments spaced. */
-  private static String simpleTypeName(TypeMirror type) {
-    return type.toString().replaceAll("\\b(?:[a-z][\\p{Alnum}_]*\\.)+", "").replace(",", ", ");
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecAnalysis.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecAnalysis.java
@@ -18,9 +18,13 @@ import javax.lang.model.type.TypeMirror;
  *   <li>The target package for generated code
  * </ul>
  *
+ * <p>The analyser only produces this for a source type that is a class, record or interface, so
+ * {@code sourceType} is always a declared type and {@code sourceTypeElement} is always its element.
+ * A type variable or array is rejected at the declaration instead.
+ *
  * @param specInterface the analysed spec interface element
- * @param sourceType the source type {@code S} from {@code OpticsSpec<S>}
- * @param sourceTypeElement the source type as a TypeElement (for generating code)
+ * @param sourceType the source type {@code S} from {@code OpticsSpec<S>}, always a declared type
+ * @param sourceTypeElement the element of {@code sourceType} (for generating code)
  * @param opticMethods abstract methods that define optics to generate
  */
 public record SpecAnalysis(

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -254,7 +254,12 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
-   * Whether a type is the given variable, or is parameterised by it at any depth.
+   * Whether a type is the given variable, or names it at any depth.
+   *
+   * <p>A variable can hide in an enclosing type as well as in a type argument: {@code
+   * Outer<S>.Inner} names {@code S} without taking it as an argument of its own. An enclosing type
+   * that is absent, or a static member type, is a {@code NoType}, which matches nothing and ends
+   * the walk.
    *
    * @param type the type to search; must not be null
    * @param variable the variable to look for; must not be null
@@ -266,7 +271,9 @@ public class SpecInterfaceAnalyser {
     }
     return switch (type) {
       case DeclaredType declared ->
-          declared.getTypeArguments().stream().anyMatch(argument -> mentions(argument, variable));
+          mentions(declared.getEnclosingType(), variable)
+              || declared.getTypeArguments().stream()
+                  .anyMatch(argument -> mentions(argument, variable));
       case ArrayType array -> mentions(array.getComponentType(), variable);
       default -> false;
     };

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -99,19 +99,30 @@ public class SpecInterfaceAnalyser {
    * @return the analysis result, or empty if the interface is invalid
    */
   public Optional<SpecAnalysis> analyse(TypeElement specInterface, String targetPackage) {
-    // Verify it's an interface
     if (specInterface.getKind() != ElementKind.INTERFACE) {
-      error("@ImportOptics on a type extending OpticsSpec must be an interface", specInterface);
+      Diagnostics.error(
+          messager,
+          specInterface,
+          "@ImportOptics",
+          "'" + specInterface.getSimpleName() + "' implements OpticsSpec but is not an interface.",
+          "A spec is read for its abstract methods, one per optic to generate, which is a shape"
+              + " only an interface has.",
+          "Declare it as an interface.");
       return Optional.empty();
     }
 
-    // Extract source type from OpticsSpec<S>
+    // The processor only routes a type here when OpticsSpec is one of its direct super-interfaces,
+    // so the one way to reach this is to have named it raw.
     TypeMirror sourceType = extractSourceType(specInterface);
     if (sourceType == null) {
-      error(
-          "Cannot determine source type. Interface must extend OpticsSpec<S> "
-              + "with a concrete type argument",
-          specInterface);
+      Diagnostics.error(
+          messager,
+          specInterface,
+          "@ImportOptics",
+          "'" + specInterface.getSimpleName() + "' extends OpticsSpec with no type argument.",
+          "The source type the optics are generated against is read from that argument, and a raw"
+              + " OpticsSpec names none.",
+          "Name the type the optics are for: 'OpticsSpec<Box>'.");
       return Optional.empty();
     }
 
@@ -190,10 +201,11 @@ public class SpecInterfaceAnalyser {
    * @param sourceType the offending type argument to {@code OpticsSpec}
    */
   private void reportUnusableSourceType(TypeElement specInterface, TypeMirror sourceType) {
-    // A type variable prints as a bare 'S', which reads like a class name the compiler failed to
-    // resolve; every other rejected kind prints as itself and needs no naming.
-    String kind =
-        sourceType.getKind() == TypeKind.TYPEVAR ? "a type variable" : "not a class or interface";
+    // A type variable and an array are the only two kinds that reach here. OpticsSpec takes a
+    // reference type, so a wildcard or primitive argument never compiles; an unresolvable one
+    // resolves to an element that is still a TypeElement, and javac reports it first; and an
+    // intersection cannot be written as a type argument at all.
+    String kind = sourceType.getKind() == TypeKind.TYPEVAR ? "a type variable" : "an array type";
     Diagnostics.error(
         messager,
         specInterface,
@@ -201,7 +213,7 @@ public class SpecInterfaceAnalyser {
         "'"
             + specInterface.getSimpleName()
             + "' declares OpticsSpec<"
-            + sourceType
+            + ProcessorUtils.simpleTypeName(sourceType)
             + ">, which is "
             + kind
             + ".",
@@ -213,19 +225,51 @@ public class SpecInterfaceAnalyser {
 
   /**
    * Names the type a variable is bounded by, so that {@code <S extends Box>} is answered with the
-   * declaration the author almost certainly meant.
+   * declaration that bound points at.
+   *
+   * <p>A bound only answers the question when it names one type that could stand in the variable's
+   * place. Several cannot, and each is left unanswered rather than guessed at: {@code Object},
+   * which every variable is bounded by and which says nothing; an intersection, {@code Box &
+   * Serializable}, which names two; another type variable, which moves the question rather than
+   * settling it; and a bound that names the variable it bounds, {@code Comparable<S>}, which is
+   * circular.
    *
    * @param sourceType the offending type argument to {@code OpticsSpec}
-   * @return the hint to append to the fix sentence, or the empty string when there is nothing
-   *     better to suggest than the bound of every type: {@code Object}
+   * @return the hint to append to the fix sentence, or the empty string when the bound has no one
+   *     type to offer
    */
   private String boundHint(TypeMirror sourceType) {
+    // getKind(), not instanceof: javac's intersection type implements DeclaredType, and asking it
+    // for a simple name yields the empty string. That is the mistake #728 was, one bound along.
     if (sourceType instanceof TypeVariable typeVariable
         && typeVariable.getUpperBound() instanceof DeclaredType bound
-        && !typeUtils.isSameType(bound, elementUtils.getTypeElement(OBJECT_FQN).asType())) {
-      return ", here OpticsSpec<" + bound.asElement().getSimpleName() + ">";
+        && bound.getKind() == TypeKind.DECLARED
+        // isSameType, not a name comparison: it also answers true for an unresolvable bound, whose
+        // own 'cannot find symbol' is the error worth reading.
+        && !typeUtils.isSameType(bound, elementUtils.getTypeElement(OBJECT_FQN).asType())
+        && !mentions(bound, typeVariable)) {
+      return ": 'OpticsSpec<" + ProcessorUtils.simpleTypeName(bound) + ">'";
     }
     return "";
+  }
+
+  /**
+   * Whether a type is the given variable, or is parameterised by it at any depth.
+   *
+   * @param type the type to search; must not be null
+   * @param variable the variable to look for; must not be null
+   * @return true when substituting {@code type} for {@code variable} would be circular
+   */
+  private boolean mentions(TypeMirror type, TypeVariable variable) {
+    if (typeUtils.isSameType(type, variable)) {
+      return true;
+    }
+    return switch (type) {
+      case DeclaredType declared ->
+          declared.getTypeArguments().stream().anyMatch(argument -> mentions(argument, variable));
+      case ArrayType array -> mentions(array.getComponentType(), variable);
+      default -> false;
+    };
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -15,7 +15,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -49,6 +51,7 @@ import org.higherkindedj.optics.processing.util.ProcessorUtils;
 public class SpecInterfaceAnalyser {
 
   private static final String OPTICS_SPEC_FQN = "org.higherkindedj.optics.annotations.OpticsSpec";
+  private static final String OBJECT_FQN = "java.lang.Object";
   private static final String LENS_FQN = "org.higherkindedj.optics.Lens";
   private static final String PRISM_FQN = "org.higherkindedj.optics.Prism";
   private static final String TRAVERSAL_FQN = "org.higherkindedj.optics.Traversal";
@@ -112,9 +115,11 @@ public class SpecInterfaceAnalyser {
       return Optional.empty();
     }
 
-    TypeElement sourceTypeElement = (TypeElement) typeUtils.asElement(sourceType);
-    if (sourceTypeElement == null) {
-      error("Source type " + sourceType + " is not a valid type element", specInterface);
+    // A type variable and an array each fail here, in different ways: asElement returns a
+    // TypeParameterElement for the first and null for the second. The pattern match covers both,
+    // and keeps a source type that is not a declared type out of the analysis that follows.
+    if (!(typeUtils.asElement(sourceType) instanceof TypeElement sourceTypeElement)) {
+      reportUnusableSourceType(specInterface, sourceType);
       return Optional.empty();
     }
 
@@ -175,6 +180,52 @@ public class SpecInterfaceAnalyser {
         "Make it an abstract method carrying a copy strategy or hint annotation, or move the"
             + " composition to a static method on this interface or to an ordinary utility class"
             + " that calls the generated statics.");
+  }
+
+  /**
+   * Reports a source type that no optic can be generated against, naming the kind it turned out to
+   * be so that a bare {@code S} does not read as a class name.
+   *
+   * @param specInterface the spec interface declaring the source type
+   * @param sourceType the offending type argument to {@code OpticsSpec}
+   */
+  private void reportUnusableSourceType(TypeElement specInterface, TypeMirror sourceType) {
+    // A type variable prints as a bare 'S', which reads like a class name the compiler failed to
+    // resolve; every other rejected kind prints as itself and needs no naming.
+    String kind =
+        sourceType.getKind() == TypeKind.TYPEVAR ? "a type variable" : "not a class or interface";
+    Diagnostics.error(
+        messager,
+        specInterface,
+        "@ImportOptics",
+        "'"
+            + specInterface.getSimpleName()
+            + "' declares OpticsSpec<"
+            + sourceType
+            + ">, which is "
+            + kind
+            + ".",
+        "An optic reads the members of its source type and rebuilds it through a constructor,"
+            + " wither or setter, so that type has to be a class, record or interface named at the"
+            + " declaration.",
+        "Name the type the optics are for as the type argument" + boundHint(sourceType) + ".");
+  }
+
+  /**
+   * Names the type a variable is bounded by, so that {@code <S extends Box>} is answered with the
+   * declaration the author almost certainly meant.
+   *
+   * @param sourceType the offending type argument to {@code OpticsSpec}
+   * @return the hint to append to the fix sentence, or the empty string when there is nothing
+   *     better to suggest than the bound of every type: {@code Object}
+   */
+  private String boundHint(TypeMirror sourceType) {
+    if (sourceType instanceof TypeVariable typeVariable
+        && typeVariable.getUpperBound() instanceof DeclaredType bound
+        && !typeUtils.isSameType(bound, elementUtils.getTypeElement(OBJECT_FQN).asType())) {
+      return ", here OpticsSpec<" + bound.asElement().getSimpleName() + ">";
+    }
+    return "";
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -51,6 +51,22 @@ public final class ProcessorUtils {
   }
 
   /**
+   * Renders a type for a diagnostic, with package qualifiers dropped and type arguments spaced.
+   *
+   * <p>Type arguments and enclosing types are kept, so {@code java.util.List<java.lang.String>}
+   * reads as {@code List<String>} and {@code com.external.Outer.Inner} as {@code Outer.Inner}. A
+   * diagnostic that offers a corrected declaration needs both: a rendering that drops either one
+   * suggests source that does not compile.
+   *
+   * @param type the type to render; must not be null
+   * @return the rendered name (non-null)
+   * @since 0.4.10
+   */
+  public static String simpleTypeName(TypeMirror type) {
+    return type.toString().replaceAll("\\b(?:[a-z][\\p{Alnum}_]*\\.)+", "").replace(",", ", ");
+  }
+
+  /**
    * The name the effect's type variable takes in a traversal generated for this record, which the
    * record must not have taken for itself.
    *

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
@@ -1570,12 +1570,26 @@ class SpecInterfaceProcessingTest {
               public class Box {}
               """);
 
+      // A generic outer with an inner class: the one shape where the variable hides in an
+      // enclosing type rather than in a type argument.
+      final var outerClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Outer",
+              """
+              package com.external;
+
+              public class Outer<X> {
+                  public class Inner {}
+              }
+              """);
+
       record Case(String name, String declaration) {}
       var cases =
           List.of(
               new Case("IntersectionSpec", "<S extends Box & java.io.Serializable>"),
               new Case("SelfReferentialSpec", "<S extends Comparable<S>>"),
               new Case("SelfReferentialArraySpec", "<S extends java.util.List<S[]>>"),
+              new Case("SelfReferentialEnclosingSpec", "<S extends Outer<S>.Inner>"),
               new Case("VariableBoundSpec", "<T extends Box, S extends T>"));
 
       for (Case testCase : cases) {
@@ -1586,6 +1600,7 @@ class SpecInterfaceProcessingTest {
                 package com.myapp;
 
                 import com.external.Box;
+                import com.external.Outer;
                 import org.higherkindedj.optics.annotations.ImportOptics;
                 import org.higherkindedj.optics.annotations.OpticsSpec;
 
@@ -1597,11 +1612,11 @@ class SpecInterfaceProcessingTest {
         var compilation =
             javac()
                 .withProcessors(new ImportOpticsProcessor())
-                .compile(externalClass, specInterface);
+                .compile(externalClass, outerClass, specInterface);
 
         assertThat(compilation).failed();
-        assertThat(compilation)
-            .hadErrorContaining("Name the type the optics are for as the type argument.");
+        // Anchored: the fix sentence must end there, with no suggestion appended after it.
+        assertThat(compilation).hadErrorContainingMatch("type argument\\.$");
       }
     }
 
@@ -1628,6 +1643,45 @@ class SpecInterfaceProcessingTest {
       assertThat(compilation).failed();
       // T is declared on the spec, so naming it in the suggestion still yields a valid declaration.
       assertThat(compilation).hadErrorContaining("as the type argument: 'OpticsSpec<List<T>>'.");
+    }
+
+    @Test
+    @DisplayName(
+        "should suggest an enclosing type parameterised by another variable the spec declares")
+    void shouldSuggestEnclosingTypeParameterisedByAnotherVariable() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Outer",
+              """
+              package com.external;
+
+              public class Outer<X> {
+                  public class Inner {}
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.EnclosingOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Outer;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface EnclosingOpticsSpec<T, S extends Outer<T>.Inner>
+                      extends OpticsSpec<S> {}
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
+
+      assertThat(compilation).failed();
+      // Only the variable being replaced makes a suggestion circular; T is the spec's to name.
+      assertThat(compilation)
+          .hadErrorContaining("as the type argument: 'OpticsSpec<Outer<T>.Inner>'.");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
@@ -1420,5 +1420,103 @@ class SpecInterfaceProcessingTest {
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("must have no parameters");
     }
+
+    @Test
+    @DisplayName("should report a type variable source type rather than crashing")
+    void shouldRejectTypeVariableSourceType() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Box",
+              """
+              package com.external;
+
+              public class Box {
+                  private String v;
+                  public String getV() { return v; }
+                  public void setV(String v) { this.v = v; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.BoxOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+              import com.external.Box;
+
+              @ImportOptics
+              public interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S> {
+
+                  @ViaCopyAndSet(setter = "setV")
+                  Lens<S, String> v();
+              }
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("'BoxOpticsSpec' declares OpticsSpec<S>, which is a type variable.");
+      assertThat(compilation)
+          .hadErrorContaining(
+              "Name the type the optics are for as the type argument, here" + " OpticsSpec<Box>.");
+    }
+
+    @Test
+    @DisplayName("should reject an unbounded type variable without suggesting Object")
+    void shouldRejectUnboundedTypeVariableSourceType() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.UnboundedOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface UnboundedOpticsSpec<S> extends OpticsSpec<S> {}
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'UnboundedOpticsSpec' declares OpticsSpec<S>, which is a type variable.");
+      assertThat(compilation)
+          .hadErrorContaining("Name the type the optics are for as the type argument.");
+    }
+
+    @Test
+    @DisplayName("should reject an array source type by naming what it is not")
+    void shouldRejectArraySourceType() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ArrayOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface ArrayOpticsSpec extends OpticsSpec<String[]> {}
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'ArrayOpticsSpec' declares OpticsSpec<java.lang.String[]>, which is not a class or"
+                  + " interface.");
+    }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
 import javax.tools.JavaFileObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -1465,7 +1466,7 @@ class SpecInterfaceProcessingTest {
           .hadErrorContaining("'BoxOpticsSpec' declares OpticsSpec<S>, which is a type variable.");
       assertThat(compilation)
           .hadErrorContaining(
-              "Name the type the optics are for as the type argument, here" + " OpticsSpec<Box>.");
+              "Name the type the optics are for as the type argument: 'OpticsSpec<Box>'.");
     }
 
     @Test
@@ -1492,10 +1493,145 @@ class SpecInterfaceProcessingTest {
               "'UnboundedOpticsSpec' declares OpticsSpec<S>, which is a type variable.");
       assertThat(compilation)
           .hadErrorContaining("Name the type the optics are for as the type argument.");
+      // Object bounds every variable, so suggesting it would be no answer at all.
+      assertThat(compilation).hadErrorContainingMatch("type argument\\.$");
     }
 
     @Test
-    @DisplayName("should reject an array source type by naming what it is not")
+    @DisplayName("should name a parameterised bound in full rather than raw")
+    void shouldNameParameterisedBoundInFull() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.ListOpticsSpec",
+              """
+              package com.myapp;
+
+              import java.util.List;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface ListOpticsSpec<S extends List<String>> extends OpticsSpec<S> {}
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("as the type argument: 'OpticsSpec<List<String>>'.");
+    }
+
+    @Test
+    @DisplayName("should name a nested bound by its enclosing type so the suggestion resolves")
+    void shouldNameNestedBoundWithEnclosingType() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Outer",
+              """
+              package com.external;
+
+              public class Outer {
+                  public static class Inner {}
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.InnerOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Outer;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface InnerOpticsSpec<S extends Outer.Inner> extends OpticsSpec<S> {}
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("as the type argument: 'OpticsSpec<Outer.Inner>'.");
+    }
+
+    @Test
+    @DisplayName(
+        "should offer no bound when the bound names two types, another variable, or itself")
+    void shouldOfferNoBoundWhenItNamesNoSingleType() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Box",
+              """
+              package com.external;
+
+              public class Box {}
+              """);
+
+      record Case(String name, String declaration) {}
+      var cases =
+          List.of(
+              new Case("IntersectionSpec", "<S extends Box & java.io.Serializable>"),
+              new Case("SelfReferentialSpec", "<S extends Comparable<S>>"),
+              new Case("SelfReferentialArraySpec", "<S extends java.util.List<S[]>>"),
+              new Case("VariableBoundSpec", "<T extends Box, S extends T>"));
+
+      for (Case testCase : cases) {
+        final var specInterface =
+            JavaFileObjects.forSourceString(
+                "com.myapp." + testCase.name(),
+                """
+                package com.myapp;
+
+                import com.external.Box;
+                import org.higherkindedj.optics.annotations.ImportOptics;
+                import org.higherkindedj.optics.annotations.OpticsSpec;
+
+                @ImportOptics
+                public interface %s%s extends OpticsSpec<S> {}
+                """
+                    .formatted(testCase.name(), testCase.declaration()));
+
+        var compilation =
+            javac()
+                .withProcessors(new ImportOpticsProcessor())
+                .compile(externalClass, specInterface);
+
+        assertThat(compilation).failed();
+        assertThat(compilation)
+            .hadErrorContaining("Name the type the optics are for as the type argument.");
+      }
+    }
+
+    @Test
+    @DisplayName("should suggest a bound parameterised by another variable the spec declares")
+    void shouldSuggestBoundParameterisedByAnotherVariable() {
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.OtherVariableOpticsSpec",
+              """
+              package com.myapp;
+
+              import java.util.List;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface OtherVariableOpticsSpec<T, S extends List<T>>
+                      extends OpticsSpec<S> {}
+              """);
+
+      var compilation = javac().withProcessors(new ImportOpticsProcessor()).compile(specInterface);
+
+      assertThat(compilation).failed();
+      // T is declared on the spec, so naming it in the suggestion still yields a valid declaration.
+      assertThat(compilation).hadErrorContaining("as the type argument: 'OpticsSpec<List<T>>'.");
+    }
+
+    @Test
+    @DisplayName("should reject an array source type by naming the kind it is")
     void shouldRejectArraySourceType() {
       final var specInterface =
           JavaFileObjects.forSourceString(
@@ -1515,8 +1651,7 @@ class SpecInterfaceProcessingTest {
       assertThat(compilation).failed();
       assertThat(compilation)
           .hadErrorContaining(
-              "'ArrayOpticsSpec' declares OpticsSpec<java.lang.String[]>, which is not a class or"
-                  + " interface.");
+              "'ArrayOpticsSpec' declares OpticsSpec<String[]>, which is an array type.");
     }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -874,6 +874,32 @@ class SpecInterfaceAnalyserTest {
     }
 
     @Test
+    @DisplayName("should report, not crash, when the source type is a type variable")
+    void shouldReportErrorForTypeVariableSourceType() {
+      var box =
+          JavaFileObjects.forSourceString(
+              "com.test.Box",
+              """
+              package com.test;
+              public record Box(String value) {}
+              """);
+
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.GenericSourceSpec",
+              """
+              package com.test;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              public interface GenericSourceSpec<S extends Box> extends OpticsSpec<S> {}
+              """);
+
+      Optional<SpecAnalysis> result =
+          analyseSpecAllowingErrors("com.test.GenericSourceSpec", box, spec);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
     @DisplayName("should skip non-OpticsSpec super-interfaces when extracting the source type")
     void shouldSkipNonOpticsSpecSuperInterfaces() {
       var person =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -857,7 +857,7 @@ class SpecInterfaceAnalyserTest {
   class CoverageHardening {
 
     @Test
-    @DisplayName("should report error when source type is not a valid type element")
+    @DisplayName("should report an array source type rather than analysing it")
     void shouldReportErrorForArraySourceType() {
       var spec =
           JavaFileObjects.forSourceString(


### PR DESCRIPTION
Fixes #728.

A spec interface that names its own type parameter as the source type crashed the processor instead of reporting anything:

```java
@ImportOptics
public interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S> {
    @ViaCopyAndSet(setter = "setV")
    Lens<S, String> v();
}
```

```
java.lang.ClassCastException: class com.sun.tools.javac.code.Symbol$TypeVariableSymbol
cannot be cast to class javax.lang.model.element.TypeElement
	at SpecInterfaceAnalyser.analyse(SpecInterfaceAnalyser.java:111)
```

Reproduced unchanged at `7e7f702c9`, so this is pre-existing and independent of the `@ViaCopyAndSet` work that surfaced it. Any optic kind on a generic spec interface reached the same cast.

## What was wrong

`analyse` cast the source type's element straight to `TypeElement`, and guarded only for null. Null is what `Types.asElement` returns for an array; a type variable resolves to a `TypeParameterElement`, which is not a `TypeElement`, so the cast threw before the guard could run.

```mermaid
flowchart TD
    S["OpticsSpec&lt;S&gt; type argument"] --> K{"what kind?"}
    K -->|"declared type"| E["TypeElement<br/>analysis proceeds"]
    K -->|"array"| N["asElement returns null<br/>guarded, reports a diagnostic"]
    K -->|"type variable"| T["asElement returns TypeParameterElement<br/>ClassCastException"]

    classDef wire fill:#8caaee,stroke:#1e66f5,color:#232634
    classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
    classDef domain fill:#a6d189,stroke:#40a02b,color:#232634
    classDef error fill:#e78284,stroke:#d20f39,color:#232634
    class S wire
    class K decision
    class E,N domain
    class T error
```

## What changed

A pattern match replaces both the cast and the null guard, so the two failing kinds share one what/why/fix diagnostic and neither reaches the analysis that follows.

```mermaid
flowchart TD
    S["OpticsSpec&lt;S&gt; type argument"] --> K{"asElement instanceof TypeElement?"}
    K -->|"yes"| E["analysis proceeds"]
    K -->|"no: type variable or array"| D["one what/why/fix diagnostic<br/>on the declaration"]
    D --> B{"is it a variable<br/>bounded by something<br/>other than Object?"}
    B -->|"yes"| H["fix line names the bound:<br/>here OpticsSpec&lt;Box&gt;"]
    B -->|"no"| G["fix line names no type"]

    classDef wire fill:#8caaee,stroke:#1e66f5,color:#232634
    classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
    classDef domain fill:#a6d189,stroke:#40a02b,color:#232634
    class S wire
    class K,B decision
    class E,D,H,G domain
```

The reported message:

```
@ImportOptics: 'BoxOpticsSpec' declares OpticsSpec<S>, which is a type variable. An optic
reads the members of its source type and rebuilds it through a constructor, wither or setter,
so that type has to be a class, record or interface named at the declaration. Name the type
the optics are for as the type argument, here OpticsSpec<Box>.
```

One step past the fix suggested on the issue: the fix line reads the bound the variable stands for, so `<S extends Box>` is answered with `OpticsSpec<Box>` rather than a hard-coded placeholder, and falls back to naming no type when the bound is `Object`. That follows what #726 did for wildcards.

The array case keeps its diagnostic and gains the what/why/fix shape:

```
@ImportOptics: 'ArrayOpticsSpec' declares OpticsSpec<java.lang.String[]>, which is not a
class or interface. ... Name the type the optics are for as the type argument.
```

## Two corrections to the issue

Neither affects the fix:

- There is no `SpecInterfaceAnalyser.findSupertype`; the walk the issue warns about does not exist in this class. The constraint is met anyway, because the guard returns `Optional.empty()` before anything downstream sees the type.
- A primitive cannot reach the guard at all, since `OpticsSpec<int>` is not legal Java. The reachable non-declared kinds are type variable and array only, and the code and its comments are written for those two.

## Scope check

Swept the processor for sibling `asElement` casts that could take a type variable. `MappingProcessor` and `MergeProcessor` already pattern-match their spec type arguments, and every other `(TypeElement)` cast is on a `DeclaredType`, where it is sound. This site was the only one.

The generic-*source* boundary the issue draws holds: `OpticsSpec<Box<T>>` still resolves to a declared type and generates parameterised optics, covered by the existing `SpecInterfaceCoverageTest.shouldHandleGenericSourceType`.

## Tests

- `SpecInterfaceProcessingTest`: bounded type variable, unbounded type variable, and array, each asserting the reported message.
- `SpecInterfaceAnalyserTest`: a type-variable case beside the existing array one.
- `hkj-book/src/optics/compiler_errors.md`: an entry for the new diagnostic in the `@ImportOptics` section.

`:hkj-processor:clean check` and a full `gradle build` are both BUILD SUCCESSFUL, including `jacocoTestCoverageVerification` and `spotlessCheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es3dKLikaETJPF9fX3PxNo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compiler diagnostics for unsupported optics specifications, including generic, array, type-variable, and invalid source types.
  - Added clearer guidance for resolving unsupported source-type declarations.
  - Improved type-name formatting in compiler messages for better readability.

- **Documentation**
  - Clarified supported source types and generic type requirements.
  - Documented compiler errors and recommended solutions for unsupported specifications.

- **Tests**
  - Added coverage for invalid generic bounds, nested and circular bounds, type variables, and array source types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->