### PR TITLE
Put the HKJ checker on the JMH processor path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,16 @@ subprojects {
             add("annotationProcessor", project(":hkj-checker"))
             add("testAnnotationProcessor", project(":hkj-checker"))
         }
+        // The JMH source set compiles against its own processor path, and only under
+        // releaseReadiness / benchmarkValidation, so a missing entry here is invisible to
+        // an ordinary build; the -Xplugin flag below is added to every JavaCompile.
+        plugins.withId("me.champeau.jmh") {
+            dependencies.add("jmhAnnotationProcessor", project(":hkj-checker"))
+        }
         tasks.withType<JavaCompile>().configureEach {
+            // JMH's generated benchmark wrappers are harness code compiled on their own
+            // processor path, with nothing of ours to check.
+            if (name == "jmhCompileGeneratedClasses") return@configureEach
             options.compilerArgs.add("-Xplugin:HKJChecker severity=warn")
             // The checker reads jdk.compiler internals, which the compiler JVM must export.
             options.isFork = true

--- a/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/FreeEffectBenchmark.java
+++ b/hkj-benchmarks/src/jmh/java/org/higherkindedj/benchmarks/FreeEffectBenchmark.java
@@ -69,6 +69,7 @@ public class FreeEffectBenchmark {
   private Free<IdKind.Witness, Integer> programWithHandleError;
 
   @Setup
+  @SuppressWarnings("migration-nudge") // benchmarks the Free/Inject primitives directly
   public void setup() {
     idMonad = IdMonad.instance();
     idFunctor =
@@ -98,7 +99,7 @@ public class FreeEffectBenchmark {
     programWithHandleError = buildProgramWithHandleError(chainDepth);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "migration-nudge"}) // benchmarks Free.liftF directly
   private Free<IdKind.Witness, Integer> buildSingleEffectProgram(int depth) {
     Free<IdKind.Witness, Integer> program = Free.liftF(new Id<>(0), idFunctor);
     for (int i = 0; i < depth; i++) {


### PR DESCRIPTION
`gradle releaseReadiness` failed at its first real step on `main`:

```
> Task :hkj-benchmarks:compileJmhJava FAILED
error: plug-in not found: HKJChecker
```

#696 added `-Xplugin:HKJChecker` to every `JavaCompile` and put `hkj-checker` on the `annotationProcessor` and `testAnnotationProcessor` paths. The JMH source set compiles on its own `jmhAnnotationProcessor` path, and only under `releaseReadiness` / `benchmarkValidation`, so the gap was invisible to every ordinary build since.

**Fix**, in the root wiring that owns the checker:
- `plugins.withId("me.champeau.jmh") { dependencies.add("jmhAnnotationProcessor", project(":hkj-checker")) }`, so any module applying the JMH plugin gets the plugin on that path too.
- `jmhCompileGeneratedClasses` is left without the flag: it compiles JMH's generated harness wrappers on their own processor path, with nothing of ours to check.

With the checker actually running over the benchmarks, it found three `migration-nudge` advisories in `FreeEffectBenchmark` (`InjectInstances.injectLeft()` and two `Free.liftF`), which `-Werror` promotes. A benchmark of the raw `Free`/`Inject` primitives is the deliberate exception that suppression exists for (same as `ConsoleProgram` and the Tutorial 05 solution), so they carry `@SuppressWarnings("migration-nudge")` on the narrowest declarations.

**Verification**: `gradle releaseReadiness` green end to end on this branch (spotless, build, JMH, benchmark assertions, full-profile pitest) — 1h 18m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L32qf2EnRPygBPEbNxEeGr