### PR TITLE
@GenerateIsos and @GeneratePathBridge: answer a generic declaration, one way or the other (#746)

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/GeneratePathBridge.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/hkt/effect/annotation/GeneratePathBridge.java
@@ -67,6 +67,13 @@ import java.lang.annotation.Target;
  *   <li>{@code IO<T>} → {@code IOPath<T>}
  * </ul>
  *
+ * <h2>Type Parameters</h2>
+ *
+ * <p>The bridge holds one delegate of the annotated interface, so it declares whatever that
+ * interface declares, bounds and all: {@code Repo<T>} yields {@code RepoPaths<T>} wrapping a {@code
+ * Repo<T>}. A {@link PathVia} method that declares parameters of its own keeps them on the bridge
+ * method, where its arguments and return type name them.
+ *
  * @see PathVia
  */
 @Target(ElementType.TYPE)

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateIsos.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateIsos.java
@@ -13,6 +13,13 @@ import java.lang.annotation.Target;
  * <p>This should be placed on a method that returns an Iso. The annotation processor will then
  * generate a static field containing the Iso instance.
  *
+ * <p>The method has to be {@code static} and declare no type parameters of its own, because the
+ * generated field is a {@code public static final} one initialised by calling it: a field has
+ * nowhere to declare type parameters, and a static initialiser has no instance to call an instance
+ * method on. A method that is either is refused at the declaration rather than generated for. Fix
+ * the type arguments where the method is declared - {@code Iso<Box<String>, String>} rather than
+ * {@code <T> Iso<Box<T>, T>} - or expose the method itself instead of a generated field.
+ *
  * <p>By default, the generated class is placed in the same package as the enclosing class. Use the
  * {@link #targetPackage()} element to specify a different package for the generated class.
  */

--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateIsos.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/GenerateIsos.java
@@ -13,12 +13,18 @@ import java.lang.annotation.Target;
  * <p>This should be placed on a method that returns an Iso. The annotation processor will then
  * generate a static field containing the Iso instance.
  *
- * <p>The method has to be {@code static} and declare no type parameters of its own, because the
- * generated field is a {@code public static final} one initialised by calling it: a field has
- * nowhere to declare type parameters, and a static initialiser has no instance to call an instance
- * method on. A method that is either is refused at the declaration rather than generated for. Fix
- * the type arguments where the method is declared - {@code Iso<Box<String>, String>} rather than
- * {@code <T> Iso<Box<T>, T>} - or expose the method itself instead of a generated field.
+ * <p>The method has to be {@code static}, take no arguments, be reachable from the package the
+ * companion is written into, and return an {@code Iso} whose two type arguments name no type
+ * variable. Every one of those is a question about the generated field rather than about the
+ * method: a {@code public static final} field has nowhere to declare a type parameter and no
+ * receiver to call an instance method on. A method that breaks any of them is refused where it is
+ * declared rather than generated for — give the iso concrete type arguments, {@code
+ * Iso<Box<String>, String>} rather than {@code <T> Iso<Box<T>, T>}, or drop the annotation and call
+ * the method directly.
+ *
+ * <p>The rule is about what the iso names, not what the method declares: {@code <T> Iso<Box,
+ * String> boxIso()} is accepted, because {@code T} is inferred at the call and never reaches the
+ * field's type.
  *
  * <p>By default, the generated class is placed in the same package as the enclosing class. Use the
  * {@link #targetPackage()} element to specify a different package for the generated class.

--- a/hkj-book/src/optics/annotations_at_a_glance.md
+++ b/hkj-book/src/optics/annotations_at_a_glance.md
@@ -28,7 +28,7 @@ Apply these to your own records and sealed types. The generated class is placed 
 | [`@GenerateSetters`](setters.md) | `record` | `XSetters` (asymmetric write-only) | When you specifically want a `Setter` rather than a full `Lens` |
 | [`@GenerateTraversals`](traversals.md) | `record` containing `List<T>` etc. | `XTraversals` (one traversal per traversable field) | Bulk operations on a collection embedded in a record |
 | [`@GeneratePrisms`](prisms.md) | `sealed interface` **or** `enum` | `XPrisms` (one prism per variant) | Sum types, including both sealed hierarchies and enum constants |
-| [`@GenerateIsos`](iso.md) | **method** returning `Iso<A, B>` | companion class with the iso as a static field | Lossless conversions between equivalent representations |
+| [`@GenerateIsos`](iso.md) | **static, no-argument method** returning `Iso<A, B>`, naming no type variable | companion class with the iso as a static field | Lossless conversions between equivalent representations |
 
 ~~~admonish tip title="Annotations stack"
 You almost always want at least `@GenerateLenses` and `@GenerateFocus` together. Add `@GenerateTraversals` if the record contains a collection field and `@GenerateFolds` if you also need read-only queries.

--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -39,6 +39,38 @@ This page is for the moment a build fails and you want to know what the message 
 
 **Fix.** Ensure the annotated method returns `Iso<A, B>`. The processor reads the type parameters to generate the static field.
 
+### "@GenerateIsos: the iso returned by 'x' names a type variable"
+
+**Cause.** One of the returned `Iso`'s two type arguments is, or contains, a type variable — `<T> Iso<Box<T>, T> boxIso()`, or an instance method of a `Holder<X>` returning `Iso<Box<X>, X>`. What gets generated is a `public static final` field, and a field has nowhere to declare one, so it would name a variable nothing brings into scope.
+
+Note this is about what the *iso* names, not what the method declares: `<T> Iso<Box, String> boxIso()` is fine, because `T` is inferred at the call and never reaches the field's type.
+
+**Fix.** Give the iso concrete type arguments where the method is declared (`Iso<Box<String>, String>`), or drop `@GenerateIsos` and call the method directly.
+
+### "@GenerateIsos: 'x' is not static"
+
+**Cause.** The annotated method is an instance method. The generated field initialises itself with a static call, and there is no instance to make it on.
+
+**Fix.** Make the method `static`.
+
+### "@GenerateIsos: 'x' takes parameters"
+
+**Cause.** The generated field initialises itself by calling the method with no arguments, and there is nothing for it to pass.
+
+**Fix.** Take the arguments away, or drop `@GenerateIsos` and call the method directly.
+
+### "@GenerateIsos: 'x' does not return an Iso with both type arguments"
+
+**Cause.** The generated field is typed from the two arguments of the returned `Iso`. A `void`, primitive, array, raw or non-`Iso` return has nothing to read them off.
+
+**Fix.** Return `Iso<S, A>` naming both, as `Iso<Point, Tuple2<Integer, Integer>>`.
+
+### "@GenerateIsos: 'x' cannot be reached from 'p'"
+
+**Cause.** The generated class lives in package `p` and calls the method from there, but the method — or a type enclosing it — is `private`, `protected` or package-private somewhere else. Most often seen with `targetPackage`.
+
+**Fix.** Make the method and its enclosing types public, or generate into the package they are already visible from.
+
 ---
 
 ## `@ImportOptics` and `OpticsSpec` interfaces

--- a/hkj-book/src/optics/iso.md
+++ b/hkj-book/src/optics/iso.md
@@ -99,6 +99,8 @@ public class Converters {
 
 This is useful when you need to avoid name collisions or organise generated code separately.
 
+The annotated method has to be `static` and declare no type parameters of its own. What gets generated is a `public static final` field initialised by calling the method, and a field has nowhere to put a `<T>` — so `@GenerateIsos` on `<T> Iso<Box<T>, T> boxIso()` is refused where it is written, rather than generating a field naming a `T` that nothing declares. Fix the type arguments at the declaration (`Iso<Box<String>, String>`), or expose the method itself and skip the generated field.
+
 ### Step 2: The Core Iso Operations
 
 An `Iso` provides two fundamental, lossless operations:

--- a/hkj-book/src/optics/iso.md
+++ b/hkj-book/src/optics/iso.md
@@ -99,7 +99,9 @@ public class Converters {
 
 This is useful when you need to avoid name collisions or organise generated code separately.
 
-The annotated method has to be `static` and declare no type parameters of its own. What gets generated is a `public static final` field initialised by calling the method, and a field has nowhere to put a `<T>` — so `@GenerateIsos` on `<T> Iso<Box<T>, T> boxIso()` is refused where it is written, rather than generating a field naming a `T` that nothing declares. Fix the type arguments at the declaration (`Iso<Box<String>, String>`), or expose the method itself and skip the generated field.
+The annotated method has to be `static`, take no arguments, be reachable from the generated package, and return an `Iso` whose two type arguments name no type variable. Each of those is a question about the *field*: `@GenerateIsos` publishes the iso as a `public static final` field, and a field has nowhere to declare a `<T>` and no receiver to call an instance method on. It is alone in this among the optics annotations — the rest generate static *methods*, which can declare type parameters and do.
+
+So `<T> Iso<Box<T>, T> boxIso()` is refused where it is written rather than generating a field naming a `T` that nothing declares. Note the rule is about what the **iso** names, not what the method declares: `<T> Iso<Box, String> boxIso()` generates fine, because `T` is inferred at the call and never reaches the field's type. Give the iso concrete type arguments (`Iso<Box<String>, String>`), or call the method directly and skip the generated field.
 
 ### Step 2: The Core Iso Operations
 

--- a/hkj-book/src/tutorials/effect/effect_cheatsheet.md
+++ b/hkj-book/src/tutorials/effect/effect_cheatsheet.md
@@ -124,10 +124,14 @@ The annotation processor generates `UserServicePaths` with:
 
 | Original return | Generated wrapper |
 |-----------------|--------------------|
-| `Optional<T>` | `OptionalPath<T>` (or `MaybePath<T>` with `@PathVia(MAYBE)`) |
+| `Optional<T>` | `OptionalPath<T>` |
+| `Maybe<T>` | `MaybePath<T>` |
 | `Either<E, T>` | `EitherPath<E, T>` |
-| `T` (with `@PathVia(IO)`) | `IOPath<T>` |
-| `CompletableFuture<T>` | `VTaskPath<T>` (or `CompletableFuturePath<T>`) |
+| `Try<T>` | `TryPath<T>` |
+| `Validated<E, T>` | `ValidationPath<E, T>` (adds a `Semigroup<E>` parameter) |
+| `IO<T>` | `IOPath<T>` |
+
+The wrapper is chosen from the declared return type alone; `@PathVia` takes `name`, `doc` and `composable`, none of which select it. A return type outside this table is refused with *"Unsupported return type for @PathVia"* — `CompletableFuture` among them, so wrap it in a `VTaskPath` or `CompletableFuturePath` by hand.
 
 The wrapper is exactly the one-liner shown in Tutorial 02 Exercise 6, generated so we never have to write it.
 

--- a/hkj-book/src/tutorials/effect/effect_cheatsheet.md
+++ b/hkj-book/src/tutorials/effect/effect_cheatsheet.md
@@ -131,6 +131,21 @@ The annotation processor generates `UserServicePaths` with:
 
 The wrapper is exactly the one-liner shown in Tutorial 02 Exercise 6, generated so we never have to write it.
 
+Type parameters carry through. A generic service gives a generic bridge — `Repo<T>` yields `RepoPaths<T>` wrapping a `Repo<T>`, bounds included — and a generic `@PathVia` method keeps its own parameters on the bridge method:
+
+```java
+@GeneratePathBridge
+public interface Repo<T extends Comparable<T>> {
+    @PathVia
+    <R> Optional<R> convert(T from, Class<R> to);
+}
+
+// generated
+public final class RepoPaths<T extends Comparable<T>> {
+    public <R> OptionalPath<R> convert(T from, Class<R> to) { ... }
+}
+```
+
 ---
 
 ## Focus-Effect bridge

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
@@ -17,8 +17,10 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Iso;
 import org.higherkindedj.optics.annotations.GenerateIsos;
@@ -69,24 +71,47 @@ public final class IsoProcessor extends AbstractProcessor {
    * Reports a method the generated field cannot be written for, and returns whether it did.
    *
    * <p>The iso is published as a {@code public static final} field initialised by calling the
-   * method. A field has nowhere to declare type parameters, and a static initialiser has no
-   * instance to call an instance method on, so both shapes are turned away here rather than left to
-   * javac to report against source the author did not write.
+   * method, so every question here is one about that field: can its type be written down, and can
+   * its initialiser reach the method. Answering them at the declaration is the point — left
+   * ungated, each of these emitted a field javac then refused, in a file the author never wrote.
    *
    * @param method the annotated method
+   * @param targetPackage the package the generated class is written into
    * @return true when the method was rejected and an error reported
    */
-  private boolean rejectsUnwritableMethod(final ExecutableElement method) {
-    if (!method.getTypeParameters().isEmpty()) {
+  private boolean rejectsUnwritableMethod(
+      final ExecutableElement method, final String targetPackage) {
+
+    final String name = method.getSimpleName().toString();
+    if (!(method.getReturnType() instanceof DeclaredType returned)
+        || !isoElement(returned)
+        || returned.getTypeArguments().size() != 2) {
       Diagnostics.error(
           processingEnv.getMessager(),
           method,
           TAG,
-          "'" + method.getSimpleName() + "' declares type parameters.",
-          "The iso is published as a static final field, which has nowhere to declare them; the"
-              + " field would name a variable nothing brings into scope.",
-          "Fix the type arguments at the declaration, as 'Iso<Box<String>, String>', or drop"
-              + " @GenerateIsos and expose the method itself.");
+          "'" + name + "' does not return an Iso with both type arguments.",
+          "The generated field is typed from the two arguments of the method's returned Iso, and"
+              + " there is nothing to read them off.",
+          "Return 'Iso<S, A>' naming both, as 'Iso<Point, Tuple2<Integer, Integer>>'.");
+      return true;
+    }
+    // What matters is whether a variable reaches the field's own type, not whether the method
+    // declares one: '<T> Iso<Box, String>' names none of its T and writes down perfectly well,
+    // while an instance method of 'Holder<X>' returning 'Iso<Box<X>, X>' declares nothing and
+    // names X twice.
+    if (returned.getTypeArguments().stream().anyMatch(IsoProcessor::namesTypeVariable)) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          method,
+          TAG,
+          "the iso returned by '" + name + "' names a type variable.",
+          "It is published as a static final field, which has nowhere to declare one; the field"
+              + " would name a variable nothing brings into scope.",
+          "Give the iso concrete type arguments at the declaration (e.g. 'Iso<Box<String>,"
+              + " String>' rather than '<T> Iso<Box<T>, T>'), or drop @GenerateIsos and call '"
+              + name
+              + "()' directly.");
       return true;
     }
     if (!method.getModifiers().contains(STATIC)) {
@@ -94,19 +119,104 @@ public final class IsoProcessor extends AbstractProcessor {
           processingEnv.getMessager(),
           method,
           TAG,
-          "'" + method.getSimpleName() + "' is not static.",
+          "'" + name + "' is not static.",
           "The generated field initialises itself by calling the method, and a static initialiser"
               + " has no instance to call it on.",
-          "Make '" + method.getSimpleName() + "' static.");
+          "Make '" + name + "' static.");
+      return true;
+    }
+    if (!method.getParameters().isEmpty()) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          method,
+          TAG,
+          "'" + name + "' takes parameters.",
+          "The generated field initialises itself by calling the method with no arguments, and"
+              + " there is nothing for it to pass.",
+          "Take the arguments away, or drop @GenerateIsos and call '" + name + "(...)' directly.");
+      return true;
+    }
+    if (!reachableFrom(method, targetPackage)) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          method,
+          TAG,
+          "'" + name + "' cannot be reached from '" + targetPackage + "'.",
+          "The generated field calls the method from the class written into that package, and"
+              + " neither the method nor a type enclosing it is visible there.",
+          "Make '"
+              + name
+              + "' and the types enclosing it public, or generate into the package they are"
+              + " already visible from.");
       return true;
     }
     return false;
   }
 
