### PR TITLE
@ViaCopyAndSet: read the copy constructor under the source type's instantiation (#732)

### DIFF
--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -87,11 +87,17 @@ A source type that is itself generic is supported, and the spec names its own ty
 
 **Fix.** Name a public supertype, generate into that package with `@ImportOptics(targetPackage = ...)`, or drop the attribute.
 
-### "@ViaCopyAndSet: copyConstructor names '...', which no constructor of '...' accepts"
+### "@ViaCopyAndSet: copyConstructor names '...', which '...' reaches as '...', and no constructor accepts"
 
-**Cause.** The name is a genuine supertype, but no single-argument constructor of `S` takes it — `java.lang.Object` and marker interfaces such as `Serializable` reach this often. The message lists the single-argument constructors that do exist.
+**Cause.** The name is a genuine supertype, but no single-argument constructor of `S` takes the type `S` actually reaches it as — `java.lang.Object` and marker interfaces such as `Serializable` reach this often. The message names both the type you gave and the one `S` reaches, which differ when `S`'s own `extends` clause pins the arguments: `class PNode<X> extends PBase<String>` reaches `PBase` as `PBase<String>`, whatever `X` is.
 
-**Fix.** Name one of the types those constructors take, or drop the attribute. The attribute is only needed when the copy constructor is overloaded — see [Copy Strategies](copy_strategies.md#viacopyandset-legacy-types-with-a-copy-constructor-and-setters).
+**Fix.** Name a supertype of `S` that one of the listed constructors takes, as the class alone without type arguments, or drop the attribute. The list carries type arguments and the attribute does not, so read it to recognise your supertype in it rather than to copy from it — and a listed type that is not a supertype of `S` cannot be named at all. The attribute is only needed when the copy constructor is overloaded — see [Copy Strategies](copy_strategies.md#viacopyandset-legacy-types-with-a-copy-constructor-and-setters).
+
+### "@ViaCopyAndSet: '...' is written with a wildcard type argument"
+
+**Cause.** The source type carries a wildcard, `OpticsSpec<Node<?>>`, and the strategy rebuilds it through a constructor. `new Node<?>(...)` is not something that can be written, whatever the arguments. `@ViaConstructor` reports the same thing for the same reason. An inner class draws the sibling message, because its constructor call needs an enclosing instance the generated class has no way to reach.
+
+**Fix.** Name the type the wildcard stands for, or switch to `@Wither`, which rebuilds through a method and names no constructor — a wildcard source type is no obstacle there.
 
 ### "@MatchWhen: predicate / getter method not found on source"
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
@@ -494,9 +495,17 @@ public class SpecInterfaceAnalyser {
               CopyStrategyKind.WITHER, CopyStrategyInfo.forWither(getter, witherMethod)));
     }
 
