### PR TITLE
Unbreak the publish: name Prism.of in prose, not a link hkj-annotations can't resolve (#755)

### DIFF
--- a/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/MatchWhen.java
+++ b/hkj-annotations/src/main/java/org/higherkindedj/optics/annotations/MatchWhen.java
@@ -66,8 +66,8 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * <p>Focus the variant that carries the value — {@code TextNode} — and read the payload with a
- * further optic. Where the value type is the point, write that prism by hand with {@link
- * org.higherkindedj.optics.Prism#of} and a build side that constructs the source.
+ * further optic. Where the value type is the point, write that prism by hand with {@code Prism.of}
+ * and a build side that constructs the source.
  *
  * @see OpticsSpec
  * @see InstanceOf


### PR DESCRIPTION
`:hkj-annotations:javadoc` has failed on `main` since #760 landed:

```
MatchWhen.java:70: error: reference not found
 * org.higherkindedj.optics.Prism#of} and a build side that constructs the source.
```

`hkj-annotations` depends on nothing, deliberately — it is the artefact a consumer puts on their annotation processor path and little else. So `org.higherkindedj.optics.Prism` is not on its javadoc classpath, and a `{@link}` to it cannot resolve however well-formed it is. The module already had the answer: `OpticsSpec` names `{@code Lens}`, `{@code Prism}`, `{@code Traversal}` in prose for exactly this reason. The sentence is unchanged; only the tag is.

```diff
- * further optic. Where the value type is the point, write that prism by hand with {@link
- * org.higherkindedj.optics.Prism#of} and a build side that constructs the source.
+ * further optic. Where the value type is the point, write that prism by hand with {@code Prism.of}
+ * and a build side that constructs the source.
```

## Why every check on #760 was green

`javadoc` runs in one workflow, and it is not the one a PR sees:

```mermaid
flowchart TD
    PR["push to a branch"] --> CI["Java CI<br/>build · test · jacoco"]
    CI --> G(["green — no javadoc task in the graph"])
    M["merge to main"] --> PUB["Publish to Maven Central"]
    PUB --> J["publishToMavenCentral<br/>→ javadoc jar"]
    J --> A[":hkj-annotations:javadoc"]
    A --> R(["reference not found"])

    classDef step fill:#8caaee,stroke:#1e66f5,color:#232634
    classDef ok fill:#a6d189,stroke:#40a02b,color:#232634
    classDef bad fill:#e78284,stroke:#d20f39,color:#232634
    class PR,CI,M,PUB,J,A step
    class G ok
    class R bad
```

The link was introduced by a documentation fix in #760, reviewed and merged with a full green tick, and the publish went red on the two pushes to `main` that followed — run `33159220081` at `38dc8be05`, run `33176071097` at `1340ae784`.

## Verification

- `gradle :hkj-annotations:javadoc` on this branch: **BUILD SUCCESSFUL** — the exact task CI reported.
- `gradle javadoc`, all modules: **BUILD SUCCESSFUL**. The 20 remaining warnings are pre-existing missing-comment ones in `hkj-spring/example`.
- `gradle :hkj-annotations:spotlessCheck`: passes.

## Worth a follow-up

Nothing gates the javadoc of a module that gets published, so the next unresolvable link arrives the same way: green PR, red release. Adding `javadoc` to the Java CI task list would close the gap on every module at once — kept out of this PR, which is the one-line unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1VSUEAAiUZTwp8jHpjL8i
