### PR TITLE
Keep type-use annotations on the way into generated source (#750)

### DIFF
--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/BaseTraversableGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/BaseTraversableGenerator.java
@@ -10,6 +10,7 @@ import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * An abstract base class for {@link TraversableGenerator} implementations that provides common
@@ -53,7 +54,7 @@ public abstract class BaseTraversableGenerator implements TraversableGenerator {
         && containerType.getTypeArguments().size() > index) {
       final TypeMirror resolved = resolveEffectiveType(containerType.getTypeArguments().get(index));
       if (resolved != null) {
-        return TypeName.get(resolved).box();
+        return ProcessorUtils.typeNameOf(resolved).box();
       }
     }
     return ClassName.get(Object.class); // Raw, absent, or a wildcard standing for anything at all.

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/basejdk/ArrayGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/basejdk/ArrayGenerator.java
@@ -16,6 +16,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeMirror;
 import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 import org.higherkindedj.optics.util.Traversals;
 
 /**
@@ -165,7 +166,7 @@ public class ArrayGenerator extends BaseTraversableGenerator {
    */
   private TypeName elementType(final RecordComponentElement component) {
     if (component.asType() instanceof ArrayType arrayType) {
-      return TypeName.get(arrayType.getComponentType());
+      return ProcessorUtils.typeNameOf(arrayType.getComponentType());
     }
     return ClassName.get(Object.class); // Fallback
   }

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/basejdk/OptionalGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/basejdk/OptionalGenerator.java
@@ -17,6 +17,7 @@ import org.higherkindedj.hkt.Kind;
 import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
 import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * A {@link TraversableGenerator} that adds support for traversing fields of type {@link
@@ -73,7 +74,9 @@ public class OptionalGenerator extends BaseTraversableGenerator {
     return CodeBlock.builder()
         // Directly use the concrete Optional from the source record.
         .addStatement(
-            "final $T optional = source.$L()", TypeName.get(component.asType()), componentName)
+            "final $T optional = source.$L()",
+            ProcessorUtils.typeNameOf(component.asType()),
+            componentName)
         .beginControlFlow("if (optional.isPresent())")
         // If present, apply the effectful function.
         .addStatement("final var g_of_b = f.apply(optional.get())")

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/EitherGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/EitherGenerator.java
@@ -18,6 +18,7 @@ import org.higherkindedj.hkt.either.Either;
 import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
 import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * A {@link TraversableGenerator} that adds support for traversing fields of type {@link Either},
@@ -76,7 +77,9 @@ public class EitherGenerator extends BaseTraversableGenerator {
         // The local keeps the component's own type, wildcards and all, so that the accessor
         // assigns to it; every other mention names the type a wildcard resolves to.
         .addStatement(
-            "final $T either = source.$L()", TypeName.get(component.asType()), componentName)
+            "final $T either = source.$L()",
+            ProcessorUtils.typeNameOf(component.asType()),
+            componentName)
         .beginControlFlow("if (either.isRight())")
         .addStatement("final var g_of_b = f.apply(either.getRight())")
         .addStatement(

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/MaybeGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/MaybeGenerator.java
@@ -18,6 +18,7 @@ import org.higherkindedj.hkt.maybe.Maybe;
 import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
 import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * A {@link TraversableGenerator} that adds support for traversing fields of type {@link Maybe}.
@@ -74,7 +75,9 @@ public class MaybeGenerator extends BaseTraversableGenerator {
     return CodeBlock.builder()
         // Directly use the concrete Maybe from the source record.
         .addStatement(
-            "final $T maybe = source.$L()", TypeName.get(component.asType()), componentName)
+            "final $T maybe = source.$L()",
+            ProcessorUtils.typeNameOf(component.asType()),
+            componentName)
         .beginControlFlow("if (maybe.isJust())")
         // If Just, apply the effectful function.
         .addStatement("final var g_of_b = f.apply(maybe.get())")

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/TryGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/TryGenerator.java
@@ -18,6 +18,7 @@ import org.higherkindedj.hkt.trymonad.Try;
 import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
 import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * A {@link TraversableGenerator} that adds support for traversing fields of type {@link Try}. This
@@ -71,7 +72,9 @@ public class TryGenerator extends BaseTraversableGenerator {
 
     return CodeBlock.builder()
         .addStatement(
-            "final $T tryA = source.$L()", TypeName.get(component.asType()), componentName)
+            "final $T tryA = source.$L()",
+            ProcessorUtils.typeNameOf(component.asType()),
+            componentName)
         // Use the safe `foldFailureFirst` method to handle both cases without throwing exceptions.
         .addStatement(
             "return tryA.foldFailureFirst(\n"

--- a/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/ValidatedGenerator.java
+++ b/hkj-processor-plugins/src/main/java/org/higherkindedj/optics/processing/generator/hkj/ValidatedGenerator.java
@@ -18,6 +18,7 @@ import org.higherkindedj.hkt.validated.Validated;
 import org.higherkindedj.optics.processing.generator.BaseTraversableGenerator;
 import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * A {@link TraversableGenerator} that adds support for traversing fields of type {@link Validated}.
@@ -77,7 +78,9 @@ public class ValidatedGenerator extends BaseTraversableGenerator {
     return CodeBlock.builder()
         // Directly use the concrete Validated type from the source record.
         .addStatement(
-            "final $T validated = source.$L()", TypeName.get(component.asType()), componentName)
+            "final $T validated = source.$L()",
+            ProcessorUtils.typeNameOf(component.asType()),
+            componentName)
         .beginControlFlow("if (validated.isValid())")
         // If Valid, apply the effectful function.
         .addStatement("final var g_of_b = f.apply(validated.get())")

--- a/hkj-processor/src/main/java/module-info.java
+++ b/hkj-processor/src/main/java/module-info.java
@@ -26,8 +26,10 @@ module org.higherkindedj.processor {
       org.higherkindedj.optics.processing.AccumulatorProcessor,
       org.higherkindedj.optics.processing.AssemblyProcessor;
 
-  // It exports the SPI so the plugins module can implement it.
+  // It exports the SPI so the plugins module can implement it, and the shared processor
+  // helpers so that a plugin names a type the same way the generators that call it do.
   exports org.higherkindedj.optics.processing.spi;
+  exports org.higherkindedj.optics.processing.util;
 
   // Export Effect Path processor package
   exports org.higherkindedj.optics.processing.effect;

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ErrorEnvelopeProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/ErrorEnvelopeProcessor.java
@@ -390,7 +390,7 @@ public class ErrorEnvelopeProcessor extends AbstractProcessor {
     CodeBlock.Builder args = CodeBlock.builder();
     boolean first = true;
     for (RecordComponentElement component : context.getRecordComponents()) {
-      args.add(first ? "($T) null" : ", ($T) null", TypeName.get(component.asType()));
+      args.add(first ? "($T) null" : ", ($T) null", ProcessorUtils.typeNameOf(component.asType()));
       first = false;
     }
     return FieldSpec.builder(
@@ -417,7 +417,7 @@ public class ErrorEnvelopeProcessor extends AbstractProcessor {
     CodeBlock.Builder args = CodeBlock.builder().add("$T.system()", TIME_SOURCE);
     for (RecordComponentElement component : domainComponents(variant)) {
       String name = component.getSimpleName().toString();
-      method.addParameter(TypeName.get(component.asType()), name);
+      method.addParameter(ProcessorUtils.typeNameOf(component.asType()), name);
       args.add(", $N", name);
     }
     return method.addStatement("return $L($L)", factoryName(variant), args.build()).build();
@@ -441,7 +441,8 @@ public class ErrorEnvelopeProcessor extends AbstractProcessor {
                 message)
             .addParameter(TIME_SOURCE, "time");
     for (RecordComponentElement component : domainComponents(variant)) {
-      method.addParameter(TypeName.get(component.asType()), component.getSimpleName().toString());
+      method.addParameter(
+          ProcessorUtils.typeNameOf(component.asType()), component.getSimpleName().toString());
     }
     method.addStatement("$T.requireNonNull(time, $S)", OBJECTS, "time must not be null");
 
@@ -522,7 +523,7 @@ public class ErrorEnvelopeProcessor extends AbstractProcessor {
     boolean first = true;
     for (RecordComponentElement component : context.getRecordComponents()) {
       String name = component.getSimpleName().toString();
-      TypeName type = TypeName.get(component.asType());
+      TypeName type = ProcessorUtils.typeNameOf(component.asType());
       builder.addField(FieldSpec.builder(type, name, Modifier.PRIVATE).build());
       ctor.addStatement("this.$1N = seed.$1N()", name);
       builder.addMethod(

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -257,7 +257,8 @@ public class FocusProcessor extends AbstractProcessor {
     if (typeParameters.isEmpty()) {
       return ClassName.get(typeElement);
     } else {
-      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      List<TypeVariableName> typeVars =
+          typeParameters.stream().map(ProcessorUtils::typeVariableOf).toList();
       return ParameterizedTypeName.get(
           ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
     }
@@ -316,7 +317,7 @@ public class FocusProcessor extends AbstractProcessor {
 
     // Add type parameters if the record is generic
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     // Build the constructor arguments for the setter lambda

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FoldProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FoldProcessor.java
@@ -26,6 +26,7 @@ import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Fold;
 import org.higherkindedj.optics.annotations.GenerateFolds;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /** Annotation processor that generates Fold optics for record types. */
 @AutoService(Processor.class)
@@ -108,7 +109,8 @@ public class FoldProcessor extends AbstractProcessor {
     if (typeParameters.isEmpty()) {
       return ClassName.get(typeElement);
     } else {
-      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      List<TypeVariableName> typeVars =
+          typeParameters.stream().map(ProcessorUtils::typeVariableOf).toList();
       return ParameterizedTypeName.get(
           ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
     }
@@ -118,7 +120,7 @@ public class FoldProcessor extends AbstractProcessor {
       RecordComponentElement component, TypeElement recordElement, TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
 
     // Check if this is an Iterable type (List, Set, etc.)
     boolean isIterable = isIterableType(component.asType());
@@ -141,7 +143,7 @@ public class FoldProcessor extends AbstractProcessor {
             .returns(foldTypeName);
 
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     // Create the foldMap implementation
@@ -209,7 +211,7 @@ public class FoldProcessor extends AbstractProcessor {
     // Only called for iterable components, and isIterableType requires a declared type.
     DeclaredType containerType = (DeclaredType) component.asType();
     if (!containerType.getTypeArguments().isEmpty()) {
-      return TypeName.get(containerType.getTypeArguments().getFirst()).box();
+      return ProcessorUtils.typeNameOf(containerType.getTypeArguments().getFirst()).box();
     }
     return ClassName.get(Object.class);
   }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/GetterProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/GetterProcessor.java
@@ -110,7 +110,8 @@ public class GetterProcessor extends AbstractProcessor {
     if (typeParameters.isEmpty()) {
       return ClassName.get(typeElement);
     } else {
-      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      List<TypeVariableName> typeVars =
+          typeParameters.stream().map(ProcessorUtils::typeVariableOf).toList();
       return ParameterizedTypeName.get(
           ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
     }
@@ -120,7 +121,7 @@ public class GetterProcessor extends AbstractProcessor {
       RecordComponentElement component, TypeElement recordElement, TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
 
     ParameterizedTypeName getterTypeName =
         ParameterizedTypeName.get(
@@ -140,7 +141,7 @@ public class GetterProcessor extends AbstractProcessor {
             .returns(getterTypeName);
 
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     methodBuilder.addStatement("return $T.of($T::$L)", Getter.class, recordTypeName, componentName);
@@ -152,7 +153,7 @@ public class GetterProcessor extends AbstractProcessor {
       RecordComponentElement component, TypeElement recordElement, TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
     String methodName = "get" + ProcessorUtils.capitalise(componentName);
     String gettersClassName = recordElement.getSimpleName().toString() + "Getters";
 
@@ -174,7 +175,7 @@ public class GetterProcessor extends AbstractProcessor {
 
     List<? extends TypeParameterElement> typeParameters = recordElement.getTypeParameters();
     for (TypeParameterElement typeParam : typeParameters) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String typeArguments =

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/IsoProcessor.java
@@ -239,8 +239,8 @@ public final class IsoProcessor extends AbstractProcessor {
     final List<? extends TypeMirror> typeArguments =
         ((DeclaredType) method.getReturnType()).getTypeArguments();
 
-    final TypeName sTypeName = TypeName.get(typeArguments.get(0));
-    final TypeName aTypeName = TypeName.get(typeArguments.get(1));
+    final TypeName sTypeName = ProcessorUtils.typeNameOf(typeArguments.get(0));
+    final TypeName aTypeName = ProcessorUtils.typeNameOf(typeArguments.get(1));
     final TypeName isoTypeName =
         ParameterizedTypeName.get(ClassName.get(Iso.class), sTypeName, aTypeName);
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/LensProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/LensProcessor.java
@@ -128,7 +128,8 @@ public class LensProcessor extends AbstractProcessor {
     if (typeParameters.isEmpty()) {
       return ClassName.get(typeElement);
     } else {
-      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      List<TypeVariableName> typeVars =
+          typeParameters.stream().map(ProcessorUtils::typeVariableOf).toList();
       return ParameterizedTypeName.get(
           ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
     }
@@ -141,7 +142,7 @@ public class LensProcessor extends AbstractProcessor {
       TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
 
     ParameterizedTypeName lensTypeName =
         ParameterizedTypeName.get(
@@ -161,7 +162,7 @@ public class LensProcessor extends AbstractProcessor {
             .returns(lensTypeName);
 
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String constructorArgs =
@@ -188,7 +189,7 @@ public class LensProcessor extends AbstractProcessor {
       RecordComponentElement component, TypeElement recordElement, TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
     String methodName = "with" + ProcessorUtils.capitalise(componentName);
     String parameterName = "new" + ProcessorUtils.capitalise(componentName);
     String lensesClassName = recordElement.getSimpleName().toString() + "Lenses";
@@ -215,7 +216,7 @@ public class LensProcessor extends AbstractProcessor {
 
     List<? extends TypeParameterElement> typeParameters = recordElement.getTypeParameters();
     for (TypeParameterElement typeParam : typeParameters) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String typeArguments =

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -313,7 +313,8 @@ public class MappingProcessor extends AbstractProcessor {
         .map(
             leaf ->
                 new LeafField(
-                    leaf.getSimpleName().toString(), TypeName.get(memberTypeIn(spec, leaf))))
+                    leaf.getSimpleName().toString(),
+                    ProcessorUtils.typeNameOf(memberTypeIn(spec, leaf))))
         .toList();
   }
 
@@ -1864,7 +1865,9 @@ public class MappingProcessor extends AbstractProcessor {
       if (leaves.isEmpty()) {
         CodeBlock arguments =
             match.spec().getTypeParameters().stream()
-                .map(variable -> CodeBlock.of("$T", TypeName.get(bindings.get(variable))))
+                .map(
+                    variable ->
+                        CodeBlock.of("$T", ProcessorUtils.typeNameOf(bindings.get(variable))))
                 .collect(CodeBlock.joining(", "));
         return new PrismResolution(
             CodeBlock.of("$T.<$L>instance().asValidatedPrism()", match.impl(), arguments), false);
@@ -3082,8 +3085,8 @@ public class MappingProcessor extends AbstractProcessor {
       List<Correspondence> comps) {
     ClassName specName = ClassName.get(spec);
     ClassName implName = implClassName(spec);
-    TypeName domainName = TypeName.get(domainDeclared);
-    TypeName wireName = TypeName.get(wireUsed);
+    TypeName domainName = ProcessorUtils.typeNameOf(domainDeclared);
+    TypeName wireName = ProcessorUtils.typeNameOf(wireUsed);
     TypeName parseReturn =
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
@@ -3294,8 +3297,8 @@ public class MappingProcessor extends AbstractProcessor {
       List<Correspondence> comps) {
     ClassName specName = ClassName.get(spec);
     ClassName implName = implClassName(spec);
-    TypeName domainName = TypeName.get(domainDeclared);
-    TypeName wireName = TypeName.get(wireUsed);
+    TypeName domainName = ProcessorUtils.typeNameOf(domainDeclared);
+    TypeName wireName = ProcessorUtils.typeNameOf(wireUsed);
     TypeName patchReturn =
         ParameterizedTypeName.get(
             VALIDATED, ParameterizedTypeName.get(NEL, FIELD_ERROR), domainName);
@@ -3455,8 +3458,8 @@ public class MappingProcessor extends AbstractProcessor {
       TypeMirror wireUsed,
       List<Correspondence> comps) {
     ClassName specName = ClassName.get(spec);
-    TypeName domainName = TypeName.get(domainDeclared);
-    TypeName wireName = TypeName.get(wireUsed);
+    TypeName domainName = ProcessorUtils.typeNameOf(domainDeclared);
+    TypeName wireName = ProcessorUtils.typeNameOf(wireUsed);
 
     if (!checkNoEmittedCollisions(
         spec,
@@ -3694,7 +3697,7 @@ public class MappingProcessor extends AbstractProcessor {
       String javadoc,
       List<LeafField> abstractLeaves) {
     List<TypeVariableName> variables =
-        spec.getTypeParameters().stream().map(TypeVariableName::get).toList();
+        spec.getTypeParameters().stream().map(ProcessorUtils::typeVariableOf).toList();
     TypeSpec.Builder builder =
         TypeSpec.classBuilder(implName)
             .addOriginatingElement(spec)
@@ -3839,7 +3842,7 @@ public class MappingProcessor extends AbstractProcessor {
           MethodSpec.methodBuilder(method.getSimpleName().toString())
               .addAnnotation(Override.class)
               .addModifiers(Modifier.PUBLIC)
-              .returns(TypeName.get(memberTypeIn(spec, method)))
+              .returns(ProcessorUtils.typeNameOf(memberTypeIn(spec, method)))
               .addJavadoc("Rename declaration only; not invocable.\n")
               .addStatement(
                   "throw new $T($S)",

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MergeProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MergeProcessor.java
@@ -34,6 +34,7 @@ import javax.lang.model.util.ElementFilter;
 import org.higherkindedj.optics.annotations.ArityCeilings;
 import org.higherkindedj.optics.annotations.GenerateMerge;
 import org.higherkindedj.optics.processing.util.Diagnostics;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Annotation processor for {@code @GenerateMerge}: forward-only assembly of one target record from
@@ -589,9 +590,10 @@ public class MergeProcessor extends AbstractProcessor {
         MethodSpec.methodBuilder(mergeMethod.getSimpleName().toString())
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PUBLIC)
-            .returns(TypeName.get(mergeMethod.getReturnType()));
+            .returns(ProcessorUtils.typeNameOf(mergeMethod.getReturnType()));
     for (VariableElement source : mergeMethod.getParameters()) {
-      method.addParameter(TypeName.get(source.asType()), source.getSimpleName().toString());
+      method.addParameter(
+          ProcessorUtils.typeNameOf(source.asType()), source.getSimpleName().toString());
       method.addStatement(
           "$T.requireNonNull($L, $S)",
           OBJECTS,

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -913,7 +913,7 @@ public class NavigatorClassGenerator {
 
     // Add type parameters if the record is generic
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     // Build the constructor arguments for the setter lambda

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/SetterProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/SetterProcessor.java
@@ -111,7 +111,8 @@ public class SetterProcessor extends AbstractProcessor {
     if (typeParameters.isEmpty()) {
       return ClassName.get(typeElement);
     } else {
-      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      List<TypeVariableName> typeVars =
+          typeParameters.stream().map(ProcessorUtils::typeVariableOf).toList();
       return ParameterizedTypeName.get(
           ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
     }
@@ -124,7 +125,7 @@ public class SetterProcessor extends AbstractProcessor {
       TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
 
     ParameterizedTypeName setterTypeName =
         ParameterizedTypeName.get(
@@ -144,7 +145,7 @@ public class SetterProcessor extends AbstractProcessor {
             .returns(setterTypeName);
 
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String constructorArgs =
@@ -171,7 +172,7 @@ public class SetterProcessor extends AbstractProcessor {
       RecordComponentElement component, TypeElement recordElement, TypeName recordTypeName) {
 
     String componentName = component.getSimpleName().toString();
-    TypeName componentTypeName = TypeName.get(component.asType());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(component.asType());
     String methodName = "with" + ProcessorUtils.capitalise(componentName);
     String parameterName = "new" + ProcessorUtils.capitalise(componentName);
     String settersClassName = recordElement.getSimpleName().toString() + "Setters";
@@ -198,7 +199,7 @@ public class SetterProcessor extends AbstractProcessor {
 
     List<? extends TypeParameterElement> typeParameters = recordElement.getTypeParameters();
     for (TypeParameterElement typeParam : typeParameters) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String typeArguments =

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/TraversalProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/TraversalProcessor.java
@@ -134,7 +134,7 @@ public class TraversalProcessor extends AbstractProcessor {
     final TypeMirror componentType = component.asType();
 
     if (componentType instanceof ArrayType arrayType) {
-      focusType = TypeName.get(arrayType.getComponentType()).box();
+      focusType = ProcessorUtils.typeNameOf(arrayType.getComponentType()).box();
     } else if (componentType instanceof DeclaredType declaredType) {
       if (declaredType.getTypeArguments().isEmpty()) {
         return null; // Cannot traverse a raw type.
@@ -151,7 +151,9 @@ public class TraversalProcessor extends AbstractProcessor {
       TypeMirror focusArgument =
           ProcessorUtils.resolveWildcard(declaredType.getTypeArguments().get(typeArgumentIndex));
       focusType =
-          focusArgument == null ? ClassName.get(Object.class) : TypeName.get(focusArgument).box();
+          focusArgument == null
+              ? ClassName.get(Object.class)
+              : ProcessorUtils.typeNameOf(focusArgument).box();
 
     } else {
       return null; // Not a type we can handle.
@@ -198,7 +200,7 @@ public class TraversalProcessor extends AbstractProcessor {
 
     final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(componentName);
     for (TypeParameterElement typeParameter : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParameter));
     }
 
     return methodBuilder
@@ -235,7 +237,7 @@ public class TraversalProcessor extends AbstractProcessor {
     }
     return ParameterizedTypeName.get(
         recordClassName,
-        typeParameters.stream().map(TypeVariableName::get).toArray(TypeName[]::new));
+        typeParameters.stream().map(ProcessorUtils::typeVariableOf).toArray(TypeName[]::new));
   }
 
   private void error(String msg, Element e) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WideningAnalysis.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WideningAnalysis.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.processing;
 
+import com.palantir.javapoet.AnnotationSpec;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.TypeName;
 import java.util.ArrayList;
@@ -351,18 +352,42 @@ public final class WideningAnalysis {
   /** The type the widened path focuses on: what the last layer peeled unwraps to. */
   private static TypeName focusType(TypeMirror componentType, List<Step> steps) {
     if (steps.isEmpty()) {
-      return TypeName.get(componentType).box();
+      return ProcessorUtils.typeNameOf(componentType).box();
     }
     Step last = steps.getLast();
     return switch (last.kind()) {
-      // .nullable() rules out the null rather than unwrapping, so the component stays in focus.
-      case NULLABLE -> TypeName.get(componentType).box();
+      // .nullable() rules out the null rather than unwrapping, so the component stays in focus -
+      // but without the annotation that put the step there. Affines.nullable() is
+      // Affine<@Nullable A, A>: the widening is what makes the focus non-null, and repeating
+      // @Nullable on it would describe a value the affine never yields.
+      case NULLABLE -> nullRuledOut(ProcessorUtils.typeNameOf(componentType).box());
       case KIND_EXACTLY_ONE, KIND_ZERO_OR_ONE, KIND_ZERO_OR_MORE -> last.kindInfo().elementType();
       case OPTIONAL, LIST, SET, COLLECTION, SPI_ZERO_OR_ONE, SPI_ZERO_OR_MORE ->
           last.innerType() == null
               ? ClassName.get(Object.class)
-              : TypeName.get(last.innerType()).box();
+              : ProcessorUtils.typeNameOf(last.innerType()).box();
     };
+  }
+
+  /**
+   * The component's name with a nullness annotation on the component itself dropped.
+   *
+   * <p>Only the outermost one goes: {@code @Nullable List<@Nullable String>} widened by {@code
+   * .nullable()} focuses a present {@code List<@Nullable String>}, whose elements are still as
+   * nullable as they were written. Anything else the author wrote at that position stays, because
+   * it is only the nullness the widening consumed.
+   */
+  private static TypeName nullRuledOut(TypeName name) {
+    List<AnnotationSpec> kept =
+        name.annotations().stream()
+            .filter(
+                annotation ->
+                    !NullableAnnotations.NULLABLE_ANNOTATION_NAMES.contains(
+                        annotation.type().toString()))
+            .toList();
+    return kept.size() == name.annotations().size()
+        ? name
+        : name.withoutAnnotations().annotated(kept);
   }
 
   /**
@@ -411,7 +436,7 @@ public final class WideningAnalysis {
     if (!witness) {
       return "." + method + "()";
     }
-    args.add(TypeName.get(step.innerType()));
+    args.add(ProcessorUtils.typeNameOf(step.innerType()));
     return ".<$T>" + method + "()";
   }
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/EffectAlgebraProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/EffectAlgebraProcessor.java
@@ -21,6 +21,7 @@ import javax.lang.model.type.TypeVariable;
 import javax.tools.Diagnostic;
 import org.higherkindedj.hkt.effect.annotation.EffectAlgebra;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Annotation processor for {@link EffectAlgebra @EffectAlgebra} that generates HKT boilerplate for
@@ -706,7 +707,7 @@ public class EffectAlgebraProcessor extends AbstractProcessor {
    */
   private static TypeName componentTypeIn(
       RecordComponentElement component, TypeVariableName resultType) {
-    return substituted(TypeName.get(component.asType()), resultType);
+    return substituted(ProcessorUtils.typeNameOf(component.asType()), resultType);
   }
 
   /**
@@ -715,10 +716,16 @@ public class EffectAlgebraProcessor extends AbstractProcessor {
    * <p>A permitted record declares the algebra's result type parameter and may declare no other,
    * and a sealed interface is implicitly static so no enclosing class's parameter is in scope
    * either. Every type variable a component can mention is therefore that one.
+   *
+   * <p>Each rebuilt layer is re-annotated. The smart constructors this feeds are emitted into a
+   * {@code @NullMarked} class, where dropping a component's {@code @Nullable} would not merely lose
+   * it but assert the opposite: {@code write(null)} would be rejected for a component the record it
+   * wraps accepts null for. A parameterised type carries its annotations on its raw type, so
+   * rebuilding from that keeps them without help.
    */
   private static TypeName substituted(TypeName type, TypeVariableName resultType) {
     if (type instanceof TypeVariableName) {
-      return resultType;
+      return resultType.annotated(type.annotations());
     }
     if (type instanceof ParameterizedTypeName parameterized) {
       TypeName[] arguments =
@@ -728,14 +735,17 @@ public class EffectAlgebraProcessor extends AbstractProcessor {
       return ParameterizedTypeName.get(parameterized.rawType(), arguments);
     }
     if (type instanceof ArrayTypeName array) {
-      return ArrayTypeName.of(substituted(array.componentType(), resultType));
+      return ArrayTypeName.of(substituted(array.componentType(), resultType))
+          .annotated(type.annotations());
     }
     if (type instanceof WildcardTypeName wildcard) {
       if (!wildcard.lowerBounds().isEmpty()) {
         return WildcardTypeName.supertypeOf(
-            substituted(wildcard.lowerBounds().getFirst(), resultType));
+                substituted(wildcard.lowerBounds().getFirst(), resultType))
+            .annotated(type.annotations());
       }
-      return WildcardTypeName.subtypeOf(substituted(wildcard.upperBounds().getFirst(), resultType));
+      return WildcardTypeName.subtypeOf(substituted(wildcard.upperBounds().getFirst(), resultType))
+          .annotated(type.annotations());
     }
     return type;
   }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
@@ -147,7 +147,7 @@ public class PathProcessor extends AbstractProcessor {
     // interface declares. Naming it raw instead would leave every method that mentions one of
     // those parameters pointing at a variable the bridge never brings into scope.
     List<TypeVariableName> interfaceVariables =
-        interfaceElement.getTypeParameters().stream().map(TypeVariableName::get).toList();
+        interfaceElement.getTypeParameters().stream().map(ProcessorUtils::typeVariableOf).toList();
     TypeName delegateType =
         interfaceVariables.isEmpty()
             ? interfaceClassName
@@ -402,7 +402,7 @@ public class PathProcessor extends AbstractProcessor {
       typeVariables.add(
           TypeVariableName.get(
               variableName.toString(),
-              bounds.stream().map(TypeName::get).toArray(TypeName[]::new)));
+              bounds.stream().map(ProcessorUtils::typeNameOf).toArray(TypeName[]::new)));
     }
 
     TypeMirror returnType = asMember.getReturnType();
@@ -510,7 +510,9 @@ public class PathProcessor extends AbstractProcessor {
     PathVia pathVia = method.getAnnotation(PathVia.class);
 
     TypeName[] effectArguments =
-        bridgeable.effectArguments().stream().map(TypeName::get).toArray(TypeName[]::new);
+        bridgeable.effectArguments().stream()
+            .map(ProcessorUtils::typeNameOf)
+            .toArray(TypeName[]::new);
     MethodSpec.Builder methodBuilder =
         MethodSpec.methodBuilder(bridgeable.bridgeName())
             .addModifiers(Modifier.PUBLIC)
@@ -518,7 +520,9 @@ public class PathProcessor extends AbstractProcessor {
     bridgeable.typeVariables().forEach(methodBuilder::addTypeVariable);
     // The bridge only passes the call on, so whatever the delegate declares it can throw, the
     // bridge declares too. Dropping them left the caller with an unreported checked exception.
-    asMember.getThrownTypes().forEach(thrown -> methodBuilder.addException(TypeName.get(thrown)));
+    asMember
+        .getThrownTypes()
+        .forEach(thrown -> methodBuilder.addException(ProcessorUtils.typeNameOf(thrown)));
 
     // Description first, then the block tags in order. A tag written before the description takes
     // the description into itself, which is what javadoc does with any text following a tag.
@@ -551,7 +555,8 @@ public class PathProcessor extends AbstractProcessor {
     for (int index = 0; index < parameters.size(); index++) {
       String parameterName = parameters.get(index).getSimpleName().toString();
       argumentNames.add(parameterName);
-      methodBuilder.addParameter(TypeName.get(parameterTypes.get(index)), parameterName);
+      methodBuilder.addParameter(
+          ProcessorUtils.typeNameOf(parameterTypes.get(index)), parameterName);
     }
 
     methodBuilder.varargs(copiesVarargs(method, asMember, effect));

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/ExternalLensGenerator.java
@@ -176,7 +176,7 @@ public class ExternalLensGenerator {
       List<? extends RecordComponentElement> allComponents,
       TypeName recordTypeName) {
 
-    TypeName componentTypeName = TypeName.get(field.type());
+    TypeName componentTypeName = ProcessorUtils.typeNameOf(field.type());
 
     ParameterizedTypeName lensTypeName =
         ParameterizedTypeName.get(
@@ -196,7 +196,7 @@ public class ExternalLensGenerator {
             .returns(lensTypeName);
 
     for (TypeParameterElement typeParam : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String constructorArgs =
@@ -222,7 +222,7 @@ public class ExternalLensGenerator {
   private MethodSpec createWitherLensMethod(
       FieldInfo field, WitherInfo wither, TypeElement classElement, TypeName classTypeName) {
 
-    TypeName fieldTypeName = TypeName.get(field.type());
+    TypeName fieldTypeName = ProcessorUtils.typeNameOf(field.type());
 
     ParameterizedTypeName lensTypeName =
         ParameterizedTypeName.get(ClassName.get(Lens.class), classTypeName, fieldTypeName.box());
@@ -241,7 +241,7 @@ public class ExternalLensGenerator {
             .returns(lensTypeName);
 
     for (TypeParameterElement typeParam : classElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     // Use wither method for setting: source.withYear(newValue)
@@ -257,7 +257,7 @@ public class ExternalLensGenerator {
 
   private MethodSpec createWithMethod(FieldInfo field, TypeElement typeElement, TypeName typeName) {
 
-    TypeName fieldTypeName = TypeName.get(field.type());
+    TypeName fieldTypeName = ProcessorUtils.typeNameOf(field.type());
     String methodName = "with" + ProcessorUtils.capitalise(field.name());
     String parameterName = "new" + ProcessorUtils.capitalise(field.name());
     String lensesClassName = typeElement.getSimpleName().toString() + "Lenses";
@@ -284,7 +284,7 @@ public class ExternalLensGenerator {
 
     List<? extends TypeParameterElement> typeParameters = typeElement.getTypeParameters();
     for (TypeParameterElement typeParam : typeParameters) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     String typeArguments =
@@ -410,7 +410,7 @@ public class ExternalLensGenerator {
 
     // The record's own parameters, as the lens methods beside this one already declare them.
     for (TypeParameterElement typeParameter : recordElement.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParameter));
     }
 
     return methodBuilder.addStatement("return $L", traversalImpl).build();
@@ -419,7 +419,7 @@ public class ExternalLensGenerator {
   // Package-private for tests.
   TypeName getFocusType(TypeMirror type, TraversableGenerator generator) {
     if (type instanceof ArrayType arrayType) {
-      return TypeName.get(arrayType.getComponentType()).box();
+      return ProcessorUtils.typeNameOf(arrayType.getComponentType()).box();
     } else if (type instanceof DeclaredType declaredType) {
       if (declaredType.getTypeArguments().isEmpty()) {
         return null; // Cannot traverse a raw type.
@@ -433,7 +433,8 @@ public class ExternalLensGenerator {
       if (declaredType.getTypeArguments().size() <= typeArgumentIndex) {
         return null; // Not enough type arguments for this generator.
       }
-      return TypeName.get(declaredType.getTypeArguments().get(typeArgumentIndex)).box();
+      return ProcessorUtils.typeNameOf(declaredType.getTypeArguments().get(typeArgumentIndex))
+          .box();
     }
     return null;
   }
@@ -443,7 +444,8 @@ public class ExternalLensGenerator {
     if (typeParameters.isEmpty()) {
       return ClassName.get(typeElement);
     } else {
-      List<TypeVariableName> typeVars = typeParameters.stream().map(TypeVariableName::get).toList();
+      List<TypeVariableName> typeVars =
+          typeParameters.stream().map(ProcessorUtils::typeVariableOf).toList();
       return ParameterizedTypeName.get(
           ClassName.get(typeElement), typeVars.toArray(new TypeName[0]));
     }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
@@ -22,7 +22,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Lens;
@@ -347,15 +346,9 @@ public class SpecInterfaceGenerator {
    */
   // Package-private for tests.
   TypeName getParameterisedTypeName(TypeMirror typeMirror) {
-    if (typeMirror instanceof DeclaredType declaredType) {
-      List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
-      if (!typeArgs.isEmpty()) {
-        TypeElement typeElement = (TypeElement) declaredType.asElement();
-        TypeName[] typeArgNames =
-            typeArgs.stream().map(ProcessorUtils::typeNameOf).toArray(TypeName[]::new);
-        return ParameterizedTypeName.get(ClassName.get(typeElement), typeArgNames);
-      }
-    }
+    // The whole walk, not a rebuild of the parameterised case: naming the arguments through
+    // typeNameOf but the head through ClassName.get(element) would keep an annotation on a type
+    // argument and drop one on the type itself.
     return ProcessorUtils.typeNameOf(typeMirror);
   }
 

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceGenerator.java
@@ -10,7 +10,6 @@ import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
-import com.palantir.javapoet.TypeVariableName;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -160,7 +159,7 @@ public class SpecInterfaceGenerator {
     // variables this signature actually names can be inferred at the call.
     for (TypeParameterElement typeParam :
         methodTypeParameters(specInterface, sourceType, focusType)) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParam));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParam));
     }
 
     // Generate method body based on optic kind
@@ -316,7 +315,7 @@ public class SpecInterfaceGenerator {
       OpticKind opticKind, TypeMirror sourceType, TypeMirror focusType) {
 
     TypeName sourceTypeName = getParameterisedTypeName(sourceType);
-    TypeName focusTypeName = TypeName.get(focusType).box();
+    TypeName focusTypeName = ProcessorUtils.typeNameOf(focusType).box();
     ClassName opticClass = getOpticClass(opticKind);
 
     return ParameterizedTypeName.get(opticClass, sourceTypeName, focusTypeName);
@@ -352,11 +351,12 @@ public class SpecInterfaceGenerator {
       List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
       if (!typeArgs.isEmpty()) {
         TypeElement typeElement = (TypeElement) declaredType.asElement();
-        TypeName[] typeArgNames = typeArgs.stream().map(TypeName::get).toArray(TypeName[]::new);
+        TypeName[] typeArgNames =
+            typeArgs.stream().map(ProcessorUtils::typeNameOf).toArray(TypeName[]::new);
         return ParameterizedTypeName.get(ClassName.get(typeElement), typeArgNames);
       }
     }
-    return TypeName.get(typeMirror);
+    return ProcessorUtils.typeNameOf(typeMirror);
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/kind/KindFieldAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/kind/KindFieldAnalyser.java
@@ -15,6 +15,7 @@ import javax.tools.Diagnostic;
 import org.higherkindedj.optics.annotations.TraverseField;
 import org.higherkindedj.optics.processing.kind.KindRegistry.KindMapping;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Analyses record fields to detect and extract information about {@code Kind<F, A>} types.
@@ -89,7 +90,7 @@ public class KindFieldAnalyser {
 
     TypeMirror witnessTypeMirror = typeArgs.get(0);
     TypeMirror elementTypeMirror = typeArgs.get(1);
-    TypeName elementType = TypeName.get(elementTypeMirror).box();
+    TypeName elementType = ProcessorUtils.typeNameOf(elementTypeMirror).box();
 
     // Check for explicit @TraverseField annotation first
     TraverseField traverseFieldAnnotation = component.getAnnotation(TraverseField.class);

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/spi/TraversableGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/spi/TraversableGenerator.java
@@ -168,7 +168,7 @@ public interface TraversableGenerator {
     }
     return ParameterizedTypeName.get(
         recordClassName,
-        typeParameters.stream().map(TypeVariableName::get).toArray(TypeName[]::new));
+        typeParameters.stream().map(ProcessorUtils::typeVariableOf).toArray(TypeName[]::new));
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -2,6 +2,13 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.processing.util;
 
+import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ArrayTypeName;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeName;
+import com.palantir.javapoet.TypeVariableName;
+import com.palantir.javapoet.WildcardTypeName;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;
@@ -15,6 +22,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
@@ -368,6 +376,99 @@ public final class ProcessorUtils {
                   && mentions(wildcard.getSuperBound(), parameter));
       default -> false;
     };
+  }
+
+  /**
+   * The name of a type as written, with its type-use annotations kept.
+   *
+   * <p>{@link TypeName#get(TypeMirror)} rebuilds a name from the element alone and never consults
+   * {@link TypeMirror#getAnnotationMirrors()} at any depth, so every type-use annotation on the
+   * declaration is dropped on the way into generated source. That is not merely a loss of
+   * information: inside a {@code @NullMarked} scope an unannotated type <em>means</em> non-null, so
+   * a dropped {@code @Nullable} asserts the opposite of what the author wrote. The scope is the
+   * consumer's to set - a {@code package-info} or {@code module-info} carrying {@code @NullMarked}
+   * covers generated files in that package as surely as an annotation the generator stamps itself -
+   * so a generator cannot know that its output is unconstrained.
+   *
+   * <p>The walk mirrors javapoet's own, re-attaching each mirror's annotations as it goes, so an
+   * annotation is kept wherever it was written: on the type itself, on a type argument at any
+   * depth, on an array's component or on the array, and on a wildcard bound.
+   *
+   * @param type the type to name; must not be null
+   * @return its name, annotated as the source annotated it (non-null)
+   * @since 0.4.10
+   */
+  public static TypeName typeNameOf(TypeMirror type) {
+    List<AnnotationSpec> annotations =
+        type.getAnnotationMirrors().stream().map(AnnotationSpec::get).toList();
+    // Dispatch on the kind, as javapoet's own visitor does, rather than on the interface: javac's
+    // intersection implements DeclaredType, so a pattern switch would send one down the declared
+    // arm and ask it for a class element it does not have. Everything this does not rebuild -
+    // a primitive, a type variable, void, and the kinds that have no name at all - javapoet names
+    // from the mirror alone, and it stays javapoet's call which of those it refuses.
+    TypeName name =
+        switch (type.getKind()) {
+          case ARRAY -> ArrayTypeName.of(typeNameOf(((ArrayType) type).getComponentType()));
+          case WILDCARD -> wildcardNameOf((WildcardType) type);
+          case DECLARED, ERROR -> declaredNameOf((DeclaredType) type);
+          default -> TypeName.get(type);
+        };
+    return annotations.isEmpty() ? name : name.annotated(annotations);
+  }
+
+  private static TypeName declaredNameOf(DeclaredType declared) {
+    ClassName rawType = ClassName.get((TypeElement) declared.asElement());
+    TypeMirror enclosingType = declared.getEnclosingType();
+    // A static member has no enclosing instance type, so javac reports NONE for it and the kind
+    // test alone settles both cases. The enclosing type is only ever read back below when it came
+    // out parameterised, and no member that could be static is written under one.
+    TypeName enclosing =
+        enclosingType.getKind() == TypeKind.NONE ? null : typeNameOf(enclosingType);
+    List<? extends TypeMirror> typeArguments = declared.getTypeArguments();
+    if (typeArguments.isEmpty() && !(enclosing instanceof ParameterizedTypeName)) {
+      return rawType;
+    }
+    List<TypeName> argumentNames = typeArguments.stream().map(ProcessorUtils::typeNameOf).toList();
+    return enclosing instanceof ParameterizedTypeName parameterised
+        ? parameterised.nestedClass(rawType.simpleName(), argumentNames)
+        : ParameterizedTypeName.get(rawType, argumentNames.toArray(new TypeName[0]));
+  }
+
+  private static TypeName wildcardNameOf(WildcardType wildcard) {
+    TypeMirror extendsBound = wildcard.getExtendsBound();
+    if (extendsBound != null) {
+      return WildcardTypeName.subtypeOf(typeNameOf(extendsBound));
+    }
+    TypeMirror superBound = wildcard.getSuperBound();
+    return superBound == null
+        ? WildcardTypeName.subtypeOf(ClassName.OBJECT)
+        : WildcardTypeName.supertypeOf(typeNameOf(superBound));
+  }
+
+  /**
+   * The declaration of a type parameter, with the annotations on its bounds kept.
+   *
+   * <p>{@link TypeVariableName#get(TypeParameterElement)} names each bound through {@link
+   * TypeName#get(TypeMirror)}, which drops the annotation, and then removes any bound that is bare
+   * {@code Object}. Between them {@code <T extends @Nullable Object>} becomes {@code <T>}, which is
+   * the narrower declaration: the generated type no longer admits an instantiation the type it
+   * wraps permits.
+   *
+   * <p>Naming the bounds through {@link #typeNameOf(TypeMirror)} is enough to fix both halves. An
+   * annotated {@code Object} is not equal to the bare one, so it survives the removal that the bare
+   * bound is still rightly subject to.
+   *
+   * @param parameter the type parameter to name; must not be null
+   * @return its name and bounds, annotated as the source annotated them (non-null)
+   * @since 0.4.10
+   */
+  public static TypeVariableName typeVariableOf(TypeParameterElement parameter) {
+    TypeName[] bounds =
+        parameter.getBounds().stream().map(ProcessorUtils::typeNameOf).toArray(TypeName[]::new);
+    TypeVariableName variable = TypeVariableName.get(parameter.getSimpleName().toString(), bounds);
+    List<AnnotationSpec> annotations =
+        parameter.getAnnotationMirrors().stream().map(AnnotationSpec::get).toList();
+    return annotations.isEmpty() ? variable : variable.annotated(annotations);
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -420,17 +420,23 @@ public final class ProcessorUtils {
     ClassName rawType = ClassName.get((TypeElement) declared.asElement());
     TypeMirror enclosingType = declared.getEnclosingType();
     // A static member has no enclosing instance type, so javac reports NONE for it and the kind
-    // test alone settles both cases. The enclosing type is only ever read back below when it came
-    // out parameterised, and no member that could be static is written under one.
+    // test alone settles both cases.
     TypeName enclosing =
         enclosingType.getKind() == TypeKind.NONE ? null : typeNameOf(enclosingType);
-    List<? extends TypeMirror> typeArguments = declared.getTypeArguments();
-    if (typeArguments.isEmpty() && !(enclosing instanceof ParameterizedTypeName)) {
-      return rawType;
+    List<TypeName> argumentNames =
+        declared.getTypeArguments().stream().map(ProcessorUtils::typeNameOf).toList();
+    if (enclosing instanceof ParameterizedTypeName parameterised) {
+      return parameterised.nestedClass(rawType.simpleName(), argumentNames);
     }
-    List<TypeName> argumentNames = typeArguments.stream().map(ProcessorUtils::typeNameOf).toList();
-    return enclosing instanceof ParameterizedTypeName parameterised
-        ? parameterised.nestedClass(rawType.simpleName(), argumentNames)
+    // An annotation on the enclosing type is written before it - `@Marker Outer.Inner` annotates
+    // Outer, not Inner - and ClassName.get(element) names the whole nesting from the element
+    // alone, so it carries none of it. Rebuilding the name under the enclosing keeps what was
+    // written there; for an unannotated enclosing it reproduces the same name.
+    if (enclosing instanceof ClassName enclosingName) {
+      rawType = enclosingName.nestedClass(rawType.simpleName());
+    }
+    return argumentNames.isEmpty()
+        ? rawType
         : ParameterizedTypeName.get(rawType, argumentNames.toArray(new TypeName[0]));
   }
 
@@ -458,17 +464,22 @@ public final class ProcessorUtils {
    * annotated {@code Object} is not equal to the bare one, so it survives the removal that the bare
    * bound is still rightly subject to.
    *
+   * <p>The bounds are all that is copied. An annotation written on the parameter itself, as in
+   * {@code <@Marker T>}, is left behind: one {@code TypeVariableName} both declares a parameter and
+   * is written wherever that parameter is named, and a generator reuses the same one for both. An
+   * annotation that is legal on the declaration need not be legal at a use - a {@code
+   * TYPE_PARAMETER} one is rejected outright as a type argument - so carrying it would emit source
+   * the consuming build cannot compile. Nothing is lost for nullness: JSpecify states a nullable
+   * parameter as {@code <T extends @Nullable Object>}, which is a bound.
+   *
    * @param parameter the type parameter to name; must not be null
-   * @return its name and bounds, annotated as the source annotated them (non-null)
+   * @return its name, with its bounds annotated as the source annotated them (non-null)
    * @since 0.4.10
    */
   public static TypeVariableName typeVariableOf(TypeParameterElement parameter) {
     TypeName[] bounds =
         parameter.getBounds().stream().map(ProcessorUtils::typeNameOf).toArray(TypeName[]::new);
-    TypeVariableName variable = TypeVariableName.get(parameter.getSimpleName().toString(), bounds);
-    List<AnnotationSpec> annotations =
-        parameter.getAnnotationMirrors().stream().map(AnnotationSpec::get).toList();
-    return annotations.isEmpty() ? variable : variable.annotated(annotations);
+    return TypeVariableName.get(parameter.getSimpleName().toString(), bounds);
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/SubtypePrismGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/SubtypePrismGenerator.java
@@ -6,7 +6,6 @@ import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
-import com.palantir.javapoet.TypeVariableName;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.processing.Messager;
@@ -58,7 +57,7 @@ public final class SubtypePrismGenerator {
             : ParameterizedTypeName.get(
                 ClassName.get(subtype),
                 subtype.getTypeParameters().stream()
-                    .map(TypeVariableName::get)
+                    .map(ProcessorUtils::typeVariableOf)
                     .toArray(TypeName[]::new));
 
     ParameterizedTypeName prismTypeName =
@@ -79,7 +78,7 @@ public final class SubtypePrismGenerator {
             .returns(prismTypeName);
 
     for (TypeParameterElement typeParameter : subtype.getTypeParameters()) {
-      methodBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+      methodBuilder.addTypeVariable(ProcessorUtils.typeVariableOf(typeParameter));
     }
 
     return methodBuilder

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/SubtypePrismGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/SubtypePrismGenerator.java
@@ -46,7 +46,7 @@ public final class SubtypePrismGenerator {
 
     String methodName = ProcessorUtils.toCamelCase(subtype.getSimpleName().toString());
     DeclaredType namedSumType = ProcessorUtils.sumTypeAsNamedBy(sumType, subtype);
-    TypeName sourceTypeName = TypeName.get(namedSumType);
+    TypeName sourceTypeName = ProcessorUtils.typeNameOf(namedSumType);
     if (rejectsUnboundParameter(messager, tag, sumType, subtype, namedSumType)) {
       return null;
     }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NullableAnnotationDetectionTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/NullableAnnotationDetectionTest.java
@@ -79,9 +79,10 @@ class NullableAnnotationDetectionTest {
 
       assertThat(compilation).succeeded();
       // The element annotation says nothing about the field, so the list widens as any other
-      // list does: by its elements, not by its nullability.
+      // list does: by its elements, not by its nullability. It does describe the element the
+      // traversal arrives at, which is why the focus keeps it.
       assertGeneratedCodeContains(
-          compilation, "com.example.TagsFocus", "TraversalPath<Tags, String> labels()");
+          compilation, "com.example.TagsFocus", "TraversalPath<Tags, @Nullable String> labels()");
       assertGeneratedCodeDoesNotContain(compilation, "com.example.TagsFocus", ".nullable()");
     }
 
@@ -106,7 +107,42 @@ class NullableAnnotationDetectionTest {
       assertGeneratedCodeContains(
           compilation, "com.example.ReadingsFocus", "AffinePath<Readings, String[]> samples()");
       assertGeneratedCodeContains(
-          compilation, "com.example.ReadingsFocus", "FocusPath<Readings, String[]> labels()");
+          compilation,
+          "com.example.ReadingsFocus",
+          "FocusPath<Readings, @Nullable String[]> labels()");
+    }
+
+    @Test
+    @DisplayName("the widening consumes the nullness and nothing else at that position")
+    void theWideningConsumesTheNullnessAndNothingElse() {
+      final JavaFileObject tag =
+          JavaFileObjects.forSourceString(
+              "com.example.Tag",
+              """
+              package com.example;
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              @Target(ElementType.TYPE_USE)
+              public @interface Tag {}
+              """);
+      final JavaFileObject source =
+          JavaFileObjects.forSourceString(
+              "com.example.Marked",
+              """
+              package com.example;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+              import org.jspecify.annotations.Nullable;
+              @GenerateFocus
+              public record Marked(@Tag @Nullable String note) {}
+              """);
+
+      Compilation compilation = javac().withProcessors(new FocusProcessor()).compile(tag, source);
+
+      assertThat(compilation).succeeded();
+      // .nullable() rules the null out, so @Nullable goes. It says nothing about @Tag, which
+      // describes the value the affine does yield and so stays on the focus.
+      assertGeneratedCodeContains(
+          compilation, "com.example.MarkedFocus", "AffinePath<Marked, @Tag String> note()");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TypeUseAnnotationSurvivalTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TypeUseAnnotationSurvivalTest.java
@@ -1,0 +1,400 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.higherkindedj.optics.processing.effect.EffectAlgebraProcessor;
+import org.higherkindedj.optics.processing.effect.PathProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A case per generator: a {@code @Nullable} the author wrote survives into what the generator
+ * emits.
+ *
+ * <p>Dropping it is not merely a loss of information. Generated source lands in the annotated
+ * type's own package, so it inherits whatever {@code @NullMarked} scope the consumer set there -
+ * and inside one, an unannotated type <em>means</em> non-null. A dropped {@code @Nullable} does not
+ * leave the contract unstated; it states the opposite of what the author wrote.
+ *
+ * <p>{@code @EffectAlgebra} is the one generator that stamps {@code @NullMarked} on its own output,
+ * so it carries the extra check that the emitted file actually compiles as the author's own call
+ * would.
+ */
+@DisplayName("Type-use annotations survive into generated code")
+class TypeUseAnnotationSurvivalTest {
+
+  private static JavaFileObject source(String qualifiedName, String body) {
+    return JavaFileObjects.forSourceString(qualifiedName, body);
+  }
+
+  @Nested
+  @DisplayName("record component optics")
+  class RecordComponentOptics {
+
+    private static final String BOX =
+        """
+        package com.example;
+
+        import java.util.List;
+        import org.jspecify.annotations.Nullable;
+        import org.higherkindedj.optics.annotations.%s;
+
+        @%s
+        public record Box<T extends @Nullable Object>(
+            T value, @Nullable String label, List<@Nullable String> tags) {}
+        """;
+
+    private static Compilation compile(String annotation, Object processor) {
+      return javac()
+          .withProcessors((javax.annotation.processing.Processor) processor)
+          .compile(source("com.example.Box", BOX.formatted(annotation, annotation)));
+    }
+
+    @Test
+    @DisplayName("@GenerateLenses keeps it in the focus, the wither's parameter and the bound")
+    void generateLensesKeepsIt() {
+      Compilation compilation = compile("GenerateLenses", new LensProcessor());
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxLenses",
+          "public static <T extends @Nullable Object> Lens<Box<T>, @Nullable String> label()");
+      // The bound is the half that decides what the generated type admits: stripped to `<T>`, the
+      // lens no longer accepts the `Box<@Nullable String>` the record itself permits.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxLenses",
+          "public static <T extends @Nullable Object> Box<T> withLabel(Box<T> source,"
+              + " @Nullable String newLabel)");
+    }
+
+    @Test
+    @DisplayName("@GenerateSetters keeps it in the setter's focus")
+    void generateSettersKeepsIt() {
+      Compilation compilation = compile("GenerateSetters", new SetterProcessor());
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxSetters",
+          "public static <T extends @Nullable Object> Setter<Box<T>, @Nullable String> label()");
+    }
+
+    @Test
+    @DisplayName("@GenerateGetters keeps it in the getter's focus and its convenience return")
+    void generateGettersKeepsIt() {
+      Compilation compilation = compile("GenerateGetters", new GetterProcessor());
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxGetters",
+          "public static <T extends @Nullable Object> Getter<Box<T>, @Nullable String> label()");
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxGetters",
+          "public static <T extends @Nullable Object> @Nullable String getLabel(Box<T> source)");
+    }
+
+    @Test
+    @DisplayName("@GenerateFolds keeps it in the fold's focus")
+    void generateFoldsKeepsIt() {
+      Compilation compilation = compile("GenerateFolds", new FoldProcessor());
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxFolds",
+          "public static <T extends @Nullable Object> Fold<Box<T>, @Nullable String> label()");
+      // A fold over a container focuses its elements, so the element annotation is the one that
+      // describes what the fold arrives at.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxFolds",
+          "public static <T extends @Nullable Object> Fold<Box<T>, @Nullable String> tags()");
+    }
+
+    @Test
+    @DisplayName("@GenerateFocus keeps the bound, and keeps only what the widening did not consume")
+    void generateFocusKeepsWhatTheWideningDidNotConsume() {
+      Compilation compilation = compile("GenerateFocus", new FocusProcessor());
+
+      assertThat(compilation).succeeded();
+      // A nullable component widens through .nullable(), which is Affine<@Nullable A, A>: the
+      // widening is what rules the null out, so the focus it arrives at is non-null again.
+      // Repeating @Nullable here would describe a value the affine never yields.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxFocus",
+          "public static <T extends @Nullable Object> AffinePath<Box<T>, String> label()");
+      // A nullable *element* is not consumed by anything: .each() arrives at exactly it.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxFocus",
+          "public static <T extends @Nullable Object> TraversalPath<Box<T>, @Nullable String>"
+              + " tags()");
+    }
+
+    @Test
+    @DisplayName("@GenerateTraversals keeps it in the traversal's focus")
+    void generateTraversalsKeepsIt() {
+      Compilation compilation = compile("GenerateTraversals", new TraversalProcessor());
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.BoxTraversals", "Traversal<Box<T>, @Nullable String> tags()");
+    }
+  }
+
+  @Nested
+  @DisplayName("generators over a declared signature")
+  class DeclaredSignatures {
+
+    @Test
+    @DisplayName("@GenerateIsos keeps it in either side of the isomorphism")
+    void generateIsosKeepsIt() {
+      Compilation compilation =
+          javac()
+              .withProcessors(new IsoProcessor())
+              .compile(
+                  source(
+                      "com.example.Converters",
+                      """
+                      package com.example;
+
+                      import org.jspecify.annotations.Nullable;
+                      import org.higherkindedj.optics.Iso;
+                      import org.higherkindedj.optics.annotations.GenerateIsos;
+
+                      public class Converters {
+                        @GenerateIsos
+                        public static Iso<@Nullable String, @Nullable CharSequence> widen() {
+                          return Iso.of(s -> s, c -> (String) c);
+                        }
+                      }
+                      """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.ConvertersIsos",
+          "public static final Iso<@Nullable String, @Nullable CharSequence> widen");
+    }
+
+    @Test
+    @DisplayName("@GenerateMerge keeps it in the parameters it repeats")
+    void generateMergeKeepsIt() {
+      Compilation compilation =
+          javac()
+              .withProcessors(new MergeProcessor())
+              .compile(
+                  source(
+                      "com.example.Parts",
+                      """
+                      package com.example;
+
+                      public final class Parts {
+                        public record Head(String title) {}
+
+                        public record Tail(String body) {}
+
+                        public record Page(String title, String body) {}
+                      }
+                      """),
+                  source(
+                      "com.example.PageAssembly",
+                      """
+                      package com.example;
+
+                      import org.jspecify.annotations.Nullable;
+                      import org.higherkindedj.optics.annotations.GenerateMerge;
+
+                      @GenerateMerge
+                      public interface PageAssembly {
+                        Parts.Page assemble(Parts.@Nullable Head head, Parts.Tail tail);
+                      }
+                      """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.PageAssemblyImpl",
+          "public Parts.Page assemble(Parts.@Nullable Head head, Parts.Tail tail)");
+    }
+
+    @Test
+    @DisplayName("@GeneratePathBridge keeps it in the bridge's parameters, focus and bound")
+    void generatePathBridgeKeepsIt() {
+      Compilation compilation =
+          javac()
+              .withProcessors(new PathProcessor())
+              .compile(
+                  source(
+                      "com.example.Lookup",
+                      """
+                      package com.example;
+
+                      import java.util.Optional;
+                      import org.jspecify.annotations.Nullable;
+                      import org.higherkindedj.hkt.effect.annotation.GeneratePathBridge;
+                      import org.higherkindedj.hkt.effect.annotation.PathVia;
+
+                      @GeneratePathBridge
+                      public interface Lookup<T extends @Nullable Object> {
+                        @PathVia
+                        Optional<@Nullable String> find(@Nullable String key);
+                      }
+                      """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.LookupPaths",
+          "public final class LookupPaths<T extends @Nullable Object>");
+      // A bridge that narrows its own parameter below the delegate's rejects a call the delegate
+      // accepts, so the wrapper is not usable everywhere the thing it wraps is.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.LookupPaths",
+          "public OptionalPath<@Nullable String> find(@Nullable String key)");
+    }
+
+    @Test
+    @DisplayName("@ImportOptics keeps it in an optic generated for a type it does not own")
+    void importOpticsKeepsIt() {
+      Compilation compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .compile(
+                  source(
+                      "com.external.Customer",
+                      """
+                      package com.external;
+
+                      import org.jspecify.annotations.Nullable;
+
+                      public record Customer(String name, @Nullable String nickname) {}
+                      """),
+                  source(
+                      "com.myapp.optics.package-info",
+                      """
+                      @ImportOptics({com.external.Customer.class})
+                      package com.myapp.optics;
+
+                      import org.higherkindedj.optics.annotations.ImportOptics;
+                      """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.myapp.optics.CustomerLenses",
+          "public static Lens<Customer, @Nullable String> nickname()");
+    }
+
+    @Test
+    @DisplayName("@GenerateErrorEnvelope keeps it in the context builder it emits")
+    void generateErrorEnvelopeKeepsIt() {
+      Compilation compilation =
+          javac()
+              .withProcessors(new ErrorEnvelopeProcessor())
+              .compile(
+                  source(
+                      "com.example.FooErrorContext",
+                      """
+                      package com.example;
+
+                      import org.jspecify.annotations.Nullable;
+
+                      public record FooErrorContext(String traceId, @Nullable String orderId) {}
+                      """),
+                  source(
+                      "com.example.FooError",
+                      """
+                      package com.example;
+
+                      import org.higherkindedj.hkt.error.ErrorEnvelope;
+                      import org.higherkindedj.optics.annotations.GenerateErrorEnvelope;
+
+                      @GenerateErrorEnvelope
+                      public sealed interface FooError {
+                        ErrorEnvelope<FooErrorContext> envelope();
+
+                        record OutOfStock(String product, ErrorEnvelope<FooErrorContext> envelope)
+                            implements FooError {}
+                      }
+                      """));
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation, "com.example.FooErrors", "public ContextBuilder orderId(@Nullable String");
+    }
+  }
+
+  @Nested
+  @DisplayName("@EffectAlgebra, whose own output is @NullMarked")
+  class NullMarkedOutput {
+
+    private static final JavaFileObject NOTE_OP =
+        JavaFileObjects.forSourceString(
+            "com.example.NoteOp",
+            """
+            package com.example;
+
+            import org.jspecify.annotations.Nullable;
+            import org.higherkindedj.hkt.effect.annotation.EffectAlgebra;
+
+            @EffectAlgebra
+            public sealed interface NoteOp<A> permits NoteOp.Write {
+              record Write<A>(@Nullable String note) implements NoteOp<A> {}
+            }
+            """);
+
+    @Test
+    @DisplayName("the smart constructor keeps it, so it accepts what the record it wraps accepts")
+    void smartConstructorKeepsIt() {
+      Compilation compilation =
+          javac().withProcessors(new EffectAlgebraProcessor()).compile(NOTE_OP);
+
+      assertThat(compilation).succeeded();
+      // Without it, `write(null)` is rejected under the file's own @NullMarked while
+      // `new NoteOp.Write<>(null)` - the call the smart constructor exists to wrap - is not.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.NoteOpOps",
+          "public static <A> Free<NoteOpKind.Witness, A> write(@Nullable String note)");
+      // The Bound inner class repeats the signature, and would repeat the loss with it.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.NoteOpOps",
+          "public <A> Free<G, A> write(@Nullable String note)");
+    }
+
+    @Test
+    @DisplayName("the emitted file compiles, annotation and its import included")
+    void theEmittedFileCompiles() {
+      // The annotation has to be written into a file that names it: an emitted @Nullable with no
+      // import is a generated file the consuming build cannot compile.
+      Compilation compilation =
+          javac().withProcessors(new EffectAlgebraProcessor()).compile(NOTE_OP);
+
+      assertThat(compilation).succeededWithoutWarnings();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.NoteOpOps",
+          "public static <A> Free<NoteOpKind.Witness, A> write");
+      GeneratorTestHelper.assertGeneratedCodeContainsRaw(
+          compilation, "com.example.NoteOpOps", "import org.jspecify.annotations.Nullable;");
+      GeneratorTestHelper.assertGeneratedCodeContainsRaw(
+          compilation, "com.example.NoteOpOps", "@NullMarked");
+    }
+  }
+}

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TypeUseAnnotationSurvivalTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/TypeUseAnnotationSurvivalTest.java
@@ -5,6 +5,7 @@ package org.higherkindedj.optics.processing;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeContains;
+import static org.higherkindedj.optics.processing.GeneratorTestHelper.assertGeneratedCodeDoesNotContain;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
@@ -301,6 +302,36 @@ class TypeUseAnnotationSurvivalTest {
     }
 
     @Test
+    @DisplayName("@GeneratePrisms keeps it in the sum type as the subtype's own clause names it")
+    void generatePrismsKeepsIt() {
+      Compilation compilation =
+          javac()
+              .withProcessors(new PrismProcessor())
+              .compile(
+                  source(
+                      "com.example.Shape",
+                      """
+                      package com.example;
+
+                      import org.jspecify.annotations.Nullable;
+                      import org.higherkindedj.optics.annotations.GeneratePrisms;
+
+                      @GeneratePrisms
+                      public sealed interface Shape<T> {
+                        record Tagged(String label) implements Shape<@Nullable String> {}
+                      }
+                      """));
+
+      assertThat(compilation).succeeded();
+      // A prism is written against the sum type the *subtype* names, and an implements clause is
+      // a use: what is written there is part of the type the prism focuses from.
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.ShapePrisms",
+          "Prism<Shape<@Nullable String>, Shape.Tagged> tagged()");
+    }
+
+    @Test
     @DisplayName("@GenerateErrorEnvelope keeps it in the context builder it emits")
     void generateErrorEnvelopeKeepsIt() {
       Compilation compilation =
@@ -336,6 +367,55 @@ class TypeUseAnnotationSurvivalTest {
       assertThat(compilation).succeeded();
       assertGeneratedCodeContains(
           compilation, "com.example.FooErrors", "public ContextBuilder orderId(@Nullable String");
+    }
+  }
+
+  @Nested
+  @DisplayName("what must not be copied")
+  class NotCopied {
+
+    @Test
+    @DisplayName("a type-parameter annotation does not leak into a type-argument position")
+    void typeParameterAnnotationDoesNotLeak() {
+      // One TypeVariableName both declares the record's parameter and is written as the type
+      // argument of `Box<T>` in every generated signature. `Box<@Marked T>` does not compile -
+      // "annotation @Marked not applicable in this type context" - so the declaration annotation
+      // has to stay behind. The bound, where JSpecify states nullability, is kept.
+      Compilation compilation =
+          javac()
+              .withProcessors(new LensProcessor())
+              .compile(
+                  source(
+                      "com.example.Marked",
+                      """
+                      package com.example;
+
+                      import java.lang.annotation.ElementType;
+                      import java.lang.annotation.Target;
+
+                      @Target(ElementType.TYPE_PARAMETER)
+                      public @interface Marked {}
+                      """),
+                  source(
+                      "com.example.Box",
+                      """
+                      package com.example;
+
+                      import org.jspecify.annotations.Nullable;
+                      import org.higherkindedj.optics.annotations.GenerateLenses;
+
+                      @GenerateLenses
+                      public record Box<@Marked T extends @Nullable Object>(T value) {}
+                      """));
+
+      // succeeded(), not just "generated": the generated file is compiled in this same run, so a
+      // leaked annotation would fail here rather than in a consumer's build.
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.BoxLenses",
+          "public static <T extends @Nullable Object> Lens<Box<T>, T> value()");
+      assertGeneratedCodeDoesNotContain(compilation, "com.example.BoxLenses", "Box<@Marked T>");
     }
   }
 

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
@@ -435,6 +435,16 @@ class ProcessorUtilsTest {
                   public static class Nested {}
               }
               """);
+      var plain =
+          JavaFileObjects.forSourceString(
+              "com.test.Plain",
+              """
+              package com.test;
+              public class Plain {
+                  public class Member {}
+                  public class Held<Y> {}
+              }
+              """);
       var subject =
           JavaFileObjects.forSourceString(
               "com.test.Subject",
@@ -462,10 +472,13 @@ class ProcessorUtilsTest {
                   Outer<@Nullable String>.Inner memberOfAnnotatedOuter;
                   Outer<@Nullable String>.Pair<Integer> parameterisedMemberOfAnnotatedOuter;
                   Outer.Nested staticallyNested;
+                  @Nullable Plain.Member annotatedEnclosing;
+                  @Nullable Plain.Held<String> annotatedEnclosingOfGeneric;
+                  Plain.Member plainEnclosing;
               }
               """);
       var processor = new CapturingProcessor();
-      javac().withProcessors(processor).compile(outer, subject);
+      javac().withProcessors(processor).compile(outer, plain, subject);
       return processor;
     }
 
@@ -542,6 +555,21 @@ class ProcessorUtilsTest {
     }
 
     @Test
+    @DisplayName("keeps an annotation on the enclosing type itself")
+    void keepsAnAnnotationOnTheEnclosingTypeItself() {
+      // `@Nullable Plain.Member` annotates Plain, not Member: javac hangs it on the enclosing
+      // type, and naming the nesting from the element alone carries none of it.
+      assertThat(probe().names)
+          .containsEntry(
+              "annotatedEnclosing", "com.test. @org.jspecify.annotations.Nullable Plain. Member")
+          .containsEntry(
+              "annotatedEnclosingOfGeneric",
+              "com.test. @org.jspecify.annotations.Nullable Plain. Held<java.lang.String>")
+          // An unannotated enclosing rebuilds to exactly the name it had.
+          .containsEntry("plainEnclosing", "com.test.Plain.Member");
+    }
+
+    @Test
     @DisplayName("keeps an annotated Object bound that javapoet would otherwise strip")
     void keepsAnAnnotatedObjectBound() {
       // `<T extends @Nullable Object>` is the declaration that admits a nullable instantiation.
@@ -555,8 +583,13 @@ class ProcessorUtilsTest {
     }
 
     @Test
-    @DisplayName("keeps an annotation written on the type parameter itself")
-    void keepsAnAnnotationOnTheTypeParameterItself() {
+    @DisplayName("leaves an annotation written on the type parameter itself behind")
+    void leavesAnAnnotationOnTheTypeParameterItselfBehind() {
+      // One TypeVariableName both declares a parameter and is written wherever that parameter is
+      // named, and generators reuse the same one for both. `Box<@Marked T>` is rejected outright
+      // - "annotation @Marked not applicable in this type context" - so carrying a declaration
+      // annotation would emit source the consuming build cannot compile. The bound, which is
+      // where JSpecify states nullability, is copied.
       var subject =
           JavaFileObjects.forSourceString(
               "com.test.Subject",
@@ -564,7 +597,8 @@ class ProcessorUtilsTest {
               package com.test;
               import java.lang.annotation.ElementType;
               import java.lang.annotation.Target;
-              public class Subject<@Subject.Marked T> {
+              import org.jspecify.annotations.Nullable;
+              public class Subject<@Subject.Marked T extends @Nullable Object> {
                   @Target(ElementType.TYPE_PARAMETER)
                   public @interface Marked {}
               }
@@ -572,7 +606,8 @@ class ProcessorUtilsTest {
       var processor = new CapturingProcessor();
       javac().withProcessors(processor).compile(subject);
 
-      assertThat(processor.variables).containsEntry("T", "@com.test.Subject.Marked T");
+      assertThat(processor.variables)
+          .containsEntry("T", "T extends java.lang. @org.jspecify.annotations.Nullable Object");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
@@ -4,8 +4,10 @@ package org.higherkindedj.optics.processing.util;
 
 import static com.google.testing.compile.Compiler.javac;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.testing.compile.JavaFileObjects;
+import com.palantir.javapoet.TypeVariableName;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -365,6 +367,283 @@ class ProcessorUtilsTest {
           .containsEntry("memberOfGenericOuter", true)
           // A static nested class has no enclosing instance type, so the outer cannot reach it.
           .containsEntry("staticallyNested", false);
+    }
+  }
+
+  /**
+   * Contract tests for {@link ProcessorUtils#typeNameOf} and {@link ProcessorUtils#typeVariableOf},
+   * driven through a real compilation so the mirrors carry the annotations javac attached. The
+   * subject declares one field per shape; each field's type is the type to name.
+   */
+  @Nested
+  @DisplayName("typeNameOf and typeVariableOf")
+  class TypeNames {
+
+    /** Renders each probe field's type, keyed by field name, plus the subject's type parameters. */
+    private static final class CapturingProcessor extends AbstractProcessor {
+      private final Map<String, String> names = new LinkedHashMap<>();
+      private final Map<String, String> variables = new LinkedHashMap<>();
+
+      @Override
+      public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+      }
+
+      @Override
+      public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+      }
+
+      @Override
+      public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+        TypeElement subject = processingEnv.getElementUtils().getTypeElement("com.test.Subject");
+        if (subject == null) {
+          return false;
+        }
+        for (VariableElement field : ElementFilter.fieldsIn(subject.getEnclosedElements())) {
+          names.put(
+              field.getSimpleName().toString(),
+              ProcessorUtils.typeNameOf(field.asType()).toString());
+        }
+        for (TypeParameterElement parameter : subject.getTypeParameters()) {
+          variables.put(parameter.getSimpleName().toString(), render(parameter));
+        }
+        return false;
+      }
+
+      /** The declaration as the generated file would write it: annotations, name, then bounds. */
+      private static String render(TypeParameterElement parameter) {
+        TypeVariableName variable = ProcessorUtils.typeVariableOf(parameter);
+        StringBuilder out = new StringBuilder();
+        variable.annotations().forEach(annotation -> out.append(annotation).append(" "));
+        out.append(variable.name());
+        variable.bounds().forEach(bound -> out.append(" extends ").append(bound));
+        return out.toString();
+      }
+    }
+
+    /** Compiles the subject once and hands back the processor holding the rendered names. */
+    private CapturingProcessor probe() {
+      var outer =
+          JavaFileObjects.forSourceString(
+              "com.test.Outer",
+              """
+              package com.test;
+              public class Outer<X> {
+                  public class Inner {}
+                  public class Pair<Y> {}
+                  public static class Nested {}
+              }
+              """);
+      var subject =
+          JavaFileObjects.forSourceString(
+              "com.test.Subject",
+              """
+              package com.test;
+              import java.util.List;
+              import java.util.Map;
+              import org.jspecify.annotations.Nullable;
+              @SuppressWarnings("unused")
+              public class Subject<T extends @Nullable Object, U extends @Nullable Number, V> {
+                  String plain;
+                  @Nullable String annotated;
+                  List<@Nullable String> annotatedArgument;
+                  @Nullable List<String> annotatedWhole;
+                  Map<@Nullable String, List<@Nullable Integer>> annotatedDeeply;
+                  String @Nullable [] annotatedArray;
+                  @Nullable String[] annotatedComponent;
+                  int @Nullable [] annotatedPrimitiveArray;
+                  int primitive;
+                  List<? extends @Nullable Number> extendsWildcard;
+                  List<? super @Nullable String> superWildcard;
+                  List<?> unboundedWildcard;
+                  @Nullable T annotatedVariable;
+                  T plainVariable;
+                  Outer<@Nullable String>.Inner memberOfAnnotatedOuter;
+                  Outer<@Nullable String>.Pair<Integer> parameterisedMemberOfAnnotatedOuter;
+                  Outer.Nested staticallyNested;
+              }
+              """);
+      var processor = new CapturingProcessor();
+      javac().withProcessors(processor).compile(outer, subject);
+      return processor;
+    }
+
+    @Test
+    @DisplayName("keeps an annotation written on the type itself, and adds none where none was")
+    void keepsAnAnnotationWrittenOnTheTypeItself() {
+      assertThat(probe().names)
+          .containsEntry("plain", "java.lang.String")
+          .containsEntry("annotated", "java.lang. @org.jspecify.annotations.Nullable String")
+          .containsEntry("primitive", "int")
+          .containsEntry("staticallyNested", "com.test.Outer.Nested");
+    }
+
+    @Test
+    @DisplayName("keeps an annotation on a type argument at any depth")
+    void keepsAnAnnotationOnATypeArgument() {
+      assertThat(probe().names)
+          .containsEntry(
+              "annotatedArgument",
+              "java.util.List<java.lang. @org.jspecify.annotations.Nullable String>")
+          .containsEntry(
+              "annotatedWhole",
+              "java.util. @org.jspecify.annotations.Nullable List<java.lang.String>")
+          .containsEntry(
+              "annotatedDeeply",
+              "java.util.Map<java.lang. @org.jspecify.annotations.Nullable String,"
+                  + " java.util.List<java.lang. @org.jspecify.annotations.Nullable Integer>>");
+    }
+
+    @Test
+    @DisplayName("keeps the array and its component apart")
+    void keepsTheArrayAndItsComponentApart() {
+      // `String @Nullable []` is a nullable array of non-null elements; `@Nullable String[]` is a
+      // non-null array of nullable ones. Collapsing them would invert one of the two.
+      assertThat(probe().names)
+          .containsEntry("annotatedArray", "java.lang.String @org.jspecify.annotations.Nullable []")
+          .containsEntry(
+              "annotatedComponent", "java.lang. @org.jspecify.annotations.Nullable String[]")
+          .containsEntry("annotatedPrimitiveArray", "int @org.jspecify.annotations.Nullable []");
+    }
+
+    @Test
+    @DisplayName("keeps an annotation on either wildcard bound, and leaves an unbounded one alone")
+    void keepsAnAnnotationOnAWildcardBound() {
+      assertThat(probe().names)
+          .containsEntry(
+              "extendsWildcard",
+              "java.util.List<? extends java.lang. @org.jspecify.annotations.Nullable Number>")
+          .containsEntry(
+              "superWildcard",
+              "java.util.List<? super java.lang. @org.jspecify.annotations.Nullable String>")
+          .containsEntry("unboundedWildcard", "java.util.List<?>");
+    }
+
+    @Test
+    @DisplayName("keeps an annotation on a type variable's use")
+    void keepsAnAnnotationOnATypeVariableUse() {
+      assertThat(probe().names)
+          .containsEntry("annotatedVariable", "@org.jspecify.annotations.Nullable T")
+          .containsEntry("plainVariable", "T");
+    }
+
+    @Test
+    @DisplayName("keeps an annotation on an enclosing type's argument")
+    void keepsAnAnnotationOnAnEnclosingTypesArgument() {
+      assertThat(probe().names)
+          .containsEntry(
+              "memberOfAnnotatedOuter",
+              "com.test.Outer<java.lang. @org.jspecify.annotations.Nullable String>.Inner")
+          .containsEntry(
+              "parameterisedMemberOfAnnotatedOuter",
+              "com.test.Outer<java.lang. @org.jspecify.annotations.Nullable String>"
+                  + ".Pair<java.lang.Integer>");
+    }
+
+    @Test
+    @DisplayName("keeps an annotated Object bound that javapoet would otherwise strip")
+    void keepsAnAnnotatedObjectBound() {
+      // `<T extends @Nullable Object>` is the declaration that admits a nullable instantiation.
+      // Stripping the bound narrows the generated type below the type it wraps.
+      assertThat(probe().variables)
+          .containsEntry("T", "T extends java.lang. @org.jspecify.annotations.Nullable Object")
+          .containsEntry("U", "U extends java.lang. @org.jspecify.annotations.Nullable Number")
+          // A bare Object bound is still stripped: it is the implicit one, and writing it back
+          // would be noise.
+          .containsEntry("V", "V");
+    }
+
+    @Test
+    @DisplayName("keeps an annotation written on the type parameter itself")
+    void keepsAnAnnotationOnTheTypeParameterItself() {
+      var subject =
+          JavaFileObjects.forSourceString(
+              "com.test.Subject",
+              """
+              package com.test;
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              public class Subject<@Subject.Marked T> {
+                  @Target(ElementType.TYPE_PARAMETER)
+                  public @interface Marked {}
+              }
+              """);
+      var processor = new CapturingProcessor();
+      javac().withProcessors(processor).compile(subject);
+
+      assertThat(processor.variables).containsEntry("T", "@com.test.Subject.Marked T");
+    }
+
+    @Test
+    @DisplayName("leaves a type javapoet has no name for to javapoet")
+    void leavesATypeJavapoetHasNoNameForToJavapoet() {
+      // An intersection reaches here through a variable's upper bound. It implements DeclaredType,
+      // so dispatching on the interface rather than the kind would ask one for a class element it
+      // does not have instead of leaving javapoet to refuse it.
+      var subject =
+          JavaFileObjects.forSourceString(
+              "com.test.Subject",
+              """
+              package com.test;
+              import java.util.List;
+              public interface Subject<V extends Runnable & List<String>> {}
+              """);
+
+      var processor =
+          new AbstractProcessor() {
+            Throwable thrown;
+
+            @Override
+            public Set<String> getSupportedAnnotationTypes() {
+              return Set.of("*");
+            }
+
+            @Override
+            public SourceVersion getSupportedSourceVersion() {
+              return SourceVersion.latestSupported();
+            }
+
+            @Override
+            public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+              TypeElement type = processingEnv.getElementUtils().getTypeElement("com.test.Subject");
+              if (type == null) {
+                return false;
+              }
+              TypeMirror intersection =
+                  ((javax.lang.model.type.TypeVariable)
+                          type.getTypeParameters().getFirst().asType())
+                      .getUpperBound();
+              thrown = catchThrowable(() -> ProcessorUtils.typeNameOf(intersection));
+              return false;
+            }
+          };
+      javac().withProcessors(processor).compile(subject);
+
+      assertThat(processor.thrown).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("names a type javac could not resolve the way a resolved one is named")
+    void namesAnUnresolvedTypeTheWayAResolvedOneIsNamed() {
+      // A processor runs before every type is resolvable, so an ERROR type reaches the walk. It
+      // is a declared type that javac could not find, and naming it as one is what lets a
+      // generator emit the name the author wrote and let the next round settle it.
+      var subject =
+          JavaFileObjects.forSourceString(
+              "com.test.Subject",
+              """
+              package com.test;
+              @SuppressWarnings("unused")
+              public class Subject {
+                  Missing unresolved;
+              }
+              """);
+
+      var processor = new CapturingProcessor();
+      javac().withProcessors(processor).compile(subject);
+
+      assertThat(processor.names).containsEntry("unresolved", "Missing");
     }
   }
 }

--- a/hkj-processor/src/test/resources/golden/NullableFieldsLenses.java.golden
+++ b/hkj-processor/src/test/resources/golden/NullableFieldsLenses.java.golden
@@ -6,6 +6,7 @@ import java.lang.Integer;
 import java.lang.String;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.annotations.Generated;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Generated optics for {@link NullableFields}. Do not edit.
@@ -27,18 +28,18 @@ public final class NullableFieldsLenses {
   /**
    * Creates a {@link Lens} for the {@code nickname} field of a {@link NullableFields}.
    *
-   * @return A non-null {@code Lens<NullableFields, String>}.
+   * @return A non-null {@code Lens<NullableFields, @Nullable String>}.
    */
-  public static Lens<NullableFields, String> nickname() {
+  public static Lens<NullableFields, @Nullable String> nickname() {
     return Lens.of(NullableFields::nickname, (source, newValue) -> new NullableFields(source.id(), newValue, source.bio(), source.score()));
   }
 
   /**
    * Creates a {@link Lens} for the {@code bio} field of a {@link NullableFields}.
    *
-   * @return A non-null {@code Lens<NullableFields, String>}.
+   * @return A non-null {@code Lens<NullableFields, @Nullable String>}.
    */
-  public static Lens<NullableFields, String> bio() {
+  public static Lens<NullableFields, @Nullable String> bio() {
     return Lens.of(NullableFields::bio, (source, newValue) -> new NullableFields(source.id(), source.nickname(), newValue, source.score()));
   }
 
@@ -71,7 +72,7 @@ public final class NullableFieldsLenses {
    * @param newNickname The new value for the {@code nickname} field.
    * @return A new, updated {@code NullableFields} instance.
    */
-  public static NullableFields withNickname(NullableFields source, String newNickname) {
+  public static NullableFields withNickname(NullableFields source, @Nullable String newNickname) {
     return nickname().set(newNickname, source);
   }
 
@@ -83,7 +84,7 @@ public final class NullableFieldsLenses {
    * @param newBio The new value for the {@code bio} field.
    * @return A new, updated {@code NullableFields} instance.
    */
-  public static NullableFields withBio(NullableFields source, String newBio) {
+  public static NullableFields withBio(NullableFields source, @Nullable String newBio) {
     return bio().set(newBio, source);
   }
 

--- a/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessor.java
+++ b/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessor.java
@@ -166,7 +166,7 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
         processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
     String simpleName = iface.getSimpleName().toString();
     List<TypeVariableName> typeVars =
-        iface.getTypeParameters().stream().map(TypeVariableName::get).toList();
+        iface.getTypeParameters().stream().map(TypeNames::typeVariableOf).toList();
     boolean generic = !typeVars.isEmpty();
 
     ClassName nativeName = ClassName.get(packageName, simpleName + "HttpExchange");
@@ -237,13 +237,13 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
 
     for (int i = 0; i < methods.size(); i++) {
       ExecutableElement method = methods.get(i);
-      TypeName successType = TypeName.get(infos.get(i).success());
+      TypeName successType = TypeNames.typeNameOf(infos.get(i).success());
       MethodSpec.Builder nativeMethod =
           MethodSpec.methodBuilder(method.getSimpleName().toString())
               .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
               .returns(ParameterizedTypeName.get(RESPONSE_ENTITY, successType));
       for (var typeParam : method.getTypeParameters()) {
-        nativeMethod.addTypeVariable(TypeVariableName.get(typeParam));
+        nativeMethod.addTypeVariable(TypeNames.typeVariableOf(typeParam));
       }
       // Copy the mapping annotations (@GetExchange, @PostExchange, version attrs, …) verbatim, but
       // not the HKJ client meta-annotations (@OnStatus/@OnStatuses) nor @Override — the generated
@@ -329,9 +329,9 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
         MethodSpec.methodBuilder(name)
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PUBLIC)
-            .returns(TypeName.get(method.getReturnType()));
+            .returns(TypeNames.typeNameOf(method.getReturnType()));
     for (var typeParam : method.getTypeParameters()) {
-      facadeMethod.addTypeVariable(TypeVariableName.get(typeParam));
+      facadeMethod.addTypeVariable(TypeNames.typeVariableOf(typeParam));
     }
     String args =
         method.getParameters().stream()
@@ -340,7 +340,7 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
     for (VariableElement parameter : method.getParameters()) {
       facadeMethod.addParameter(
           ParameterSpec.builder(
-                  TypeName.get(parameter.asType()), parameter.getSimpleName().toString())
+                  TypeNames.typeNameOf(parameter.asType()), parameter.getSimpleName().toString())
               .build());
     }
 
@@ -479,7 +479,7 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
   private ParameterSpec copyParameter(VariableElement parameter) {
     String parameterName = parameter.getSimpleName().toString();
     ParameterSpec.Builder builder =
-        ParameterSpec.builder(TypeName.get(parameter.asType()), parameterName);
+        ParameterSpec.builder(TypeNames.typeNameOf(parameter.asType()), parameterName);
     for (AnnotationMirror mirror : parameter.getAnnotationMirrors()) {
       AnnotationSpec spec = AnnotationSpec.get(mirror);
       if (needsExplicitName(mirror, parameter)) {
@@ -659,6 +659,8 @@ public class HkjHttpClientProcessor extends AbstractProcessor {
    * The raw {@link ClassName} of an error type, for use in {@code decoderFactory.create(E.class)}.
    */
   private static ClassName rawClass(TypeMirror error) {
+    // Not TypeNames.typeNameOf: this name is emitted as a class literal, and `@Nullable E.class`
+    // does not compile. The raw class is the whole point here, annotations included.
     TypeName name = TypeName.get(error);
     if (name instanceof ParameterizedTypeName parameterized) {
       return parameterized.rawType();

--- a/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/TypeNames.java
+++ b/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/TypeNames.java
@@ -69,13 +69,19 @@ final class TypeNames {
     // test alone settles both cases.
     TypeName enclosing =
         enclosingType.getKind() == TypeKind.NONE ? null : typeNameOf(enclosingType);
-    List<? extends TypeMirror> typeArguments = declared.getTypeArguments();
-    if (typeArguments.isEmpty() && !(enclosing instanceof ParameterizedTypeName)) {
-      return rawType;
+    List<TypeName> argumentNames =
+        declared.getTypeArguments().stream().map(TypeNames::typeNameOf).toList();
+    if (enclosing instanceof ParameterizedTypeName parameterised) {
+      return parameterised.nestedClass(rawType.simpleName(), argumentNames);
     }
-    List<TypeName> argumentNames = typeArguments.stream().map(TypeNames::typeNameOf).toList();
-    return enclosing instanceof ParameterizedTypeName parameterised
-        ? parameterised.nestedClass(rawType.simpleName(), argumentNames)
+    // An annotation on the enclosing type is written before it - `@Marker Outer.Inner` annotates
+    // Outer, not Inner - and ClassName.get(element) carries none of it. Rebuilding the name under
+    // the enclosing keeps it; for an unannotated enclosing it reproduces the same name.
+    if (enclosing instanceof ClassName enclosingName) {
+      rawType = enclosingName.nestedClass(rawType.simpleName());
+    }
+    return argumentNames.isEmpty()
+        ? rawType
         : ParameterizedTypeName.get(rawType, argumentNames.toArray(new TypeName[0]));
   }
 
@@ -98,15 +104,17 @@ final class TypeNames {
    * {@code Object}. Between them {@code <T extends @Nullable Object>} becomes {@code <T>}, and the
    * generated client no longer admits an instantiation the interface it fronts permits.
    *
+   * <p>The bounds are all that is copied. An annotation written on the parameter itself, as in
+   * {@code <@Marker T>}, is left behind: the same {@code TypeVariableName} declares the parameter
+   * and is written wherever it is named, and an annotation legal on the declaration need not be
+   * legal at a use - a {@code TYPE_PARAMETER} one is rejected outright as a type argument.
+   *
    * @param parameter the type parameter to name; must not be null
-   * @return its name and bounds, annotated as the source annotated them (non-null)
+   * @return its name, with its bounds annotated as the source annotated them (non-null)
    */
   static TypeVariableName typeVariableOf(TypeParameterElement parameter) {
     TypeName[] bounds =
         parameter.getBounds().stream().map(TypeNames::typeNameOf).toArray(TypeName[]::new);
-    TypeVariableName variable = TypeVariableName.get(parameter.getSimpleName().toString(), bounds);
-    List<AnnotationSpec> annotations =
-        parameter.getAnnotationMirrors().stream().map(AnnotationSpec::get).toList();
-    return annotations.isEmpty() ? variable : variable.annotated(annotations);
+    return TypeVariableName.get(parameter.getSimpleName().toString(), bounds);
   }
 }

--- a/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/TypeNames.java
+++ b/hkj-spring/client-processor/src/main/java/org/higherkindedj/spring/client/processor/TypeNames.java
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.spring.client.processor;
+
+import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ArrayTypeName;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeName;
+import com.palantir.javapoet.TypeVariableName;
+import com.palantir.javapoet.WildcardTypeName;
+import java.util.List;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+
+/**
+ * Names a type as the author wrote it, with its type-use annotations kept.
+ *
+ * <p>{@link TypeName#get(TypeMirror)} rebuilds a name from the element alone and never consults
+ * {@link TypeMirror#getAnnotationMirrors()} at any depth, so every type-use annotation on a
+ * declaration is dropped on the way into generated source. A client is generated into the annotated
+ * interface's own package, which is the consumer's to mark: under a {@code @NullMarked} {@code
+ * package-info} or {@code module-info}, an unannotated type <em>means</em> non-null, so a dropped
+ * {@code @Nullable} does not leave the contract unstated - it states the opposite of what the
+ * author wrote, on a facade that is meant to mirror their interface exactly.
+ *
+ * <p>This is a copy of {@code ProcessorUtils.typeNameOf} in {@code hkj-processor}, kept rather than
+ * shared. Sharing would mean depending on that module, which is an annotation processor: it would
+ * join this one on the consumer's processor path and generate optics they never asked for. The two
+ * copies are small, and the walk they perform is javapoet's own; if one changes, the other should.
+ */
+final class TypeNames {
+
+  private TypeNames() {
+    // Utility class - prevent instantiation
+  }
+
+  /**
+   * The name of a type as written, with its type-use annotations kept.
+   *
+   * @param type the type to name; must not be null
+   * @return its name, annotated as the source annotated it (non-null)
+   */
+  static TypeName typeNameOf(TypeMirror type) {
+    List<AnnotationSpec> annotations =
+        type.getAnnotationMirrors().stream().map(AnnotationSpec::get).toList();
+    // Dispatch on the kind, as javapoet's own visitor does, rather than on the interface: javac's
+    // intersection implements DeclaredType, so a pattern switch would send one down the declared
+    // arm and ask it for a class element it does not have.
+    TypeName name =
+        switch (type.getKind()) {
+          case ARRAY -> ArrayTypeName.of(typeNameOf(((ArrayType) type).getComponentType()));
+          case WILDCARD -> wildcardNameOf((WildcardType) type);
+          case DECLARED, ERROR -> declaredNameOf((DeclaredType) type);
+          default -> TypeName.get(type);
+        };
+    return annotations.isEmpty() ? name : name.annotated(annotations);
+  }
+
+  private static TypeName declaredNameOf(DeclaredType declared) {
+    ClassName rawType = ClassName.get((TypeElement) declared.asElement());
+    TypeMirror enclosingType = declared.getEnclosingType();
+    // A static member has no enclosing instance type, so javac reports NONE for it and the kind
+    // test alone settles both cases.
+    TypeName enclosing =
+        enclosingType.getKind() == TypeKind.NONE ? null : typeNameOf(enclosingType);
+    List<? extends TypeMirror> typeArguments = declared.getTypeArguments();
+    if (typeArguments.isEmpty() && !(enclosing instanceof ParameterizedTypeName)) {
+      return rawType;
+    }
+    List<TypeName> argumentNames = typeArguments.stream().map(TypeNames::typeNameOf).toList();
+    return enclosing instanceof ParameterizedTypeName parameterised
+        ? parameterised.nestedClass(rawType.simpleName(), argumentNames)
+        : ParameterizedTypeName.get(rawType, argumentNames.toArray(new TypeName[0]));
+  }
+
+  private static TypeName wildcardNameOf(WildcardType wildcard) {
+    TypeMirror extendsBound = wildcard.getExtendsBound();
+    if (extendsBound != null) {
+      return WildcardTypeName.subtypeOf(typeNameOf(extendsBound));
+    }
+    TypeMirror superBound = wildcard.getSuperBound();
+    return superBound == null
+        ? WildcardTypeName.subtypeOf(ClassName.OBJECT)
+        : WildcardTypeName.supertypeOf(typeNameOf(superBound));
+  }
+
+  /**
+   * The declaration of a type parameter, with the annotations on its bounds kept.
+   *
+   * <p>{@link TypeVariableName#get(TypeParameterElement)} names each bound through {@link
+   * TypeName#get(TypeMirror)}, which drops the annotation, and then removes any bound that is bare
+   * {@code Object}. Between them {@code <T extends @Nullable Object>} becomes {@code <T>}, and the
+   * generated client no longer admits an instantiation the interface it fronts permits.
+   *
+   * @param parameter the type parameter to name; must not be null
+   * @return its name and bounds, annotated as the source annotated them (non-null)
+   */
+  static TypeVariableName typeVariableOf(TypeParameterElement parameter) {
+    TypeName[] bounds =
+        parameter.getBounds().stream().map(TypeNames::typeNameOf).toArray(TypeName[]::new);
+    TypeVariableName variable = TypeVariableName.get(parameter.getSimpleName().toString(), bounds);
+    List<AnnotationSpec> annotations =
+        parameter.getAnnotationMirrors().stream().map(AnnotationSpec::get).toList();
+    return annotations.isEmpty() ? variable : variable.annotated(annotations);
+  }
+}

--- a/hkj-spring/client-processor/src/test/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessorTest.java
+++ b/hkj-spring/client-processor/src/test/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessorTest.java
@@ -653,6 +653,45 @@ class HkjHttpClientProcessorTest {
     }
 
     @Test
+    @DisplayName("a type-parameter annotation does not leak into a type-argument position")
+    void typeParameterAnnotationDoesNotLeak() {
+      // The same TypeVariableName declares the client's parameter and is written as the type
+      // argument of `NullRepo<T>` in `implements`. `NullRepo<@Marked T>` does not compile, so a
+      // declaration annotation has to stay behind.
+      Compilation marked =
+          compile(
+              JavaFileObjects.forSourceLines(
+                  "com.example.Marked",
+                  "package com.example;",
+                  "import java.lang.annotation.ElementType;",
+                  "import java.lang.annotation.Target;",
+                  "@Target(ElementType.TYPE_PARAMETER)",
+                  "public @interface Marked {}"),
+              JavaFileObjects.forSourceLines(
+                  "com.example.MarkedRepo",
+                  "package com.example;",
+                  "import org.higherkindedj.hkt.effect.EitherPath;",
+                  "import org.higherkindedj.spring.client.HkjHttpClient;",
+                  "import org.springframework.web.bind.annotation.PathVariable;",
+                  "import org.springframework.web.service.annotation.GetExchange;",
+                  "import org.springframework.web.service.annotation.HttpExchange;",
+                  "@HttpExchange(\"/items\")",
+                  "@HkjHttpClient",
+                  "public interface MarkedRepo<@Marked T> {",
+                  "  @GetExchange(\"/{id}\")",
+                  "  EitherPath<UserError, T> get(@PathVariable String id);",
+                  "}"),
+              USER_ERROR);
+
+      // The generated sources are compiled in this same run, so a leaked annotation fails here.
+      assertThat(marked).succeeded();
+      assertThat(marked)
+          .generatedSourceFile("com.example.MarkedRepoClient")
+          .contentsAsUtf8String()
+          .doesNotContain("@Marked");
+    }
+
+    @Test
     @DisplayName("a type parameter keeps the annotated Object bound javapoet would strip")
     void typeParameterBoundKeepsIt() {
       Compilation generic =

--- a/hkj-spring/client-processor/src/test/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessorTest.java
+++ b/hkj-spring/client-processor/src/test/java/org/higherkindedj/spring/client/processor/HkjHttpClientProcessorTest.java
@@ -596,6 +596,99 @@ class HkjHttpClientProcessorTest {
   }
 
   @Nested
+  @DisplayName("keeps the type-use annotations the author wrote")
+  class TypeUseAnnotations {
+
+    /**
+     * A client is generated into the annotated interface's own package, which the consumer is free
+     * to mark {@code @NullMarked}. Inside one an unannotated type means non-null, so a dropped
+     * {@code @Nullable} does not leave the facade's contract unstated - it states the opposite of
+     * the interface the facade exists to mirror.
+     */
+    private final Compilation compilation =
+        compile(
+            JavaFileObjects.forSourceLines(
+                "com.example.NullableApi",
+                "package com.example;",
+                "import org.higherkindedj.hkt.effect.EitherPath;",
+                "import org.higherkindedj.spring.client.HkjHttpClient;",
+                "import org.jspecify.annotations.Nullable;",
+                "import org.springframework.web.bind.annotation.PathVariable;",
+                "import org.springframework.web.service.annotation.GetExchange;",
+                "import org.springframework.web.service.annotation.HttpExchange;",
+                "@HttpExchange(\"/users\")",
+                "@HkjHttpClient",
+                "public interface NullableApi {",
+                "  @GetExchange(\"/{id}\")",
+                "  EitherPath<UserError, @Nullable UserDto> get(",
+                "      @PathVariable String id, @Nullable String trace);",
+                "}"),
+            USER_DTO,
+            USER_ERROR);
+
+    @Test
+    @DisplayName("the native interface keeps it in the success type it unwraps to")
+    void nativeInterfaceKeepsIt() {
+      assertThat(compilation).succeeded();
+      assertThat(compilation)
+          .generatedSourceFile("com.example.NullableApiHttpExchange")
+          .contentsAsUtf8String()
+          .contains("ResponseEntity<@Nullable UserDto> get(");
+    }
+
+    @Test
+    @DisplayName("the facade keeps it in the parameters and the return it mirrors")
+    void facadeKeepsIt() {
+      assertThat(compilation).succeeded();
+      assertThat(compilation)
+          .generatedSourceFile("com.example.NullableApiClient")
+          .contentsAsUtf8String()
+          .contains("EitherPath<UserError, @Nullable UserDto> get(");
+      // A facade that narrows a parameter below the interface's rejects a call the interface
+      // accepts, so it is not usable everywhere the thing it fronts is.
+      assertThat(compilation)
+          .generatedSourceFile("com.example.NullableApiClient")
+          .contentsAsUtf8String()
+          .contains("@Nullable String trace");
+    }
+
+    @Test
+    @DisplayName("a type parameter keeps the annotated Object bound javapoet would strip")
+    void typeParameterBoundKeepsIt() {
+      Compilation generic =
+          compile(
+              JavaFileObjects.forSourceLines(
+                  "com.example.NullRepo",
+                  "package com.example;",
+                  "import org.higherkindedj.hkt.effect.EitherPath;",
+                  "import org.higherkindedj.spring.client.HkjHttpClient;",
+                  "import org.jspecify.annotations.Nullable;",
+                  "import org.springframework.web.bind.annotation.PathVariable;",
+                  "import org.springframework.web.service.annotation.GetExchange;",
+                  "import org.springframework.web.service.annotation.HttpExchange;",
+                  "@HttpExchange(\"/items\")",
+                  "@HkjHttpClient",
+                  "public interface NullRepo<T extends @Nullable Object> {",
+                  "  @GetExchange(\"/{id}\")",
+                  "  EitherPath<UserError, T> get(@PathVariable String id);",
+                  "}"),
+              USER_ERROR);
+
+      assertThat(generic).succeeded();
+      // Stripped to `<T>`, the client no longer admits the `NullRepo<@Nullable UserDto>` the
+      // interface it implements permits.
+      assertThat(generic)
+          .generatedSourceFile("com.example.NullRepoHttpExchange")
+          .contentsAsUtf8String()
+          .contains("interface NullRepoHttpExchange<T extends @Nullable Object>");
+      assertThat(generic)
+          .generatedSourceFile("com.example.NullRepoClient")
+          .contentsAsUtf8String()
+          .containsMatch("class NullRepoClient<T extends @Nullable Object>");
+    }
+  }
+
+  @Nested
   @DisplayName("supports generic interfaces (codegen-only)")
   class Generics {
 


### PR DESCRIPTION
Fixes #750.

`TypeName.get(TypeMirror)` rebuilds a name from the element alone and never consults `getAnnotationMirrors()` at any depth; `TypeVariableName.get` reads bounds off the declaration and then strips `Object` from them. Between them every type-use annotation the author wrote was dropped on the way into generated code.

That is not merely a loss of information. Generated source lands in the annotated type's own package, so it inherits whatever `@NullMarked` scope the **consumer** set there — and inside one, an unannotated type *means* non-null.

```mermaid
flowchart TD
    A["author writes<br/>@Nullable String note"] --> B["TypeName.get(TypeMirror)"]
    B -->|"annotations<br/>not copied"| C["String"]
    E["author writes<br/>&lt;T extends @Nullable Object&gt;"] --> F["TypeVariableName.get"]
    F -->|"reads the declaration,<br/>then strips Object"| G["&lt;T&gt;"]
    C --> D{"is the generated file<br/>in a @NullMarked scope?"}
    G --> D
    D -->|"the generator stamps it<br/>@EffectAlgebra"| X["reads as non-null"]
    D -->|"the consumer's package-info<br/>or module-info does"| X
    D -->|"neither"| L["unannotated,<br/>no contract"]
    X --> Z{"does a nullness<br/>checker run?"}
    Z -->|"not in this build"| S["silent:<br/>wrong contract, uncaught"]
    Z -->|"a consumer's does"| R["reported, in the one file<br/>a suppression cannot be written"]

    classDef bad fill:#e78284,stroke:#d20f39,color:#232634
    classDef meh fill:#e5c890,stroke:#df8e1d,color:#232634
    class R bad
    class S,L meh
```

`hkj-examples` already had a live instance: `ShipmentInfoLenses.warehouseId()` promised a non-null focus over a component the record's own `create(…)` factory passes `null` into.

## The fix

`ProcessorUtils.typeNameOf(TypeMirror)` and `typeVariableOf(TypeParameterElement)` — the walk javapoet performs, re-attaching each mirror's annotations as it goes. Naming bounds through the first fixes the second for free: an annotated `Object` is not equal to the bare one, so it survives the strip the bare bound is still rightly subject to.

Dispatch is on the type's **kind** rather than its interface, as javapoet's own visitor does. javac's intersection implements `DeclaredType`, so a pattern switch would send one down the declared arm and ask it for a class element it does not have.

Adopted at **26 sites in `hkj-processor`** and **7 in `hkj-processor-plugins`** (which needed `exports org.higherkindedj.optics.processing.util`). Sites that cannot carry an annotation are deliberately left alone, and each is commented where it is not obvious: declaration types, names bound for a `{@link}`, and mirrors read from an annotation's class literal — `@Nullable E.class` does not compile.

### A widened focus drops the nullness the widening consumed

`Affines.nullable()` is `Affine<@Nullable A, A>`: the widening is what rules the null out. So an `AffinePath` reached through `.nullable()` focuses a value that is non-null again, and repeating `@Nullable` there would describe a value the affine never yields. `AffinePath`'s own javadoc documents the pair.

Only the recognised nullness annotations go, and only at that position:

| declaration | generated |
|---|---|
| `@Nullable String label` | `AffinePath<Box, String> label()` — `.nullable()` consumed it |
| `List<@Nullable String> tags` | `TraversalPath<Box, @Nullable String> tags()` — `.each()` arrives at exactly it |
| `@Tag @Nullable String note` | `AffinePath<Marked, @Tag String> note()` — only the nullness was consumed |
| `String @Nullable []` vs `@Nullable String[]` | the array and its component stay apart |

### `hkj-spring/client-processor` keeps its own copy

Sharing would mean depending on `hkj-processor`, which is an annotation processor: it would join this one on a Spring consumer's processor path and generate optics they never asked for. The copy says so in its javadoc.

## Verified

Every row of the issue's table, plus the in-tree instance:

```java
public static <A> Free<NoteOpKind.Witness, A> write(@Nullable String note)   // was: String note
public final class NullSvcPaths<T extends @Nullable Object>                  // was: <T>
public OptionalPath<@Nullable String> find(@Nullable String key)             // was: <String>(String)
public static Lens<ShipmentInfo, @Nullable String> warehouseId()             // hkj-examples
```

- **16 new tests** — a case per generator (lenses, setters, getters, folds, focus, traversals, isos, merge, path bridge, imported optics, error envelope, `@EffectAlgebra`) plus 3 for the Spring client. Each was shown load-bearing by mutating the helper back to plain javapoet: all 16 fail, all 16 restore.
- `@EffectAlgebra` carries the extra check, being the one generator that stamps `@NullMarked` itself: the emitted file `succeededWithoutWarnings`, import included.
- `ProcessorUtilsTest` covers the walk shape by shape — nested arguments, both array positions, wildcard bounds, annotated type-variable uses, enclosing types, an unresolved `ERROR` type, and an intersection left to javapoet.
- 10 existing tests moved to the corrected expectations and one golden regenerated; the `NullableFieldsLenses` golden is itself a neat before/after of the bug.
- `ProcessorUtils` and `WideningAnalysis` stay at their pinned 100% line/branch/instruction.
- Full `gradle clean build` green, 190 tasks.

## Follow-up

#767 is the other half, targeted at 0.5.0: `Lens<S, A>` and friends declare a bare `<A>` inside a `@NullMarked` module, so the annotation now emitted lands in types that do not yet admit it. `Affines.nullable()` and `Prisms.notNull()` already write that instantiation today, so the declarations are behind the code either way — this PR just makes it reachable from generated source too. Nothing here depends on it: the emitted annotation is correct and inert without a nullness checker, so the two can ship a release apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2m2qjQVe9VN69tjjy8W3C


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved type-use annotations such as `@Nullable` in generated optics, processor output, and HTTP client code.
  - Improved handling of annotated arrays, generics, wildcards, nested types, and type-variable bounds.
  - Ensured `.nullable()` removes only nullability while retaining other annotations.

- **Enhancements**
  - Generated method signatures and parameters now accurately reflect source-level annotations.
  - Added shared type-resolution support for consistent generated code across processors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->