### PR TITLE
@ImportOptics: one test per strategy and hint on a generic spec (#736)

### DIFF
--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -923,8 +923,10 @@ public class SpecInterfaceAnalyser {
         reportMissingPrismHint(method);
         return Optional.empty();
       }
-      // Validate subtype relationship (Decision 6)
-      if (!typeUtils.isSubtype(targetType, sourceType)) {
+      // Erasures, because that is what the generated 'source instanceof Target' tests. The
+      // annotation carries a class constant, which is always raw, so comparing it against an
+      // instantiated source would reject every generic hierarchy.
+      if (!typeUtils.isSubtype(typeUtils.erasure(targetType), typeUtils.erasure(sourceType))) {
         error(
             "@InstanceOf target '"
                 + targetType

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericSpecInterfaceAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericSpecInterfaceAxisTest.java
@@ -1,0 +1,306 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One case per copy strategy and per optic hint, each against a spec interface that declares its
+ * own type parameter.
+ *
+ * <p>A generic spec is where a processor that reads the source type's <em>declaration</em> and one
+ * that reads its <em>instantiation</em> disagree, and every optic method here is written so that
+ * the spec's parameter is named under a different letter from the source type's. Where the two
+ * agree by coincidence the fault is invisible, so this file holds them apart on purpose.
+ *
+ * <p>{@code @Wither} and {@code @ViaBuilder} rebuild through a method and read no member of the
+ * source type, so they are structurally blind to that class of fault. They are here to keep the
+ * axis complete rather than because they are at risk.
+ */
+@DisplayName("Every strategy and hint on a generic spec interface")
+class GenericSpecInterfaceAxisTest {
+
+  /** A generic class carrying one of every shape a strategy reaches for. */
+  private static final JavaFileObject BOX =
+      JavaFileObjects.forSourceString(
+          "com.external.Box",
+          """
+          package com.external;
+
+          import java.util.List;
+
+          public class Box<X> extends Base<X> {
+              private X content;
+              private List<X> items;
+              public Box() {}
+              public Box(X content, String label) { this.content = content; this.label = label; }
+              public Box(Base<X> other) { this.label = other.label; }
+              public X content() { return content; }
+              public String label() { return label; }
+              public List<X> items() { return items; }
+              public void setLabel(String label) { this.label = label; }
+              public Box<X> withLabel(String label) {
+                  Box<X> copy = new Box<>();
+                  copy.content = content;
+                  copy.label = label;
+                  copy.items = items;
+                  return copy;
+              }
+              public Box<X> withItems(List<X> items) {
+                  Box<X> copy = new Box<>();
+                  copy.content = content;
+                  copy.label = label;
+                  copy.items = items;
+                  return copy;
+              }
+              public Builder<X> toBuilder() { return new Builder<>(); }
+              public static final class Builder<X> {
+                  private String label;
+                  public Builder<X> label(String label) { this.label = label; return this; }
+                  public Box<X> build() { return new Box<>(); }
+              }
+          }
+          """);
+
+  private static final JavaFileObject BASE =
+      JavaFileObjects.forSourceString(
+          "com.external.Base",
+          """
+          package com.external;
+
+          public class Base<X> {
+              protected String label;
+          }
+          """);
+
+  private static final JavaFileObject SHAPE =
+      JavaFileObjects.forSourceString(
+          "com.external.Shape",
+          """
+          package com.external;
+
+          public sealed interface Shape<X> permits Circle {}
+          """);
+
+  private static final JavaFileObject CIRCLE =
+      JavaFileObjects.forSourceString(
+          "com.external.Circle",
+          """
+          package com.external;
+
+          public record Circle<X>(X tag) implements Shape<X> {}
+          """);
+
+  private static final JavaFileObject NODE =
+      JavaFileObjects.forSourceString(
+          "com.external.Node",
+          """
+          package com.external;
+
+          public class Node<X> {
+              public boolean isLeaf() { return true; }
+              public Leaf<X> asLeaf() { return null; }
+          }
+          """);
+
+  private static final JavaFileObject LEAF =
+      JavaFileObjects.forSourceString(
+          "com.external.Leaf",
+          """
+          package com.external;
+
+          public class Leaf<X> extends Node<X> {}
+          """);
+
+  private static final JavaFileObject BOX_TRAVERSALS =
+      JavaFileObjects.forSourceString(
+          "org.higherkindedj.optics.BoxTraversals",
+          """
+          package org.higherkindedj.optics;
+
+          import com.external.Box;
+
+          public final class BoxTraversals {
+              private BoxTraversals() {}
+              public static <U> Traversal<Box<U>, U> items() { return null; }
+          }
+          """);
+
+  /**
+   * Compiles a spec interface body. The spec's parameter is always {@code U} while every source
+   * type declares {@code X}, so a processor reading the wrong one cannot pass by coincidence.
+   */
+  private Compilation compile(String specBody) {
+    var specInterface =
+        JavaFileObjects.forSourceString(
+            "com.myapp.SubjectOpticsSpec",
+            """
+            package com.myapp;
+
+            import com.external.Base;
+            import com.external.Box;
+            import com.external.Circle;
+            import com.external.Leaf;
+            import com.external.Node;
+            import com.external.Shape;
+            import java.util.List;
+            import org.higherkindedj.optics.Lens;
+            import org.higherkindedj.optics.Prism;
+            import org.higherkindedj.optics.Traversal;
+            import org.higherkindedj.optics.annotations.ImportOptics;
+            import org.higherkindedj.optics.annotations.InstanceOf;
+            import org.higherkindedj.optics.annotations.MatchWhen;
+            import org.higherkindedj.optics.annotations.OpticsSpec;
+            import org.higherkindedj.optics.annotations.ThroughField;
+            import org.higherkindedj.optics.annotations.TraverseWith;
+            import org.higherkindedj.optics.annotations.ViaBuilder;
+            import org.higherkindedj.optics.annotations.ViaConstructor;
+            import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+            import org.higherkindedj.optics.annotations.Wither;
+
+            @ImportOptics
+            %s
+            """
+                .formatted(specBody));
+
+    // Every fixture, every time: the spec template imports them all, so a subset would fail on
+    // the import rather than on anything the test is about.
+    return javac()
+        .withProcessors(new ImportOpticsProcessor())
+        .compile(BASE, BOX, SHAPE, CIRCLE, NODE, LEAF, BOX_TRAVERSALS, specInterface);
+  }
+
+  private void assertGeneratedSignature(Compilation compilation, String signature) {
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(compilation, "com.myapp.SubjectOptics", signature);
+  }
+
+  @Test
+  @DisplayName("@Wither rebuilds through a method, so it reads no member of the source type")
+  void witherOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @Wither("withLabel")
+                Lens<Box<U>, String> label();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Lens<Box<U>, String> label()");
+  }
+
+  @Test
+  @DisplayName("@ViaBuilder rebuilds through the builder the source type hands back")
+  void viaBuilderOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @ViaBuilder(getter = "label", setter = "label")
+                Lens<Box<U>, String> label();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Lens<Box<U>, String> label()");
+  }
+
+  @Test
+  @DisplayName("@ViaConstructor names the constructor arguments in the spec's own terms")
+  void viaConstructorOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @ViaConstructor(parameterOrder = {"content", "label"})
+                Lens<Box<U>, String> label();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Lens<Box<U>, String> label()");
+    assertGeneratedCodeContains(compilation, "com.myapp.SubjectOptics", "new Box<U>(");
+  }
+
+  @Test
+  @DisplayName("@ViaCopyAndSet reads the copy constructor under the source type's instantiation")
+  void viaCopyAndSetOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @ViaCopyAndSet(setter = "setLabel", copyConstructor = "com.external.Base")
+                Lens<Box<U>, String> label();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Lens<Box<U>, String> label()");
+    // The parameter is declared Base<X>; under Box<U> it is Base<U>, which is what the cast names.
+    assertGeneratedCodeContains(
+        compilation, "com.myapp.SubjectOptics", "new Box<U>((Base<U>) source)");
+  }
+
+  @Test
+  @DisplayName("@InstanceOf narrows a generic sealed hierarchy, which erasure is what tests")
+  void instanceOfOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Shape<U>> {
+                @InstanceOf(Circle.class)
+                Prism<Shape<U>, Circle<U>> circle();
+            }""");
+
+    // The annotation carries a class constant, which is always raw, so the subtype check has to
+    // ask what the generated 'source instanceof Circle' asks.
+    assertGeneratedSignature(compilation, "public static <U> Prism<Shape<U>, Circle<U>> circle()");
+  }
+
+  @Test
+  @DisplayName("@MatchWhen narrows through the source type's own getter")
+  void matchWhenOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Node<U>> {
+                @MatchWhen(predicate = "isLeaf", getter = "asLeaf")
+                Prism<Node<U>, Leaf<U>> leaf();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Prism<Node<U>, Leaf<U>> leaf()");
+  }
+
+  @Test
+  @DisplayName("@ThroughField auto-detects the container under the source type's instantiation")
+  void throughFieldOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @Wither("withItems")
+                Lens<Box<U>, List<U>> items();
+
+                @ThroughField(field = "items")
+                Traversal<Box<U>, U> eachItem();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Traversal<Box<U>, U> eachItem()");
+  }
+
+  @Test
+  @DisplayName("@TraverseWith composes the traversal the spec names")
+  void traverseWithOnAGenericSpec() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @TraverseWith("org.higherkindedj.optics.BoxTraversals.items()")
+                Traversal<Box<U>, U> eachItem();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Traversal<Box<U>, U> eachItem()");
+  }
+}


### PR DESCRIPTION
Adds the generic-spec test axis recommended in #736, and fixes the bug it found on its first run.

## Why an axis

#732 shipped in #727 and was found only by a review panel on a later PR. The reason it could hide:

> **No copy strategy had a generic-*spec* test except `@Wither` — and `@Wither` is structurally blind to this fault**, because it rebuilds through a method and reads no member of the source type.

`@ImportOptics` generic specs became first-class in #730, which turns a family of latent faults into reachable ones. `GenericSpecInterfaceAxisTest` gives every strategy and hint one case against a spec that declares its own type parameter:

| | strategy / hint | at risk? |
|---|---|---|
| ✔ | `@Wither` | no — rebuilds through a method |
| ✔ | `@ViaBuilder` | no — rebuilds through a builder |
| ✔ | `@ViaConstructor` | yes — names constructor arguments |
| ✔ | `@ViaCopyAndSet` | yes — reads a constructor parameter (#732, fixed in #735) |
| ✔ | `@InstanceOf` | **yes — found broken, fixed here** |
| ✔ | `@MatchWhen` | yes — reads the source type's getter |
| ✔ | `@ThroughField` | yes — auto-detects a container type |
| ✔ | `@TraverseWith` | yes — composes a named traversal |

Every case holds the spec's parameter at `U` while every source type declares `X`. That is the whole point: **where the two letters agree, the fault is invisible**, which is exactly how #732 survived. The two blind strategies are included to keep the axis complete rather than because they are at risk, and the file says so.

## The bug it found

`@InstanceOf` rejected every generic sealed hierarchy:

```java
public sealed interface Shape<X> permits Circle {}
public record Circle<X>(X tag) implements Shape<X> {}

@ImportOptics
public interface SubjectOpticsSpec<U> extends OpticsSpec<Shape<U>> {
    @InstanceOf(Circle.class)
    Prism<Shape<U>, Circle<U>> circle();
}
```

```
@InstanceOf target 'com.external.Circle' is not a subtype of source type 'com.external.Shape<U>'.
```

The annotation carries a **class constant**, which is always raw, and the check compared it against the **instantiated** source — `isSubtype(Circle, Shape<U>)` is false, because a raw type is not a subtype of a parameterised one. Another instance of the declaration-vs-instantiation family #736 is about.

The generated narrowing is `source instanceof Circle`, which Java evaluates on erasures, so that is the question the check now asks:

```java
if (!typeUtils.isSubtype(typeUtils.erasure(targetType), typeUtils.erasure(sourceType))) {
```

Reverting that one line fails the new `@InstanceOf` case and nothing else — confirmed by stashing it.

The existing rejection of a genuinely unrelated target still holds: erasing both sides does not make `Plant` a subtype of `Animal`.

## Three shapes that looked broken and were not

Worth recording, since the axis is also a worked example of what these annotations expect:

- **`@ThroughField`** needs a lens for the field declared beside the traversal; without it the generated traversal composes with an optic that was never generated.
- **`@TraverseWith`** takes the traversal as its single unnamed attribute, not `container`/`traversal`.
- **`copyConstructor`** names a **supertype** of `S`, not merely any constructor parameter type.

Each is written the working way in the new file. I checked all three before recording them as bugs — none was one.

## Verification

`clean build` across all modules: BUILD SUCCESSFUL, EXIT=0. `SpecInterfaceAnalyser` stays at 100% line, branch and instruction.

The other three instances in #736 — `NavigatorClassGenerator`, `ExternalLensGenerator`, `findFieldType` — are untouched here; they need fixes rather than tests, and the issue stays open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es3dKLikaETJPF9fX3PxNo
