### PR TITLE
Hold ProcessorUtils at 100% coverage (#740)

### DIFF
--- a/hkj-processor/build.gradle.kts
+++ b/hkj-processor/build.gradle.kts
@@ -112,6 +112,7 @@ tasks.jacocoTestCoverageVerification {
                 "org.higherkindedj.optics.processing.effect.PathProcessor*",
                 "org.higherkindedj.optics.processing.external.SpecInterfaceAnalyser*",
                 "org.higherkindedj.optics.processing.external.CopyStrategyCodeGenerator*",
+                "org.higherkindedj.optics.processing.util.ProcessorUtils*",
             )
             limit {
                 counter = "LINE"


### PR DESCRIPTION
One line of `hkj-processor/build.gradle.kts`, from the last unticked box in #740.

#740 lifted three near-copies of the `asMemberOf` call into `ProcessorUtils` and closed by noting that the class was not in the module's 100% list, where the rest of the shared analysis already sits. It is the class that most wants the rule: `ProcessorUtils`' own javadoc says its helpers "live together so that a subtlety settled for one processor is settled for all of them", which is exactly the property that makes an unreachable branch there a design signal about every processor at once, rather than a residual in one.

`ProcessorUtils` is already at 100% on all three counters, so this pins what holds today rather than asking for new tests:

```
INSTRUCTION  0 missed / 530      BRANCH  0 missed / 94
LINE         0 missed / 109      METHOD  0 missed / 21
```

## Checked by falsification

A coverage pattern that matches nothing passes exactly as quietly as a class that is genuinely covered, which is the failure mode worth ruling out before trusting a line like this. So the rule was confirmed to bite rather than observed to pass: an uncovered method added to `ProcessorUtils` fails `jacocoTestCoverageVerification` **by name**, on all three counters —

```
Rule violated for class org.higherkindedj.optics.processing.util.ProcessorUtils:
  lines covered ratio is 0.97, but expected minimum is 1.00
  branches covered ratio is 0.97, but expected minimum is 1.00
  instructions covered ratio is 0.98, but expected minimum is 1.00
```

— and the probe was then reverted. `:hkj-processor:check` is green on the branch as it stands.

Worth noting for anyone reproducing that: `gradle :hkj-processor:clean :hkj-processor:jacocoTestCoverageVerification` in **one** invocation verifies against a stale report, because nothing orders `clean` before the report task. The two have to be separate builds, which is how the false pass above nearly went unnoticed.

#740 stays open: its remaining thread is whether a generic mix-in should be *resolved* under its instantiation rather than refused, which the gate still answers with "not supported yet".