-  private void processMethod(final ExecutableElement method) throws IOException {
-    if (rejectsUnwritableMethod(method)) {
-      return;
+  /**
+   * Whether a declared type is {@code org.higherkindedj.optics.Iso} itself.
+   *
+   * <p>Cast, not a pattern: a declared type's element is a {@link TypeElement}, an unresolvable one
+   * included, so there is no other kind for a test to turn away.
+   */
+  private static boolean isoElement(final DeclaredType type) {
+    return ((TypeElement) type.asElement())
+        .getQualifiedName()
+        .contentEquals(Iso.class.getCanonicalName());
+  }
+
+  /**
+   * Whether a type names a type variable anywhere inside it.
+   *
+   * <p>Asked of the field's own type arguments, so it has to see through every layer one can be
+   * buried in: {@code List<T>}, {@code T[]}, {@code List<? extends T>} and {@code Outer<T>.Inner}
+   * all name one, and a field naming any of them declares nothing that brings it into scope.
+   */
+  private static boolean namesTypeVariable(final TypeMirror type) {
+    return switch (type.getKind()) {
+      case TYPEVAR -> true;
+      case ARRAY -> namesTypeVariable(((ArrayType) type).getComponentType());
+      case WILDCARD -> {
+        final WildcardType wildcard = (WildcardType) type;
+        yield (wildcard.getExtendsBound() != null && namesTypeVariable(wildcard.getExtendsBound()))
+            || (wildcard.getSuperBound() != null && namesTypeVariable(wildcard.getSuperBound()));
+      }
+      case DECLARED -> {
+        final DeclaredType declared = (DeclaredType) type;
+        yield declared.getTypeArguments().stream().anyMatch(IsoProcessor::namesTypeVariable)
+            || namesTypeVariable(declared.getEnclosingType());
+      }
+      default -> false;
+    };
+  }
+
+  /**
+   * Whether a member, and every type enclosing it, is visible from the generated package.
+   *
+   * <p>{@code protected} counts as package access here: the generated class extends nothing, so
+   * being a subclass is never how it reaches the member.
+   */
+  private boolean reachableFrom(final Element member, final String targetPackage) {
+    for (Element current = member;
+        current.getKind() != ElementKind.PACKAGE;
+        current = current.getEnclosingElement()) {
+      final Set<Modifier> modifiers = current.getModifiers();
+      if (modifiers.contains(Modifier.PRIVATE)) {
+        return false;
+      }
+      if (!modifiers.contains(PUBLIC)
+          && !processingEnv
+              .getElementUtils()
+              .getPackageOf(current)
+              .getQualifiedName()
+              .contentEquals(targetPackage)) {
+        return false;
+      }
     }
+    return true;
+  }
+
+  private void processMethod(final ExecutableElement method) throws IOException {
     final TypeElement classElement = (TypeElement) method.getEnclosingElement();
     final String methodName = method.getSimpleName().toString();
     final String className = classElement.getSimpleName().toString();
@@ -118,14 +228,12 @@ public final class IsoProcessor extends AbstractProcessor {
     final String targetPackage = annotation.targetPackage();
     final String packageName = targetPackage.isEmpty() ? defaultPackage : targetPackage;
 
-    final DeclaredType isoType = (DeclaredType) method.getReturnType();
-    final List<? extends TypeMirror> typeArguments = isoType.getTypeArguments();
-    if (typeArguments.size() != 2) {
-      processingEnv
-          .getMessager()
-          .printMessage(Diagnostic.Kind.ERROR, "Iso must have two type arguments", method);
+    if (rejectsUnwritableMethod(method, packageName)) {
       return;
     }
+    // Checked by the gate above: a two-argument Iso, naming no type variable.
+    final List<? extends TypeMirror> typeArguments =
+        ((DeclaredType) method.getReturnType()).getTypeArguments();
 
     final TypeName sTypeName = TypeName.get(typeArguments.get(0));
     final TypeName aTypeName = TypeName.get(typeArguments.get(1));

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
@@ -22,6 +22,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Iso;
 import org.higherkindedj.optics.annotations.GenerateIsos;
+import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
 
 /**
@@ -31,6 +32,8 @@ import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport
 @AutoService(Processor.class)
 @SupportedAnnotationTypes("org.higherkindedj.optics.annotations.GenerateIsos")
 public final class IsoProcessor extends AbstractProcessor {
+
+  private static final String TAG = "@GenerateIsos";
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
@@ -62,7 +65,48 @@ public final class IsoProcessor extends AbstractProcessor {
     }
   }
 
+  /**
+   * Reports a method the generated field cannot be written for, and returns whether it did.
+   *
+   * <p>The iso is published as a {@code public static final} field initialised by calling the
+   * method. A field has nowhere to declare type parameters, and a static initialiser has no
+   * instance to call an instance method on, so both shapes are turned away here rather than left to
+   * javac to report against source the author did not write.
+   *
+   * @param method the annotated method
+   * @return true when the method was rejected and an error reported
+   */
+  private boolean rejectsUnwritableMethod(final ExecutableElement method) {
+    if (!method.getTypeParameters().isEmpty()) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          method,
+          TAG,
+          "'" + method.getSimpleName() + "' declares type parameters.",
+          "The iso is published as a static final field, which has nowhere to declare them; the"
+              + " field would name a variable nothing brings into scope.",
+          "Fix the type arguments at the declaration, as 'Iso<Box<String>, String>', or drop"
+              + " @GenerateIsos and expose the method itself.");
+      return true;
+    }
+    if (!method.getModifiers().contains(STATIC)) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          method,
+          TAG,
+          "'" + method.getSimpleName() + "' is not static.",
+          "The generated field initialises itself by calling the method, and a static initialiser"
+              + " has no instance to call it on.",
+          "Make '" + method.getSimpleName() + "' static.");
+      return true;
+    }
+    return false;
+  }
+
   private void processMethod(final ExecutableElement method) throws IOException {
+    if (rejectsUnwritableMethod(method)) {
+      return;
+    }
     final TypeElement classElement = (TypeElement) method.getEnclosingElement();
     final String methodName = method.getSimpleName().toString();
     final String className = classElement.getSimpleName().toString();

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
@@ -26,6 +26,7 @@ import org.higherkindedj.optics.Iso;
 import org.higherkindedj.optics.annotations.GenerateIsos;
 import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * An annotation processor that generates a container class with static Iso fields for each method
@@ -136,7 +137,36 @@ public final class IsoProcessor extends AbstractProcessor {
           "Take the arguments away, or drop @GenerateIsos and call '" + name + "(...)' directly.");
       return true;
     }
-    if (!reachableFrom(method, targetPackage)) {
+    final TypeElement unreachable =
+        returned.getTypeArguments().stream()
+            .map(
+                argument ->
+                    ProcessorUtils.firstUnreachableIn(
+                        processingEnv.getElementUtils(), argument, targetPackage))
+            .filter(java.util.Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+    if (unreachable != null) {
+      Diagnostics.error(
+          processingEnv.getMessager(),
+          method,
+          TAG,
+          "the iso returned by '"
+              + name
+              + "' names '"
+              + unreachable.getSimpleName()
+              + "', which cannot be reached from '"
+              + targetPackage
+              + "'.",
+          "The generated field writes its own type out in full, so every type named inside it has"
+              + " to be visible where the field is declared.",
+          "Make '"
+              + unreachable.getSimpleName()
+              + "' and the types enclosing it public, or generate into the package they are"
+              + " already visible from.");
+      return true;
+    }
+    if (!ProcessorUtils.reachableFrom(processingEnv.getElementUtils(), method, targetPackage)) {
       Diagnostics.error(
           processingEnv.getMessager(),
           method,
@@ -188,32 +218,6 @@ public final class IsoProcessor extends AbstractProcessor {
       }
       default -> false;
     };
-  }
-
-  /**
-   * Whether a member, and every type enclosing it, is visible from the generated package.
-   *
-   * <p>{@code protected} counts as package access here: the generated class extends nothing, so
-   * being a subclass is never how it reaches the member.
-   */
-  private boolean reachableFrom(final Element member, final String targetPackage) {
-    for (Element current = member;
-        current.getKind() != ElementKind.PACKAGE;
-        current = current.getEnclosingElement()) {
-      final Set<Modifier> modifiers = current.getModifiers();
-      if (modifiers.contains(Modifier.PRIVATE)) {
-        return false;
-      }
-      if (!modifiers.contains(PUBLIC)
-          && !processingEnv
-              .getElementUtils()
-              .getPackageOf(current)
-              .getQualifiedName()
-              .contentEquals(targetPackage)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   private void processMethod(final ExecutableElement method) throws IOException {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
@@ -128,7 +128,12 @@ public class PathProcessor extends AbstractProcessor {
                 "Generated Path bridge for {@link $T}.\n\n<p>Do not edit.\n", interfaceClassName)
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addOriginatingElement(interfaceElement);
-    interfaceVariables.forEach(classBuilder::addTypeVariable);
+    interfaceVariables.forEach(
+        variable -> {
+          classBuilder.addTypeVariable(variable);
+          // Doclint wants one per parameter, and nobody can add it to a generated file by hand.
+          classBuilder.addJavadoc("\n@param <$L> as declared by the delegate\n", variable.name());
+        });
 
     // Add delegate field
     classBuilder.addField(
@@ -172,6 +177,22 @@ public class PathProcessor extends AbstractProcessor {
   }
 
   private MethodSpec createBridgeMethod(ExecutableElement method, PathVia pathVia) {
+    // The bridge calls the method through its delegate, which reaches an abstract or default
+    // member and nothing else. Left ungated, both of these emitted a call javac refuses, against
+    // a file the author never wrote.
+    Set<Modifier> modifiers = method.getModifiers();
+    if (modifiers.contains(Modifier.STATIC) || modifiers.contains(Modifier.PRIVATE)) {
+      error(
+          "@PathVia on '"
+              + method.getSimpleName()
+              + "': the bridge reaches the method through its delegate, and a "
+              + (modifiers.contains(Modifier.STATIC) ? "static" : "private")
+              + " interface method cannot be called that way. Fix: make it an abstract or default"
+              + " instance method, or drop @PathVia from it.",
+          method);
+      return null;
+    }
+
     String methodName =
         pathVia.name().isEmpty() ? method.getSimpleName().toString() : pathVia.name();
     String doc = pathVia.doc();
@@ -198,7 +219,12 @@ public class PathProcessor extends AbstractProcessor {
     // already, from the class.
     method.getTypeParameters().stream()
         .map(TypeVariableName::get)
-        .forEach(methodBuilder::addTypeVariable);
+        .forEach(
+            variable -> {
+              methodBuilder.addTypeVariable(variable);
+              methodBuilder.addJavadoc(
+                  "@param <$L> as declared by the delegate method\n", variable.name());
+            });
 
     // Add documentation
     if (!doc.isEmpty()) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
@@ -14,10 +14,12 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
 import org.higherkindedj.hkt.effect.annotation.PathVia;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Annotation processor that generates Path bridge classes for service interfaces.
@@ -120,6 +122,13 @@ public class PathProcessor extends AbstractProcessor {
             : ParameterizedTypeName.get(
                 interfaceClassName, interfaceVariables.toArray(TypeName[]::new));
 
+    // A bound is written into the bridge's own declaration, so it has to be nameable there. Only
+    // targetPackage can make that false: written beside the interface, whatever the interface can
+    // name the bridge can name too.
+    if (rejectsUnnameableBound(interfaceElement, interfaceElement, packageName)) {
+      return;
+    }
+
     // Build the bridge class
     TypeSpec.Builder classBuilder =
         TypeSpec.classBuilder(bridgeClassName)
@@ -159,6 +168,9 @@ public class PathProcessor extends AbstractProcessor {
         ExecutableElement method = (ExecutableElement) enclosed;
         PathVia pathVia = method.getAnnotation(PathVia.class);
         if (pathVia != null) {
+          if (rejectsUnnameableBound(method, interfaceElement, packageName)) {
+            continue;
+          }
           MethodSpec bridgeMethod = createBridgeMethod(method, pathVia);
           if (bridgeMethod != null) {
             classBuilder.addMethod(bridgeMethod);
@@ -174,6 +186,49 @@ public class PathProcessor extends AbstractProcessor {
             .build();
 
     javaFile.writeTo(processingEnv.getFiler());
+  }
+
+  /**
+   * Reports a type parameter whose bound the generated package cannot name, and returns whether it
+   * did.
+   *
+   * <p>The bridge repeats its delegate's bounds verbatim, so a bound naming a package-private type
+   * lands in a declaration that cannot see it. Only {@code targetPackage} makes this reachable: a
+   * bridge written beside its interface can name everything the interface can.
+   *
+   * @param declarer the interface or method whose parameters are being copied
+   * @param interfaceElement the annotated interface, which the diagnostic is reported against
+   * @param packageName the package the bridge is written into
+   * @return true when a bound was rejected and an error reported
+   */
+  private boolean rejectsUnnameableBound(
+      Parameterizable declarer, TypeElement interfaceElement, String packageName) {
+
+    Elements elements = processingEnv.getElementUtils();
+    for (TypeParameterElement parameter : declarer.getTypeParameters()) {
+      for (TypeMirror bound : parameter.getBounds()) {
+        TypeElement unreachable = ProcessorUtils.firstUnreachableIn(elements, bound, packageName);
+        if (unreachable != null) {
+          error(
+              "@GeneratePathBridge on '"
+                  + interfaceElement.getSimpleName()
+                  + "': the bound on '"
+                  + parameter.getSimpleName()
+                  + "' names '"
+                  + unreachable.getSimpleName()
+                  + "', which cannot be reached from '"
+                  + packageName
+                  + "'. The bridge repeats the bound in its own declaration, and it is not visible"
+                  + " there. Fix: make '"
+                  + unreachable.getSimpleName()
+                  + "' public, or drop targetPackage so the bridge is written beside the"
+                  + " interface.",
+              declarer);
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private MethodSpec createBridgeMethod(ExecutableElement method, PathVia pathVia) {
@@ -217,19 +272,19 @@ public class PathProcessor extends AbstractProcessor {
     // A generic delegate method's parameters are named by the return type and the arguments copied
     // below, so the bridge method has to declare them itself; the interface's own are in scope
     // already, from the class.
-    method.getTypeParameters().stream()
-        .map(TypeVariableName::get)
-        .forEach(
-            variable -> {
-              methodBuilder.addTypeVariable(variable);
-              methodBuilder.addJavadoc(
-                  "@param <$L> as declared by the delegate method\n", variable.name());
-            });
+    List<TypeVariableName> methodVariables =
+        method.getTypeParameters().stream().map(TypeVariableName::get).toList();
+    methodVariables.forEach(methodBuilder::addTypeVariable);
 
-    // Add documentation
+    // Description first, then the block tags in order. A tag written before the description takes
+    // the description into itself, which is what javadoc does with any text following a tag.
     if (!doc.isEmpty()) {
       methodBuilder.addJavadoc("$L\n\n", doc);
     }
+    methodVariables.forEach(
+        variable ->
+            methodBuilder.addJavadoc(
+                "@param <$L> as declared by the delegate method\n", variable.name()));
     methodBuilder.addJavadoc(
         "@return Path-wrapped result from {@link $L#$L}\n",
         method.getEnclosingElement().getSimpleName(),

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
@@ -109,6 +109,16 @@ public class PathProcessor extends AbstractProcessor {
     String bridgeClassName = interfaceName + suffix;
 
     ClassName interfaceClassName = ClassName.get(interfaceElement);
+    // The bridge holds one delegate of the annotated interface, so it declares whatever that
+    // interface declares. Naming it raw instead would leave every method that mentions one of
+    // those parameters pointing at a variable the bridge never brings into scope.
+    List<TypeVariableName> interfaceVariables =
+        interfaceElement.getTypeParameters().stream().map(TypeVariableName::get).toList();
+    TypeName delegateType =
+        interfaceVariables.isEmpty()
+            ? interfaceClassName
+            : ParameterizedTypeName.get(
+                interfaceClassName, interfaceVariables.toArray(TypeName[]::new));
 
     // Build the bridge class
     TypeSpec.Builder classBuilder =
@@ -118,17 +128,17 @@ public class PathProcessor extends AbstractProcessor {
                 "Generated Path bridge for {@link $T}.\n\n<p>Do not edit.\n", interfaceClassName)
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addOriginatingElement(interfaceElement);
+    interfaceVariables.forEach(classBuilder::addTypeVariable);
 
     // Add delegate field
     classBuilder.addField(
-        FieldSpec.builder(interfaceClassName, "delegate", Modifier.PRIVATE, Modifier.FINAL)
-            .build());
+        FieldSpec.builder(delegateType, "delegate", Modifier.PRIVATE, Modifier.FINAL).build());
 
     // Add constructor
     classBuilder.addMethod(
         MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(interfaceClassName, "delegate")
+            .addParameter(delegateType, "delegate")
             .addJavadoc(
                 "Creates a new Path bridge wrapping the given delegate.\n\n"
                     + "@param delegate the service to wrap; must not be null\n")
@@ -182,6 +192,13 @@ public class PathProcessor extends AbstractProcessor {
         MethodSpec.methodBuilder(methodName)
             .addModifiers(Modifier.PUBLIC)
             .returns(mapping.pathType());
+
+    // A generic delegate method's parameters are named by the return type and the arguments copied
+    // below, so the bridge method has to declare them itself; the interface's own are in scope
+    // already, from the class.
+    method.getTypeParameters().stream()
+        .map(TypeVariableName::get)
+        .forEach(methodBuilder::addTypeVariable);
 
     // Add documentation
     if (!doc.isEmpty()) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -7,7 +7,9 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
@@ -17,6 +19,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 /**
@@ -71,6 +74,89 @@ public final class ProcessorUtils {
    */
   public static boolean hasTypeArguments(TypeMirror type) {
     return type instanceof DeclaredType declared && !declared.getTypeArguments().isEmpty();
+  }
+
+  /**
+   * Whether a member, and every type enclosing it, is visible from a generated class's package.
+   *
+   * <p>Generated code names what it calls; a member it cannot see is a compile error in a file its
+   * author never wrote. {@code protected} counts as package access here, because a generated
+   * companion extends nothing — being a subclass is never how it reaches anything.
+   *
+   * @param elements the round's element utilities
+   * @param member the member or type to test
+   * @param targetPackage the package the generated class is written into
+   * @return true when the member and every type enclosing it can be named from there
+   * @since 0.4.10
+   */
+  public static boolean reachableFrom(Elements elements, Element member, String targetPackage) {
+    for (Element current = member;
+        current.getKind() != ElementKind.PACKAGE;
+        current = current.getEnclosingElement()) {
+      Set<Modifier> modifiers = current.getModifiers();
+      if (modifiers.contains(Modifier.PRIVATE)) {
+        return false;
+      }
+      if (!modifiers.contains(Modifier.PUBLIC)
+          && !elements.getPackageOf(current).getQualifiedName().contentEquals(targetPackage)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * The first type named anywhere inside {@code type} that a generated class in {@code
+   * targetPackage} could not name, or null when every one of them is reachable.
+   *
+   * <p>Written out, a type names more than its own head: {@code Iso<Box<Secret>, String>} names
+   * {@code Secret}, and a field declaring it does not compile wherever {@code Secret} cannot be
+   * seen. So the walk descends through type arguments, array components, wildcard bounds and
+   * enclosing types, the same layers a type variable can hide in.
+   *
+   * @param elements the round's element utilities
+   * @param type the type the generated source will write out
+   * @param targetPackage the package the generated class is written into
+   * @return the first unreachable type element, or null
+   * @since 0.4.10
+   */
+  public static TypeElement firstUnreachableIn(
+      Elements elements, TypeMirror type, String targetPackage) {
+    switch (type.getKind()) {
+      case ARRAY -> {
+        return firstUnreachableIn(elements, ((ArrayType) type).getComponentType(), targetPackage);
+      }
+      case WILDCARD -> {
+        WildcardType wildcard = (WildcardType) type;
+        for (TypeMirror bound :
+            new TypeMirror[] {wildcard.getExtendsBound(), wildcard.getSuperBound()}) {
+          if (bound != null) {
+            TypeElement unreachable = firstUnreachableIn(elements, bound, targetPackage);
+            if (unreachable != null) {
+              return unreachable;
+            }
+          }
+        }
+        return null;
+      }
+      case DECLARED -> {
+        DeclaredType declared = (DeclaredType) type;
+        TypeElement element = (TypeElement) declared.asElement();
+        if (!reachableFrom(elements, element, targetPackage)) {
+          return element;
+        }
+        for (TypeMirror argument : declared.getTypeArguments()) {
+          TypeElement unreachable = firstUnreachableIn(elements, argument, targetPackage);
+          if (unreachable != null) {
+            return unreachable;
+          }
+        }
+        return firstUnreachableIn(elements, declared.getEnclosingType(), targetPackage);
+      }
+      default -> {
+        return null;
+      }
+    }
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericsAcceptanceAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericsAcceptanceAxisTest.java
@@ -4,6 +4,7 @@ package org.higherkindedj.optics.processing;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
@@ -23,18 +24,29 @@ import org.junit.jupiter.api.Test;
  * type variable nothing brought into scope, which the author met as {@code cannot find symbol} in a
  * file they never wrote.
  *
- * <p>The accepted rows assert compilation, not a signature, because that is the whole claim: what
- * comes out has to build. The refusing rows assert the wording, because a refusal whose remedy
- * cannot be followed is the other half of the same fault.
+ * <p>The accepted rows assert compilation under the consuming build's own {@code -Werror} flags,
+ * not a signature, because that is the whole claim: what comes out has to build where it lands. The
+ * refusing rows assert the wording, and one row per refusal follows the remedy it names, because a
+ * refusal that cannot be acted on is the other half of the same fault.
  *
- * <p>{@code @GeneratePrisms} belongs in this matrix and is verified in {@link
- * PrismProcessorIntegrationTest} instead, where the hierarchy fixtures it needs already live.
+ * <p>Two annotations are answered elsewhere. {@code @ImportOptics} has an axis of its own in {@link
+ * GenericSpecInterfaceAxisTest}, one case per copy strategy and optic hint against a spec that
+ * declares its own parameter. {@code @GeneratePrisms} has no row anywhere: on a generic hierarchy
+ * it accepts the declaration and emits raw-typed prisms, which is neither answer, and what it
+ * should emit instead is not settled yet (#742).
  */
 @DisplayName("What every generating annotation does with a generic declaration")
 class GenericsAcceptanceAxisTest {
 
   private static Compilation compile(Processor processor, JavaFileObject... sources) {
-    return javac().withProcessors(processor).compile(sources);
+    // The consuming build's flags, not javac's defaults, as SpecInterfaceProcessingTest does.
+    // Plain succeeded() passes on raw generated output, which is how an annotation that drops its
+    // type parameters altogether looks from the outside - accepted, and a -Werror failure in the
+    // build that consumes it.
+    return javac()
+        .withOptions("-Xlint:unchecked,rawtypes", "-Werror")
+        .withProcessors(processor)
+        .compile(sources);
   }
 
   @Nested
@@ -59,7 +71,8 @@ class GenericsAcceptanceAxisTest {
                   """));
 
       assertThat(compilation).succeeded();
-      assertThat(compilation).generatedSourceFile("com.example.BoxLenses");
+      assertGeneratedCodeContains(
+          compilation, "com.example.BoxLenses", "public static <T> Lens<Box<T>, T> value()");
     }
 
     @Test
@@ -81,7 +94,10 @@ class GenericsAcceptanceAxisTest {
                   """));
 
       assertThat(compilation).succeeded();
-      assertThat(compilation).generatedSourceFile("com.example.BagTraversals");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BagTraversals",
+          "public static <T> Traversal<Bag<T>, T> items()");
     }
 
     @Test
@@ -102,7 +118,149 @@ class GenericsAcceptanceAxisTest {
                   """));
 
       assertThat(compilation).succeeded();
-      assertThat(compilation).generatedSourceFile("com.example.CellFocus");
+      assertGeneratedCodeContains(
+          compilation, "com.example.CellFocus", "public static <T> FocusPath<Cell<T>, T> value()");
+    }
+
+    @Test
+    @DisplayName("@GenerateIsos on a generic method whose parameter the iso never names")
+    void generateIsosWhoseParameterTheIsoNeverNames() {
+      var compilation =
+          compile(
+              new IsoProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Conv",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.Iso;
+                  import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                  public class Conv {
+                      public record Box(String value) {}
+
+                      @GenerateIsos
+                      public static <T> Iso<Box, String> boxIso() {
+                          return Iso.of(Box::value, Box::new);
+                      }
+                  }
+                  """));
+
+      // T is inferred at the call and never reaches the field's type, so the field writes down
+      // exactly as it would without it. Refusing on the declaration alone turned this away.
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.ConvIsos",
+          "public static final Iso<Conv.Box, String> boxIso = Conv.boxIso();");
+    }
+
+    @Test
+    @DisplayName("@GenerateGetters on a generic record")
+    void generateGetters() {
+      var compilation =
+          compile(
+              new GetterProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.GBox",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateGetters;
+
+                  @GenerateGetters
+                  public record GBox<T>(T value, String label) {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.GBoxGetters", "public static <T> Getter<GBox<T>, T> value()");
+    }
+
+    @Test
+    @DisplayName("@GenerateSetters on a generic record")
+    void generateSetters() {
+      var compilation =
+          compile(
+              new SetterProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.SBox",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateSetters;
+
+                  @GenerateSetters
+                  public record SBox<T>(T value, String label) {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.SBoxSetters", "public static <T> Setter<SBox<T>, T> value()");
+    }
+
+    @Test
+    @DisplayName("@GenerateFolds on a generic record")
+    void generateFolds() {
+      var compilation =
+          compile(
+              new FoldProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.FBox",
+                  """
+                  package com.example;
+
+                  import java.util.List;
+                  import org.higherkindedj.optics.annotations.GenerateFolds;
+
+                  @GenerateFolds
+                  public record FBox<T>(List<T> items, String label) {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.FBoxFolds", "public static <T> Fold<FBox<T>, T> items()");
+    }
+
+    @Test
+    @DisplayName("@GenerateMapping on a spec declaring its own parameter")
+    void generateMapping() {
+      var compilation =
+          compile(
+              new MappingProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Page",
+                  """
+                  package com.example;
+
+                  import java.util.List;
+
+                  public record Page<T>(List<T> items, String cursor) {}
+                  """),
+              JavaFileObjects.forSourceString(
+                  "com.example.PageDto",
+                  """
+                  package com.example;
+
+                  import java.util.List;
+
+                  public record PageDto<T>(List<T> items, String cursor) {}
+                  """),
+              JavaFileObjects.forSourceString(
+                  "com.example.PageMapping",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateMapping;
+                  import org.higherkindedj.optics.annotations.MappingSpec;
+
+                  @GenerateMapping
+                  public interface PageMapping<T> extends MappingSpec<Page<T>, PageDto<T>> {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.PageMappingImpl", "class PageMappingImpl<T>");
     }
 
     @Test
@@ -128,8 +286,11 @@ class GenericsAcceptanceAxisTest {
                   """));
 
       // The bridge holds one delegate of the interface, so it declares what the interface does.
+      // The delegate field is asserted too: a raw one still compiles, just not under -Werror.
       assertThat(compilation).succeeded();
-      assertThat(compilation).generatedSourceFile("com.example.RepoPaths");
+      assertGeneratedCodeContains(compilation, "com.example.RepoPaths", "class RepoPaths<T>");
+      assertGeneratedCodeContains(
+          compilation, "com.example.RepoPaths", "private final Repo<T> delegate;");
     }
 
     @Test
@@ -156,7 +317,8 @@ class GenericsAcceptanceAxisTest {
 
       // The bridge method copies the delegate's signature, so it declares the method's own too.
       assertThat(compilation).succeeded();
-      assertThat(compilation).generatedSourceFile("com.example.SvcPaths");
+      assertGeneratedCodeContains(
+          compilation, "com.example.SvcPaths", "public <T> OptionalPath<T> find(Class<T> type)");
     }
 
     @Test
@@ -184,7 +346,12 @@ class GenericsAcceptanceAxisTest {
       // T on the class with its bound, R on the method: putting either in the other's place names
       // a variable out of scope at one of the two use sites.
       assertThat(compilation).succeeded();
-      assertThat(compilation).generatedSourceFile("com.example.BothRepoPaths");
+      assertGeneratedCodeContains(
+          compilation, "com.example.BothRepoPaths", "class BothRepoPaths<T extends Comparable<T>>");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BothRepoPaths",
+          "public <R> OptionalPath<R> convert(T from, Class<R> to)");
     }
   }
 
@@ -218,7 +385,10 @@ class GenericsAcceptanceAxisTest {
 
       // A static final field has nowhere to declare <T>, so there is no correct source to emit.
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("'boxIso' declares type parameters");
+      assertThat(compilation)
+          .hadErrorContaining("the iso returned by 'boxIso' names a type variable");
+      assertThat(compilation)
+          .hadErrorContaining("Give the iso concrete type arguments at the declaration");
     }
 
     @Test
@@ -248,6 +418,69 @@ class GenericsAcceptanceAxisTest {
       // The field initialises itself with a static call; an instance method has no receiver for it.
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("'boxIso' is not static");
+      assertThat(compilation).hadErrorContaining("Make 'boxIso' static.");
+    }
+
+    @Test
+    @DisplayName("@GenerateIsos on an instance method naming its enclosing class's parameter")
+    void generateIsosNamingAnEnclosingParameter() {
+      var compilation =
+          compile(
+              new IsoProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Holder",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.Iso;
+                  import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                  public class Holder<X> {
+                      public record Box<T>(T value) {}
+
+                      @GenerateIsos
+                      public Iso<Box<X>, X> boxIso() { return Iso.of(Box::value, Box::new); }
+                  }
+                  """));
+
+      // The method declares nothing; X comes from the class. Reported as the variable it is,
+      // because "make it static" is a remedy this method cannot follow - a static method of
+      // Holder<X> cannot name X either.
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("names a type variable");
+    }
+
+    @Test
+    @DisplayName("@GenerateIsos: both remedies it names actually work")
+    void generateIsosRemediesWork() {
+      // The refusals are only half an answer if what they tell the author to write does not
+      // compile. Both messages name this shape: concrete arguments, on a static method.
+      var compilation =
+          compile(
+              new IsoProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Conv",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.Iso;
+                  import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                  public class Conv {
+                      public record Box<T>(T value) {}
+
+                      @GenerateIsos
+                      public static Iso<Box<String>, String> boxIso() {
+                          return Iso.of(Box::value, Box::new);
+                      }
+                  }
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.ConvIsos",
+          "public static final Iso<Conv.Box<String>, String> boxIso = Conv.boxIso();");
     }
 
     @Test
@@ -271,6 +504,7 @@ class GenericsAcceptanceAxisTest {
 
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("'PairMerge' is generic");
+      assertThat(compilation).hadErrorContaining("Merge concrete record types.");
     }
 
     @Test
@@ -292,6 +526,7 @@ class GenericsAcceptanceAxisTest {
 
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("the record is generic");
+      assertThat(compilation).hadErrorContaining("remove the type parameters");
     }
 
     @Test
@@ -315,6 +550,7 @@ class GenericsAcceptanceAxisTest {
 
       assertThat(compilation).failed();
       assertThat(compilation).hadErrorContaining("'Failure' is generic");
+      assertThat(compilation).hadErrorContaining("Declare the hierarchy without type parameters.");
     }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericsAcceptanceAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericsAcceptanceAxisTest.java
@@ -1,0 +1,320 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.annotation.processing.Processor;
+import javax.tools.JavaFileObject;
+import org.higherkindedj.optics.processing.effect.PathProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One row per generating annotation: what it does when the thing it is put on is generic.
+ *
+ * <p>Every annotation here answers a generic declaration one of exactly two ways — it generates
+ * source that compiles, or it refuses at the declaration and says why. There is no third answer,
+ * and the two that had no row took it: both accepted the declaration and emitted source naming a
+ * type variable nothing brought into scope, which the author met as {@code cannot find symbol} in a
+ * file they never wrote.
+ *
+ * <p>The accepted rows assert compilation, not a signature, because that is the whole claim: what
+ * comes out has to build. The refusing rows assert the wording, because a refusal whose remedy
+ * cannot be followed is the other half of the same fault.
+ *
+ * <p>{@code @GeneratePrisms} belongs in this matrix and is verified in {@link
+ * PrismProcessorIntegrationTest} instead, where the hierarchy fixtures it needs already live.
+ */
+@DisplayName("What every generating annotation does with a generic declaration")
+class GenericsAcceptanceAxisTest {
+
+  private static Compilation compile(Processor processor, JavaFileObject... sources) {
+    return javac().withProcessors(processor).compile(sources);
+  }
+
+  @Nested
+  @DisplayName("generates source that compiles")
+  class Accepted {
+
+    @Test
+    @DisplayName("@GenerateLenses on a generic record")
+    void generateLenses() {
+      var compilation =
+          compile(
+              new LensProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Box",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateLenses;
+
+                  @GenerateLenses
+                  public record Box<T>(T value, String label) {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.example.BoxLenses");
+    }
+
+    @Test
+    @DisplayName("@GenerateTraversals on a generic record")
+    void generateTraversals() {
+      var compilation =
+          compile(
+              new TraversalProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Bag",
+                  """
+                  package com.example;
+
+                  import java.util.List;
+                  import org.higherkindedj.optics.annotations.GenerateTraversals;
+
+                  @GenerateTraversals
+                  public record Bag<T>(List<T> items, String label) {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.example.BagTraversals");
+    }
+
+    @Test
+    @DisplayName("@GenerateFocus on a generic record")
+    void generateFocus() {
+      var compilation =
+          compile(
+              new FocusProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Cell",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateFocus;
+
+                  @GenerateFocus
+                  public record Cell<T>(T value, String label) {}
+                  """));
+
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.example.CellFocus");
+    }
+
+    @Test
+    @DisplayName("@GeneratePathBridge on a generic interface")
+    void pathBridgeOnAGenericInterface() {
+      var compilation =
+          compile(
+              new PathProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Repo",
+                  """
+                  package com.example;
+
+                  import java.util.Optional;
+                  import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                  import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                  @GeneratePathBridge
+                  public interface Repo<T> {
+                      @PathVia
+                      Optional<String> byId(T id);
+                  }
+                  """));
+
+      // The bridge holds one delegate of the interface, so it declares what the interface does.
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.example.RepoPaths");
+    }
+
+    @Test
+    @DisplayName("@GeneratePathBridge on a generic method")
+    void pathBridgeOnAGenericMethod() {
+      var compilation =
+          compile(
+              new PathProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Svc",
+                  """
+                  package com.example;
+
+                  import java.util.Optional;
+                  import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                  import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                  @GeneratePathBridge
+                  public interface Svc {
+                      @PathVia
+                      <T> Optional<T> find(Class<T> type);
+                  }
+                  """));
+
+      // The bridge method copies the delegate's signature, so it declares the method's own too.
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.example.SvcPaths");
+    }
+
+    @Test
+    @DisplayName("@GeneratePathBridge on both at once, each parameter in its own place")
+    void pathBridgeOnBoth() {
+      var compilation =
+          compile(
+              new PathProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.BothRepo",
+                  """
+                  package com.example;
+
+                  import java.util.Optional;
+                  import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                  import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                  @GeneratePathBridge
+                  public interface BothRepo<T extends Comparable<T>> {
+                      @PathVia
+                      <R> Optional<R> convert(T from, Class<R> to);
+                  }
+                  """));
+
+      // T on the class with its bound, R on the method: putting either in the other's place names
+      // a variable out of scope at one of the two use sites.
+      assertThat(compilation).succeeded();
+      assertThat(compilation).generatedSourceFile("com.example.BothRepoPaths");
+    }
+  }
+
+  @Nested
+  @DisplayName("refuses at the declaration, with a remedy that can be followed")
+  class Refused {
+
+    @Test
+    @DisplayName("@GenerateIsos on a generic method")
+    void generateIsosOnAGenericMethod() {
+      var compilation =
+          compile(
+              new IsoProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Conv",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.Iso;
+                  import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                  public class Conv {
+                      public record Box<T>(T value) {}
+
+                      @GenerateIsos
+                      public static <T> Iso<Box<T>, T> boxIso() {
+                          return Iso.of(Box::value, Box::new);
+                      }
+                  }
+                  """));
+
+      // A static final field has nowhere to declare <T>, so there is no correct source to emit.
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'boxIso' declares type parameters");
+    }
+
+    @Test
+    @DisplayName("@GenerateIsos on an instance method")
+    void generateIsosOnAnInstanceMethod() {
+      var compilation =
+          compile(
+              new IsoProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Conv",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.Iso;
+                  import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                  public class Conv {
+                      public record Box<T>(T value) {}
+
+                      @GenerateIsos
+                      public Iso<Box<String>, String> boxIso() {
+                          return Iso.of(Box::value, Box::new);
+                      }
+                  }
+                  """));
+
+      // The field initialises itself with a static call; an instance method has no receiver for it.
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'boxIso' is not static");
+    }
+
+    @Test
+    @DisplayName("@GenerateMerge on a generic spec")
+    void generateMerge() {
+      var compilation =
+          compile(
+              new MergeProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.PairMerge",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateMerge;
+
+                  @GenerateMerge
+                  public interface PairMerge<T> {
+                      String assemble(String a, Integer b);
+                  }
+                  """));
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'PairMerge' is generic");
+    }
+
+    @Test
+    @DisplayName("@GenerateAssembly on a generic record")
+    void generateAssembly() {
+      var compilation =
+          compile(
+              new AssemblyProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Pair",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateAssembly;
+
+                  @GenerateAssembly
+                  public record Pair<T>(T left, String right) {}
+                  """));
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("the record is generic");
+    }
+
+    @Test
+    @DisplayName("@GenerateErrorEnvelope on a generic hierarchy")
+    void generateErrorEnvelope() {
+      var compilation =
+          compile(
+              new ErrorEnvelopeProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Failure",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GenerateErrorEnvelope;
+
+                  @GenerateErrorEnvelope
+                  public sealed interface Failure<T> permits Failure.NotFound {
+                      record NotFound(String id) implements Failure<String> {}
+                  }
+                  """));
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'Failure' is generic");
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericsAcceptanceAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericsAcceptanceAxisTest.java
@@ -19,21 +19,22 @@ import org.junit.jupiter.api.Test;
  * One row per generating annotation: what it does when the thing it is put on is generic.
  *
  * <p>Every annotation here answers a generic declaration one of exactly two ways — it generates
- * source that compiles, or it refuses at the declaration and says why. There is no third answer,
- * and the two that had no row took it: both accepted the declaration and emitted source naming a
- * type variable nothing brought into scope, which the author met as {@code cannot find symbol} in a
- * file they never wrote.
+ * source that compiles, or it refuses at the declaration and says why. A processor that does
+ * neither accepts the declaration and emits source naming a type variable nothing brings into
+ * scope, which the author meets as {@code cannot find symbol} in a file they never wrote.
  *
- * <p>The accepted rows assert compilation under the consuming build's own {@code -Werror} flags,
- * not a signature, because that is the whole claim: what comes out has to build where it lands. The
- * refusing rows assert the wording, and one row per refusal follows the remedy it names, because a
+ * <p>The accepted rows assert the generated signature, compiled under the consuming build's own
+ * {@code -Werror} flags, because that is the whole claim: what comes out has to build where it
+ * lands, and on javac's defaults an annotation that drops its type parameters altogether looks
+ * exactly like success. The refusing rows assert the remedy as well as the complaint, because a
  * refusal that cannot be acted on is the other half of the same fault.
  *
- * <p>Two annotations are answered elsewhere. {@code @ImportOptics} has an axis of its own in {@link
- * GenericSpecInterfaceAxisTest}, one case per copy strategy and optic hint against a spec that
- * declares its own parameter. {@code @GeneratePrisms} has no row anywhere: on a generic hierarchy
- * it accepts the declaration and emits raw-typed prisms, which is neither answer, and what it
- * should emit instead is not settled yet (#742).
+ * <p>The rest are answered elsewhere, or the question does not arise. {@code @ImportOptics} has an
+ * axis of its own in {@link GenericSpecInterfaceAxisTest}, one case per copy strategy and optic
+ * hint against a spec that declares its own parameter. {@code @GenerateAccumulators} and
+ * {@code @GenerateForComprehensions} target a package rather than a declaration, so nothing they
+ * see can be generic; {@code @EffectAlgebra} and {@code @PathSource} require a parameter, so
+ * generic is the only shape they take, and their arity rules are tested with them.
  */
 @DisplayName("What every generating annotation does with a generic declaration")
 class GenericsAcceptanceAxisTest {
@@ -153,6 +154,35 @@ class GenericsAcceptanceAxisTest {
           compilation,
           "com.example.ConvIsos",
           "public static final Iso<Conv.Box, String> boxIso = Conv.boxIso();");
+    }
+
+    @Test
+    @DisplayName("@GeneratePrisms on a generic sealed hierarchy")
+    void generatePrisms() {
+      var compilation =
+          compile(
+              new PrismProcessor(),
+              JavaFileObjects.forSourceString(
+                  "com.example.Shape",
+                  """
+                  package com.example;
+
+                  import org.higherkindedj.optics.annotations.GeneratePrisms;
+
+                  @GeneratePrisms
+                  public sealed interface Shape<T> {
+                      record Circle<T>(T radius) implements Shape<T> {}
+                      record Square<T>(T side) implements Shape<T> {}
+                  }
+                  """));
+
+      // Both sides of the prism are written in the subtype's own vocabulary (#742). Emitting the
+      // pair raw also compiles - just not under the flags the consuming build uses.
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.ShapePrisms",
+          "public static <T> Prism<Shape<T>, Shape.Circle<T>> circle()");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/IsoProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/IsoProcessorIntegrationTest.java
@@ -102,6 +102,51 @@ public class IsoProcessorIntegrationTest {
     assertThat(notVisible).failed();
     assertThat(notVisible).hadErrorContaining("cannot be reached from 'com.example'");
 
+    // Reaching the method is not enough: the field writes its own type out, so what the iso names
+    // has to be visible where the field is declared.
+    var typeArgumentNotVisible =
+        compileIso(
+            "Conv",
+            """
+            public class Conv {
+                private record Secret(String v) {}
+                @GenerateIsos
+                public static Iso<Secret, String> secretIso() {
+                    return Iso.of(Secret::v, Secret::new);
+                }
+            }""");
+    assertThat(typeArgumentNotVisible).failed();
+    assertThat(typeArgumentNotVisible)
+        .hadErrorContaining("names 'Secret', which cannot be reached from 'com.example'");
+
+    // And it looks inside the arguments, not only at their heads.
+    var nestedArgumentNotVisible =
+        compileIso(
+            "Nested",
+            """
+            public class Nested {
+                private record Secret(String v) {}
+                public record Box<A>(A value) {}
+                @GenerateIsos
+                public static Iso<Box<Secret>, String> boxIso() { return null; }
+            }""");
+    assertThat(nestedArgumentNotVisible).failed();
+    assertThat(nestedArgumentNotVisible).hadErrorContaining("names 'Secret'");
+
+    // Including through a wildcard bound, which is written out with the rest of the type.
+    var wildcardBoundNotVisible =
+        compileIso(
+            "Wild",
+            """
+            public class Wild {
+                private interface Secret {}
+                public record Box<A>(A value) {}
+                @GenerateIsos
+                public static Iso<Box<? extends Secret>, String> boxIso() { return null; }
+            }""");
+    assertThat(wildcardBoundNotVisible).failed();
+    assertThat(wildcardBoundNotVisible).hadErrorContaining("names 'Secret'");
+
     // The enclosing type has to be visible too: the field names it to make the call.
     var enclosingNotVisible =
         compileIso(

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/IsoProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/IsoProcessorIntegrationTest.java
@@ -6,7 +6,9 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
 
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class IsoProcessorIntegrationTest {
@@ -52,5 +54,171 @@ public class IsoProcessorIntegrationTest {
     // Verify the generated class and its content
     final String generatedClassName = "com.example.PointConvertersIsos";
     assertGeneratedCodeContains(compilation, generatedClassName, expectedIsoField);
+  }
+
+  private static Compilation compileIso(String name, String body) {
+    return javac()
+        .withProcessors(new IsoProcessor())
+        .compile(
+            JavaFileObjects.forSourceString(
+                "com.example." + name,
+                """
+                package com.example;
+
+                import org.higherkindedj.optics.Iso;
+                import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                %s
+                """
+                    .formatted(body)));
+  }
+
+  @Test
+  @DisplayName("refuses a method the generated field cannot call")
+  void refusesAMethodTheFieldCannotCall() {
+    var takesArguments =
+        compileIso(
+            "Args",
+            """
+            public class Args {
+                public record Box(String value) {}
+                @GenerateIsos
+                public static Iso<Box, String> boxIso(String prefix) {
+                    return Iso.of(Box::value, Box::new);
+                }
+            }""");
+    assertThat(takesArguments).failed();
+    assertThat(takesArguments).hadErrorContaining("'boxIso' takes parameters");
+
+    var notVisible =
+        compileIso(
+            "Hidden",
+            """
+            public class Hidden {
+                public record Box(String value) {}
+                @GenerateIsos
+                private static Iso<Box, String> boxIso() { return Iso.of(Box::value, Box::new); }
+            }""");
+    assertThat(notVisible).failed();
+    assertThat(notVisible).hadErrorContaining("cannot be reached from 'com.example'");
+
+    // The enclosing type has to be visible too: the field names it to make the call.
+    var enclosingNotVisible =
+        compileIso(
+            "Outer",
+            """
+            public class Outer {
+                public record Box(String value) {}
+                private static class Nested {
+                    @GenerateIsos
+                    public static Iso<Box, String> boxIso() { return Iso.of(Box::value, Box::new); }
+                }
+            }""");
+    assertThat(enclosingNotVisible).failed();
+    assertThat(enclosingNotVisible).hadErrorContaining("cannot be reached from 'com.example'");
+
+    // Package access is enough when the field lands in that same package.
+    var packagePrivateSamePackage =
+        compileIso(
+            "Near",
+            """
+            public class Near {
+                public record Box(String value) {}
+                @GenerateIsos
+                static Iso<Box, String> boxIso() { return Iso.of(Box::value, Box::new); }
+            }""");
+    assertThat(packagePrivateSamePackage).succeeded();
+
+    // targetPackage moves the field away from what package access reaches.
+    var packagePrivateAcrossPackages =
+        compileIso(
+            "Moved",
+            """
+            public class Moved {
+                public record Box(String value) {}
+                @GenerateIsos(targetPackage = "com.other")
+                static Iso<Box, String> boxIso() { return Iso.of(Box::value, Box::new); }
+            }""");
+    assertThat(packagePrivateAcrossPackages).failed();
+    assertThat(packagePrivateAcrossPackages)
+        .hadErrorContaining("cannot be reached from 'com.other'");
+  }
+
+  @Test
+  @DisplayName("refuses a return type it cannot read two arguments off, without crashing")
+  void refusesAReturnTypeItCannotRead() {
+    for (String returned :
+        java.util.List.of(
+            "public static void boxIso() {}",
+            "public static int boxIso() { return 0; }",
+            "public static String[] boxIso() { return null; }",
+            "public static java.util.Map<String, Integer> boxIso() { return null; }")) {
+      var compilation =
+          compileIso(
+              "Ret",
+              """
+              public class Ret {
+                  @GenerateIsos
+                  %s
+              }"""
+                  .formatted(returned));
+
+      // Every one of these used to reach a cast: void, primitive and array threw
+      // ClassCastException out of the processor with no diagnostic at all. A raw Iso reached the
+      // arity check instead, and keeps its own case in ProcessorCoverageTest.
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("does not return an Iso with both type arguments");
+    }
+  }
+
+  @Test
+  @DisplayName("sees a type variable through every layer it can be buried in")
+  void seesATypeVariableThroughEveryLayer() {
+    // One method per layer the walk has an arm for. Each is refused on its own, so a layer the
+    // walk cannot see through would generate a field naming the variable it missed.
+    for (String returned :
+        java.util.List.of(
+            "Iso<Box<T[]>, String>",
+            "Iso<Box<? extends T>, String>",
+            "Iso<Box<? super T>, String>",
+            "Iso<Outer<T>.Inner, String>",
+            "Iso<Box<java.util.List<T>>, String>")) {
+      var compilation =
+          compileIso(
+              "Layers",
+              """
+              public class Layers {
+                  public record Box<A>(A value) {}
+                  public static class Outer<A> { public class Inner {} }
+                  @GenerateIsos
+                  public static <T> %s buried() { return null; }
+              }"""
+                  .formatted(returned));
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining("the iso returned by 'buried' names a type variable");
+    }
+
+    // The controls: a wildcard with no bound at all, and bounds naming no variable, are layers
+    // the walk has to see all the way through and find nothing.
+    for (String returned :
+        java.util.List.of(
+            "Iso<Box<String[]>, String>",
+            "Iso<Box<?>, String>",
+            "Iso<Box<? extends CharSequence>, String>",
+            "Iso<Box<? super String>, String>")) {
+      var concrete =
+          compileIso(
+              "Plain",
+              """
+              public class Plain {
+                  public record Box<A>(A value) {}
+                  @GenerateIsos
+                  public static %s buried() { return null; }
+              }"""
+                  .formatted(returned));
+      assertThat(concrete).succeeded();
+    }
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ProcessorCoverageTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ProcessorCoverageTest.java
@@ -464,7 +464,8 @@ class ProcessorCoverageTest {
       Compilation compilation = javac().withProcessors(new IsoProcessor()).compile(sourceFile);
 
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("two type arguments");
+      assertThat(compilation)
+          .hadErrorContaining("'iso' does not return an Iso with both type arguments");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/PathProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/PathProcessorIntegrationTest.java
@@ -354,6 +354,57 @@ class PathProcessorIntegrationTest {
   class ErrorCases {
 
     @Test
+    @DisplayName("refuses a @PathVia method the delegate cannot be asked for")
+    void refusesStaticAndPrivatePathViaMethods() {
+      var statics =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  JavaFileObjects.forSourceString(
+                      "com.example.StaticSvc",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge
+                      public interface StaticSvc {
+                          @PathVia
+                          static Optional<String> lookup(String k) { return Optional.of(k); }
+                      }
+                      """));
+
+      assertThat(statics).failed();
+      assertThat(statics).hadErrorContaining("a static interface method cannot be called that way");
+
+      var privates =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  JavaFileObjects.forSourceString(
+                      "com.example.PrivateSvc",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge
+                      public interface PrivateSvc {
+                          @PathVia
+                          private Optional<String> hidden(String k) { return Optional.of(k); }
+                      }
+                      """));
+
+      assertThat(privates).failed();
+      assertThat(privates)
+          .hadErrorContaining("a private interface method cannot be called that way");
+    }
+
+    @Test
     @DisplayName("fails when @GeneratePathBridge is applied to a class")
     void shouldFailForClass() {
       final var sourceFile =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/PathProcessorIntegrationTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/effect/PathProcessorIntegrationTest.java
@@ -4,6 +4,7 @@ package org.higherkindedj.optics.processing.effect;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContainsRaw;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -352,6 +353,128 @@ class PathProcessorIntegrationTest {
   @Nested
   @DisplayName("Error Cases")
   class ErrorCases {
+
+    @Test
+    @DisplayName("refuses a bound the target package cannot name")
+    void refusesABoundTheTargetPackageCannotName() {
+      var hidden =
+          JavaFileObjects.forSourceString(
+              "com.example.Hidden",
+              """
+              package com.example;
+
+              class Hidden {}
+              """);
+
+      var onTheInterface =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  hidden,
+                  JavaFileObjects.forSourceString(
+                      "com.example.Repo",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge(targetPackage = "com.other")
+                      public interface Repo<T extends Hidden> {
+                          @PathVia
+                          Optional<String> byId(T id);
+                      }
+                      """));
+
+      assertThat(onTheInterface).failed();
+      assertThat(onTheInterface)
+          .hadErrorContaining("the bound on 'T' names 'Hidden', which cannot be reached");
+
+      var onTheMethod =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  hidden,
+                  JavaFileObjects.forSourceString(
+                      "com.example.MethodRepo",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge(targetPackage = "com.other")
+                      public interface MethodRepo {
+                          @PathVia
+                          <T extends Hidden> Optional<String> byId(T id);
+                      }
+                      """));
+
+      assertThat(onTheMethod).failed();
+      assertThat(onTheMethod)
+          .hadErrorContaining("the bound on 'T' names 'Hidden', which cannot be reached");
+
+      // Beside the interface, the same bound is nameable and nothing is refused.
+      var beside =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  hidden,
+                  JavaFileObjects.forSourceString(
+                      "com.example.NearRepo",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge
+                      public interface NearRepo<T extends Hidden> {
+                          @PathVia
+                          Optional<String> byId(T id);
+                      }
+                      """));
+
+      assertThat(beside).succeeded();
+    }
+
+    @Test
+    @DisplayName("writes the description before the block tags it belongs above")
+    void writesTheDescriptionBeforeTheBlockTags() {
+      var compilation =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  JavaFileObjects.forSourceString(
+                      "com.example.DocSvc",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge
+                      public interface DocSvc {
+                          @PathVia(doc = "Finds a thing by its type.")
+                          <T> Optional<T> find(Class<T> type);
+                      }
+                      """));
+
+      // A tag written before the description swallows it: javadoc reads everything after a block
+      // tag as that tag's own text, so the sentence became part of the @param.
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContainsRaw(
+          compilation,
+          "com.example.DocSvcPaths",
+          "   * Finds a thing by its type.\n"
+              + "   *\n"
+              + "   * @param <T> as declared by the delegate method\n"
+              + "   * @return Path-wrapped result from {@link DocSvc#find}");
+    }
 
     @Test
     @DisplayName("refuses a @PathVia method the delegate cannot be asked for")


### PR DESCRIPTION
Closes the remaining two sites of #746 — the two annotations that accepted a generic declaration and then emitted source naming a type variable nothing declared, which the author met as `cannot find symbol` in a file they never wrote.

The two sites want opposite answers, and which one an annotation gets is decided by whether there is any correct source to emit:

```mermaid
flowchart TD
    A["annotation meets a<br/>generic declaration"] --> B{"can the generated<br/>shape name a type<br/>parameter?"}
    B -->|"yes — it emits a method<br/>or a class"| R["<b>resolve</b><br/>declare the parameters<br/>the signature names"]
    B -->|"no — it emits a<br/>static final field"| F["<b>refuse</b><br/>at the declaration,<br/>with a followable remedy"]
    B -->|"neither — emit it raw"| X["the bug<br/>#746 is about"]

    classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
    classDef good fill:#a6d189,stroke:#40a02b,color:#232634
    classDef bad fill:#e78284,stroke:#d20f39,color:#232634
    class B decision
    class R,F good
    class X bad
```

## `@GenerateIsos` — refuse

The iso is published as a `public static final` field initialised by calling the method. A field has nowhere to declare a `<T>`, so there is no correct source to emit; the method is refused where it is written, as `@GenerateMerge`, `@GenerateAssembly` and `@GenerateErrorEnvelope` already refuse theirs.

The gate asks what the **iso names**, not what the method declares — the distinction matters in both directions:

| declaration | before | now |
|---|---|---|
| `<T> Iso<Box<T>, T> boxIso()` | `cannot find symbol: class T` | refused: *the iso returned by 'boxIso' names a type variable* |
| `<T> Iso<Box, String> boxIso()` | generated fine | still generated — `T` is inferred at the call and never reaches the field |
| `Iso<Box<X>, X>` on an instance method of `Holder<X>` | `cannot find symbol` | refused as the type variable it is |

That last row is why the naive predicate is wrong: the method declares nothing, so a gate reading `getTypeParameters()` falls through and says *"make it static"* — a remedy this method cannot follow, because a static method of `Holder<X>` cannot name `X` either.

The same pass closes four more shapes the processor was silent on, each of which had been javac complaining about generated code:

- an **instance** method — the field's initialiser is a static call with no receiver
- a method **taking arguments** — the initialiser passes none
- a method or enclosing type the **generated package cannot see** (`private`, or package-private under `targetPackage`)
- a return type that is **not a two-argument `Iso`** — which for `void`, a primitive and an array had been a `ClassCastException` out of the processor, with no diagnostic at all

## `@GeneratePathBridge` — resolve

Here the generated shapes *can* name parameters, so they do. Two sets, landing in two places, and both are needed at once:

```java
@GeneratePathBridge
public interface BothRepo<T extends Comparable<T>> {
    @PathVia <R> Optional<R> convert(T from, Class<R> to);
}
```
```java
public final class BothRepoPaths<T extends Comparable<T>> {   // from the interface, bounds included
    private final BothRepo<T> delegate;                        // was raw
    public <R> OptionalPath<R> convert(T from, Class<R> to) {  // from the method
```

The raw delegate field was a `-Werror` build-breaker for *any* generic service interface, including ones whose `@PathVia` methods never mention `T`.

This also adds the mirror of the `@GenerateIsos` guard: a `@PathVia` method that is `static` or `private` is refused, because the bridge reaches its delegate and neither can be called that way.

## The axis

#746's real ask was the missing test. `GenericsAcceptanceAxisTest` holds one row per generating annotation, asserting which of the only two answers it gives, and compiles under the consuming build's own `-Xlint:unchecked,rawtypes -Werror` rather than javac's defaults — because on defaults, an annotation that drops its type parameters altogether looks exactly like success. Reverting the delegate field to raw passed all eleven rows *and all 2,079 tests in the module* before that change; two rows catch it now.

`@GeneratePrisms` was the **third** instance of this bug, not the second: on a generic hierarchy it emitted raw prisms, failing the same gate. #745 has since merged and settled it, so it now has a row like the rest — this branch is rebased onto that, and the row asserts the signature it produces.

## Verification

Every fix was confirmed by putting the defect back and watching the named test fail. `clean build` across all 190 tasks: BUILD SUCCESSFUL. Every line added is covered; two branches no test could reach were deleted rather than tested around.

A five-lens panel (correctness, type safety, ergonomics, architecture, test quality) ran against the first commit and found two real defects in the new guard plus the false `@GeneratePrisms` pointer — all addressed in the second commit. Defects it found in `PathProcessor` that are *not* about generics are filed separately rather than folded in here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified requirements and troubleshooting guidance for generated isos and path bridges.
  * Expanded service wrapper mapping documentation, including supported effect types and generic bridges.

* **Bug Fixes**
  * Improved validation and diagnostics for invalid iso and path bridge declarations.
  * Generic type parameters are now preserved in generated path bridges.
  * Static and private path methods are rejected with clear compiler errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->