### PR TITLE
Close out #740: the sealed axis rows, and the raw-site policies as deliberate

### DIFF
--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -909,6 +909,11 @@ public class MappingProcessor extends AbstractProcessor {
    * A component's type as seen under the spec's instantiation of its record. The substitution runs
    * only for generic records, so concrete pairs stay on the exact pre-instantiation path (and never
    * rely on {@code asMemberOf} accepting record components).
+   *
+   * <p>Reading the declaration's parameters rather than the site's arguments is what makes that
+   * true, and it is safe only because a raw domain never gets here: {@code @GenerateMapping}
+   * refuses one at the declaration. See {@link ProcessorUtils#memberOf} for why this reader and the
+   * two in {@code SpecInterfaceAnalyser} answer a raw site differently on purpose.
    */
   private TypeMirror componentType(DeclaredType owner, RecordComponentElement component) {
     return ((TypeElement) owner.asElement()).getTypeParameters().isEmpty()

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -847,8 +847,9 @@ public class SpecInterfaceAnalyser {
    * <p>Unlike {@link #memberTypeOf} this does not guard on {@link
    * ProcessorUtils#carriesInstantiation}, and a raw source type does reach it: nothing refuses
    * {@code OpticsSpec<Box>} for a generic {@code Box}, so the parameter comes back erased. That gap
-   * is not this method's to close - the raw source type should not have been accepted - and adding
-   * a guard here would only hide it one level further in.
+   * is not this method's to close - the raw source type should not have been accepted, which is
+   * #771 - and a guard here would bury it one level in while every other reader, and the raw name
+   * in each generated signature, stayed wrong.
    *
    * @param sourceType the instantiated source type {@code S}
    * @param constructor a single-argument constructor, whose one parameter is read

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -844,6 +844,12 @@ public class SpecInterfaceAnalyser {
    * <p>Only the class's own variables are substituted. A constructor that declares parameters of
    * its own keeps them, and is left to be rejected.
    *
+   * <p>Unlike {@link #memberTypeOf} this does not guard on {@link
+   * ProcessorUtils#carriesInstantiation}, and a raw source type does reach it: nothing refuses
+   * {@code OpticsSpec<Box>} for a generic {@code Box}, so the parameter comes back erased. That gap
+   * is not this method's to close - the raw source type should not have been accepted - and adding
+   * a guard here would only hide it one level further in.
+   *
    * @param sourceType the instantiated source type {@code S}
    * @param constructor a single-argument constructor, whose one parameter is read
    * @return the parameter type under {@code sourceType}'s instantiation
@@ -1229,6 +1235,11 @@ public class SpecInterfaceAnalyser {
    * it as {@code Holder<List<String>>}, so what the traversal has to be detected for is {@code
    * List<String>}. Reading the declaration instead both rejects a container it could have found and
    * names a variable the spec never wrote.
+   *
+   * <p>The guard is why this is not {@link ProcessorUtils#memberOf} outright: that helper lets a
+   * raw site erase, and erasing here rejected a container the spec had written (#738). The two
+   * raw-site answers differ on purpose - see {@link ProcessorUtils#memberOf} for the map of which
+   * reader wants which.
    *
    * @param sourceType the instantiated source type {@code S}
    * @param member the accessor to read

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -311,6 +311,23 @@ public final class ProcessorUtils {
    * instead lets analysis pass and leaves the generator emitting a call the erased member cannot
    * take.
    *
+   * <p>That is this helper's policy, not the only one in the processor, and the difference is
+   * deliberate rather than drift. A caller that must not erase guards the call itself, because what
+   * a raw site should produce is the caller's question:
+   *
+   * <ul>
+   *   <li>{@code SpecInterfaceAnalyser.memberTypeOf} guards with {@link #carriesInstantiation} and
+   *       reads the declaration under a raw site. Erasing there rejected a container the spec had
+   *       written, which is the {@code @ThroughField} regression #738 caught.
+   *   <li>{@code MappingProcessor.componentType} asks whether the record <em>declares</em>
+   *       parameters rather than whether the site supplies them, so that a concrete pair never
+   *       relies on {@code asMemberOf} accepting a record component. A raw domain cannot reach it:
+   *       {@code @GenerateMapping} refuses one at the declaration.
+   * </ul>
+   *
+   * <p>Settled under #740: the three readers are not near-copies to be merged. Consolidating them
+   * would have to pick one raw-site answer, and they want different ones.
+   *
    * @param types the round's type utilities; must not be null
    * @param owner the instantiated type the member is read on; must not be null
    * @param member the member to read; must not be null

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericMappingWireAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericMappingWireAxisTest.java
@@ -211,6 +211,146 @@ class GenericMappingWireAxisTest {
   }
 
   @Test
+  @DisplayName(
+      "a sealed wire, whose variant spec reaches its vocabulary through a generic ancestor")
+  void sealedWireWithAGenericAncestor() {
+    // The sealed column reads members in two places at once: the variant spec is an ordinary
+    // record pair, and the sum spec reads the pairs to build its dispatch. A member left as
+    // declared in either would put a free variable into one of the two Impls.
+    var model =
+        JavaFileObjects.forSourceString(
+            "com.example.Sealed",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.validated.ValidatedPrism;
+
+            public final class Sealed {
+              public record Pan(String digits) {}
+
+              public sealed interface Pay permits Card {}
+
+              public record Card(Pan pan) implements Pay {}
+
+              public sealed interface PayDto permits CardDto {}
+
+              public record CardDto(String pan) implements PayDto {}
+
+              public interface BasePans<T> {
+                default ValidatedPrism<String, T> pan() {
+                  throw new UnsupportedOperationException();
+                }
+              }
+
+              public interface Pans extends BasePans<Pan> {}
+            }
+            """);
+
+    var variantSpec =
+        JavaFileObjects.forSourceString(
+            "com.example.CardMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface CardMapping
+                extends MappingSpec<Sealed.Card, Sealed.CardDto>, Sealed.Pans {}
+            """);
+
+    var sumSpec =
+        JavaFileObjects.forSourceString(
+            "com.example.PayMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface PayMapping extends MappingSpec<Sealed.Pay, Sealed.PayDto> {}
+            """);
+
+    var compilation = compile(model, variantSpec, sumSpec);
+
+    assertThat(compilation).succeeded();
+    // The variant's leaf arrives at Pan, the argument Pans gives BasePans, not at its T.
+    assertGeneratedCodeContains(
+        compilation,
+        "com.example.CardMappingImpl",
+        "return new Sealed.CardDto(pan().build(domain.pan()))");
+    // And the sum dispatches to it.
+    assertGeneratedCodeContains(
+        compilation,
+        "com.example.PayMappingImpl",
+        "case Sealed.Card v -> CardMappingImpl.INSTANCE.build(v)");
+  }
+
+  @Test
+  @DisplayName("a sealed wire whose sum type extends a generic interface")
+  void sealedWireWhoseSumExtendsAGenericInterface() {
+    // The sum itself is non-generic, but it inherits an accessor from a generic supertype. That
+    // is the sealed form of the bean's inherited column: nothing on the type names a parameter,
+    // and a member does.
+    var model =
+        JavaFileObjects.forSourceString(
+            "com.example.Tagged",
+            """
+            package com.example;
+
+            public final class Tagged {
+              public interface HasTag<T> {
+                T tag();
+              }
+
+              public sealed interface Pay extends HasTag<String> permits Card {}
+
+              public record Card(String number, String tag) implements Pay {}
+
+              public sealed interface PayDto permits CardDto {}
+
+              public record CardDto(String number, String tag) implements PayDto {}
+            }
+            """);
+
+    var variantSpec =
+        JavaFileObjects.forSourceString(
+            "com.example.TaggedCardMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface TaggedCardMapping extends MappingSpec<Tagged.Card, Tagged.CardDto> {}
+            """);
+
+    var sumSpec =
+        JavaFileObjects.forSourceString(
+            "com.example.TaggedPayMapping",
+            """
+            package com.example;
+
+            import org.higherkindedj.optics.annotations.GenerateMapping;
+            import org.higherkindedj.optics.annotations.MappingSpec;
+
+            @GenerateMapping
+            public interface TaggedPayMapping extends MappingSpec<Tagged.Pay, Tagged.PayDto> {}
+            """);
+
+    var compilation = compile(model, variantSpec, sumSpec);
+
+    assertThat(compilation).succeeded();
+    assertGeneratedCodeContains(
+        compilation,
+        "com.example.TaggedPayMappingImpl",
+        "case Tagged.Card v -> TaggedCardMappingImpl.INSTANCE.build(v)");
+  }
+
+  @Test
   @DisplayName("a mix-in reached through a generic ancestor is read under the spec")
   void mixinWithAGenericAncestor() {
     var base =


### PR DESCRIPTION
Closes out two of the three loose ends on #740. Tests plus javadoc; no behaviour change.

## 1. The sealed rows the axis was missing

`GenericMappingWireAxisTest` had both record columns, the bean-inheriting-from-a-generic-base column and a dozen mix-in rows — and no sealed wire.

The sealed shape earns its own cell because it reads members in two places at once: the variant spec is an ordinary record pair, and the sum spec reads those pairs to build its dispatch. A member left as declared in either puts a free variable into one of *two* Impls rather than one.

- **`sealedWireWithAGenericAncestor`** — a variant spec whose vocabulary arrives through a non-generic mix-in extending a generic one, plus the sum that dispatches to it. Load-bearing: fails alongside the seven existing mix-in rows when `memberSignatureIn` is reverted to reading the declaration.
- **`sealedWireWhoseSumExtendsAGenericInterface`** — an acceptance cell rather than a substitution one. A non-generic sum inheriting an accessor from a generic supertype: the sealed form of the bean column's "nothing on the type names a parameter, and a member does". It pins that the shape is not refused; it does not fail under that mutation and is not claimed to.

A *generic* sealed pair stays refused, which `MappingProcessorTest.genericSealedRejected` already covers.

## 2. The three "near-copies" are settled as deliberate

#740 asked for `MappingProcessor.componentType`, `SpecInterfaceAnalyser.constructorParameterType` and `SpecInterfaceAnalyser.memberTypeOf` to be lifted into one documented helper. They have since diverged on purpose, and the divergence *is* the content: each answers a **raw** site differently, so consolidating would have to pick one answer for all three.

| reader | raw site |
|---|---|
| `ProcessorUtils.memberOf` | erases — what the language says a raw type's members are |
| `SpecInterfaceAnalyser.memberTypeOf` | guards, reads the declaration — erasing rejected a container the spec had written (#738) |
| `MappingProcessor.componentType` | asks whether the record *declares* parameters, not whether the site supplies them, so a concrete pair never relies on `asMemberOf` accepting a record component |

The map lives on `memberOf`, with a pointer back to it from each reader, so a future consistency sweep meets the reason before the similarity.

## A gap found while settling that, left open on purpose

`constructorParameterType` is the one that is **not** settled, and it is documented as such where it lives rather than quietly guarded.

It does not guard, and a raw source type does reach it, because nothing refuses `OpticsSpec<Box>` for a generic `Box`. Compiled: `@ImportOptics` accepts a raw source and emits a file that fails the consuming build under its own flags —

```
RawNodeOptics.java:24: warning: [rawtypes] found raw type: GenNode
  public static Lens<GenNode, String> label() {
RawNodeOptics.java:27: warning: [rawtypes] found raw type: GenNode
      (source, newValue) -> new GenNode(source.other(), newValue));
```

— which is the shape #748 fixed for `@GeneratePathBridge` (`PathProcessor.firstRawIn` refuses exactly this) and that `ProcessorUtils.isRaw` exists to ask. Adding a guard inside `constructorParameterType` would only bury it: the raw source type should not have been accepted in the first place. Wants its own issue rather than a fix folded in here.

`gradle :hkj-processor:check` green.
