### PR TITLE
Bump local projectVersion fallback to 0.4.11-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // Global properties for all modules
 group = "io.github.higher-kinded-j"
-version = project.findProperty("projectVersion")?.toString() ?: "0.4.10-SNAPSHOT"
+version = project.findProperty("projectVersion")?.toString() ?: "0.4.11-SNAPSHOT"
 
 
 // Repositories for root project (required for OpenRewrite dependencies)


### PR DESCRIPTION
v0.4.10 is tagged and released (https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.10), so the local `projectVersion` fallback in `build.gradle.kts` moves to `0.4.11-SNAPSHOT`, per the #687 precedent after v0.4.9.

Only `build.gradle.kts` changes: the release history already opened its `0.4.11-SNAPSHOT (Latest)` placeholder in #775, and the README and Quickstart use `LATEST_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L32qf2EnRPygBPEbNxEeGr