### PR TITLE
@GeneratePrisms: name both sides of a prism for a generic hierarchy (#742)

### DIFF
--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/PrismProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/PrismProcessor.java
@@ -3,11 +3,14 @@
 package org.higherkindedj.optics.processing;
 
 import com.google.auto.service.AutoService;
+import com.palantir.javapoet.AnnotationSpec;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.JavaFile;
 import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
+import com.palantir.javapoet.TypeVariableName;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +25,9 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Prism;
 import org.higherkindedj.optics.annotations.GeneratePrisms;
@@ -151,29 +156,60 @@ public class PrismProcessor extends AbstractProcessor {
    */
   private MethodSpec createPrismMethodForSubtype(TypeElement sumType, TypeElement subtype) {
     String methodName = ProcessorUtils.toCamelCase(subtype.getSimpleName().toString());
-    ClassName sumTypeName = ClassName.get(sumType);
-    ClassName subTypeName = ClassName.get(subtype);
+
+    // The prism is written in the subtype's vocabulary: its own parameters, and the sum type as
+    // its own extends/implements clause instantiates it. Reading the sum type's declaration
+    // instead would name variables the method never declares.
+    DeclaredType named = ProcessorUtils.sumTypeAsNamedBy(subtype, sumType);
+    TypeName sourceTypeName = named == null ? ClassName.get(sumType) : TypeName.get(named);
+    TypeName subTypeName =
+        subtype.getTypeParameters().isEmpty()
+            ? ClassName.get(subtype)
+            : ParameterizedTypeName.get(
+                ClassName.get(subtype),
+                subtype.getTypeParameters().stream()
+                    .map(TypeVariableName::get)
+                    .toArray(TypeName[]::new));
 
     ParameterizedTypeName prismTypeName =
-        ParameterizedTypeName.get(ClassName.get(Prism.class), sumTypeName, subTypeName);
+        ParameterizedTypeName.get(ClassName.get(Prism.class), sourceTypeName, subTypeName);
 
-    return MethodSpec.methodBuilder(methodName)
-        .addJavadoc(
-            "Creates a {@link $T} that focuses on the {@link $T} subtype of the {@link $T} sum"
-                + " type.\n\n"
-                + "@return A non-null {@code Prism<$T, $T>}.",
-            Prism.class,
-            subTypeName,
-            sumTypeName,
-            sumTypeName,
-            subTypeName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .returns(prismTypeName)
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(methodName)
+            .addJavadoc(
+                "Creates a {@link $T} that focuses on the {@link $T} subtype of the {@link $T} sum"
+                    + " type.\n\n"
+                    + "@return A non-null {@code Prism<$T, $T>}.",
+                Prism.class,
+                ClassName.get(subtype),
+                ClassName.get(sumType),
+                sourceTypeName,
+                subTypeName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(prismTypeName);
+
+    for (TypeParameterElement typeParameter : subtype.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+    }
+
+    if (!subtype.getTypeParameters().isEmpty()) {
+      // instanceof tests an erasure, so a parameterised subtype narrows through the raw name and
+      // is handed back parameterised. The sealed hierarchy is what makes that sound - a GenShape<T>
+      // that is a GenCircle can only be a GenCircle<T> - but javac cannot see it, so the warning
+      // is answered here rather than left for the consuming build.
+      methodBuilder.addAnnotation(
+          AnnotationSpec.builder(SuppressWarnings.class)
+              .addMember("value", "$S", "unchecked")
+              .addMember("value", "$S", "rawtypes")
+              .build());
+    }
+
+    return methodBuilder
         .addStatement(
             "return $T.of(source -> source instanceof $T ? $T.of(($T) source) : $T.empty(), value"
                 + " -> value)",
             Prism.class,
-            subTypeName,
+            ClassName.get(subtype),
             Optional.class,
             subTypeName,
             Optional.class)

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalPrismGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalPrismGenerator.java
@@ -3,6 +3,10 @@
 package org.higherkindedj.optics.processing.external;
 
 import com.palantir.javapoet.*;
+import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeName;
+import com.palantir.javapoet.TypeVariableName;
 import java.io.IOException;
 import java.util.Optional;
 import javax.annotation.processing.Filer;
@@ -10,6 +14,8 @@ import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Prism;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
@@ -66,7 +72,7 @@ public class ExternalPrismGenerator {
 
     // Generate prism methods for each permitted subtype
     for (TypeElement subtype : analysis.permittedSubtypes()) {
-      prismsClassBuilder.addMethod(createPrismMethodForSubtype(sumTypeName, subtype));
+      prismsClassBuilder.addMethod(createPrismMethodForSubtype(sealedInterface, subtype));
     }
 
     writeFile(targetPackage, prismsClassBuilder.build());
@@ -103,30 +109,62 @@ public class ExternalPrismGenerator {
     writeFile(targetPackage, prismsClassBuilder.build());
   }
 
-  private MethodSpec createPrismMethodForSubtype(ClassName sumTypeName, TypeElement subtype) {
+  private MethodSpec createPrismMethodForSubtype(TypeElement sumType, TypeElement subtype) {
     String methodName = ProcessorUtils.toCamelCase(subtype.getSimpleName().toString());
-    ClassName subTypeName = ClassName.get(subtype);
+
+    // The prism is written in the subtype's vocabulary: its own parameters, and the sum type as
+    // its own extends/implements clause instantiates it. Reading the sum type's declaration
+    // instead would name variables the method never declares.
+    DeclaredType named = ProcessorUtils.sumTypeAsNamedBy(subtype, sumType);
+    TypeName sourceTypeName = named == null ? ClassName.get(sumType) : TypeName.get(named);
+    TypeName subTypeName =
+        subtype.getTypeParameters().isEmpty()
+            ? ClassName.get(subtype)
+            : ParameterizedTypeName.get(
+                ClassName.get(subtype),
+                subtype.getTypeParameters().stream()
+                    .map(TypeVariableName::get)
+                    .toArray(TypeName[]::new));
 
     ParameterizedTypeName prismTypeName =
-        ParameterizedTypeName.get(ClassName.get(Prism.class), sumTypeName, subTypeName);
+        ParameterizedTypeName.get(ClassName.get(Prism.class), sourceTypeName, subTypeName);
 
-    return MethodSpec.methodBuilder(methodName)
-        .addJavadoc(
-            "Creates a {@link $T} that focuses on the {@link $T} subtype of the {@link $T} sum"
-                + " type.\n\n"
-                + "@return A non-null {@code Prism<$T, $T>}.",
-            Prism.class,
-            subTypeName,
-            sumTypeName,
-            sumTypeName,
-            subTypeName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .returns(prismTypeName)
+    MethodSpec.Builder methodBuilder =
+        MethodSpec.methodBuilder(methodName)
+            .addJavadoc(
+                "Creates a {@link $T} that focuses on the {@link $T} subtype of the {@link $T} sum"
+                    + " type.\n\n"
+                    + "@return A non-null {@code Prism<$T, $T>}.",
+                Prism.class,
+                ClassName.get(subtype),
+                ClassName.get(sumType),
+                sourceTypeName,
+                subTypeName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(prismTypeName);
+
+    for (TypeParameterElement typeParameter : subtype.getTypeParameters()) {
+      methodBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+    }
+
+    if (!subtype.getTypeParameters().isEmpty()) {
+      // instanceof tests an erasure, so a parameterised subtype narrows through the raw name and
+      // is handed back parameterised. The sealed hierarchy is what makes that sound - a GenShape<T>
+      // that is a GenCircle can only be a GenCircle<T> - but javac cannot see it, so the warning
+      // is answered here rather than left for the consuming build.
+      methodBuilder.addAnnotation(
+          AnnotationSpec.builder(SuppressWarnings.class)
+              .addMember("value", "$S", "unchecked")
+              .addMember("value", "$S", "rawtypes")
+              .build());
+    }
+
+    return methodBuilder
         .addStatement(
             "return $T.of(source -> source instanceof $T ? $T.of(($T) source) : $T.empty(), value"
                 + " -> value)",
             Prism.class,
-            subTypeName,
+            ClassName.get(subtype),
             Optional.class,
             subTypeName,
             Optional.class)

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.processing.util;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -71,6 +72,30 @@ public final class ProcessorUtils {
    */
   public static boolean hasTypeArguments(TypeMirror type) {
     return type instanceof DeclaredType declared && !declared.getTypeArguments().isEmpty();
+  }
+
+  /**
+   * The sum type as one of its permitted subtypes instantiates it.
+   *
+   * <p>A prism for a subtype is written against the sum type the <em>subtype</em> names, not the
+   * sum type's own declaration: {@code GenCircle<T> implements GenShape<T>} focuses {@code
+   * GenShape<T>}, while {@code Tagged implements GenShape<String>} focuses {@code GenShape<String>}
+   * and needs no parameter of its own.
+   *
+   * @param subtype the permitted subtype; must not be null
+   * @param sumType the sealed type it is permitted by; must not be null
+   * @return the sum type as {@code subtype} names it, or null when it does not name it directly
+   * @since 0.4.10
+   */
+  public static DeclaredType sumTypeAsNamedBy(TypeElement subtype, TypeElement sumType) {
+    List<TypeMirror> candidates = new ArrayList<>(subtype.getInterfaces());
+    candidates.add(subtype.getSuperclass());
+    for (TypeMirror candidate : candidates) {
+      if (candidate instanceof DeclaredType declared && declared.asElement().equals(sumType)) {
+        return declared;
+      }
+    }
+    return null;
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericImportedTypeAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericImportedTypeAxisTest.java
@@ -151,7 +151,7 @@ class GenericImportedTypeAxisTest {
   }
 
   @Test
-  @DisplayName("a sealed interface, and a generic one, whose prisms are still named raw")
+  @DisplayName("a sealed interface, and a generic one, whose prisms name both sides")
   void sealedInterfaces() {
     var plainShape =
         JavaFileObjects.forSourceString(
@@ -196,13 +196,56 @@ class GenericImportedTypeAxisTest {
 
     var genericCompilation = compile("com.external.GenShape.class", genShape, genCircle);
     assertThat(genericCompilation).succeeded();
-    // Both sides are named raw, so the prism does not compose with an optic that carries the
-    // hierarchy's argument. Generating Prism<GenShape<T>, GenCircle<T>> is issue #742; this pins
-    // what is emitted until then, rather than leaving the cell unexercised.
+    // The prism is written in the subtype's vocabulary: its own parameter, and the sum type as its
+    // own implements clause instantiates it, so it composes with an optic carrying the argument.
     assertGeneratedCodeContains(
         genericCompilation,
         "com.myapp.optics.GenShapePrisms",
-        "public static Prism<GenShape, GenCircle> genCircle()");
+        "public static <T> Prism<GenShape<T>, GenCircle<T>> genCircle()");
+  }
+
+  @Test
+  @DisplayName("a permitted subtype that pins the argument, and one that adds its own")
+  void sealedSubtypeParameterShapes() {
+    var shape =
+        JavaFileObjects.forSourceString(
+            "com.external.MixShape",
+            """
+            package com.external;
+
+            public sealed interface MixShape<T> permits MixTagged, MixPair {}
+            """);
+    var tagged =
+        JavaFileObjects.forSourceString(
+            "com.external.MixTagged",
+            """
+            package com.external;
+
+            public record MixTagged(String label) implements MixShape<String> {}
+            """);
+    var pair =
+        JavaFileObjects.forSourceString(
+            "com.external.MixPair",
+            """
+            package com.external;
+
+            public record MixPair<A, B>(A a, B b) implements MixShape<A> {}
+            """);
+
+    var compilation = compile("com.external.MixShape.class", shape, tagged, pair);
+
+    assertThat(compilation).succeeded();
+    // The clause pins the argument, so the method declares nothing.
+    assertGeneratedCodeContains(
+        compilation,
+        "com.myapp.optics.MixShapePrisms",
+        "public static Prism<MixShape<String>, MixTagged> mixTagged()");
+    // B is the subtype's own and appears in the focus, so it is declared even though the sum type
+    // does not bind it - what the author wrote, rather than a parameter invented for them.
+    assertGeneratedCodeContains(
+        compilation,
+        "com.myapp.optics.MixShapePrisms",
+        "public static <A, B> Prism<MixShape<A>, MixPair<A, B>> mixPair()");
   }
 
   @Test


### PR DESCRIPTION
Fixes #742.

> **Base note.** Stacked on #743, which is itself stacked on #738 and #741 — the axis cell this changes was added there. Merge in that order; this then reduces to the two generators plus the axis update.

A prism for a permitted subtype named both the sum type and the subtype **raw**, and declared no type parameters:

```java
public sealed interface GenShape<T> permits GenCircle {}
public record GenCircle<T>(T tag) implements GenShape<T> {}
```
```java
public static Prism<GenShape, GenCircle> genCircle() { ... }   // before
```

It compiled — which is why nothing caught it for so long — but a raw prism composes with nothing carrying the hierarchy's argument, and the rawness spreads into whatever the caller writes next.

## The reading that answers all three shapes

The prism is written in the **subtype's** vocabulary: its own parameters declared on the method, and the sum type as the subtype's own `implements` clause instantiates it.

| the subtype declares | generated |
|---|---|
| `Circle<T> implements Shape<T>` | `static <T> Prism<Shape<T>, Circle<T>> circle()` |
| `Tagged implements Shape<String>` | `static Prism<Shape<String>, Tagged> tagged()` |
| `Pair<A, B> implements Shape<A>` | `static <A, B> Prism<Shape<A>, Pair<A, B>> pair()` |
| `Leaf implements Plain` | unchanged |

**`Pair` is the one worth stating.** `B` is the subtype's own and appears in the focus type, so it is declared even though the sum type does not bind it. That follows what #730 settled: a signature declares the parameters it **names**, and `B` is one the author wrote — unlike #730's `B`, which was invented for them from a declaration they never referenced.

## The unchecked cast

`instanceof` tests an erasure, so a parameterised subtype narrows through the raw name. Here the sealed hierarchy is what makes that sound — a `Shape<T>` that is a `Circle` can only be a `Circle<T>` — but javac cannot see it, so the warning is answered where it arises rather than left for a consuming build under `-Werror`. Verified by compiling the generated output with `-Xlint:unchecked,rawtypes -Werror`.

This is the *sound* sibling of #733, where an `@InstanceOf` target carries no such guarantee and the same cast genuinely can throw.

## Both generators

`PrismProcessor` (`@GeneratePrisms`) and `ExternalPrismGenerator` (`@ImportOptics`) had the same code. Both change, so the two paths keep agreeing — the thing #726 got wrong by fixing one of a pair and leaving the mirror.

## How it was found, and what that says

The axis added in #743 pinned the raw output **deliberately**, with a comment naming this issue. Running the full suite after the fix produced exactly one failure out of 2088 — that cell, and nothing else. No other test had pinned the raw prisms.

That is what pinning a known-wrong behaviour is for: closing the gap shows up as a test to update rather than as a cell nobody was looking at. The cell now pins what is generated, and two more join it for the pinned and extra-parameter subtypes.

## Verification

`clean build` across all modules: BUILD SUCCESSFUL, EXIT=0, with the 100% gates intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es3dKLikaETJPF9fX3PxNo