+    // analyse() admits a source type only when asElement gives a TypeElement, which on javac
+    // leaves DECLARED, ERROR and INTERSECTION - every one of them a DeclaredType. That is what
+    // makes the cast total; 'is a declared type' on its own would not, as #728 found.
+    DeclaredType declaredSource = (DeclaredType) sourceType;
+
     // Check for @ViaConstructor
     AnnotationMirror viaConstructor = findAnnotation(method, VIA_CONSTRUCTOR_FQN);
     if (viaConstructor != null) {
+      if (rebuildsThroughUnwritableConstructor(method, declaredSource, "@ViaConstructor")) {
+        return Optional.empty();
+      }
       String[] parameterOrder = getAnnotationStringArray(viaConstructor, "parameterOrder");
       return Optional.of(
           new CopyStrategyResult(
@@ -506,6 +515,9 @@ public class SpecInterfaceAnalyser {
     // Check for @ViaCopyAndSet
     AnnotationMirror viaCopyAndSet = findAnnotation(method, VIA_COPY_AND_SET_FQN);
     if (viaCopyAndSet != null) {
+      if (rebuildsThroughUnwritableConstructor(method, declaredSource, "@ViaCopyAndSet")) {
+        return Optional.empty();
+      }
       String copyConstructor = getAnnotationString(viaCopyAndSet, "copyConstructor", "");
       String setter = getAnnotationString(viaCopyAndSet, "setter", "");
       if (copyConstructor.isEmpty()) {
@@ -514,7 +526,7 @@ public class SpecInterfaceAnalyser {
                 CopyStrategyKind.VIA_COPY_AND_SET, CopyStrategyInfo.forCopyAndSet(null, setter)));
       }
       return resolveCopyConstructorParameterType(
-              method, sourceType, sourceTypeElement, targetPackage, copyConstructor)
+              method, declaredSource, targetPackage, copyConstructor)
           .map(
               parameterType ->
                   new CopyStrategyResult(
@@ -541,6 +553,62 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
+   * Reports a source type whose own constructor call cannot be written, and returns whether it did.
+   *
+   * <p>A strategy that rebuilds through a constructor emits {@code new S(...)}, and a wildcard
+   * cannot be written as a type argument there: {@code new Node<?>(...)} is not Java, whatever the
+   * arguments. The strategies that rebuild through a wither or a builder name no constructor and
+   * are unaffected, so this is asked per strategy rather than of the source type as a whole.
+   *
+   * <p>Only the outermost arguments matter. A wildcard nested inside one, {@code Node<List<?>>},
+   * writes perfectly well.
+   *
+   * @param method the annotated optic method, for error reporting
+   * @param declared the source type {@code S}
+   * @param annotation the strategy annotation tag, for the diagnostic
+   * @return true when the source type was rejected and an error reported
+   */
+  private boolean rebuildsThroughUnwritableConstructor(
+      ExecutableElement method, DeclaredType declared, String annotation) {
+
+    boolean wildcard =
+        declared.getTypeArguments().stream()
+            .anyMatch(argument -> argument.getKind() == TypeKind.WILDCARD);
+    // A DeclaredType's element is always a TypeElement. Only a member type that is not static
+    // carries an enclosing instance; a nested interface, enum or record is implicitly static.
+    TypeElement element = (TypeElement) declared.asElement();
+    boolean innerClass =
+        element.getNestingKind() == NestingKind.MEMBER
+            && !element.getModifiers().contains(Modifier.STATIC);
+    if (!wildcard && !innerClass) {
+      return false;
+    }
+    String name = ProcessorUtils.simpleTypeName(declared);
+    Diagnostics.error(
+        messager,
+        method,
+        annotation,
+        "'"
+            + name
+            + "' is "
+            + (wildcard ? "written with a wildcard type argument" : "an inner class")
+            + ", and this strategy rebuilds it through a constructor.",
+        "The generated set function calls 'new "
+            + name
+            + "(...)', which is not something that can be written for "
+            + (wildcard
+                ? "a wildcard: a constructor call has to name the type argument."
+                : "an inner class: the call needs an enclosing instance the generated class has"
+                    + " no way to reach."),
+        wildcard
+            ? "Name the type the wildcard stands for, or use @Wither, which rebuilds through a"
+                + " method and needs no constructor."
+            : "Declare the source type static, or use @Wither, which rebuilds through a method and"
+                + " needs no constructor.");
+    return true;
+  }
+
+  /**
    * Resolves the type named by {@code @ViaCopyAndSet(copyConstructor = ...)} to the supertype of
    * {@code S} that the generated cast will name.
    *
@@ -559,15 +627,13 @@ public class SpecInterfaceAnalyser {
    *
    * @param method the annotated optic method, for error reporting
    * @param sourceType the source type {@code S}
-   * @param sourceTypeElement the resolved element for {@code S}
    * @param targetPackage the package the optics class is generated into
    * @param copyConstructor the fully qualified name from the annotation; never empty
    * @return the resolved supertype, or empty if it was rejected (an error has been reported)
    */
   private Optional<TypeMirror> resolveCopyConstructorParameterType(
       ExecutableElement method,
-      TypeMirror sourceType,
-      TypeElement sourceTypeElement,
+      DeclaredType sourceType,
       String targetPackage,
       String copyConstructor) {
 
@@ -613,26 +679,31 @@ public class SpecInterfaceAnalyser {
       return Optional.empty();
     }
 
-    if (!hasConstructorAccepting(sourceTypeElement, sourceType, supertype.get(), targetPackage)) {
+    // The cast that will be emitted, not the name the attribute gave: where S pins the supertype's
+    // arguments the two differ, and only the emitted one explains the rejection.
+    if (!hasConstructorAccepting(sourceType, supertype.get(), targetPackage)) {
       Diagnostics.error(
           messager,
           method,
           "@ViaCopyAndSet",
           "copyConstructor names '"
               + parameterElement.getQualifiedName()
-              + "', which no constructor of '"
-              + sourceType
-              + "' accepts.",
+              + "', which '"
+              + ProcessorUtils.simpleTypeName(sourceType)
+              + "' reaches as '"
+              + ProcessorUtils.simpleTypeName(supertype.get())
+              + "', and no constructor accepts.",
           "The generated set function calls 'new "
-              + sourceTypeElement.getSimpleName()
+              + ProcessorUtils.simpleTypeName(sourceType)
               + "(("
-              + parameterElement.getSimpleName()
+              + ProcessorUtils.simpleTypeName(supertype.get())
               + ") source)'. Found "
-              + describeSingleArgumentConstructors(sourceTypeElement, sourceType, targetPackage)
+              + describeSingleArgumentConstructors(sourceType, targetPackage)
               + ".",
-          "Name a type one of those constructors takes, or drop the attribute to pass '"
-              + sourceType
-              + "' unchanged.");
+          "Name a supertype of '"
+              + ProcessorUtils.simpleTypeName(sourceType)
+              + "' that one of those constructors takes, as the class alone without type"
+              + " arguments, or drop the attribute to pass the source unchanged.");
       return Optional.empty();
     }
 
@@ -721,27 +792,24 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
-   * Returns whether {@code sourceTypeElement} declares a constructor the generated class can call a
-   * single {@code argument} through.
+   * Returns whether {@code sourceType} declares a constructor the generated class can call a single
+   * {@code argument} through.
    *
-   * @param sourceTypeElement the source type {@code S}
+   * @param sourceType the instantiated source type {@code S}, which the constructors are read under
    * @param argument the type the generated cast produces
    * @param targetPackage the package the optics class is generated into
    * @return true if some constructor it can reach accepts it
    */
   private boolean hasConstructorAccepting(
-      TypeElement sourceTypeElement,
-      TypeMirror sourceType,
-      TypeMirror argument,
-      String targetPackage) {
+      DeclaredType sourceType, TypeMirror argument, String targetPackage) {
     for (ExecutableElement constructor :
-        ElementFilter.constructorsIn(sourceTypeElement.getEnclosedElements())) {
+        ElementFilter.constructorsIn(sourceType.asElement().getEnclosedElements())) {
       List<? extends VariableElement> parameters = constructor.getParameters();
       // A constructor the generated class cannot call is no use, however well it fits.
       if (parameters.size() != 1 || !isAccessibleFrom(constructor, targetPackage)) {
         continue;
       }
-      TypeMirror parameterType = parameterTypeAsSeenBy(sourceType, constructor);
+      TypeMirror parameterType = constructorParameterType(sourceType, constructor);
       if (typeUtils.isAssignable(argument, parameterType)) {
         return true;
       }
@@ -755,23 +823,28 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
-   * The constructor's single parameter as the instantiated source type sees it.
+   * The constructor's one parameter as seen under the source type's instantiation.
    *
    * <p>Read off the constructor directly, the parameter speaks the source type's own declaration:
-   * {@code Holder<X>} declaring {@code Holder(Base<X> other)} gives {@code Base<X>}. The argument
-   * it is compared against comes from a supertype walk over the instantiated type, so it speaks the
-   * spec's variables, {@code Base<U>}. The two can never match until one is rewritten in the
-   * other's terms.
+   * {@code Node<X>} declaring {@code Node(Base<X> other)} gives {@code Base<X>}. The argument it is
+   * compared against comes from a supertype walk over the instantiated type, so it speaks the
+   * spec's variables, {@code Base<U>}. Where the source type declares parameters of its own the two
+   * can never match until one is rewritten in the other's terms; where it declares none, the
+   * rewrite is a no-op and the declared parameter was already the answer.
    *
-   * @param sourceType the instantiated source type S
-   * @param constructor the constructor whose parameter to read
+   * <p>Only the class's own variables are substituted. A constructor that declares parameters of
+   * its own keeps them, and is left to be rejected.
+   *
+   * @param sourceType the instantiated source type {@code S}
+   * @param constructor a single-argument constructor, whose one parameter is read
    * @return the parameter type under {@code sourceType}'s instantiation
    */
-  private TypeMirror parameterTypeAsSeenBy(TypeMirror sourceType, ExecutableElement constructor) {
-    // analyse() rejects a source type that is not a declared type before any optic method is read,
-    // which is the invariant SpecAnalysis records.
-    ExecutableType asMember =
-        (ExecutableType) typeUtils.asMemberOf((DeclaredType) sourceType, constructor);
+  private TypeMirror constructorParameterType(
+      DeclaredType sourceType, ExecutableElement constructor) {
+    // Total: asMemberOf answers with an ExecutableType for an executable member, and the only
+    // shape that would not - an unresolvable source type, whose members resolve to itself - never
+    // reaches here, because such a type enumerates no constructors for the caller to loop over.
+    ExecutableType asMember = (ExecutableType) typeUtils.asMemberOf(sourceType, constructor);
     return asMember.getParameterTypes().getFirst();
   }
 
@@ -781,19 +854,23 @@ public class SpecInterfaceAnalyser {
    * <p>Only the reachable ones: naming a constructor the generated class cannot call would send the
    * reader after a type that fails the same way.
    *
-   * @param sourceTypeElement the source type {@code S}
+   * @param sourceType the instantiated source type {@code S}, so the list names the parameters as
+   *     it sees them
    * @param targetPackage the package the optics class is generated into
    * @return the parameter types it takes one at a time, or a phrase saying it takes none
    */
-  private String describeSingleArgumentConstructors(
-      TypeElement sourceTypeElement, TypeMirror sourceType, String targetPackage) {
-    // The same instantiation the check uses, so the list names the types the author would have to
-    // write rather than the ones the source type declared them under.
+  private String describeSingleArgumentConstructors(DeclaredType sourceType, String targetPackage) {
+    // The same instantiation the check uses, so a reader comparing the list against the name they
+    // gave is comparing like with like. The names carry type arguments and the attribute does not,
+    // so the list is there to be recognised rather than copied from.
     List<String> parameterTypes =
-        ElementFilter.constructorsIn(sourceTypeElement.getEnclosedElements()).stream()
+        ElementFilter.constructorsIn(sourceType.asElement().getEnclosedElements()).stream()
             .filter(constructor -> constructor.getParameters().size() == 1)
             .filter(constructor -> isAccessibleFrom(constructor, targetPackage))
-            .map(constructor -> parameterTypeAsSeenBy(sourceType, constructor).toString())
+            .map(
+                constructor ->
+                    ProcessorUtils.simpleTypeName(
+                        constructorParameterType(sourceType, constructor)))
             .toList();
     return parameterTypes.isEmpty()
         ? "no single-argument constructor it can call"

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -15,6 +15,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
@@ -612,7 +613,7 @@ public class SpecInterfaceAnalyser {
       return Optional.empty();
     }
 
-    if (!hasConstructorAccepting(sourceTypeElement, supertype.get(), targetPackage)) {
+    if (!hasConstructorAccepting(sourceTypeElement, sourceType, supertype.get(), targetPackage)) {
       Diagnostics.error(
           messager,
           method,
@@ -627,7 +628,7 @@ public class SpecInterfaceAnalyser {
               + "(("
               + parameterElement.getSimpleName()
               + ") source)'. Found "
-              + describeSingleArgumentConstructors(sourceTypeElement, targetPackage)
+              + describeSingleArgumentConstructors(sourceTypeElement, sourceType, targetPackage)
               + ".",
           "Name a type one of those constructors takes, or drop the attribute to pass '"
               + sourceType
@@ -729,7 +730,10 @@ public class SpecInterfaceAnalyser {
    * @return true if some constructor it can reach accepts it
    */
   private boolean hasConstructorAccepting(
-      TypeElement sourceTypeElement, TypeMirror argument, String targetPackage) {
+      TypeElement sourceTypeElement,
+      TypeMirror sourceType,
+      TypeMirror argument,
+      String targetPackage) {
     for (ExecutableElement constructor :
         ElementFilter.constructorsIn(sourceTypeElement.getEnclosedElements())) {
       List<? extends VariableElement> parameters = constructor.getParameters();
@@ -737,7 +741,7 @@ public class SpecInterfaceAnalyser {
       if (parameters.size() != 1 || !isAccessibleFrom(constructor, targetPackage)) {
         continue;
       }
-      TypeMirror parameterType = parameters.getFirst().asType();
+      TypeMirror parameterType = parameterTypeAsSeenBy(sourceType, constructor);
       if (typeUtils.isAssignable(argument, parameterType)) {
         return true;
       }
@@ -751,6 +755,27 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
+   * The constructor's single parameter as the instantiated source type sees it.
+   *
+   * <p>Read off the constructor directly, the parameter speaks the source type's own declaration:
+   * {@code Holder<X>} declaring {@code Holder(Base<X> other)} gives {@code Base<X>}. The argument
+   * it is compared against comes from a supertype walk over the instantiated type, so it speaks the
+   * spec's variables, {@code Base<U>}. The two can never match until one is rewritten in the
+   * other's terms.
+   *
+   * @param sourceType the instantiated source type S
+   * @param constructor the constructor whose parameter to read
+   * @return the parameter type under {@code sourceType}'s instantiation
+   */
+  private TypeMirror parameterTypeAsSeenBy(TypeMirror sourceType, ExecutableElement constructor) {
+    // analyse() rejects a source type that is not a declared type before any optic method is read,
+    // which is the invariant SpecAnalysis records.
+    ExecutableType asMember =
+        (ExecutableType) typeUtils.asMemberOf((DeclaredType) sourceType, constructor);
+    return asMember.getParameterTypes().getFirst();
+  }
+
+  /**
    * Names the single-argument constructors the generated class can call, for the rejection message.
    *
    * <p>Only the reachable ones: naming a constructor the generated class cannot call would send the
@@ -761,12 +786,14 @@ public class SpecInterfaceAnalyser {
    * @return the parameter types it takes one at a time, or a phrase saying it takes none
    */
   private String describeSingleArgumentConstructors(
-      TypeElement sourceTypeElement, String targetPackage) {
+      TypeElement sourceTypeElement, TypeMirror sourceType, String targetPackage) {
+    // The same instantiation the check uses, so the list names the types the author would have to
+    // write rather than the ones the source type declared them under.
     List<String> parameterTypes =
         ElementFilter.constructorsIn(sourceTypeElement.getEnclosedElements()).stream()
             .filter(constructor -> constructor.getParameters().size() == 1)
             .filter(constructor -> isAccessibleFrom(constructor, targetPackage))
-            .map(constructor -> constructor.getParameters().getFirst().asType().toString())
+            .map(constructor -> parameterTypeAsSeenBy(sourceType, constructor).toString())
             .toList();
     return parameterTypes.isEmpty()
         ? "no single-argument constructor it can call"

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
@@ -624,8 +624,9 @@ class SpecInterfaceProcessingTest {
               import org.higherkindedj.optics.annotations.OpticsSpec;
               import org.higherkindedj.optics.annotations.ViaCopyAndSet;
 
-              // The spec reuses the source type's own parameter name, so that what is asserted
-              // here is the constructor match alone.
+              // <X> repeats the source type's own parameter name on purpose. Node's X and the
+              // spec's X are distinct variables despite the shared spelling, which is the shape
+              // the bug had, so renaming this to <U> would prove less than it looks like it does.
               @ImportOptics
               public interface NodeOpticsSpec<X> extends OpticsSpec<Node<X>> {
 
@@ -638,15 +639,15 @@ class SpecInterfaceProcessingTest {
           javac().withProcessors(new ImportOpticsProcessor()).compile(base, node, specInterface);
 
       // Node declares Node(Base<X> other) against its own X; the supertype walk hands over the
-      // spec's X. Same name, different variable, so reading the parameter as declared never
-      // matched.
+      // spec's X. Same name, different variable, so the parameter has to be read under Node<X>'s
+      // instantiation rather than as declared.
       assertCompilationSucceeded(compilation);
       assertGeneratedCodeContains(
           compilation, "com.myapp.NodeOptics", "new Node<X>((Base<X>) source)");
     }
 
     @Test
-    @DisplayName("should name the instantiated parameter types when no constructor matches")
+    @DisplayName("should name the parameter types with the source type's own arguments")
     void shouldNameInstantiatedParameterTypesWhenNoConstructorMatches() {
       final var base =
           JavaFileObjects.forSourceString(
@@ -710,7 +711,385 @@ class SpecInterfaceProcessingTest {
       // Under Node<U> the parameter is Other<U>; naming it Other<X> would send the author looking
       // for a variable their own declaration does not have.
       assertThat(compilation).hadErrorContaining("single-argument constructors taking");
-      assertThat(compilation).hadErrorContaining("com.external.Other<U>");
+      assertThat(compilation).hadErrorContaining("Other<U>");
+    }
+
+    @Test
+    @DisplayName("should substitute the spec's parameter name into the emitted cast")
+    void shouldSubstituteSpecParameterNameIntoTheCast() {
+      final var base =
+          JavaFileObjects.forSourceString(
+              "com.external.Base",
+              """
+              package com.external;
+
+              public class Base<X> {
+                  protected String name;
+              }
+              """);
+
+      final var node =
+          JavaFileObjects.forSourceString(
+              "com.external.Node",
+              """
+              package com.external;
+
+              public class Node<X> extends Base<X> {
+                  public Node(Base<X> other) { this.name = other.name; }
+                  public String name() { return name; }
+                  public void setName(String name) { this.name = name; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.NodeOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Node;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+              @ImportOptics
+              public interface NodeOpticsSpec<U> extends OpticsSpec<Node<U>> {
+
+                  @ViaCopyAndSet(copyConstructor = "com.external.Base", setter = "setName")
+                  Lens<Node<U>, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(base, node, specInterface);
+
+      // The cast names the spec's U, not Node's own X, which is what pins the direction of the
+      // substitution rather than merely that one happened.
+      assertCompilationSucceeded(compilation);
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.NodeOptics", "new Node<U>((Base<U>) source)");
+    }
+
+    @Test
+    @DisplayName("should match a varargs copy constructor through the source type's instantiation")
+    void shouldMatchVarargsCopyConstructorOnGenericSpec() {
+      final var base =
+          JavaFileObjects.forSourceString(
+              "com.external.Base",
+              """
+              package com.external;
+
+              public class Base<X> {
+                  protected String name;
+              }
+              """);
+
+      final var node =
+          JavaFileObjects.forSourceString(
+              "com.external.Node",
+              """
+              package com.external;
+
+              public class Node<X> extends Base<X> {
+                  @SafeVarargs
+                  public Node(Base<X>... others) { this.name = others[0].name; }
+                  public String name() { return name; }
+                  public void setName(String name) { this.name = name; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.NodeOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Node;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+              @ImportOptics
+              public interface NodeOpticsSpec<U> extends OpticsSpec<Node<U>> {
+
+                  @ViaCopyAndSet(copyConstructor = "com.external.Base", setter = "setName")
+                  Lens<Node<U>, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(base, node, specInterface);
+
+      // Substituting into an array type gives an array type, so the component is still there to
+      // read for the varargs arm.
+      assertCompilationSucceeded(compilation);
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.NodeOptics", "new Node<U>((Base<U>) source)");
+    }
+
+    @Test
+    @DisplayName("should reject a source type whose constructor call cannot be written")
+    void shouldRejectSourceTypeWhoseConstructorCallCannotBeWritten() {
+      final var base =
+          JavaFileObjects.forSourceString(
+              "com.external.Base",
+              """
+              package com.external;
+
+              public class Base<X> {
+                  protected String name;
+              }
+              """);
+
+      final var node =
+          JavaFileObjects.forSourceString(
+              "com.external.Node",
+              """
+              package com.external;
+
+              public class Node<X> extends Base<X> {
+                  public Node() {}
+                  public Node(Base<X> other) { this.name = other.name; }
+                  public String name() { return name; }
+                  public void setName(String name) { this.name = name; }
+                  public Node<X> withName(String name) {
+                      Node<X> n = new Node<>();
+                      n.name = name;
+                      return n;
+                  }
+              }
+              """);
+
+      record Case(String name, String annotation) {}
+      var cases =
+          List.of(
+              new Case(
+                  "CopyAndSetSpec",
+                  "@ViaCopyAndSet(setter = \"setName\","
+                      + " copyConstructor = \"com.external.Base\")"),
+              new Case("PlainCopyAndSetSpec", "@ViaCopyAndSet(setter = \"setName\")"));
+
+      for (Case testCase : cases) {
+        final var specInterface =
+            JavaFileObjects.forSourceString(
+                "com.myapp." + testCase.name(),
+                """
+                package com.myapp;
+
+                import com.external.Node;
+                import org.higherkindedj.optics.Lens;
+                import org.higherkindedj.optics.annotations.ImportOptics;
+                import org.higherkindedj.optics.annotations.OpticsSpec;
+                import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+                @ImportOptics
+                public interface %s extends OpticsSpec<Node<?>> {
+                    %s
+                    Lens<Node<?>, String> name();
+                }
+                """
+                    .formatted(testCase.name(), testCase.annotation()));
+
+        Compilation compilation =
+            javac().withProcessors(new ImportOpticsProcessor()).compile(base, node, specInterface);
+
+        // Reported at the spec, not left to javac inside a file the author never wrote.
+        assertThat(compilation).failed();
+        assertThat(compilation).hadErrorContaining("is written with a wildcard type argument");
+        assertThat(compilation).hadErrorContaining("Name the type the wildcard stands for");
+      }
+    }
+
+    @Test
+    @DisplayName("should reject a wildcard source type for @ViaConstructor too")
+    void shouldRejectWildcardSourceTypeForViaConstructor() {
+      final var bag =
+          JavaFileObjects.forSourceString(
+              "com.external.Bag",
+              """
+              package com.external;
+
+              public record Bag<T>(String name, T value) {}
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.BagOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Bag;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaConstructor;
+
+              @ImportOptics
+              public interface BagOpticsSpec extends OpticsSpec<Bag<?>> {
+                  @ViaConstructor(parameterOrder = {"name", "value"})
+                  Lens<Bag<?>, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(bag, specInterface);
+
+      // @ViaConstructor rebuilds the same way, so it is asked the same question.
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("@ViaConstructor");
+      assertThat(compilation).hadErrorContaining("is written with a wildcard type argument");
+    }
+
+    @Test
+    @DisplayName("should accept a static nested source type, which needs no enclosing instance")
+    void shouldAcceptStaticNestedSourceType() {
+      final var outer =
+          JavaFileObjects.forSourceString(
+              "com.external.Outer",
+              """
+              package com.external;
+
+              public class Outer {
+                  public static class Nested {
+                      private String name;
+                      public Nested() {}
+                      public Nested(Nested other) { this.name = other.name; }
+                      public String name() { return name; }
+                      public void setName(String name) { this.name = name; }
+                  }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.NestedOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Outer;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+              @ImportOptics
+              public interface NestedOpticsSpec extends OpticsSpec<Outer.Nested> {
+                  @ViaCopyAndSet(setter = "setName")
+                  Lens<Outer.Nested, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(outer, specInterface);
+
+      // Static, so 'new Outer.Nested(...)' writes perfectly well and the guard stands aside.
+      assertCompilationSucceeded(compilation);
+    }
+
+    @Test
+    @DisplayName("should reject an inner class source type, whose call needs an enclosing instance")
+    void shouldRejectInnerClassSourceType() {
+      final var outer =
+          JavaFileObjects.forSourceString(
+              "com.external.Outer",
+              """
+              package com.external;
+
+              public class Outer {
+                  public class Inner {
+                      protected String name;
+                      public Inner() {}
+                      public String name() { return name; }
+                      public void setName(String name) { this.name = name; }
+                  }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.InnerOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Outer;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+              @ImportOptics
+              public interface InnerOpticsSpec extends OpticsSpec<Outer.Inner> {
+                  @ViaCopyAndSet(setter = "setName")
+                  Lens<Outer.Inner, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(outer, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("is an inner class");
+      assertThat(compilation).hadErrorContaining("Declare the source type static");
+    }
+
+    @Test
+    @DisplayName("should leave a wildcard source type to @Wither, which names no constructor")
+    void shouldAllowWildcardSourceTypeWithWither() {
+      final var base =
+          JavaFileObjects.forSourceString(
+              "com.external.Base",
+              """
+              package com.external;
+
+              public class Base<X> {
+                  protected String name;
+              }
+              """);
+
+      final var node =
+          JavaFileObjects.forSourceString(
+              "com.external.Node",
+              """
+              package com.external;
+
+              public class Node<X> extends Base<X> {
+                  public Node() {}
+                  public String name() { return name; }
+                  public Node<X> withName(String name) {
+                      Node<X> n = new Node<>();
+                      n.name = name;
+                      return n;
+                  }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.WitherOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Node;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.Wither;
+
+              @ImportOptics
+              public interface WitherOpticsSpec extends OpticsSpec<Node<?>> {
+                  @Wither("withName")
+                  Lens<Node<?>, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(base, node, specInterface);
+
+      // The guard is asked per strategy: a wither rebuilds through a method, so the wildcard the
+      // constructor arms cannot write is no obstacle here.
+      assertCompilationSucceeded(compilation);
     }
 
     @Test
@@ -764,7 +1143,7 @@ class SpecInterfaceProcessingTest {
               .compile(OVERLOADED_BASE, OVERLOADED_NODE, overloadedSpec("java.io.Serializable"));
 
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("which no constructor of");
+      assertThat(compilation).hadErrorContaining("and no constructor accepts");
       assertThat(compilation).hadErrorContaining("single-argument constructors taking");
       assertThat(compilation).hadErrorCount(1);
     }
@@ -935,8 +1314,8 @@ class SpecInterfaceProcessingTest {
       // Shut(ShutBase) fits but is private; Shut(Object) is package-private and com.myapp is not
       // that package. Only the public Shut(Shut) is reachable, and it does not take a ShutBase.
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("which no constructor of");
-      assertThat(compilation).hadErrorContaining("taking [com.external.Shut]");
+      assertThat(compilation).hadErrorContaining("and no constructor accepts");
+      assertThat(compilation).hadErrorContaining("taking [Shut]");
       assertThat(compilation).hadErrorCount(1);
     }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
@@ -586,6 +586,134 @@ class SpecInterfaceProcessingTest {
     }
 
     @Test
+    @DisplayName("should match a copy constructor through the spec's own type parameter")
+    void shouldMatchCopyConstructorOnGenericSpec() {
+      final var base =
+          JavaFileObjects.forSourceString(
+              "com.external.Base",
+              """
+              package com.external;
+
+              public class Base<X> {
+                  protected String name;
+              }
+              """);
+
+      final var node =
+          JavaFileObjects.forSourceString(
+              "com.external.Node",
+              """
+              package com.external;
+
+              public class Node<X> extends Base<X> {
+                  public Node(Base<X> other) { this.name = other.name; }
+                  public String name() { return name; }
+                  public void setName(String name) { this.name = name; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.NodeOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Node;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+              // The spec reuses the source type's own parameter name, so that what is asserted
+              // here is the constructor match alone.
+              @ImportOptics
+              public interface NodeOpticsSpec<X> extends OpticsSpec<Node<X>> {
+
+                  @ViaCopyAndSet(copyConstructor = "com.external.Base", setter = "setName")
+                  Lens<Node<X>, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(base, node, specInterface);
+
+      // Node declares Node(Base<X> other) against its own X; the supertype walk hands over the
+      // spec's X. Same name, different variable, so reading the parameter as declared never
+      // matched.
+      assertCompilationSucceeded(compilation);
+      assertGeneratedCodeContains(
+          compilation, "com.myapp.NodeOptics", "new Node<X>((Base<X>) source)");
+    }
+
+    @Test
+    @DisplayName("should name the instantiated parameter types when no constructor matches")
+    void shouldNameInstantiatedParameterTypesWhenNoConstructorMatches() {
+      final var base =
+          JavaFileObjects.forSourceString(
+              "com.external.Base",
+              """
+              package com.external;
+
+              public class Base<X> {
+                  protected String name;
+              }
+              """);
+
+      final var other =
+          JavaFileObjects.forSourceString(
+              "com.external.Other",
+              """
+              package com.external;
+
+              public class Other<X> extends Base<X> {}
+              """);
+
+      final var node =
+          JavaFileObjects.forSourceString(
+              "com.external.Node",
+              """
+              package com.external;
+
+              public class Node<X> extends Base<X> {
+                  public Node(Other<X> other) {}
+                  public String name() { return name; }
+                  public void setName(String name) { this.name = name; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.NodeOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Node;
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+
+              @ImportOptics
+              public interface NodeOpticsSpec<U> extends OpticsSpec<Node<U>> {
+
+                  @ViaCopyAndSet(copyConstructor = "com.external.Base", setter = "setName")
+                  Lens<Node<U>, String> name();
+              }
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(base, other, node, specInterface);
+
+      assertThat(compilation).failed();
+      // Under Node<U> the parameter is Other<U>; naming it Other<X> would send the author looking
+      // for a variable their own declaration does not have.
+      assertThat(compilation).hadErrorContaining("single-argument constructors taking");
+      assertThat(compilation).hadErrorContaining("com.external.Other<U>");
+    }
+
+    @Test
     @DisplayName("should not cast when the copy constructor names the source type itself")
     void shouldOmitCastWhenCopyConstructorNamesSourceType() {
       Compilation compilation =


### PR DESCRIPTION
Fixes #732. Rebased on `main` after #734 (#730) merged.

`@ViaCopyAndSet(copyConstructor = ...)` was unusable on any spec interface with a generic source type. The check derived its argument from the **instantiated** source type — a supertype walk that substitutes — and compared it against a constructor parameter read **as declared**:

```
argument       Base<U>   the spec's variable, from the walk over Node<U>
parameterType  Base<X>   Node's own variable, read off the constructor
```

They speak different declarations, so `isAssignable` was never true and every generic spec was rejected. Reading the parameter through `asMemberOf` rewrites it under the source type's own instantiation, which is the question actually being asked: the emitted call is `new Node<U>((Base<U>) source)`, so what matters is the parameter as `Node<U>` sees it.

**Same name is not the same variable** — a spec that reuses the source type's parameter name was rejected too, since those are distinct type-variable elements. That is what the first test uses, deliberately: holding the name fixed leaves the constructor match as the only thing under test.

`@Wither`, `@ViaConstructor` and `@ViaBuilder` carry names rather than types, so none was affected.

## Second commit: what the panel found

### The rejection message could not be followed

A reviewer followed the fix sentence step by step and got nowhere, twice. It said *"Name a type one of those constructors takes"* and listed `com.external.Other<U>`:

| attempt | result |
|---|---|
| paste `com.external.Other<U>` | rejected — the attribute takes no type arguments |
| strip to `com.external.Other` | rejected — `Node<U>` does not extend it |

`Other` is a **sibling** of the source type, so the attribute can never name it. The sentence now says what the attribute can actually accept — a supertype, named as the class alone — and the list is documented as something to recognise a name in rather than copy from.

### The message misreported the code it generates

It claimed `new Node((Base) source)` while the emitted code is `new Node<U>((Base<U>) source)` — contradicting #723's own release note, which says the cast is parameterised "rather than raw". Both the snippet and the list now go through `ProcessorUtils.simpleTypeName`, the helper written for exactly this. Two sibling `@ViaCopyAndSet` diagnostics rendered their snippets the same way and move with it.

Where `S`'s `extends` clause **pins** the supertype's arguments — `class PNode<X> extends PBase<String>` — naming the supertype was rejected with no way to see why, because the message showed only the name given and never the type `S` reaches it as. It now names both.

### A regression the fix would have shipped

Reading the constructor under the instantiation had been intercepting a wildcard source type **by accident**. With that gone, `OpticsSpec<Node<?>>` was accepted and javac failed inside the generated file with `unexpected type … found: ?` — an error with no position in anything the author wrote, which is precisely what these checks exist to prevent.

The underlying hole is older and wider than `copyConstructor`: both arms of `@ViaCopyAndSet` and `@ViaConstructor` fail the same way, with or without the attribute. So the guard replaces an accident with a diagnostic, and covers the arms that never had one.

It is asked **per strategy**, not of the source type as a whole — `@Wither` rebuilds through a method, needs no constructor, and a wildcard source type works fine there. A test pins that. The same guard rejects an inner-class source type, whose call needs an enclosing instance the generated class cannot reach; a *static* nested type is accepted, and that is pinned too.

### A cast justified by an invariant that does not exist

My comment said `analyse()` "rejects a source type that is not a declared type". It does not: its guard is `asElement(sourceType) instanceof TypeElement`, which admits `DECLARED`, `ERROR` **and** `INTERSECTION` — all three `DeclaredType` on javac. The cast is total, but for a different reason than the one I wrote, and "is a declared type" is exactly the mistake #728 was. The comment now states what the guard establishes, the narrowing happens once, and `hasConstructorAccepting` no longer carries the instantiated type and its element side by side — the shape this whole bug class comes from.

Two branches that no test could reach were removed rather than waived, per the rule the coverage list states.

## What this is one of

`@ViaCopyAndSet` had **no** generic-spec test before this PR, and neither did any other copy strategy except `@Wither` — which is structurally blind to this fault, because it reads no member of the source type. One `@ViaCopyAndSet` case on `OpticsSpec<Node<X>>` would have caught #732 the day #727 landed.

The panel's sweep found three more instances of the same declaration-vs-instantiation confusion, each verified by compiling it. They are filed separately rather than folded in here, along with the missing test axis.

## Verification

Both original tests confirmed as real regression guards — stash the fix, both fail; restore, both pass. `SpecInterfaceAnalyser` stays at 100% line, branch and instruction. `clean build` across all modules: BUILD SUCCESSFUL, EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es3dKLikaETJPF9fX3PxNo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified compiler errors for generic supertypes, constructor compatibility, wildcard source types, and available alternatives.

- **Bug Fixes**
  - Improved handling of generic type substitutions when validating copy constructors.
  - Added clearer diagnostics for incompatible, inaccessible, wildcard, and non-static inner-class source types.
  - Preserved support for compatible varargs constructors and static nested types.

- **Tests**
  - Expanded coverage for generic parameters, wildcard handling, constructor matching, nested classes, and diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->