### PR TITLE
hkj-book: stop three headings being read as HTML

### DIFF
--- a/.github/scripts/book-heading-html-check.cjs
+++ b/.github/scripts/book-heading-html-check.cjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/*
+ * Fail a heading that hands raw HTML to the browser.
+ *
+ * A heading quoting a compiler diagnostic often names a generic type, and a
+ * bare `<S>` in markdown is not text: it is passed through as HTML. The damage
+ * depends on whether the tag happens to be a real element.
+ *
+ *   <S>  is <s>, the strikethrough element. Nothing closes it, so every block
+ *        after the heading renders struck through.
+ *   <T>  is no element at all. The browser swallows the tag and renders its
+ *        children, so the type argument silently disappears from the page.
+ *
+ * The fix in both cases is a code span: `OpticsSpec<S>`.
+ *
+ * Scope is headings only, deliberately. Prose carries intentional raw HTML in
+ * this book (the <pre class="hkj-railway-diagram"> blocks build their art from
+ * <span> and <b>), so widening this check would be noise rather than signal.
+ * An opening tag carrying attributes is left alone for the same reason: that
+ * shape is always deliberate, as in reading.md's styled badge.
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const bookSrc = path.join(repoRoot, "hkj-book", "src");
+
+/** Every .md under hkj-book/src, depth first. */
+function markdownFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return markdownFiles(full);
+    return entry.isFile() && entry.name.endsWith(".md") ? [full] : [];
+  });
+}
+
+/**
+ * A fence closes only on its own marker, so the ``` blocks nested inside a
+ * ~~~admonish block do not end it. Tracking the open marker rather than a
+ * boolean is what keeps the two kinds from cancelling each other out.
+ */
+function headingsOutsideFences(text) {
+  const headings = [];
+  let fence = null;
+  text.split("\n").forEach((line, i) => {
+    const marker = line.match(/^\s*(`{3,}|~{3,})/);
+    if (marker) {
+      const [char, len] = [marker[1][0], marker[1].length];
+      if (!fence) fence = { char, len };
+      else if (char === fence.char && len >= fence.len) fence = null;
+      return;
+    }
+    if (!fence && line.startsWith("#")) headings.push({ line: i + 1, text: line });
+  });
+  return headings;
+}
+
+let failures = 0;
+let scanned = 0;
+
+for (const file of markdownFiles(bookSrc).sort()) {
+  const rel = path.relative(repoRoot, file);
+  for (const heading of headingsOutsideFences(fs.readFileSync(file, "utf8"))) {
+    scanned++;
+    // Code spans are the fix, so anything already inside one is fine.
+    const bare = heading.text.replace(/`[^`]*`/g, "");
+    for (const match of bare.matchAll(/<([A-Za-z][A-Za-z0-9]*)>/g)) {
+      failures++;
+      const tag = match[1];
+      const effect =
+        tag.toLowerCase() === "s"
+          ? "renders as <s>, so this heading and everything after it is struck through"
+          : `is read as an HTML tag, so "<${tag}>" is swallowed and vanishes from the page`;
+      console.log(`FAIL  ${rel}:${heading.line}  <${tag}> ${effect}`);
+      console.log(`      ${heading.text.trim()}`);
+      console.log(
+        `::error file=${rel},line=${heading.line}::<${tag}> in a heading ${effect}. Put the type in a code span, as \`Foo<${tag}>\`.`
+      );
+    }
+  }
+}
+
+console.log(
+  failures
+    ? `${failures} heading(s) pass raw HTML to the browser`
+    : `${scanned} headings carry no raw HTML`
+);
+process.exit(failures ? 1 : 0);

--- a/.github/workflows/book-mermaid-check.yml
+++ b/.github/workflows/book-mermaid-check.yml
@@ -1,8 +1,12 @@
 name: Book Mermaid Parse Check
 
-# Parse-checks every ```mermaid fence in hkj-book/src against the pinned
-# browser-side mermaid library, so a diagram syntax error fails the PR
-# instead of reaching the published book as a render-time error box.
+# Two things the published book cannot tell you are broken until a reader sees
+# them, so they fail the PR instead:
+#   - every ```mermaid fence in hkj-book/src is parsed against the pinned
+#     browser-side mermaid library, catching a diagram syntax error before it
+#     reaches the book as a render-time error box;
+#   - every heading is checked for raw HTML, because a bare <S> in a heading is
+#     the <s> element and silently strikes through the rest of the page.
 # No branches filter on pull_request: stacked PRs are checked too.
 on:
   pull_request:
@@ -10,6 +14,7 @@ on:
       - 'hkj-book/src/**'
       - '.github/scripts/fetch_mermaid.sh'
       - '.github/scripts/mermaid-check/**'
+      - '.github/scripts/book-heading-html-check.cjs'
       - '.github/workflows/book-mermaid-check.yml'
   push:
     branches: [ "main" ]
@@ -17,6 +22,7 @@ on:
       - 'hkj-book/src/**'
       - '.github/scripts/fetch_mermaid.sh'
       - '.github/scripts/mermaid-check/**'
+      - '.github/scripts/book-heading-html-check.cjs'
       - '.github/workflows/book-mermaid-check.yml'
 
 permissions:
@@ -35,6 +41,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      - name: Check headings for raw HTML
+        run: node .github/scripts/book-heading-html-check.cjs
 
       - name: Fetch pinned mermaid library
         run: .github/scripts/fetch_mermaid.sh

--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -91,7 +91,7 @@ Note this is about what the *iso* names, not what the method declares: `<T> Iso<
 
 **Fix.** Keep the spec interface to annotated abstract methods. Composed optics belong in a `static` method on the interface, or in an ordinary utility class; either one calls the generated statics by name, for example `JsonNodeOptics.object().andThen(...)`.
 
-### "'XOpticsSpec' declares OpticsSpec<S>, which is a type variable"
+### "'XOpticsSpec' declares `OpticsSpec<S>`, which is a type variable"
 
 **Cause.** The spec interface is generic, and its own type parameter is the source type: `interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S>`. Optics are generated against one named type, read for its members and rebuilt through its constructor, wither or setter, so a type parameter standing for whatever a caller picks has nothing to generate from. An array source type produces the same diagnostic with a different opening, `declares OpticsSpec<String[]>, which is an array type`, and the same remedy.
 
@@ -105,7 +105,7 @@ A source type that is itself generic is supported, and the spec names its own ty
 
 **Fix.** Verify that `SubType` extends or implements the spec's `<S>` parameter. If you are working with sum types that don't use a sealed hierarchy (such as Jackson's pre-3.x `JsonNode`), use `@MatchWhen` with predicate and getter method names instead.
 
-### "@InstanceOf: '...' declares its focus as 'Circle<T>', which the test cannot narrow to"
+### "@InstanceOf: '...' declares its focus as `Circle<T>`, which the test cannot narrow to"
 
 **Cause.** The prism promises a type argument the test cannot check. `@InstanceOf` takes a class constant, which is raw, and the generated `instanceof` runs after erasure, so the only arguments the narrowed value is known to have are the ones the source type pins down. `class Circle<X> extends Shape` reached from a `Shape` that declares no parameters pins none: every instantiation passes the same test, and a `Prism<Shape, Circle<T>>` would hand any of them back as the `T` the caller asked for, to fail on the first read.
 

--- a/hkj-book/src/tutorials/solutions_guide.md
+++ b/hkj-book/src/tutorials/solutions_guide.md
@@ -264,7 +264,7 @@ LIST.widen(listValue)
 2. Check annotation is on top-level or static class (not local class)
 3. Verify `@GenerateLenses` import is correct
 
-#### Error: "method mapN in interface Applicative<F> cannot be applied"
+#### Error: "method mapN in interface `Applicative<F>` cannot be applied"
 **Cause**: Wrong number of arguments or incorrect type parameters.
 
 **Fix**: Check you're using the right `map2`/`map3`/`map4`/`map5` for the number of values you're combining.


### PR DESCRIPTION
Reported on `optics/compiler_errors.md`: everything from line 94 onwards renders **struck through**.

## Cause

The heading quotes the processor's diagnostic verbatim, which puts the type argument outside any code span:

```
### "'XOpticsSpec' declares OpticsSpec<S>, which is a type variable"
```

Markdown passes a bare `<S>` through as raw HTML. HTML tag names are case-insensitive, so the browser reads it as `<s>` — the **strikethrough element** — and nothing ever closes it. Every following block inherits it.

## The quieter half of the same bug

Two more headings have it with a different symptom. `<T>` and `<F>` are not HTML elements, so the browser swallows the tag and renders its children, which means the type argument silently **disappears**:

| Page | Written | Rendered |
|---|---|---|
| `optics/compiler_errors.md:108` | `declares its focus as 'Circle<T>'` | `declares its focus as 'Circle'` |
| `tutorials/solutions_guide.md:267` | `method mapN in interface Applicative<F>` | `method mapN in interface Applicative` |

That one matters here for the same reason invented diagnostics did: a reader searching for the message they saw will not match the text on the page.

## Fix

All three carry the type in a code span now, which is what the same page already does for `` `XPrisms.java` `` and `` `.each()` `` in its other headings.

I swept **every heading in the book** for a bare `<tag>` outside a code span. These three were the only genuine cases; the one remaining hit is `reading.md`'s deliberately styled `<span>` badge. No inbound link targets any of the three anchors, so the slug changes are safe.

Local gates: `bookVerify` green, 48 mermaid diagrams parse clean.