### PR TITLE
hkj-book: apply the exemplar treatment to the optics chapter front matter

### DIFF
--- a/hkj-book/src/optics/annotations_at_a_glance.md
+++ b/hkj-book/src/optics/annotations_at_a_glance.md
@@ -5,7 +5,7 @@
 ~~~admonish info title="What You'll Learn"
 - Which annotation to apply for each optic type, and what target each annotation expects (record, sealed interface, enum, method, package-info).
 - How to choose between `@ImportOptics` and an `OpticsSpec` interface for types you don't own.
-- The eight spec-method hints that drive optic generation for external types: prism matchers, lens copy strategies, traversal hints, and `Kind`-field configuration.
+- The eight spec-method hints that drive optic generation for external types: two prism matchers, four lens copy strategies, and two traversal hints.
 - Where in the book to look for the in-depth treatment of each annotation.
 ~~~
 
@@ -63,6 +63,9 @@ External types like `LocalDate`, Jackson's `JsonNode`, JOOQ records, and Protobu
 | [`@GenerateMapping`](../mapping/ch_intro.md) | interface extending `MappingSpec<Domain, Wire>` | `XMappingImpl` with a total `build` and an accumulating, located `parse` | Bidirectional boundary mapping with validation: every bad field reported at once |
 | [`@GenerateMapping`](../mapping/beans_patch.md#sparse-patch-write-back-updatespec) | interface extending `UpdateSpec<Domain, Wire>` (bean wire) | `XMappingImpl` with only `updateFrom(Wire) : Edits.Accumulated<Domain>` | Sparse PATCH write-back: fold the present (non-null) request fields into an update, leave the absent ones |
 | [`@MapField(to = "...")`](../mapping/ch_intro.md) | abstract method on the spec, named after the domain component | a rename in both directions | Domain and wire components with different names |
+| [`@GenerateAssembly`](../monads/validated_assembly.md) | `record` | `XAssembly`, a staged builder over `Validated<NonEmptyList<FieldError>, R>` with one method per component | Building a record from independently validated parts, collecting every error, with no arity ceiling |
+| [`@GenerateMerge`](../mapping/merge_envelopes.md) | interface whose abstract method names target and sources | a forward-only assembly of one target record from several sources | Merging several records into one; no inverse is generated, because the multi-source case has none |
+| [`@GenerateErrorEnvelope`](../mapping/merge_envelopes.md) | `sealed interface` whose variants each carry one `ErrorEnvelope<C>` | per-variant factories, a fluent context builder, and a context wither | Giving a sealed error hierarchy a typed context without repeating it on every variant |
 
 Leaves, nesting, `List`/`Optional` lifting, sealed dispatch, the `asIso()`/`asLens()` tiers, and the sparse `UpdateSpec` tier are covered in [Record Mapping](../mapping/ch_intro.md).
 
@@ -99,15 +102,19 @@ External record-like types rarely have a single copy mechanism. The processor us
 | `@ThroughField` | A traversal composing a lens-to-field with the auto-detected container traversal |
 | `@TraverseWith` | A traversal using an explicitly named `Traverse` instance |
 
-### Kind-field configuration
+---
 
-| Annotation | Effect |
-|---|---|
-| [`@TraverseField`](kind_field_support.md) | Configures how a `Kind<F, A>` field is processed by the Focus DSL generator. Pair with `KindSemantics` to declare cardinality (`EXACTLY_ONE`, `ZERO_OR_ONE`, `ZERO_OR_MORE`). |
+## 5. Kind-field configuration (on a record component)
+
+This one is not a spec-method hint: it targets a **record component**, so it goes on the field of your own record, not on a method of an `OpticsSpec` interface.
+
+| Annotation | Apply to | Effect |
+|---|---|---|
+| [`@TraverseField`](kind_field_support.md) | record component of type `Kind<F, A>` | Configures how the Focus DSL generator treats the field. Pair with `KindSemantics` to declare cardinality (`EXACTLY_ONE`, `ZERO_OR_ONE`, `ZERO_OR_MORE`). |
 
 ---
 
-## 5. Build setup
+## 6. Build setup
 
 The HKJ Gradle and Maven plugins wire the annotation processor in for you. Apply the plugin and every annotation on this page is available immediately. See [Build Plugins: One-Line HKJ Setup](../tooling/gradle_plugin.md) for the plugin DSL, or [Manual Setup](../tooling/manual_setup.md) if you need to configure dependencies by hand.
 
@@ -115,7 +122,7 @@ For compile-time path-type checking, see [Compile-Time Checks](../tooling/compil
 
 ---
 
-## 6. Quick decision guide
+## 7. Quick decision guide
 
 | You have... | You want to... | Reach for |
 |---|---|---|
@@ -133,13 +140,22 @@ For compile-time path-type checking, see [Compile-Time Checks](../tooling/compil
 
 ---
 
-## Where next?
+~~~admonish info title="Key Takeaways"
+* **The target tells you which annotation you want.** A record takes `@GenerateLenses` and friends, a sealed interface or enum takes `@GeneratePrisms`, a static method takes `@GenerateIsos`, and a type you do not own is reached through `@ImportOptics` or an `OpticsSpec` interface.
+* **Annotations stack rather than compete.** Each generates its own companion class, so a record carrying three of them gets three, and you pick the entry point that matches the task.
+* **The spec-method hints exist because external types have no single copy mechanism.** Four of the eight say how to rebuild the object; two say how to narrow a variant; two say how to reach a container.
+* **`@TraverseField` is the odd one out.** It goes on a record component of your own, not on a spec method, which is why it has a section to itself.
+~~~
 
-- **New to optics?** Start with the [Quickstart](quickstart.md), three runnable examples in 100 lines.
-- **Updating a nested record right now?** Jump to the [Focus DSL](focus_dsl.md).
-- **Working with external types?** See [Optics for External Types](importing_optics.md) and [Taming JSON with Jackson](optics_spec_interfaces.md).
-- **Mapping DTOs at a service boundary?** See [Record Mapping](../mapping/ch_intro.md).
-- **Want hands-on practice?** The [Lens & Prism Journey](../tutorials/optics/lens_prism_journey.md) is 40 minutes, 30 exercises.
+---
+
+~~~admonish tip title="See Also"
+- [Quickstart](quickstart.md): the same annotations doing real work, in three examples
+- [Optics for External Types](importing_optics.md): the `@ImportOptics` route in full
+- [Taming JSON with Jackson](optics_spec_interfaces.md): the spec-interface route, and when to prefer it
+- [Record Mapping](../mapping/ch_intro.md): the mapping and assembly generators in section 3
+- [Lens & Prism Journey](../tutorials/optics/lens_prism_journey.md): 40 minutes and 30 exercises, hands-on
+~~~
 
 ---
 

--- a/hkj-book/src/optics/annotations_at_a_glance.md
+++ b/hkj-book/src/optics/annotations_at_a_glance.md
@@ -110,7 +110,17 @@ This one is not a spec-method hint: it targets a **record component**, so it goe
 
 | Annotation | Apply to | Effect |
 |---|---|---|
-| [`@TraverseField`](kind_field_support.md) | record component of type `Kind<F, A>` | Configures how the Focus DSL generator treats the field. Pair with `KindSemantics` to declare cardinality (`EXACTLY_ONE`, `ZERO_OR_ONE`, `ZERO_OR_MORE`). |
+| [`@TraverseField`](kind_field_support.md) | record component of type `Kind<F, A>` | Names the `Traverse<F>` instance the Focus DSL generator should walk the field with, and the cardinality that decides the path type it generates |
+
+`KindSemantics` is an enum, not a second annotation: it is the value of `@TraverseField`'s own `semantics` element. `traverse` is required and takes a fully qualified expression yielding a `Traverse<F>`, such as a singleton field or a factory call:
+
+```java
+@TraverseField(
+    traverse = "com.example.TreeTraverse.INSTANCE",
+    semantics = KindSemantics.ZERO_OR_ONE)
+```
+
+`semantics` defaults to `ZERO_OR_MORE`, which generates a `TraversalPath`; `EXACTLY_ONE` and `ZERO_OR_ONE` both generate an `AffinePath`.
 
 ---
 

--- a/hkj-book/src/optics/ch_intro.md
+++ b/hkj-book/src/optics/ch_intro.md
@@ -27,43 +27,35 @@ public record User(String name, Address address) {}
 User updated = UserFocus.address().street().name().set("New Street", user);
 ```
 
-The same record can carry several annotations, each generating its own companion class for a different use case. The five sections of this chapter take you from the foundational optics through the Java-friendly APIs and into a cookbook of practical recipes.
+The same record can carry several annotations, each generating its own companion class for a different use case. The seven sections of this chapter take you from the foundational optics through the Java-friendly APIs and the recipe cookbook, and end at a reference you can look things up in.
 
 ---
 
-## The Optics Hierarchy
+## How the optic types relate
 
-Before diving in, it helps to see how the optic types relate to one another:
+Eight optic types, one shared supertype, and one real specialisation between them:
 
-```
-                    ┌─────────┐
-                    │  Fold   │  (read-only, zero-or-more)
-                    └────┬────┘
-                         │
-              ┌──────────┴──────────┐
-              │                     │
-         ┌────┴────┐          ┌─────┴─────┐
-         │ Getter  │          │ Traversal │  (read-write, zero-or-more)
-         └────┬────┘          └─────┬─────┘
-              │                     │
-              │               ┌─────┴─────┐
-              │               │           │
-         ┌────┴────┐    ┌─────┴─────┐ ┌───┴───┐
-         │  Lens   │    │  Affine   │ │Setter │
-         └────┬────┘    └─────┬─────┘ └───────┘
-              │         (zero-or-one)
-              │               │
-              │         ┌─────┴─────┐
-              │         │   Prism   │
-              │         └─────┬─────┘
-              │               │
-              └───────┬───────┘
-                 ┌────┴────┐
-                 │   Iso   │  (exactly-one, reversible)
-                 └─────────┘
+```mermaid
+flowchart TD
+    O(["Optic"])
+    O --> F(["Fold<br/>read, zero or more"])
+    O --> T(["Traversal<br/>read+write, zero or more"])
+    O --> St(["Setter<br/>write, zero or more"])
+    O --> L(["Lens<br/>read+write, exactly one"])
+    O --> A(["Affine<br/>read+write, zero or one"])
+    O --> P(["Prism<br/>read+write, one variant"])
+    O --> I(["Iso<br/>read+write, reversible"])
+    F --> G(["Getter<br/>read, exactly one"])
+
+    classDef root fill:#8caaee,stroke:#1e66f5,color:#232634
+    classDef tier fill:#a6d189,stroke:#40a02b,color:#232634
+    class O root
+    class F,T,St,L,A,P,I,G tier
 ```
 
-Arrows indicate "can be used as" relationships. A Lens can stand in wherever a Getter or Fold is expected; an Iso, the most specific optic, can stand in as any of the others. Affine sits between Traversal and Prism, representing precisely zero-or-one focus, which makes it ideal for optional fields.
+The arrows are `extends`, and `Getter extends Fold` is the **only** one between two optic types: everything else extends `Optic` directly, which makes them siblings rather than a hierarchy. So a `Lens` is not a `Fold`, and you cannot pass one where a `Fold` is expected. `lens.asFold()` is an explicit conversion, and [Conversions](conversions.md) lists every conversion that exists.
+
+What the diagram groups instead is capability, and that is the useful question: how many values does the optic focus, and may you write through it? Those two answers pick your optic, which is what [Decision Trees](decision_trees.md) walks you through.
 
 ---
 
@@ -73,6 +65,8 @@ Arrows indicate "can be used as" relationships. A Lens can stand in wherever a G
 - **Precision and Filtering** – Narrow focus by predicate or index. Filtered and indexed traversals, the `Each`, `At`, and `Ixed` type classes, character-level string traversals, and advanced Prism patterns, including predicate matching with `nearly`.
 - **Java-Friendly APIs** – Three complementary APIs that make optics feel native to Java: the Focus DSL for path-based navigation, the Fluent API for validation-aware updates, and the Free Monad DSL for programs-as-data. Backed by annotation-driven code generation (`@GenerateLenses`, `@GenerateFocus`, `@GeneratePrisms`, and friends). For the domain ↔ DTO boundary, see the dedicated [Mapping at the Boundary](../mapping/ch_intro.md) chapter.
 - **Integration and Recipes** – A complete walkthrough composing Lens, Prism, and Traversal into a validation pipeline, integration with the library's core types (Either, Maybe, Validated, Optional), multi-edit and sparse REST PATCH updates, and a cookbook of ready-to-use solutions for the nested-update problems you will actually meet in production.
+- **Advanced Optics** – Optic operations built as a value first and executed second: the Free Monad DSL that describes the program, and the interpreters that run, log or check it.
+- **Reference** – The lookup half of the chapter. What each optic type declares, how to convert between them, what the processor's error messages mean, and the decision trees for picking one.
 ~~~
 
 ---
@@ -86,6 +80,8 @@ Arrows indicate "can be used as" relationships. A Lens can stand in wherever a G
 5. [Precision and Filtering](ch3_intro.md) - Filtered, indexed, and predicate-based optics
 6. [Java-Friendly APIs](ch4_intro.md) - Focus DSL, Fluent API, code generation
 7. [Integration and Recipes](ch5_intro.md) - Validation workflows, multi-edit and PATCH, cookbook
+8. [Advanced Optics](ch6_intro.md) - Free Monad DSL, interpreters, programs as data
+9. [Reference](ch7_intro.md) - Capabilities, conversions, compiler errors, decision trees
 
 ---
 
@@ -95,6 +91,15 @@ Arrows indicate "can be used as" relationships. A Lens can stand in wherever a G
 - **Just need to update a nested record right now?** Skip straight to the [Focus DSL](focus_dsl.md) and come back to the foundational material when you need it.
 - **Mapping a domain record to/from a wire DTO?** Go straight to [Record Mapping](../mapping/ch_intro.md); it needs none of the optics curriculum first.
 - **New to the concepts?** Start with [Fundamentals](ch1_intro.md).
+~~~
+
+---
+
+~~~admonish tip title="See Also"
+- [Decision Trees](decision_trees.md): pick the optic, the API and the annotation by answering a question at a time
+- [Optic Capabilities](optic_capabilities.md): what each optic type declares, and what it reaches only by conversion
+- [Mapping at the Boundary](../mapping/ch_intro.md): the domain to wire problem, which needs none of this chapter first
+- [Optics Tutorial Track](../tutorials/optics/ch_intro.md): the same material as exercises, if you learn by doing
 ~~~
 
 ---

--- a/hkj-book/src/optics/ch_intro.md
+++ b/hkj-book/src/optics/ch_intro.md
@@ -36,16 +36,15 @@ The same record can carry several annotations, each generating its own companion
 Eight optic types, one shared supertype, and one real specialisation between them:
 
 ```mermaid
-flowchart TD
-    O(["Optic"])
-    O --> F(["Fold<br/>read, zero or more"])
-    O --> T(["Traversal<br/>read+write, zero or more"])
-    O --> St(["Setter<br/>write, zero or more"])
-    O --> L(["Lens<br/>read+write, exactly one"])
-    O --> A(["Affine<br/>read+write, zero or one"])
-    O --> P(["Prism<br/>read+write, one variant"])
-    O --> I(["Iso<br/>read+write, reversible"])
-    F --> G(["Getter<br/>read, exactly one"])
+flowchart BT
+    F(["Fold<br/>read, zero or more"]) --> O(["Optic"])
+    T(["Traversal<br/>read+write, zero or more"]) --> O
+    St(["Setter<br/>write, zero or more"]) --> O
+    L(["Lens<br/>read+write, exactly one"]) --> O
+    A(["Affine<br/>read+write, zero or one"]) --> O
+    P(["Prism<br/>read+write, one variant"]) --> O
+    I(["Iso<br/>read+write, reversible"]) --> O
+    G(["Getter<br/>read, exactly one"]) --> F
 
     classDef root fill:#8caaee,stroke:#1e66f5,color:#232634
     classDef tier fill:#a6d189,stroke:#40a02b,color:#232634
@@ -53,7 +52,7 @@ flowchart TD
     class F,T,St,L,A,P,I,G tier
 ```
 
-The arrows are `extends`, and `Getter extends Fold` is the **only** one between two optic types: everything else extends `Optic` directly, which makes them siblings rather than a hierarchy. So a `Lens` is not a `Fold`, and you cannot pass one where a `Fold` is expected. `lens.asFold()` is an explicit conversion, and [Conversions](conversions.md) lists every conversion that exists.
+Each arrow reads *extends*, pointing from a type to the one it extends: `Fold extends Optic`, `Getter extends Fold`. That last is the **only** inheritance between two optic types: everything else extends `Optic` directly, which makes them siblings rather than a hierarchy. So a `Lens` is not a `Fold`, and you cannot pass one where a `Fold` is expected. `lens.asFold()` is an explicit conversion, and [Conversions](conversions.md) lists every conversion that exists.
 
 What the diagram groups instead is capability, and that is the useful question: how many values does the optic focus, and may you write through it? Those two answers pick your optic, which is what [Decision Trees](decision_trees.md) walks you through.
 

--- a/hkj-book/src/optics/quickstart.md
+++ b/hkj-book/src/optics/quickstart.md
@@ -61,13 +61,14 @@ Sealed interfaces and collection fields use the same annotation-driven pattern.
 
 ```java
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import org.higherkindedj.optics.annotations.*;
 
 @GeneratePrisms
 public sealed interface Status permits Pending, Shipped, Cancelled {
     record Pending() implements Status {}
-    record Shipped(java.time.Instant at) implements Status {}
+    record Shipped(Instant at) implements Status {}
     record Cancelled(String reason) implements Status {}
 }
 
@@ -80,23 +81,38 @@ public record Order(String id, Status status, List<LineItem> items) {}
 
 **Apply a 10% discount to every line item:**
 
+<!-- verify -->
 ```java
-Order discounted = OrderFocus.items().each().price()
+Order discounted = OrderFocus.items().via(LineItemFocus.price())
     .modifyAll(p -> p.multiply(new BigDecimal("0.9")), order);
 ```
 
-`OrderFocus.items().each()` walks every element of the `List<LineItem>`. Continuing with `.price()` zooms each element down to the price field. `modifyAll` applies the function in one pass and returns a new `Order`.
+`OrderFocus.items()` already walks every element of the `List<LineItem>`: the generated accessor ends in `.each()` for you, so it hands back a path focused on a `LineItem`, not on the list. `.via(LineItemFocus.price())` zooms each element down to the price field, and `modifyAll` applies the function in one pass to return a new `Order`.
+
+A `List` field widens through the built-in traversal, which returns a plain path, so the next hop is `.via(...)`. `generateNavigators = true` shortens that to `.price()` for a field whose type is itself navigable, such as the `Address` in section 1.
+
+~~~admonish warning title="Do not add your own `.each()`"
+`OrderFocus.items().each()` compiles and then fails at run time. The accessor is already element-level, so the extra `each()` tries to read a `LineItem` as a `List`; its type parameter is inferred from whatever you assign it to, which is why the compiler lets it through. `TraversalPath.each()` is for a focus that is *itself* a list, and its javadoc documents the `ClassCastException`.
+~~~
 
 **Match only `Pending` orders:**
 
+<!-- verify -->
 ```java
 boolean isPending = StatusPrisms.pending().matches(order.status());
 
+// modify rebuilds the variant it narrowed to, so the function is Cancelled -> Cancelled.
+Status tidied = StatusPrisms.cancelled()
+    .modify(c -> new Status.Cancelled(c.reason().strip()), order.status());
+
+// Moving to a different variant is not a modify. Read through the prism, then build.
 Status fulfilled = StatusPrisms.pending()
-    .modify(p -> new Status.Shipped(java.time.Instant.now()), order.status());
+    .getOptional(order.status())
+    .<Status>map(pending -> new Status.Shipped(Instant.now()))
+    .orElse(order.status());
 ```
 
-A `Prism` is a `Lens` for sum types: it succeeds when the variant matches and is a no-op otherwise.
+A `Prism` is the sum-type counterpart of a lens: it succeeds when the variant matches and is a no-op otherwise. Note what `modify` will and will not do. Its function is `A -> A`, so it rebuilds the *same* variant; changing `Pending` into `Shipped` is a read followed by a build, not a modification.
 
 ~~~admonish note title="Two views of the same record"
 We added three annotations to `Order`. They don't conflict; each generates its own companion class (`OrderLenses`, `OrderFocus`, `OrderTraversals`) and you pick the entry point that matches your task.
@@ -148,14 +164,23 @@ Same composition, same vocabulary, applied to a type you can't modify. See [Tami
 
 ---
 
-## Where next?
+~~~admonish info title="Key Takeaways"
+* **The annotations generate plain Java at compile time.** `XLenses`, `XFocus`, `XPrisms` and `XTraversals` are ordinary classes you call with ordinary method chains. Nothing here uses runtime reflection.
+* **`@GenerateLenses` and `@GenerateFocus` are the pair to reach for.** Lenses give you `withFoo` and the classic optics; Focus gives you the path DSL. `generateNavigators = true` is what lets the next hop read as `.street()` rather than `.via(AddressFocus.street())`.
+* **A collection accessor is already element-level.** `OrderFocus.items()` focuses a `LineItem`, because the generated method ends in `.each()` for you. Adding another `.each()` compiles and then fails at run time.
+* **A prism rebuilds the variant it narrowed to.** `modify` is `A -> A`, so it cannot turn a `Pending` into a `Shipped`; that is a read through the prism followed by building the new variant.
+* **Types you do not own join the same vocabulary.** An `OpticsSpec` interface plus `@ImportOptics` generates optics for `JsonNode`, JOOQ records or JDK types, and they compose with everything else.
+~~~
 
-- **Looking up an annotation?** [Annotations at a Glance](annotations_at_a_glance.md) lists every `@Generate*` and `@OpticsSpec` hint with its target and what it produces.
-- **Just want to update a nested record?** Continue with the [Focus DSL](focus_dsl.md).
-- **Mapping a domain record to/from a wire DTO?** [Record Mapping](../mapping/ch_intro.md) generates both directions at compile time, with every bad field reported at once.
-- **Choosing between Focus DSL, Fluent API, or Free Monad DSL?** The [Java-Friendly APIs](ch4_intro.md) chapter has a decision tree.
-- **Choosing which optic for your data shape?** [Integration and Recipes](ch5_intro.md) carries a flowchart and a complete pipeline example.
-- **Theory first?** [What Are Optics?](optics_intro.md) is the conceptual introduction.
+---
+
+~~~admonish tip title="See Also"
+- [Annotations at a Glance](annotations_at_a_glance.md): every `@Generate*` and spec hint, with its target and what it produces
+- [Focus DSL](focus_dsl.md): the path-based API this page previews, in full
+- [Java-Friendly APIs](ch4_intro.md): choosing between the Focus DSL, the Fluent API and the Free Monad DSL
+- [What Are Optics?](optics_intro.md): the conceptual introduction, if you would rather start with the idea
+- [Record Mapping](../mapping/ch_intro.md): the domain to wire boundary, which needs none of this chapter first
+~~~
 
 ~~~admonish tip title="Ready for hands-on?"
 The [Optics Tutorial Track](../tutorials/optics/ch_intro.md) is exercise-driven. Six journeys (~225 minutes total, 134 exercises) run from Lens & Prism through the Focus DSL to batching, coupled updates, and the generated DTO boundary. Recommended once you've finished this Quickstart.

--- a/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
@@ -53,7 +53,7 @@ class BookSnippetVerificationTest {
    * copy of it, so those snippets no longer need a marker. That is the only reason this number may
    * fall.
    */
-  private static final int MINIMUM_VERIFIED_SNIPPETS = 313;
+  private static final int MINIMUM_VERIFIED_SNIPPETS = 315;
 
   /**
    * Every documentation root whose code is verified. The book was the first; the skills are the

--- a/hkj-examples/src/test/resources/fixtures/optics_quickstart.java
+++ b/hkj-examples/src/test/resources/fixtures/optics_quickstart.java
@@ -1,0 +1,44 @@
+// Fixture for hkj-book/src/optics/quickstart.md
+//
+// The page's section 2 snippets discount every line item through a generated
+// navigator, and match one variant of a sealed status. The records live here and
+// the annotation processor generates the *Lenses, *Focus and *Prisms companions
+// during snippet compilation.
+//
+// A List field widens through the built-in traversal and hands back a plain
+// TraversalPath, so the hop to the element's field is .via(LineItemFocus.price()).
+//
+// NOTE: imports in a fixture serve the snippet this file is spliced into.
+// Spotless excludes src/test/resources so an "unused import" cleanup cannot
+// break fixtures (see build.gradle.kts).
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import org.higherkindedj.optics.annotations.GenerateFocus;
+import org.higherkindedj.optics.annotations.GenerateLenses;
+import org.higherkindedj.optics.annotations.GeneratePrisms;
+import org.higherkindedj.optics.annotations.GenerateTraversals;
+
+@GeneratePrisms
+sealed interface Status permits Status.Pending, Status.Shipped, Status.Cancelled {
+  record Pending() implements Status {}
+
+  record Shipped(Instant at) implements Status {}
+
+  record Cancelled(String reason) implements Status {}
+}
+
+@GenerateLenses
+@GenerateFocus
+record LineItem(String sku, BigDecimal price) {}
+
+@GenerateLenses
+@GenerateFocus
+@GenerateTraversals
+record Order(String id, Status status, List<LineItem> items) {}
+
+/** The snippet class extends this, which is what puts {@code order} in scope. */
+class Fixture {
+  static final Order order = new Order("A-1", new Status.Pending(), List.of());
+}


### PR DESCRIPTION
The three pages above `ch1` — the chapter landing page, the Quickstart and Annotations at a Glance — were the last of the optics chapter left untreated. The landing page had drifted furthest.

## The hierarchy diagram taught subtyping that does not exist

`ch_intro.md`'s ASCII diagram captioned its arrows "can be used as". Against the declarations, only one such arrow is real:

```mermaid
flowchart LR
    A["Getter extends Fold"] --> B["the only subtype relation<br/>between two optic types"]
    C["Lens, Prism, Iso, Affine,<br/>Traversal, Setter, Fold"] --> D["all extend Optic directly:<br/>siblings, not a hierarchy"]
    classDef ok fill:#a6d189,stroke:#40a02b,color:#232634
    classDef note fill:#e5c890,stroke:#df8e1d,color:#232634
    class A,C ok
    class B,D note
```

So "a `Lens` can stand in wherever a `Getter` or `Fold` is expected" was false — `lens.asFold()` is an explicit conversion. "An `Iso`, the most specific optic, can stand in as any of the others" was false twice: it has `asLens`, `asTraversal` and `asFold`, and no route to a `Prism` or `Affine` at all. The chapter's own [Conversions](https://github.com/higher-kinded-j/higher-kinded-j/blob/main/hkj-book/src/optics/conversions.md) page already documented these as conversions.

The ASCII art is now a mermaid diagram of what the types declare, with the arrows labelled as `extends`.

The same page also still described **five** sections and listed neither Advanced Optics nor Reference.

## The Quickstart's collection example did not work

A `List` component's generated accessor is already element-level — the processor emits `FocusPath.of(lens, "items").each()` — so the page's own `.each()` was one too many. It compiles, because `each()`'s type parameter is inferred from the assignment through an unchecked cast, and then throws `ClassCastException`, exactly as `TraversalPath.each()`'s javadoc says.

The prism example did not compile at all: `Prism.modify` is `Function<A, A>`, so it rebuilds the variant it narrowed to and cannot turn a `Pending` into a `Shipped`.

Both are now **under the verify gate** with a fixture, so the next person to break them is told. The gate caught a further mistake in my own first fix, which is the point of it.

## Annotations at a Glance

`@TraverseField` was filed among the spec-method hints, under a sentence saying to apply them to abstract methods — it targets a `RECORD_COMPONENT`. It now has its own section. The page also omitted `@GenerateAssembly`, `@GenerateMerge` and `@GenerateErrorEnvelope` while calling itself the complete surface. The "eight spec-method hints" count is correct and now stated as what it is: 2 prism matchers, 4 copy strategies, 2 traversal hints.

## Also

Key Takeaways and See Also throughout; the chapter intro was the only one of the eight without a See Also. Ratchet 313 → 315.

Local gates: `gradle :hkj-examples:bookVerify` green, 34 mermaid diagrams parse clean, every link on the three pages resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded optics introductions with clearer capability diagrams, relationships, focus cardinality, and navigation.
  - Updated the quickstart with improved status, traversal, and prism examples, plus additional guidance and tutorials.
  - Restructured the annotations reference with expanded annotation coverage, clearer setup guidance, decision support, and takeaways.

- **Tests**
  - Added verification coverage for the updated optics quickstart examples.
  - Increased the minimum number of documentation snippets validated by the compilation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->