### PR TITLE
Two more generic axes: imported types, and mapping wire shapes (#740)

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateFocus.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateFocus.java
@@ -75,7 +75,8 @@ public @interface GenerateFocus {
    *
    * <p>This enables patterns like {@code PersonFocus.address().city()} without explicit {@code
    * .via()} calls. Navigator classes are generated for fields whose types are also annotated with
-   * {@code @GenerateFocus}.
+   * {@code @GenerateFocus} and declare no type parameters of their own; a field whose type is
+   * generic keeps its plain {@code FocusPath} method, composed with {@code .via()}.
    *
    * <p>The navigator classes:
    *

--- a/hkj-book/src/optics/focus_navigation.md
+++ b/hkj-book/src/optics/focus_navigation.md
@@ -215,9 +215,10 @@ Not every field does, and knowing which is the difference between a chain that c
 ```mermaid
 flowchart TD
     F{"The field's type is..."}
-    F -->|"a record annotated<br/>@GenerateFocus"| N(["Navigator<br/>chain with a method call"])
+    F -->|"a non-generic record<br/>annotated @GenerateFocus"| N(["Navigator<br/>chain with a method call"])
     F -->|"Optional, List, Set,<br/>Collection"| W(["Widened path<br/>chain with .via()"])
-    F -->|"an SPI container whose<br/>element type is annotated"| N
+    F -->|"an SPI container whose<br/>element type is annotated<br/>and non-generic"| N
+    F -->|"a generic record annotated<br/>@GenerateFocus"| P
     F -->|"anything else"| P(["Plain path<br/>chain with .via()"])
 
     classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
@@ -227,6 +228,8 @@ flowchart TD
 ```
 
 The middle branch is the one that surprises people. `Optional`, `List`, `Set` and `Collection` are widened by the processor before navigators are considered, so a `List<Department> departments` field gives you a `TraversalPath<Company, Department>` and never a `DepartmentsNavigator`. Container types that arrive through the SPI (a `Map`, an Eclipse Collections `ImmutableList`, an `Either`) *are* eligible, and get a navigator when their element type is itself annotated.
+
+A target that declares type parameters of its own does not. A navigator is an inner class parameterised by the source type alone, so it has no way to name them — `Inner<String> inner` and `Map<String, Inner<String>> inners` both keep the plain path, chained with `.via()`. The processor says so as a note against the field, naming the chain to write instead.
 
 <!-- verify -->
 ```java

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -101,11 +101,19 @@ public class NavigatorClassGenerator {
   /**
    * Whether the Focus method for this component steps into a {@code ZERO_OR_MORE} container.
    *
-   * <p>A container holding a navigable element always does — reaching that element is what its
-   * navigator exists for — and otherwise the declaring record's {@code widenCollections} decides.
+   * <p>A container whose element reaches a navigator always does — reaching that element is what
+   * the navigator exists for — and otherwise the declaring record's {@code widenCollections}
+   * decides.
+   *
+   * <p>The question is the one {@link #navigatorTarget} answers, not merely whether the element is
+   * navigable. A container the widening steps into but no navigator is offered for would leave the
+   * navigation method declaring a traversal and returning a focus, and every reason a navigator is
+   * declined — the element is generic, the record turned navigators off, the field is filtered out
+   * — reaches that same disagreement.
    */
   private boolean widensContainers(TypeElement record, RecordComponentElement component) {
-    return spiNavigable(component.asType()) != null || focusSettings(record).widenCollections();
+    return (spiNavigable(component.asType()) != null && navigatorTarget(record, component) != null)
+        || focusSettings(record).widenCollections();
   }
 
   /**
@@ -141,6 +149,7 @@ public class NavigatorClassGenerator {
     for (RecordComponentElement component : recordElement.getRecordComponents()) {
       TypeElement target = navigatorTarget(recordElement, component);
       if (target == null) {
+        reportGenericTargetSkipped(recordElement, component);
         continue;
       }
       focusClassBuilder.addType(
@@ -150,13 +159,69 @@ public class NavigatorClassGenerator {
   }
 
   /**
+   * Says why a component asking for a navigator did not get one, when the reason is that its target
+   * is generic.
+   *
+   * <p>The declaring record asked for navigators and gets one fewer than the components suggest,
+   * which is the same surprise a delegate-name collision produces and is reported the same way.
+   * Every other reason a component has no navigator is visible in what it is: not navigable, or
+   * filtered out by the record's own include/exclude.
+   *
+   * @param recordElement the record declaring the component
+   * @param component the component whose navigator was not generated
+   */
+  private void reportGenericTargetSkipped(
+      TypeElement recordElement, RecordComponentElement component) {
+
+    TypeElement navigable = navigableTarget(component);
+    if (navigable == null || !declaresTypeParameters(navigable)) {
+      return;
+    }
+    String componentName = component.getSimpleName().toString();
+    processingEnv
+        .getMessager()
+        .printMessage(
+            Diagnostic.Kind.NOTE,
+            "Navigator for field '"
+                + componentName
+                + "' is not generated: "
+                + navigable.getSimpleName()
+                + " declares type parameters, which a navigator has no way to name. Use "
+                + focusClassOf(recordElement).simpleName()
+                + "."
+                + componentName
+                + "().via("
+                + focusClassOf(navigable).simpleName()
+                + ".…()) to chain through it.",
+            component);
+  }
+
+  /**
+   * The navigable type a component reaches, generic or not, before the navigator question is asked
+   * of it.
+   *
+   * @param component the component to read
+   * @return the navigable type it reaches, or null when it reaches none
+   */
+  private TypeElement navigableTarget(RecordComponentElement component) {
+    TypeMirror fieldType = component.asType();
+    TypeElement direct = navigableTypeElement(fieldType);
+    if (direct != null) {
+      return direct;
+    }
+    SpiNavigable spiNavigable = spiNavigable(fieldType);
+    return spiNavigable == null ? null : spiNavigable.element();
+  }
+
+  /**
    * The type a record's Focus method for this component navigates to, or null when that method
    * hands back a path instead.
    *
-   * <p>A component reaches a navigator either by being a navigable type itself or by being an SPI
-   * container of one. Every site that asks — the navigator class, the method that returns it, and a
-   * navigation method composing it from another record — reads the answer from here, so they cannot
-   * disagree about which components have one.
+   * <p>A component reaches a navigator by being a navigable type itself, or by being an SPI
+   * container of one, and in either case only when that type declares no type parameters of its
+   * own. Every site that asks — the navigator class, the method that returns it, and a navigation
+   * method composing it from another record — reads the answer from here, so they cannot disagree
+   * about which components have one.
    *
    * @param record the record that declares the component
    * @param component the component
@@ -167,16 +232,11 @@ public class NavigatorClassGenerator {
         || !shouldGenerateNavigator(record, component)) {
       return null;
     }
-    TypeMirror fieldType = component.asType();
-    TypeElement direct = navigableTypeElement(fieldType);
-    if (direct != null) {
-      return generic(direct) ? null : direct;
-    }
-    SpiNavigable spiNavigable = spiNavigable(fieldType);
-    if (spiNavigable == null) {
+    TypeElement navigable = navigableTarget(component);
+    if (navigable == null) {
       return null;
     }
-    return generic(spiNavigable.element()) ? null : spiNavigable.element();
+    return declaresTypeParameters(navigable) ? null : navigable;
   }
 
   /**
@@ -190,7 +250,7 @@ public class NavigatorClassGenerator {
    * @param navigable the navigable type the component reaches
    * @return true when it declares type parameters
    */
-  private boolean generic(TypeElement navigable) {
+  private static boolean declaresTypeParameters(TypeElement navigable) {
     return !navigable.getTypeParameters().isEmpty();
   }
 
@@ -774,8 +834,8 @@ public class NavigatorClassGenerator {
 
     String componentName = component.getSimpleName().toString();
 
-    // A component whose type reaches a navigable one — directly, or as the element of an SPI
-    // container — gets this navigator method in place of the plain path method. Hardcoded
+    // A component whose type reaches a non-generic navigable one — directly, or as the element of
+    // an SPI container — gets this navigator method in place of the plain path method. Hardcoded
     // Optional/Collection fields are not among them: createFocusPathMethod widens those through
     // .some()/.each() instead.
     TypeElement target = navigatorTarget(recordElement, component);

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -170,10 +170,28 @@ public class NavigatorClassGenerator {
     TypeMirror fieldType = component.asType();
     TypeElement direct = navigableTypeElement(fieldType);
     if (direct != null) {
-      return direct;
+      return generic(direct) ? null : direct;
     }
     SpiNavigable spiNavigable = spiNavigable(fieldType);
-    return spiNavigable == null ? null : spiNavigable.element();
+    if (spiNavigable == null) {
+      return null;
+    }
+    return generic(spiNavigable.element()) ? null : spiNavigable.element();
+  }
+
+  /**
+   * Whether a navigable type declares type parameters of its own.
+   *
+   * <p>A navigator is an inner class parameterised by the source type alone, and its navigation
+   * methods read the target's components from the target's own declaration. Both would name the
+   * target's variables, which are in scope on neither. The component keeps its plain path method,
+   * which carries the instantiation and composes the same way.
+   *
+   * @param navigable the navigable type the component reaches
+   * @return true when it declares type parameters
+   */
+  private boolean generic(TypeElement navigable) {
+    return !navigable.getTypeParameters().isEmpty();
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
@@ -345,8 +345,10 @@ public class ExternalLensGenerator {
     }
 
     final ClassName recordClassName = ClassName.get(recordElement);
+    // The instantiated name, not the raw one: the generated method declares the record's own type
+    // parameters, so every use of the record in this signature has to name them.
     final ParameterizedTypeName traversalTypeName =
-        ParameterizedTypeName.get(ClassName.get(Traversal.class), recordClassName, focusType);
+        ParameterizedTypeName.get(ClassName.get(Traversal.class), recordTypeName, focusType);
 
     final CodeBlock modifyFBody =
         generator.generateModifyF(component, recordClassName, allComponents);
@@ -356,6 +358,11 @@ public class ExternalLensGenerator {
         ParameterizedTypeName.get(
             ClassName.get(WitnessArity.class), ClassName.get(TypeArity.class).nestedClass("Unary"));
 
+    // A record that claims F for a parameter of its own takes the effect elsewhere, read from the
+    // one place the generators writing uses of it also read.
+    final TypeVariableName effect =
+        TypeVariableName.get(ProcessorUtils.effectVariableName(recordElement), witnessArityBound);
+
     final TypeSpec traversalImpl =
         TypeSpec.anonymousClassBuilder("")
             .addSuperinterface(traversalTypeName)
@@ -363,45 +370,50 @@ public class ExternalLensGenerator {
                 MethodSpec.methodBuilder("modifyF")
                     .addAnnotation(Override.class)
                     .addModifiers(Modifier.PUBLIC)
-                    .addTypeVariable(TypeVariableName.get("F", witnessArityBound))
+                    .addTypeVariable(effect)
                     .addParameter(
                         ParameterizedTypeName.get(
                             ClassName.get(Function.class),
                             focusType,
                             ParameterizedTypeName.get(
-                                ClassName.get(Kind.class), TypeVariableName.get("F"), focusType)),
+                                ClassName.get(Kind.class), effect, focusType)),
                         "f")
-                    .addParameter(recordClassName, "source")
+                    .addParameter(recordTypeName, "source")
                     .addParameter(
-                        ParameterizedTypeName.get(
-                            ClassName.get(Applicative.class), TypeVariableName.get("F")),
+                        ParameterizedTypeName.get(ClassName.get(Applicative.class), effect),
                         "applicative")
                     .returns(
                         ParameterizedTypeName.get(
-                            ClassName.get(Kind.class), TypeVariableName.get("F"), recordClassName))
+                            ClassName.get(Kind.class), effect, recordTypeName))
                     .addCode(modifyFBody)
                     .build())
             .build();
 
     String methodName = field.name() + "Traversal";
 
-    return MethodSpec.methodBuilder(methodName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addJavadoc(
-            "Creates a {@link $T} for the {@code $L} field of a {@link $T}.\n"
-                + "<p>This traversal focuses on all items within the {@code $L} collection,"
-                + " allowing an effectful function\n"
-                + "to be applied to each one.\n\n"
-                + "@return A non-null {@code Traversal<$T, $T>}.",
-            ClassName.get(Traversal.class),
-            field.name(),
-            recordClassName,
-            field.name(),
-            recordClassName,
-            focusType.box())
-        .returns(traversalTypeName)
-        .addStatement("return $L", traversalImpl)
-        .build();
+    final MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(methodName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addJavadoc(
+                "Creates a {@link $T} for the {@code $L} field of a {@link $T}.\n"
+                    + "<p>This traversal focuses on all items within the {@code $L} collection,"
+                    + " allowing an effectful function\n"
+                    + "to be applied to each one.\n\n"
+                    + "@return A non-null {@code Traversal<$T, $T>}.",
+                ClassName.get(Traversal.class),
+                field.name(),
+                recordClassName,
+                field.name(),
+                recordTypeName,
+                focusType.box())
+            .returns(traversalTypeName);
+
+    // The record's own parameters, as the lens methods beside this one already declare them.
+    for (TypeParameterElement typeParameter : recordElement.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+    }
+
+    return methodBuilder.addStatement("return $L", traversalImpl).build();
   }
 
   // Package-private for tests.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -1053,7 +1053,7 @@ public class SpecInterfaceAnalyser {
           "Cannot auto-detect traversal for field '"
               + fieldName
               + "' of type '"
-              + fieldType
+              + ProcessorUtils.simpleTypeName(fieldType)
               + "'. "
               + "Supported types: List, Set, Optional, Map, arrays. "
               + "Please specify traversal() explicitly, e.g.: "
@@ -1072,14 +1072,6 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
-   * Finds the type of a field on a type element by looking for accessor methods or record
-   * components.
-   *
-   * @param typeElement the type to search
-   * @param fieldName the field name to find
-   * @return the field's type, or null if not found
-   */
-  /**
    * A member's type as the instantiated source type sees it, unwrapping an accessor's return.
    *
    * <p>Read off the element, a member of {@code Holder<T>} speaks {@code T}; the spec instantiated
@@ -1088,15 +1080,33 @@ public class SpecInterfaceAnalyser {
    * names a variable the spec never wrote.
    *
    * @param sourceType the instantiated source type {@code S}
-   * @param member the accessor or component to read
+   * @param member the accessor to read
    * @return the member's type under {@code sourceType}'s instantiation
    */
   private TypeMirror memberTypeOf(DeclaredType sourceType, ExecutableElement member) {
+    // A source type with no arguments has nothing to substitute, and asking anyway would lose
+    // what the member does declare: under a raw site javac erases every member, so a field typed
+    // List<String> on a raw Holder would come back as List and match no container.
+    if (sourceType.getTypeArguments().isEmpty()) {
+      return member.getReturnType();
+    }
+    // Total: asMemberOf answers with an ExecutableType for an executable member, and the one shape
+    // that would not - an unresolvable source type, whose members resolve to itself - enumerates
+    // no members for the caller to have found.
     return ((ExecutableType) typeUtils.asMemberOf(sourceType, member)).getReturnType();
   }
 
+  /**
+   * The type a named field has on the instantiated source type.
+   *
+   * @param sourceType the instantiated source type to search
+   * @param fieldName the field name to find
+   * @return the field's type under that instantiation, or null if not found
+   */
   private TypeMirror findFieldType(TypeMirror sourceType, String fieldName) {
-    // The source type is always declared by the time an optic method is read.
+    // analyse() admits a source type only when asElement gives a TypeElement, which on javac
+    // leaves DECLARED, ERROR and INTERSECTION - every one of them a DeclaredType. That is what
+    // makes the cast total, the same reasoning parseCopyStrategy's spells out.
     DeclaredType declaredSource = (DeclaredType) sourceType;
     TypeElement typeElement = (TypeElement) declaredSource.asElement();
 
@@ -1139,7 +1149,9 @@ public class SpecInterfaceAnalyser {
         VariableElement field = (VariableElement) enclosed;
         if (field.getSimpleName().contentEquals(fieldName)
             && field.getModifiers().contains(Modifier.PUBLIC)) {
-          return typeUtils.asMemberOf(declaredSource, field);
+          return declaredSource.getTypeArguments().isEmpty()
+              ? field.asType()
+              : typeUtils.asMemberOf(declaredSource, field);
         }
       }
     }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -391,7 +391,7 @@ public class SpecInterfaceAnalyser {
         prismHintInfo = prismResult.get().info();
       }
       case TRAVERSAL -> {
-        var traversalResult = parseTraversalHint(method, sourceTypeElement, specInterface);
+        var traversalResult = parseTraversalHint(method, sourceType, specInterface);
         if (traversalResult.isEmpty()) {
           // parseTraversalHint has reported why.
           return Optional.empty();
@@ -976,7 +976,7 @@ public class SpecInterfaceAnalyser {
   private record TraversalHintResult(TraversalHintKind kind, TraversalHintInfo info) {}
 
   private Optional<TraversalHintResult> parseTraversalHint(
-      ExecutableElement method, TypeElement sourceTypeElement, TypeElement specInterface) {
+      ExecutableElement method, TypeMirror sourceType, TypeElement specInterface) {
     // Check for @TraverseWith
     AnnotationMirror traverseWith = findAnnotation(method, TRAVERSE_WITH_FQN);
     if (traverseWith != null) {
@@ -995,8 +995,7 @@ public class SpecInterfaceAnalyser {
 
       // Auto-detect traversal if not specified
       if (traversal.isEmpty()) {
-        Optional<String> autoDetected =
-            autoDetectTraversalForField(fieldName, sourceTypeElement, method);
+        Optional<String> autoDetected = autoDetectTraversalForField(fieldName, sourceType, method);
         if (autoDetected.isEmpty()) {
           // Error already reported in autoDetectTraversalForField
           return Optional.empty();
@@ -1023,21 +1022,21 @@ public class SpecInterfaceAnalyser {
    * Auto-detects the appropriate traversal for a field based on its type.
    *
    * @param fieldName the name of the field to look up
-   * @param sourceTypeElement the resolved element for the source type containing the field
+   * @param sourceType the instantiated source type containing the field
    * @param method the method element (for error reporting)
    * @return the traversal reference string, or empty if detection failed
    */
   private Optional<String> autoDetectTraversalForField(
-      String fieldName, TypeElement sourceTypeElement, ExecutableElement method) {
+      String fieldName, TypeMirror sourceType, ExecutableElement method) {
 
     // Look up the field's type on the source type
-    TypeMirror fieldType = findFieldType(sourceTypeElement, fieldName);
+    TypeMirror fieldType = findFieldType(sourceType, fieldName);
     if (fieldType == null) {
       error(
           "Cannot auto-detect traversal: field '"
               + fieldName
               + "' not found on type '"
-              + sourceTypeElement.getQualifiedName()
+              + ProcessorUtils.simpleTypeName(sourceType)
               + "'. "
               + "Check that the field name matches an accessor method or record component.",
           method);
@@ -1080,12 +1079,32 @@ public class SpecInterfaceAnalyser {
    * @param fieldName the field name to find
    * @return the field's type, or null if not found
    */
-  private TypeMirror findFieldType(TypeElement typeElement, String fieldName) {
+  /**
+   * A member's type as the instantiated source type sees it, unwrapping an accessor's return.
+   *
+   * <p>Read off the element, a member of {@code Holder<T>} speaks {@code T}; the spec instantiated
+   * it as {@code Holder<List<String>>}, so what the traversal has to be detected for is {@code
+   * List<String>}. Reading the declaration instead both rejects a container it could have found and
+   * names a variable the spec never wrote.
+   *
+   * @param sourceType the instantiated source type {@code S}
+   * @param member the accessor or component to read
+   * @return the member's type under {@code sourceType}'s instantiation
+   */
+  private TypeMirror memberTypeOf(DeclaredType sourceType, ExecutableElement member) {
+    return ((ExecutableType) typeUtils.asMemberOf(sourceType, member)).getReturnType();
+  }
+
+  private TypeMirror findFieldType(TypeMirror sourceType, String fieldName) {
+    // The source type is always declared by the time an optic method is read.
+    DeclaredType declaredSource = (DeclaredType) sourceType;
+    TypeElement typeElement = (TypeElement) declaredSource.asElement();
+
     // For records, check record components first
     if (typeElement.getKind() == ElementKind.RECORD) {
       for (var component : typeElement.getRecordComponents()) {
         if (component.getSimpleName().contentEquals(fieldName)) {
-          return component.asType();
+          return memberTypeOf(declaredSource, component.getAccessor());
         }
       }
     }
@@ -1110,7 +1129,7 @@ public class SpecInterfaceAnalyser {
           && method.getParameters().isEmpty()
           && method.getModifiers().contains(Modifier.PUBLIC)
           && !method.getModifiers().contains(Modifier.STATIC)) {
-        return method.getReturnType();
+        return memberTypeOf(declaredSource, method);
       }
     }
 
@@ -1120,7 +1139,7 @@ public class SpecInterfaceAnalyser {
         VariableElement field = (VariableElement) enclosed;
         if (field.getSimpleName().contentEquals(fieldName)
             && field.getModifiers().contains(Modifier.PUBLIC)) {
-          return field.asType();
+          return typeUtils.asMemberOf(declaredSource, field);
         }
       }
     }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericImportedTypeAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericImportedTypeAxisTest.java
@@ -1,0 +1,229 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One case per shape {@code @ImportOptics({Class...})} auto-detects, each in a non-generic and a
+ * generic form.
+ *
+ * <p>The generic half is where a generator that names the imported type <em>raw</em> and one that
+ * reads a component's own type arguments disagree. The two agree for every non-generic shape, so
+ * the fault is invisible without this half — which is how a generic record's traversal named a type
+ * parameter it never declared, in a class whose lens methods declared theirs correctly.
+ *
+ * <p>Where the generic form is not yet generated as it should be, the case pins what <em>is</em>
+ * emitted and names the gap, so that closing it shows up here as a test to update rather than as a
+ * cell nobody was looking at.
+ */
+@DisplayName("Every imported shape, generic and not")
+class GenericImportedTypeAxisTest {
+
+  /** Imports the named classes into {@code com.myapp.optics} and compiles. */
+  private Compilation compile(String importedClasses, JavaFileObject... sources) {
+    var packageInfo =
+        JavaFileObjects.forSourceString(
+            "com.myapp.optics.package-info",
+            """
+            @ImportOptics({%s})
+            package com.myapp.optics;
+
+            import org.higherkindedj.optics.annotations.ImportOptics;
+            """
+                .formatted(importedClasses));
+
+    var all = new JavaFileObject[sources.length + 1];
+    System.arraycopy(sources, 0, all, 0, sources.length);
+    all[sources.length] = packageInfo;
+    return javac().withProcessors(new ImportOpticsProcessor()).compile(all);
+  }
+
+  @Test
+  @DisplayName("a record, and a generic record whose parameters the methods declare")
+  void records() {
+    var plain =
+        JavaFileObjects.forSourceString(
+            "com.external.PlainRec",
+            """
+            package com.external;
+
+            import java.util.List;
+
+            public record PlainRec(String name, List<String> items) {}
+            """);
+
+    var generic =
+        JavaFileObjects.forSourceString(
+            "com.external.GenRec",
+            """
+            package com.external;
+
+            import java.util.List;
+
+            public record GenRec<T>(String name, List<T> items) {}
+            """);
+
+    var plainCompilation = compile("com.external.PlainRec.class", plain);
+    assertThat(plainCompilation).succeeded();
+    assertGeneratedCodeContains(
+        plainCompilation,
+        "com.myapp.optics.PlainRecLenses",
+        "public static Lens<PlainRec, String> name()");
+    assertGeneratedCodeContains(
+        plainCompilation,
+        "com.myapp.optics.PlainRecLenses",
+        "public static Traversal<PlainRec, String> itemsTraversal()");
+
+    var genericCompilation = compile("com.external.GenRec.class", generic);
+    assertThat(genericCompilation).succeeded();
+    assertGeneratedCodeContains(
+        genericCompilation,
+        "com.myapp.optics.GenRecLenses",
+        "public static <T> Lens<GenRec<T>, String> name()");
+    // The traversal is the method that named the record raw while its neighbours did not.
+    assertGeneratedCodeContains(
+        genericCompilation,
+        "com.myapp.optics.GenRecLenses",
+        "public static <T> Traversal<GenRec<T>, T> itemsTraversal()");
+  }
+
+  @Test
+  @DisplayName("a wither class, and a generic wither class")
+  void witherClasses() {
+    var plain =
+        JavaFileObjects.forSourceString(
+            "com.external.PlainBox",
+            """
+            package com.external;
+
+            import java.util.List;
+
+            public class PlainBox {
+                private String name;
+                private List<String> items;
+                public String name() { return name; }
+                public List<String> items() { return items; }
+                public PlainBox withName(String name) { return this; }
+                public PlainBox withItems(List<String> items) { return this; }
+            }
+            """);
+
+    var generic =
+        JavaFileObjects.forSourceString(
+            "com.external.GenBox",
+            """
+            package com.external;
+
+            import java.util.List;
+
+            public class GenBox<T> {
+                private String name;
+                private List<T> items;
+                public String name() { return name; }
+                public List<T> items() { return items; }
+                public GenBox<T> withName(String name) { return this; }
+                public GenBox<T> withItems(List<T> items) { return this; }
+            }
+            """);
+
+    var plainCompilation = compile("com.external.PlainBox.class", plain);
+    assertThat(plainCompilation).succeeded();
+    assertGeneratedCodeContains(
+        plainCompilation,
+        "com.myapp.optics.PlainBoxLenses",
+        "public static Lens<PlainBox, String> name()");
+
+    var genericCompilation = compile("com.external.GenBox.class", generic);
+    assertThat(genericCompilation).succeeded();
+    assertGeneratedCodeContains(
+        genericCompilation,
+        "com.myapp.optics.GenBoxLenses",
+        "public static <T> Lens<GenBox<T>, List<T>> items()");
+  }
+
+  @Test
+  @DisplayName("a sealed interface, and a generic one, whose prisms are still named raw")
+  void sealedInterfaces() {
+    var plainShape =
+        JavaFileObjects.forSourceString(
+            "com.external.PlainShape",
+            """
+            package com.external;
+
+            public sealed interface PlainShape permits PlainCircle {}
+            """);
+    var plainCircle =
+        JavaFileObjects.forSourceString(
+            "com.external.PlainCircle",
+            """
+            package com.external;
+
+            public record PlainCircle(double radius) implements PlainShape {}
+            """);
+
+    var genShape =
+        JavaFileObjects.forSourceString(
+            "com.external.GenShape",
+            """
+            package com.external;
+
+            public sealed interface GenShape<T> permits GenCircle {}
+            """);
+    var genCircle =
+        JavaFileObjects.forSourceString(
+            "com.external.GenCircle",
+            """
+            package com.external;
+
+            public record GenCircle<T>(T tag) implements GenShape<T> {}
+            """);
+
+    var plainCompilation = compile("com.external.PlainShape.class", plainShape, plainCircle);
+    assertThat(plainCompilation).succeeded();
+    assertGeneratedCodeContains(
+        plainCompilation,
+        "com.myapp.optics.PlainShapePrisms",
+        "public static Prism<PlainShape, PlainCircle> plainCircle()");
+
+    var genericCompilation = compile("com.external.GenShape.class", genShape, genCircle);
+    assertThat(genericCompilation).succeeded();
+    // Both sides are named raw, so the prism does not compose with an optic that carries the
+    // hierarchy's argument. Generating Prism<GenShape<T>, GenCircle<T>> is issue #742; this pins
+    // what is emitted until then, rather than leaving the cell unexercised.
+    assertGeneratedCodeContains(
+        genericCompilation,
+        "com.myapp.optics.GenShapePrisms",
+        "public static Prism<GenShape, GenCircle> genCircle()");
+  }
+
+  @Test
+  @DisplayName("an enum, which has no generic form")
+  void enums() {
+    var status =
+        JavaFileObjects.forSourceString(
+            "com.external.Status",
+            """
+            package com.external;
+
+            public enum Status { PENDING, ACTIVE }
+            """);
+
+    // An enum cannot declare type parameters, so this row has one cell by construction.
+    var compilation = compile("com.external.Status.class", status);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(
+        compilation,
+        "com.myapp.optics.StatusPrisms",
+        "public static Prism<Status, Status> pending()");
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericMappingWireAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericMappingWireAxisTest.java
@@ -1,0 +1,255 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One case per wire shape {@code @GenerateMapping} accepts, each with its type parameters supplied
+ * three ways: none at all, declared by the spec, and inherited from a generic base.
+ *
+ * <p>The inherited column is the one that hid a defect. A wire that declares no parameters of its
+ * own still reaches members that do — {@code class UserDto extends BaseDto<String>} answers {@code
+ * T getId()} — and a gate that asks only whether the wire itself is generic lets those through
+ * unread. Every other column agrees whether members are read as declared or under the wire, so the
+ * fault is invisible without this one.
+ */
+@DisplayName("Every mapping wire shape, generic and not")
+class GenericMappingWireAxisTest {
+
+  private static final JavaFileObject DOMAIN =
+      JavaFileObjects.forSourceString(
+          "com.example.Dom",
+          """
+          package com.example;
+
+          public record Dom(String id, String name) {}
+          """);
+
+  private Compilation compile(JavaFileObject... sources) {
+    return javac().withProcessors(new MappingProcessor()).compile(sources);
+  }
+
+  @Test
+  @DisplayName("a record wire, with no type parameters")
+  void recordWire() {
+    var wire =
+        JavaFileObjects.forSourceString(
+            "com.example.RecWire",
+            """
+            package com.example;
+
+            public record RecWire(String id, String name) {}
+            """);
+
+    var spec =
+        JavaFileObjects.forSourceString(
+            "com.example.RecMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface RecMapping extends MappingSpec<Dom, RecWire> {}
+            """);
+
+    var compilation = compile(DOMAIN, wire, spec);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.RecMappingImpl");
+  }
+
+  @Test
+  @DisplayName("a record wire whose parameters the spec declares")
+  void genericRecordWire() {
+    var domain =
+        JavaFileObjects.forSourceString(
+            "com.example.Page",
+            """
+            package com.example;
+
+            import java.util.List;
+
+            public record Page<T>(List<T> items, String cursor) {}
+            """);
+
+    var wire =
+        JavaFileObjects.forSourceString(
+            "com.example.PageDto",
+            """
+            package com.example;
+
+            import java.util.List;
+
+            public record PageDto<T>(List<T> items, String cursor) {}
+            """);
+
+    var spec =
+        JavaFileObjects.forSourceString(
+            "com.example.PageMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface PageMapping<T> extends MappingSpec<Page<T>, PageDto<T>> {}
+            """);
+
+    var compilation = compile(domain, wire, spec);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.PageMappingImpl");
+  }
+
+  @Test
+  @DisplayName("a bean wire, with no type parameters")
+  void beanWire() {
+    var wire =
+        JavaFileObjects.forSourceString(
+            "com.example.BeanWire",
+            """
+            package com.example;
+
+            public class BeanWire {
+                private String id;
+                private String name;
+                public BeanWire() {}
+                public String getId() { return id; }
+                public void setId(String id) { this.id = id; }
+                public String getName() { return name; }
+                public void setName(String name) { this.name = name; }
+            }
+            """);
+
+    var spec =
+        JavaFileObjects.forSourceString(
+            "com.example.BeanMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface BeanMapping extends MappingSpec<Dom, BeanWire> {}
+            """);
+
+    var compilation = compile(DOMAIN, wire, spec);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.BeanMappingImpl");
+  }
+
+  @Test
+  @DisplayName("a bean wire inheriting a property from a generic base")
+  void beanWireInheritingFromAGenericBase() {
+    var base =
+        JavaFileObjects.forSourceString(
+            "com.example.GenBase",
+            """
+            package com.example;
+
+            public class GenBase<T> {
+                private T id;
+                public T getId() { return id; }
+                public void setId(T id) { this.id = id; }
+            }
+            """);
+
+    var wire =
+        JavaFileObjects.forSourceString(
+            "com.example.InhWire",
+            """
+            package com.example;
+
+            public class InhWire extends GenBase<String> {
+                private String name;
+                public InhWire() {}
+                public String getName() { return name; }
+                public void setName(String name) { this.name = name; }
+            }
+            """);
+
+    var spec =
+        JavaFileObjects.forSourceString(
+            "com.example.InhMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface InhMapping extends MappingSpec<Dom, InhWire> {}
+            """);
+
+    // InhWire declares no parameters, so a gate reading only its own would pass it; getId() is
+    // still 'T getId()' until it is read under InhWire.
+    var compilation = compile(DOMAIN, base, wire, spec);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation).generatedSourceFile("com.example.InhMappingImpl");
+  }
+
+  @Test
+  @DisplayName("a mix-in carrying a generic ancestor's members is rejected by name")
+  void mixinWithAGenericAncestor() {
+    var base =
+        JavaFileObjects.forSourceString(
+            "com.example.BaseVocab",
+            """
+            package com.example;
+
+            public interface BaseVocab<T> {}
+            """);
+
+    var mixin =
+        JavaFileObjects.forSourceString(
+            "com.example.Vocab",
+            """
+            package com.example;
+
+            public interface Vocab extends BaseVocab<String> {}
+            """);
+
+    var wire =
+        JavaFileObjects.forSourceString(
+            "com.example.MixWire",
+            """
+            package com.example;
+
+            public record MixWire(String id, String name) {}
+            """);
+
+    var spec =
+        JavaFileObjects.forSourceString(
+            "com.example.MixMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface MixMapping extends MappingSpec<Dom, MixWire>, Vocab {}
+            """);
+
+    // Members are collected across the whole ancestry, so the gate is too, and it names the
+    // ancestor that is actually generic rather than the one the spec lists.
+    var compilation = compile(DOMAIN, base, mixin, wire, spec);
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("mix-in 'BaseVocab' is generic");
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ImportOpticsProcessorTest.java
@@ -75,6 +75,42 @@ class ImportOpticsProcessorTest {
     }
 
     @Test
+    @DisplayName("should generate a traversal with type parameters for a generic record")
+    void shouldGenerateTraversalWithTypeParametersForGenericRecord() {
+      final var externalRecord =
+          JavaFileObjects.forSourceString(
+              "com.external.Bag",
+              """
+              package com.external;
+
+              import java.util.List;
+
+              public record Bag<T>(String name, List<T> items) {}
+              """);
+
+      final var packageInfo =
+          JavaFileObjects.forSourceString(
+              "com.myapp.optics.package-info",
+              """
+              @ImportOptics({com.external.Bag.class})
+              package com.myapp.optics;
+
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalRecord, packageInfo);
+
+      // The lens methods beside it already declared the record's parameters; the traversal named
+      // the record raw and declared none, so the container's element type had nothing to bind to.
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.myapp.optics.BagLenses",
+          "public static <T> Traversal<Bag<T>, T> itemsTraversal()");
+    }
+
+    @Test
     @DisplayName("should generate lenses with type parameters for generic record")
     void shouldGenerateLensesForGenericRecord() {
       final var externalRecord =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorCoverageTest.java
@@ -1237,4 +1237,75 @@ class NavigatorCoverageTest {
           compilation, "com.example.WideRootFocus", "TraversalPath<S, String> deep()");
     }
   }
+
+  @Test
+  @DisplayName("a generic navigable target keeps its plain path method instead of a navigator")
+  void genericNavigableTargetKeepsThePlainPathMethod() {
+    final var inner =
+        JavaFileObjects.forSourceString(
+            "com.myapp.Inner",
+            """
+            package com.myapp;
+
+            import org.higherkindedj.optics.annotations.GenerateFocus;
+
+            @GenerateFocus(generateNavigators = true)
+            public record Inner<T>(T value, String label) {}
+            """);
+
+    final var outer =
+        JavaFileObjects.forSourceString(
+            "com.myapp.Outer",
+            """
+            package com.myapp;
+
+            import org.higherkindedj.optics.annotations.GenerateFocus;
+
+            @GenerateFocus(generateNavigators = true)
+            public record Outer(Inner<String> inner, String tag) {}
+            """);
+
+    // A navigator is parameterised by the source type alone and reads its target's components from
+    // the target's own declaration, so a generic target would name variables in scope on neither.
+    var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeDoesNotContain(compilation, "com.myapp.OuterFocus", "class InnerNavigator");
+  }
+
+  @Test
+  @DisplayName("a generic navigable inside a container keeps its plain path method too")
+  void genericNavigableInsideAContainerKeepsThePlainPathMethod() {
+    final var inner =
+        JavaFileObjects.forSourceString(
+            "com.myapp.Inner",
+            """
+            package com.myapp;
+
+            import org.higherkindedj.optics.annotations.GenerateFocus;
+
+            @GenerateFocus(generateNavigators = true)
+            public record Inner<T>(T value, String label) {}
+            """);
+
+    final var outer =
+        JavaFileObjects.forSourceString(
+            "com.myapp.Outer",
+            """
+            package com.myapp;
+
+            import java.util.Map;
+            import org.higherkindedj.optics.annotations.GenerateFocus;
+
+            @GenerateFocus(generateNavigators = true)
+            public record Outer(Map<String, Inner<String>> inners, String tag) {}
+            """);
+
+    // The element of a container reaches a navigator the same way a component does, so it is asked
+    // the same question.
+    var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeDoesNotContain(compilation, "com.myapp.OuterFocus", "class InnersNavigator");
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NavigatorCoverageTest.java
@@ -9,6 +9,7 @@ import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGene
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
 import javax.tools.JavaFileObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -1238,74 +1239,225 @@ class NavigatorCoverageTest {
     }
   }
 
-  @Test
-  @DisplayName("a generic navigable target keeps its plain path method instead of a navigator")
-  void genericNavigableTargetKeepsThePlainPathMethod() {
-    final var inner =
-        JavaFileObjects.forSourceString(
-            "com.myapp.Inner",
-            """
-            package com.myapp;
+  @Nested
+  @DisplayName("Generic Navigable Targets")
+  class GenericNavigableTargets {
 
-            import org.higherkindedj.optics.annotations.GenerateFocus;
+    @Test
+    @DisplayName("a generic navigable target keeps its plain path method instead of a navigator")
+    void genericNavigableTargetKeepsThePlainPathMethod() {
+      final var inner =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Inner",
+              """
+              package com.myapp;
 
-            @GenerateFocus(generateNavigators = true)
-            public record Inner<T>(T value, String label) {}
-            """);
+              import org.higherkindedj.optics.annotations.GenerateFocus;
 
-    final var outer =
-        JavaFileObjects.forSourceString(
-            "com.myapp.Outer",
-            """
-            package com.myapp;
+              @GenerateFocus(generateNavigators = true)
+              public record Inner<T>(T value, String label) {}
+              """);
 
-            import org.higherkindedj.optics.annotations.GenerateFocus;
+      final var outer =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Outer",
+              """
+              package com.myapp;
 
-            @GenerateFocus(generateNavigators = true)
-            public record Outer(Inner<String> inner, String tag) {}
-            """);
+              import org.higherkindedj.optics.annotations.GenerateFocus;
 
-    // A navigator is parameterised by the source type alone and reads its target's components from
-    // the target's own declaration, so a generic target would name variables in scope on neither.
-    var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
+              @GenerateFocus(generateNavigators = true)
+              public record Outer(Inner<String> inner, String tag) {}
+              """);
 
-    assertThat(compilation).succeeded();
-    assertGeneratedCodeDoesNotContain(compilation, "com.myapp.OuterFocus", "class InnerNavigator");
-  }
+      // A navigator is parameterised by the source type alone and reads its target's components
+      // from
+      // the target's own declaration, so a generic target would name variables in scope on neither.
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
 
-  @Test
-  @DisplayName("a generic navigable inside a container keeps its plain path method too")
-  void genericNavigableInsideAContainerKeepsThePlainPathMethod() {
-    final var inner =
-        JavaFileObjects.forSourceString(
-            "com.myapp.Inner",
-            """
-            package com.myapp;
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeDoesNotContain(
+          compilation, "com.myapp.OuterFocus", "class InnerNavigator");
+    }
 
-            import org.higherkindedj.optics.annotations.GenerateFocus;
+    @Test
+    @DisplayName("a generic navigable inside a container keeps its plain path method too")
+    void genericNavigableInsideAContainerKeepsThePlainPathMethod() {
+      final var inner =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Inner",
+              """
+              package com.myapp;
 
-            @GenerateFocus(generateNavigators = true)
-            public record Inner<T>(T value, String label) {}
-            """);
+              import org.higherkindedj.optics.annotations.GenerateFocus;
 
-    final var outer =
-        JavaFileObjects.forSourceString(
-            "com.myapp.Outer",
-            """
-            package com.myapp;
+              @GenerateFocus(generateNavigators = true)
+              public record Inner<T>(T value, String label) {}
+              """);
 
-            import java.util.Map;
-            import org.higherkindedj.optics.annotations.GenerateFocus;
+      final var outer =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Outer",
+              """
+              package com.myapp;
 
-            @GenerateFocus(generateNavigators = true)
-            public record Outer(Map<String, Inner<String>> inners, String tag) {}
-            """);
+              import java.util.Map;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
 
-    // The element of a container reaches a navigator the same way a component does, so it is asked
-    // the same question.
-    var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
+              @GenerateFocus(generateNavigators = true)
+              public record Outer(Map<String, Inner<String>> inners, String tag) {}
+              """);
 
-    assertThat(compilation).succeeded();
-    assertGeneratedCodeDoesNotContain(compilation, "com.myapp.OuterFocus", "class InnersNavigator");
+      // The element of a container reaches a navigator the same way a component does, so it is
+      // asked
+      // the same question.
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeDoesNotContain(
+          compilation, "com.myapp.OuterFocus", "class InnersNavigator");
+    }
+
+    @Test
+    @DisplayName("a record navigating into one keeps a focus path, not a widened traversal")
+    void aRecordNavigatingIntoOneKeepsAFocusPath() {
+      final var inner =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Inner",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Inner<T>(T value, String label) {}
+              """);
+
+      final var mid =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Mid",
+              """
+              package com.myapp;
+
+              import java.util.Map;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Mid(Map<String, Inner<String>> inners, String tag) {}
+              """);
+
+      final var root =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Root",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Root(Mid mid, String name) {}
+              """);
+
+      // The widening decides the return type before the navigator question is asked, so a
+      // container whose element gets no navigator must not be widened into either - or the
+      // method declares a traversal and returns a focus.
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, mid, root);
+
+      assertThat(compilation).succeeded();
+    }
+
+    @Test
+    @DisplayName("a container whose navigator is declined for any reason is not widened into")
+    void aContainerWhoseNavigatorIsDeclinedIsNotWidenedInto() {
+      record Case(String name, String midAnnotation) {}
+      var cases =
+          List.of(
+              new Case("NavigatorsOff", "@GenerateFocus(generateNavigators = false)"),
+              new Case(
+                  "FieldExcluded",
+                  "@GenerateFocus(generateNavigators = true, excludeFields = \"leaves\")"));
+
+      for (Case testCase : cases) {
+        final var leaf =
+            JavaFileObjects.forSourceString(
+                "com.myapp.Leaf",
+                """
+                package com.myapp;
+
+                import org.higherkindedj.optics.annotations.GenerateFocus;
+
+                @GenerateFocus(generateNavigators = true)
+                public record Leaf(String value) {}
+                """);
+
+        final var mid =
+            JavaFileObjects.forSourceString(
+                "com.myapp.Mid",
+                """
+                package com.myapp;
+
+                import java.util.Map;
+                import org.higherkindedj.optics.annotations.GenerateFocus;
+
+                %s
+                public record Mid(Map<String, Leaf> leaves, String tag) {}
+                """
+                    .formatted(testCase.midAnnotation()));
+
+        final var root =
+            JavaFileObjects.forSourceString(
+                "com.myapp.Root",
+                """
+                package com.myapp;
+
+                import org.higherkindedj.optics.annotations.GenerateFocus;
+
+                @GenerateFocus(generateNavigators = true)
+                public record Root(Mid mid, String name) {}
+                """);
+
+        // The widening fixes the navigation method's return type before the navigator question is
+        // asked, so the two have to be the same question however the answer comes out.
+        var compilation = javac().withProcessors(new FocusProcessor()).compile(leaf, mid, root);
+
+        assertThat(compilation).succeeded();
+      }
+    }
+
+    @Test
+    @DisplayName("says why the navigator the record asked for is not there")
+    void saysWhyTheNavigatorIsNotThere() {
+      final var inner =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Inner",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Inner<T>(T value, String label) {}
+              """);
+
+      final var outer =
+          JavaFileObjects.forSourceString(
+              "com.myapp.Outer",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus(generateNavigators = true)
+              public record Outer(Inner<String> inner, String tag) {}
+              """);
+
+      var compilation = javac().withProcessors(new FocusProcessor()).compile(inner, outer);
+
+      // The record asked for navigators and gets one fewer than its components suggest, which is
+      // the same surprise a delegate-name collision reports.
+      assertThat(compilation).succeeded();
+      assertThat(compilation).hadNoteContaining("Navigator for field 'inner' is not generated");
+      assertThat(compilation).hadNoteContaining("OuterFocus.inner().via(InnerFocus.");
+    }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ThroughFieldAutoDetectTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ThroughFieldAutoDetectTest.java
@@ -1141,4 +1141,59 @@ class ThroughFieldAutoDetectTest {
 
     assertThat(compilation).succeeded();
   }
+
+  @Test
+  @DisplayName("auto-detects on a raw source type, whose members are not substituted")
+  void autoDetectsOnARawSourceType() {
+    final var holder =
+        JavaFileObjects.forSourceString(
+            "com.external.RawHolder",
+            """
+            package com.external;
+
+            import java.util.List;
+
+            public class RawHolder<T> {
+                private List<String> items;
+                public List<String> items() { return items; }
+                public RawHolder<T> withItems(List<String> items) {
+                    RawHolder<T> copy = new RawHolder<>();
+                    copy.items = items;
+                    return copy;
+                }
+            }
+            """);
+
+    final var specInterface =
+        JavaFileObjects.forSourceString(
+            "com.myapp.RawOpticsSpec",
+            """
+            package com.myapp;
+
+            import com.external.RawHolder;
+            import java.util.List;
+            import org.higherkindedj.optics.Lens;
+            import org.higherkindedj.optics.Traversal;
+            import org.higherkindedj.optics.annotations.ImportOptics;
+            import org.higherkindedj.optics.annotations.OpticsSpec;
+            import org.higherkindedj.optics.annotations.ThroughField;
+            import org.higherkindedj.optics.annotations.Wither;
+
+            @ImportOptics
+            @SuppressWarnings("rawtypes")
+            public interface RawOpticsSpec extends OpticsSpec<RawHolder> {
+                @Wither("withItems")
+                Lens<RawHolder, List<String>> items();
+
+                @ThroughField(field = "items")
+                Traversal<RawHolder, String> eachItem();
+            }
+            """);
+
+    // Under a raw site javac erases every member, so asking it to substitute would turn a field
+    // typed List<String> into a raw List and match no container. There is nothing to substitute.
+    Compilation compilation = compile(holder, specInterface);
+
+    assertThat(compilation).succeeded();
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ThroughFieldAutoDetectTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ThroughFieldAutoDetectTest.java
@@ -1089,4 +1089,56 @@ class ThroughFieldAutoDetectTest {
           .contains("Traversals.forOptional()");
     }
   }
+
+  @Test
+  @DisplayName("auto-detects through a field whose type the spec instantiates")
+  void autoDetectsThroughAnInstantiatedFieldType() {
+    final var holder =
+        JavaFileObjects.forSourceString(
+            "com.external.Holder",
+            """
+            package com.external;
+
+            public class Holder<T> {
+                private T items;
+                public T items() { return items; }
+                public Holder<T> withItems(T items) {
+                    Holder<T> copy = new Holder<>();
+                    copy.items = items;
+                    return copy;
+                }
+            }
+            """);
+
+    final var specInterface =
+        JavaFileObjects.forSourceString(
+            "com.myapp.HolderOpticsSpec",
+            """
+            package com.myapp;
+
+            import com.external.Holder;
+            import java.util.List;
+            import org.higherkindedj.optics.Lens;
+            import org.higherkindedj.optics.Traversal;
+            import org.higherkindedj.optics.annotations.ImportOptics;
+            import org.higherkindedj.optics.annotations.OpticsSpec;
+            import org.higherkindedj.optics.annotations.ThroughField;
+            import org.higherkindedj.optics.annotations.Wither;
+
+            @ImportOptics
+            public interface HolderOpticsSpec extends OpticsSpec<Holder<List<String>>> {
+                @Wither("withItems")
+                Lens<Holder<List<String>>, List<String>> items();
+
+                @ThroughField(field = "items")
+                Traversal<Holder<List<String>>, String> eachItem();
+            }
+            """);
+
+    // The accessor is declared 'T items()'. Read off the element that is a type variable, which
+    // no container detection can match; under Holder<List<String>> it is List<String>.
+    Compilation compilation = compile(holder, specInterface);
+
+    assertThat(compilation).succeeded();
+  }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyserTest.java
@@ -969,6 +969,46 @@ class SpecInterfaceAnalyserTest {
     }
 
     @Test
+    @DisplayName("should read a public field under the instantiation the spec names")
+    void shouldReadPublicFieldUnderTheInstantiation() {
+      var squad =
+          JavaFileObjects.forSourceString(
+              "com.test.GenericSquad",
+              """
+              package com.test;
+              public class GenericSquad<T> {
+                  public T members;
+                  public GenericSquad() {}
+              }
+              """);
+
+      var spec =
+          JavaFileObjects.forSourceString(
+              "com.test.GenericSquadSpec",
+              """
+              package com.test;
+              import java.util.List;
+              import org.higherkindedj.optics.Traversal;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ThroughField;
+
+              public interface GenericSquadSpec extends OpticsSpec<GenericSquad<List<String>>> {
+                  @ThroughField(field = "members")
+                  Traversal<GenericSquad<List<String>>, String> members();
+              }
+              """);
+
+      // Declared T, instantiated List<String>. Read off the element there is no container to
+      // detect; read under the instantiation there is.
+      Optional<SpecAnalysis> result =
+          analyseSpec("com.test.GenericSquadSpec", squad, spec, THROUGH_FIELD);
+
+      assertThat(result).isPresent();
+      var method = result.get().opticMethods().getFirst();
+      assertThat(method.traversalHint()).isEqualTo(TraversalHintKind.THROUGH_FIELD);
+    }
+
+    @Test
     @DisplayName("should return empty parameter order for default @ViaConstructor")
     void shouldReturnEmptyParameterOrderForDefaultViaConstructor() {
       var coord =


### PR DESCRIPTION
Adds the two test axes recommended in #740, and files the gap they found.

> **Base note.** Contains merges of both open branches it depends on — #738 (the generic-record traversal) and #741 (the inherited bean property). Merge those first; this then reduces to the two new test files. Without either, three of the nine cells fail — which is the point.

## Why two more axes

#737 added a generic-spec axis for `@ImportOptics` **spec interfaces**, and it found a bug on its first run. The other two paths into the processor had none, and both had a live defect in the generic half at the time of writing.

### `GenericImportedTypeAxisTest` — `@ImportOptics({Class...})`

Every shape the auto-detection path accepts, in a non-generic and a generic form:

| shape | non-generic | generic |
|---|---|---|
| record | ✔ | ✔ — the traversal that named the record raw (#738) |
| wither class | ✔ | ✔ |
| sealed interface | ✔ | ⚠ raw prisms — **#742** |
| enum | ✔ | *n/a — an enum cannot declare parameters* |

The generic half is where a generator naming the imported type **raw** and one reading a component's own type arguments disagree. Every non-generic form agrees whichever way it is read — which is exactly how a generic record's traversal named a parameter it never declared, in a class whose lens methods declared theirs correctly.

### `GenericMappingWireAxisTest` — `@GenerateMapping`

Every wire shape, with its type parameters supplied three ways:

| wire | none | declared by the spec | inherited from a generic base |
|---|---|---|---|
| record | ✔ | ✔ | *n/a — a record cannot extend* |
| bean | ✔ | — | ✔ — the property read as declared (#741) |
| mix-in ancestry | — | — | ✔ rejected, naming the ancestor that is generic |

**The inherited column is the one that hid a defect.** A wire declaring no parameters of its own still reaches members that do — `class UserDto extends BaseDto<String>` answers `T getId()` — and a gate asking only whether the wire itself is generic let those through unread. Every other column agrees whether members are read as declared or under the wire.

## Confirmed as real guards

Reverting the three main-source files to their `origin/main` state fails exactly three of the nine cells, one per bug:

```
a bean wire inheriting a property from a generic base            FAILED
a record, and a generic record whose parameters the methods declare  FAILED
a mix-in carrying a generic ancestor's members is rejected by name   FAILED
9 tests completed, 3 failed
```

## The gap it found: #742

`@ImportOptics` on a generic sealed hierarchy generates `Prism<GenShape, GenCircle>` — **raw on both sides**. It compiles, so nothing fails a build, but the prism will not compose with any optic carrying the hierarchy's argument. `PrismProcessor` does the same, so the two prism generators are consistent with each other and both want the same change.

The cell asserts what **is** emitted, with a comment naming the issue. Pinning current behaviour rather than omitting the row means closing #742 shows up here as a test to update, instead of as a cell nobody was looking at.

## Verification

`clean build` across all modules: BUILD SUCCESSFUL, EXIT=0.

Still open on #740 after this: nothing. #742 and #739 carry what is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es3dKLikaETJPF9fX3PxNo
