### PR TITLE
@ImportOptics: refuse a source type that names a raw type (#771)

### DIFF
--- a/hkj-book/src/optics/compiler_errors.md
+++ b/hkj-book/src/optics/compiler_errors.md
@@ -111,9 +111,15 @@ It is a note rather than a warning on purpose. `@GenerateTraversals` has no per-
 
 **Cause.** The spec interface is generic, and its own type parameter is the source type: `interface BoxOpticsSpec<S extends Box> extends OpticsSpec<S>`. Optics are generated against one named type, read for its members and rebuilt through its constructor, wither or setter, so a type parameter standing for whatever a caller picks has nothing to generate from. An array source type produces the same diagnostic with a different opening, `declares OpticsSpec<String[]>, which is an array type`, and the same remedy.
 
-**Fix.** Name the type the optics are for as the type argument: `OpticsSpec<Box>`. Where the bound names a single type, the message suggests it for you.
+**Fix.** Name the type the optics are for as the type argument, with its own type arguments where it has any: `OpticsSpec<Box>`. Where the bound names a single type that is not raw, the message suggests it for you.
 
 A source type that is itself generic is supported, and the spec names its own type parameters: `interface BoxOpticsSpec<U> extends OpticsSpec<Box<U>>` generates `static <U> Lens<Box<U>, String> label()`. See [Spec Interfaces](optics_spec_interfaces.md#generic-spec-interfaces) for which parameters a generated method declares. It is only a bare type variable, standing for the whole source type, that has no source to read.
+
+### "'XOpticsSpec' declares `OpticsSpec<Box>`, which names the raw type 'Box'"
+
+**Cause.** The source type names a generic type without its arguments. Every generated optic repeats the source type verbatim, so the generated file, which you cannot edit, would carry a `[rawtypes]` warning that the `@SuppressWarnings` on your own spec does not cover, and a `@ViaConstructor` rebuild read under a raw type erases its parameters into an `[unchecked]` call besides. Three shapes draw the error: the source type itself written bare (`OpticsSpec<Box>` for a `Box<X>`), a member type behind a generic outer written bare (`OpticsSpec<Outer.Holder>`, raw by JLS 4.8 even though `Holder` declares nothing of its own), and a raw type argument (`OpticsSpec<Box<List>>`). Raw is not the same as bare: a non-generic source type, or a static nested type of a generic outer, has no arguments to supply and is accepted as written.
+
+**Fix.** Name the raw type's arguments in the `OpticsSpec` clause: `OpticsSpec<Box<String>>`, `OpticsSpec<Outer<String>.Holder>`, `OpticsSpec<Box<List<String>>>`. A spec whose optics should stay generic declares its own type parameters and passes them on, `interface BoxOpticsSpec<U> extends OpticsSpec<Box<U>>`, as above. See [Spec Interfaces](optics_spec_interfaces.md#generic-spec-interfaces).
 
 ### "@ThroughField: '...' reaches field 'items', which is declared as `ArrayList<String>` rather than as the List interface"
 

--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -28,6 +28,10 @@ _In development. Release notes will be added here as changes land on `main`._
 
   _Behaviour change:_ selection previously followed registration order on some routes, so an override could win or lose by where its services entry landed, and only the Focus DSL's widening reported a tie. Two equal-priority providers claiming one type now draw the warning on every route, which a consuming build running javac with `-Werror` turns into an error; rank one of them, or drop one from the processor path.
 
+- **`@ImportOptics` asks a raw source type for its arguments** ([#771](https://github.com/higher-kinded-j/higher-kinded-j/issues/771)): a spec interface whose source type names a raw type anywhere, the type itself (`OpticsSpec<Box>` for a `Box<X>`), a member type behind a generic outer written bare (`OpticsSpec<Outer.Holder>`), or a raw type argument (`OpticsSpec<Box<List>>`), is refused at the declaration, pointing at the type to complete and at the generic-spec form (`OpticsSpec<Box<U>>`) for optics that should stay generic. See the entry in [Compiler Errors](optics/compiler_errors.md#xopticsspec-declares-opticsspecbox-which-names-the-raw-type-box).
+
+  _Behaviour change, moving a javac failure to the declaration:_ the shape previously generated a file naming the type raw throughout, which failed the consuming build under `-Xlint:rawtypes -Werror` in a file the spec author cannot edit; the spec now hears about it at its own declaration.
+
 ### [v0.4.10](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.10) (30 August 2026)
 
 This release gives the mapper a stock vocabulary and takes every generating annotation through a generics pass: each one now emits source the consuming build compiles under `-Werror`, or explains at the declaration what it needs instead. The book gains a **Mapping at the Boundary** chapter with a law-checked capstone, and the house style it introduced now runs through the Optics and Resilience chapters.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/effect/PathProcessor.java
@@ -20,7 +20,6 @@ import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
-import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -780,54 +779,12 @@ public class PathProcessor extends AbstractProcessor {
    */
   private static TypeElement firstRawIn(List<? extends TypeMirror> written) {
     for (TypeMirror type : written) {
-      TypeElement raw = firstRawIn(type);
+      TypeElement raw = ProcessorUtils.firstRawIn(type);
       if (raw != null) {
         return raw;
       }
     }
     return null;
-  }
-
-  private static TypeElement firstRawIn(TypeMirror type) {
-    switch (type.getKind()) {
-      case ARRAY -> {
-        return firstRawIn(((ArrayType) type).getComponentType());
-      }
-      case WILDCARD -> {
-        // A bound is written out with the wildcard that carries it, so `? extends List` puts a
-        // raw List in the generated file as surely as a bare one does.
-        WildcardType wildcard = (WildcardType) type;
-        for (TypeMirror bound :
-            new TypeMirror[] {wildcard.getExtendsBound(), wildcard.getSuperBound()}) {
-          if (bound != null) {
-            TypeElement raw = firstRawIn(bound);
-            if (raw != null) {
-              return raw;
-            }
-          }
-        }
-        return null;
-      }
-      case DECLARED -> {
-        DeclaredType declared = (DeclaredType) type;
-        TypeElement element = (TypeElement) declared.asElement();
-        if (!element.getTypeParameters().isEmpty() && declared.getTypeArguments().isEmpty()) {
-          return element;
-        }
-        for (TypeMirror argument : declared.getTypeArguments()) {
-          TypeElement raw = firstRawIn(argument);
-          if (raw != null) {
-            return raw;
-          }
-        }
-        // The enclosing link too: `Outer.Inner` is raw in `Outer` even where `Inner` declares
-        // nothing of its own. An absent or static enclosing type is a NoType, which ends the walk.
-        return firstRawIn(declared.getEnclosingType());
-      }
-      default -> {
-        return null;
-      }
-    }
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/InstanceOfNarrowing.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/InstanceOfNarrowing.java
@@ -177,7 +177,8 @@ final class InstanceOfNarrowing {
       case DeclaredType declared when actual instanceof DeclaredType actualDeclared -> {
         // Same class, argument for argument. Two different classes of the same arity line up
         // position by position and would pin every variable to a type it was never asked to be;
-        // a raw source is the same class with no arguments to read.
+        // a raw extends clause on the way to the source names the class with no arguments to
+        // read (a raw source type itself is refused at the spec's declaration).
         if (typeUtils.isSameType(typeUtils.erasure(declared), typeUtils.erasure(actualDeclared))
             && declared.getTypeArguments().size() == actualDeclared.getTypeArguments().size()) {
           for (int index = 0; index < declared.getTypeArguments().size(); index++) {
@@ -190,8 +191,8 @@ final class InstanceOfNarrowing {
       }
       case ArrayType array when actual instanceof ArrayType actualArray ->
           match(array.getComponentType(), actualArray.getComponentType(), matched);
-      // Anything else - a wildcard, a raw source, a hierarchy the target does not reach - pins
-      // nothing, which is the answer that leaves the parameter free.
+      // Anything else - a wildcard, or a hierarchy the target does not reach - pins nothing,
+      // which is the answer that leaves the parameter free.
       case null, default -> {}
     }
   }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -148,7 +148,9 @@ public class SpecInterfaceAnalyser {
     // read for members javac would erase.
     TypeElement rawNamed = ProcessorUtils.firstRawIn(sourceType);
     if (rawNamed != null) {
-      reportRawSourceType(specInterface, sourceType, sourceTypeElement, rawNamed);
+      // The element gate above proves the source is a declared type: nothing else resolves to
+      // a TypeElement.
+      reportRawSourceType(specInterface, (DeclaredType) sourceType, rawNamed);
       return Optional.empty();
     }
 
@@ -217,19 +219,15 @@ public class SpecInterfaceAnalyser {
    *
    * @param specInterface the spec interface declaring the source type
    * @param sourceType the offending type argument to {@code OpticsSpec}
-   * @param sourceTypeElement the source type's element
    * @param rawNamed the element of the first raw type named in the source type
    */
   private void reportRawSourceType(
-      TypeElement specInterface,
-      TypeMirror sourceType,
-      TypeElement sourceTypeElement,
-      TypeElement rawNamed) {
+      TypeElement specInterface, DeclaredType sourceType, TypeElement rawNamed) {
     String rawName = rawNamed.getSimpleName().toString();
     // The generic-spec example only answers the source type itself being raw; a raw enclosing
-    // type or argument has its arguments named in place.
-    boolean sourceItself =
-        rawNamed.getQualifiedName().contentEquals(sourceTypeElement.getQualifiedName());
+    // type or argument has its arguments named in place. Asked of the root type, not by element:
+    // OpticsSpec<Box<Box>> names the raw inner Box, whose element is the outer's too.
+    boolean sourceItself = ProcessorUtils.isRaw(sourceType);
     Diagnostics.error(
         messager,
         specInterface,

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/external/SpecInterfaceAnalyser.java
@@ -141,6 +141,17 @@ public class SpecInterfaceAnalyser {
       return Optional.empty();
     }
 
+    // A raw type anywhere in the source type passes the gate above - its element is still a
+    // TypeElement - whether the source type itself is raw, an enclosing level is (JLS 4.8 makes
+    // Outer.Holder raw in a generic Outer), or a type argument is. Every generated optic repeats
+    // the source type as written, so each shape is refused here in its own right rather than
+    // read for members javac would erase.
+    TypeElement rawNamed = ProcessorUtils.firstRawIn(sourceType);
+    if (rawNamed != null) {
+      reportRawSourceType(specInterface, sourceType, sourceTypeElement, rawNamed);
+      return Optional.empty();
+    }
+
     List<ExecutableElement> methods = ElementFilter.methodsIn(specInterface.getEnclosedElements());
 
     // A default method has no home in the generated class: a body cannot be read during
@@ -201,6 +212,50 @@ public class SpecInterfaceAnalyser {
   }
 
   /**
+   * Reports a source type naming a raw type, which is a perfectly good source missing its
+   * arguments; the remedy is to supply them, not to change the type.
+   *
+   * @param specInterface the spec interface declaring the source type
+   * @param sourceType the offending type argument to {@code OpticsSpec}
+   * @param sourceTypeElement the source type's element
+   * @param rawNamed the element of the first raw type named in the source type
+   */
+  private void reportRawSourceType(
+      TypeElement specInterface,
+      TypeMirror sourceType,
+      TypeElement sourceTypeElement,
+      TypeElement rawNamed) {
+    String rawName = rawNamed.getSimpleName().toString();
+    // The generic-spec example only answers the source type itself being raw; a raw enclosing
+    // type or argument has its arguments named in place.
+    boolean sourceItself =
+        rawNamed.getQualifiedName().contentEquals(sourceTypeElement.getQualifiedName());
+    Diagnostics.error(
+        messager,
+        specInterface,
+        "@ImportOptics",
+        "'"
+            + specInterface.getSimpleName()
+            + "' declares OpticsSpec<"
+            + ProcessorUtils.simpleTypeName(sourceType)
+            + ">, which names the raw type '"
+            + rawName
+            + "'.",
+        "Every generated optic repeats the source type verbatim, and a raw type in generated"
+            + " source is a [rawtypes] warning that the suppression on your own declaration does"
+            + " not cover; a constructor read under a raw type erases its parameters besides.",
+        "Name '"
+            + rawName
+            + "'s type arguments in the OpticsSpec clause"
+            + (sourceItself
+                ? "; a spec whose optics should stay generic declares its own type parameters"
+                    + " and passes them on (OpticsSpec<"
+                    + rawName
+                    + "<U>>)."
+                : "."));
+  }
+
+  /**
    * Reports a source type that no optic can be generated against, naming the kind it turned out to
    * be so that a bare {@code S} does not read as a class name.
    *
@@ -254,7 +309,9 @@ public class SpecInterfaceAnalyser {
         // isSameType, not a name comparison: it also answers true for an unresolvable bound, whose
         // own 'cannot find symbol' is the error worth reading.
         && !typeUtils.isSameType(bound, elementUtils.getTypeElement(OBJECT_FQN).asType())
-        && !ProcessorUtils.mentions(bound, typeVariable.asElement())) {
+        && !ProcessorUtils.mentions(bound, typeVariable.asElement())
+        // A hint naming a raw bound would steer straight into the raw-source refusal.
+        && ProcessorUtils.firstRawIn(bound) == null) {
       return ": 'OpticsSpec<" + ProcessorUtils.simpleTypeName(bound) + ">'";
     }
     return "";
@@ -849,11 +906,10 @@ public class SpecInterfaceAnalyser {
    * its own keeps them, and is left to be rejected.
    *
    * <p>Unlike {@link #memberTypeOf} this does not guard on {@link
-   * ProcessorUtils#carriesInstantiation}, and a raw source type does reach it: nothing refuses
-   * {@code OpticsSpec<Box>} for a generic {@code Box}, so the parameter comes back erased. That gap
-   * is not this method's to close - the raw source type should not have been accepted, which is
-   * #771 - and a guard here would bury it one level in while every other reader, and the raw name
-   * in each generated signature, stayed wrong.
+   * ProcessorUtils#carriesInstantiation}, and needs no guard: a source type naming a raw type is
+   * refused at the spec's declaration (#771) before any member is read, so every type reaching here
+   * supplies its arguments or has none to supply. A guard would bury a fault the gate already
+   * reports.
    *
    * @param sourceType the instantiated source type {@code S}
    * @param constructor a single-argument constructor, whose one parameter is read

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -209,6 +209,59 @@ public final class ProcessorUtils {
   }
 
   /**
+   * The first raw type named anywhere in {@code type}, or null when none is raw.
+   *
+   * <p>A generic type written without its arguments, at any depth: a bare {@code List} head, a
+   * {@code List} inside an argument or a wildcard bound, a {@code List[]} component. The enclosing
+   * link counts too: {@code Outer.Inner} is raw in {@code Outer} even where {@code Inner} declares
+   * nothing of its own (JLS 4.8); an absent or static enclosing type is a {@code NoType}, which
+   * ends the walk. A caller that copies the type verbatim into generated source asks this first,
+   * because every raw name it copies is a {@code [rawtypes]} warning in the file it lands in.
+   *
+   * @param type the type as it was written
+   * @return the element of the first raw type named, or null
+   * @since 0.4.11
+   */
+  public static TypeElement firstRawIn(TypeMirror type) {
+    switch (type.getKind()) {
+      case ARRAY -> {
+        return firstRawIn(((ArrayType) type).getComponentType());
+      }
+      case WILDCARD -> {
+        // A bound is written out with the wildcard that carries it, so `? extends List` puts a
+        // raw List in the generated file as surely as a bare one does.
+        WildcardType wildcard = (WildcardType) type;
+        for (TypeMirror bound :
+            new TypeMirror[] {wildcard.getExtendsBound(), wildcard.getSuperBound()}) {
+          if (bound != null) {
+            TypeElement raw = firstRawIn(bound);
+            if (raw != null) {
+              return raw;
+            }
+          }
+        }
+        return null;
+      }
+      case DECLARED -> {
+        DeclaredType declared = (DeclaredType) type;
+        if (isRaw(declared)) {
+          return (TypeElement) declared.asElement();
+        }
+        for (TypeMirror argument : declared.getTypeArguments()) {
+          TypeElement raw = firstRawIn(argument);
+          if (raw != null) {
+            return raw;
+          }
+        }
+        return firstRawIn(declared.getEnclosingType());
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+
+  /**
    * Whether a declared type carries an instantiation for {@code asMemberOf} to substitute.
    *
    * <p>Asked before reading a member under a type, because {@code asMemberOf} does the wrong thing
@@ -318,7 +371,9 @@ public final class ProcessorUtils {
    * <ul>
    *   <li>{@code SpecInterfaceAnalyser.memberTypeOf} guards with {@link #carriesInstantiation} and
    *       reads the declaration under a raw site. Erasing there rejected a container the spec had
-   *       written, which is the {@code @ThroughField} regression #738 caught.
+   *       written, which is the {@code @ThroughField} regression #738 caught. A raw source type is
+   *       now refused at the spec's declaration (#771), so the site the guard reads as declared
+   *       today is a non-generic one.
    *   <li>{@code MappingProcessor.componentType} asks whether the record <em>declares</em>
    *       parameters rather than whether the site supplies them, so that a concrete pair never
    *       relies on {@code asMemberOf} accepting a record component. A raw domain cannot reach it:

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericSpecInterfaceAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericSpecInterfaceAxisTest.java
@@ -475,6 +475,28 @@ class GenericSpecInterfaceAxisTest {
   }
 
   @Test
+  @DisplayName("a raw argument of the source's own class completes the argument, not the spec")
+  void rawArgumentOfTheSourceClassItselfRefused() {
+    // The raw inner Box's element is the outer's too, so the hint must ask the root type: the
+    // remedy is completing the inner argument, not reshaping the source to OpticsSpec<Box<U>>.
+    var compilation =
+        compile(
+            """
+            @SuppressWarnings("rawtypes")
+            public interface SubjectOpticsSpec extends OpticsSpec<Box<Box>> {
+                @Wither("withLabel")
+                Lens<Box<Box>, String> label();
+            }""");
+
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("declares OpticsSpec<Box<Box>>, which names the raw type 'Box'.");
+    assertThat(compilation)
+        .hadErrorContaining("Name 'Box's type arguments in the OpticsSpec clause.");
+    assertThat(compilation).hadErrorCount(1);
+  }
+
+  @Test
   @DisplayName("a raw source type is refused once, not once per @ViaConstructor member it erases")
   void rawSourceTypeRefusedWithViaConstructor() {
     var compilation =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericSpecInterfaceAxisTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GenericSpecInterfaceAxisTest.java
@@ -24,6 +24,11 @@ import org.junit.jupiter.api.Test;
  * <p>{@code @Wither} and {@code @ViaBuilder} rebuild through a method and read no member of the
  * source type, so they are structurally blind to that class of fault. They are here to keep the
  * axis complete rather than because they are at risk.
+ *
+ * <p>The source-type axis also runs here: a source naming a raw type anywhere (itself, a generic
+ * enclosing type written bare, a raw type argument) is refused at the declaration, and the accepted
+ * shapes are compiled under the consuming build's {@code -Xlint:unchecked,rawtypes -Werror}, so a
+ * warning in the generated file fails the test the way it fails the build.
  */
 @DisplayName("Every strategy and hint on a generic spec interface")
 class GenericSpecInterfaceAxisTest {
@@ -157,6 +162,16 @@ class GenericSpecInterfaceAxisTest {
               public static <U> Traversal<Box<U>, U> items() { return null; }
           }
           """);
+
+  /** The full refusal for a raw source type, pinned verbatim once. */
+  private static final String RAW_SOURCE_ERROR =
+      "@ImportOptics: 'SubjectOpticsSpec' declares OpticsSpec<Box>, which names the raw type"
+          + " 'Box'. Every generated optic repeats the source type verbatim, and a raw type in"
+          + " generated source is a [rawtypes] warning that the suppression on your own"
+          + " declaration does not cover; a constructor read under a raw type erases its"
+          + " parameters besides. Name 'Box's type arguments in the OpticsSpec clause; a spec"
+          + " whose optics should stay generic declares its own type parameters and passes them"
+          + " on (OpticsSpec<Box<U>>).";
 
   /**
    * Compiles a spec interface body. The spec's parameter is always {@code U} while every source
@@ -349,5 +364,177 @@ class GenericSpecInterfaceAxisTest {
     // all, so auto-detection turns away a List the spec plainly named.
     assertGeneratedSignature(
         compilation, "public static Traversal<Outer<List<String>>.Holder, String> eachItem()");
+  }
+
+  /**
+   * Compiles a spec interface body under the consuming build's flags, so a warning in the generated
+   * file fails here the way it fails there. A separate, smaller template on purpose: only the
+   * fixtures a row names are compiled, so the flags judge the generated file rather than the shared
+   * fixture set.
+   */
+  private Compilation compileUnderConsumerFlags(String specBody) {
+    var specInterface =
+        JavaFileObjects.forSourceString(
+            "com.myapp.SubjectOpticsSpec",
+            """
+            package com.myapp;
+
+            import com.external.Box;
+            import com.external.Registry;
+            import java.util.List;
+            import org.higherkindedj.optics.Lens;
+            import org.higherkindedj.optics.annotations.ImportOptics;
+            import org.higherkindedj.optics.annotations.OpticsSpec;
+            import org.higherkindedj.optics.annotations.ViaConstructor;
+            import org.higherkindedj.optics.annotations.Wither;
+
+            @ImportOptics
+            %s
+            """
+                .formatted(specBody));
+
+    return javac()
+        .withProcessors(new ImportOpticsProcessor())
+        .withOptions("-Xlint:unchecked,rawtypes", "-Werror")
+        .compile(BASE, BOX, REGISTRY, specInterface);
+  }
+
+  /** A generic outer whose static nested type is not raw when written bare (JLS 4.8). */
+  private static final JavaFileObject REGISTRY =
+      JavaFileObjects.forSourceString(
+          "com.external.Registry",
+          """
+          package com.external;
+
+          public class Registry<X> {
+              public static class Tag {
+                  private String label;
+                  public String label() { return label; }
+                  public Tag withLabel(String label) { return this; }
+              }
+          }
+          """);
+
+  @Test
+  @DisplayName("a raw source type is refused at the declaration, before any strategy runs")
+  void rawSourceTypeRefused() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec extends OpticsSpec<Box> {
+                @Wither("withLabel")
+                Lens<Box, String> label();
+            }""");
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(RAW_SOURCE_ERROR);
+    assertThat(compilation).hadErrorCount(1);
+  }
+
+  @Test
+  @DisplayName("a raw enclosing type is refused: JLS 4.8 makes the member type raw too")
+  void rawEnclosingSourceTypeRefused() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec extends OpticsSpec<Outer.Holder> {
+                @Wither("withItems")
+                Lens<Outer.Holder, String> items();
+            }""");
+
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            "@ImportOptics: 'SubjectOpticsSpec' declares OpticsSpec<Outer.Holder>, which names"
+                + " the raw type 'Outer'. Every generated optic repeats the source type verbatim,"
+                + " and a raw type in generated source is a [rawtypes] warning that the"
+                + " suppression on your own declaration does not cover; a constructor read under"
+                + " a raw type erases its parameters besides. Name 'Outer's type arguments in the"
+                + " OpticsSpec clause.");
+    assertThat(compilation).hadErrorCount(1);
+  }
+
+  @Test
+  @DisplayName("a raw type argument is refused: the generated file repeats it verbatim")
+  void rawTypeArgumentInSourceTypeRefused() {
+    var compilation =
+        compile(
+            """
+            @SuppressWarnings("rawtypes")
+            public interface SubjectOpticsSpec extends OpticsSpec<Box<List>> {
+                @Wither("withLabel")
+                Lens<Box<List>, String> label();
+            }""");
+
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("declares OpticsSpec<Box<List>>, which names the raw type 'List'.");
+    assertThat(compilation)
+        .hadErrorContaining("Name 'List's type arguments in the OpticsSpec clause.");
+    assertThat(compilation).hadErrorCount(1);
+  }
+
+  @Test
+  @DisplayName("a raw source type is refused once, not once per @ViaConstructor member it erases")
+  void rawSourceTypeRefusedWithViaConstructor() {
+    var compilation =
+        compile(
+            """
+            public interface SubjectOpticsSpec extends OpticsSpec<Box> {
+                @Wither("withLabel")
+                Lens<Box, String> label();
+
+                @ViaConstructor(parameterOrder = {"content", "label"})
+                Lens<Box, String> content();
+            }""");
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(RAW_SOURCE_ERROR);
+    assertThat(compilation).hadErrorCount(1);
+  }
+
+  @Test
+  @DisplayName("an instantiated source type generates optics that hold under -Werror")
+  void instantiatedSourceTypeHoldsUnderConsumerFlags() {
+    var compilation =
+        compileUnderConsumerFlags(
+            """
+            public interface SubjectOpticsSpec extends OpticsSpec<Box<String>> {
+                @Wither("withLabel")
+                Lens<Box<String>, String> label();
+
+                @ViaConstructor(parameterOrder = {"content", "label"})
+                Lens<Box<String>, String> content();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static Lens<Box<String>, String> label()");
+  }
+
+  @Test
+  @DisplayName("a static nested type of a generic outer is not raw, and holds under -Werror")
+  void staticNestedOfGenericOuterAccepted() {
+    var compilation =
+        compileUnderConsumerFlags(
+            """
+            public interface SubjectOpticsSpec extends OpticsSpec<Registry.Tag> {
+                @Wither("withLabel")
+                Lens<Registry.Tag, String> label();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static Lens<Registry.Tag, String> label()");
+  }
+
+  @Test
+  @DisplayName("a generic spec's generated optics hold under -Werror")
+  void genericSpecHoldsUnderConsumerFlags() {
+    var compilation =
+        compileUnderConsumerFlags(
+            """
+            public interface SubjectOpticsSpec<U> extends OpticsSpec<Box<U>> {
+                @ViaConstructor(parameterOrder = {"content", "label"})
+                Lens<Box<U>, String> label();
+            }""");
+
+    assertGeneratedSignature(compilation, "public static <U> Lens<Box<U>, String> label()");
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/SpecInterfaceProcessingTest.java
@@ -1977,6 +1977,55 @@ class SpecInterfaceProcessingTest {
     }
 
     @Test
+    @DisplayName("should not suggest a raw bound as the source type")
+    void shouldNotSuggestARawBound() {
+      final var externalClass =
+          JavaFileObjects.forSourceString(
+              "com.external.Crate",
+              """
+              package com.external;
+
+              public class Crate<X> {
+                  private String v;
+                  public String getV() { return v; }
+                  public void setV(String v) { this.v = v; }
+              }
+              """);
+
+      final var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.CrateOpticsSpec",
+              """
+              package com.myapp;
+
+              import org.higherkindedj.optics.Lens;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+              import org.higherkindedj.optics.annotations.ViaCopyAndSet;
+              import com.external.Crate;
+
+              @ImportOptics
+              @SuppressWarnings("rawtypes")
+              public interface CrateOpticsSpec<S extends Crate> extends OpticsSpec<S> {
+
+                  @ViaCopyAndSet(setter = "setV")
+                  Lens<S, String> v();
+              }
+              """);
+
+      var compilation =
+          javac().withProcessors(new ImportOpticsProcessor()).compile(externalClass, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'CrateOpticsSpec' declares OpticsSpec<S>, which is a type variable.");
+      // A hint naming the raw Crate would steer straight into the raw-source refusal, so the fix
+      // sentence ends unanswered instead.
+      assertThat(compilation).hadErrorContainingMatch("type argument\\.$");
+    }
+
+    @Test
     @DisplayName("should reject an unbounded type variable without suggesting Object")
     void shouldRejectUnboundedTypeVariableSourceType() {
       final var specInterface =

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ThroughFieldAutoDetectTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/ThroughFieldAutoDetectTest.java
@@ -1832,8 +1832,8 @@ class ThroughFieldAutoDetectTest {
   }
 
   @Test
-  @DisplayName("auto-detects on a raw source type, whose members are not substituted")
-  void autoDetectsOnARawSourceType() {
+  @DisplayName("a raw source type is refused before auto-detection runs")
+  void rawSourceTypeIsRefusedBeforeAutoDetection() {
     final var holder =
         JavaFileObjects.forSourceString(
             "com.external.RawHolder",
@@ -1879,10 +1879,15 @@ class ThroughFieldAutoDetectTest {
             }
             """);
 
-    // Under a raw site javac erases every member, so asking it to substitute would turn a field
-    // typed List<String> into a raw List and match no container. There is nothing to substitute.
+    // Every optic generated from a raw source names it raw, so the spec is refused at its own
+    // declaration (#771) rather than auto-detection reading members javac would erase.
     Compilation compilation = compile(holder, specInterface);
 
-    assertThat(compilation).succeeded();
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            "'RawOpticsSpec' declares OpticsSpec<RawHolder>, which names the raw type"
+                + " 'RawHolder'.");
+    assertThat(compilation).hadErrorCount(1);
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/InstanceOfNarrowingTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/external/InstanceOfNarrowingTest.java
@@ -519,8 +519,8 @@ class InstanceOfNarrowingTest {
     }
 
     @Test
-    @DisplayName("pins nothing from a raw source type")
-    void pinsNothingFromARawSource() {
+    @DisplayName("a raw source type is refused before narrowing runs")
+    void rawSourceTypeIsRefusedBeforeNarrowing() {
       var compilation =
           compile(
               """
@@ -531,7 +531,54 @@ class InstanceOfNarrowingTest {
               }""");
 
       assertThat(compilation).failed();
-      assertThat(compilation).hadErrorContaining("pins nothing to X");
+      assertThat(compilation)
+          .hadErrorContaining(
+              "'SubjectOpticsSpec' declares OpticsSpec<Node>, which names the raw type"
+                  + " 'Node'.");
+      assertThat(compilation).hadErrorCount(1);
+    }
+
+    @Test
+    @DisplayName("pins nothing through a raw extends clause on the way to the source")
+    void pinsNothingThroughARawExtendsClause() {
+      var rawLeaf =
+          JavaFileObjects.forSourceString(
+              "com.external.RawLeaf",
+              """
+              package com.external;
+
+              @SuppressWarnings("rawtypes")
+              public class RawLeaf<Y> extends Node {}
+              """);
+      var specInterface =
+          JavaFileObjects.forSourceString(
+              "com.myapp.SubjectOpticsSpec",
+              """
+              package com.myapp;
+
+              import com.external.Node;
+              import com.external.RawLeaf;
+              import org.higherkindedj.optics.Prism;
+              import org.higherkindedj.optics.annotations.ImportOptics;
+              import org.higherkindedj.optics.annotations.InstanceOf;
+              import org.higherkindedj.optics.annotations.OpticsSpec;
+
+              @ImportOptics
+              public interface SubjectOpticsSpec<U> extends OpticsSpec<Node<U>> {
+                  @InstanceOf(RawLeaf.class)
+                  Prism<Node<U>, RawLeaf<U>> leaf();
+              }""");
+
+      // RawLeaf reaches Node through a raw extends clause, so its view of the source names the
+      // class with no arguments to read against Node<U>'s one: nothing pins Y.
+      var compilation =
+          javac()
+              .withProcessors(new ImportOpticsProcessor())
+              .withOptions("-Xlint:unchecked,rawtypes", "-Werror")
+              .compile(NODE, rawLeaf, specInterface);
+
+      assertThat(compilation).failed();
+      assertThat(compilation).hadErrorContaining("'Node<U>' pins nothing to Y");
       assertThat(compilation).hadErrorCount(1);
     }
   }


### PR DESCRIPTION
Closes #771.

`@ImportOptics` refused a source type that is not a class, but not one that is a class and simply has no type arguments. `OpticsSpec<Box>` for a `Box<X>` was accepted, and every optic generated from it named `Box` raw: a `[rawtypes]` warning in a file the author cannot edit, and under `@ViaConstructor` an `[unchecked]` call besides, since a constructor read under a raw type erases its parameters. The file failed the consuming build under its own flags.

## The second question, asked at the gate

```mermaid
flowchart TD
    A["OpticsSpec&lt;S&gt;"] --> B{"asElement(S)<br/>is a TypeElement?"}
    B -->|"no: type variable, array"| R1["refused:<br/>'which is a type variable'"]
    B -->|yes| C{"does S name a raw<br/>type anywhere?"}
    C -->|"Box&lt;String&gt;, Box&lt;U&gt;,<br/>Customer, Registry.Tag"| G["read under the instantiation"]
    C -->|"Box &#183; Outer.Holder &#183; Box&lt;List&gt;"| R2["refused: name the arguments,<br/>or pass the spec's own through"]

    classDef gate fill:#e5c890,stroke:#df8e1d,color:#232634
    classDef good fill:#a6d189,stroke:#40a02b,color:#232634
    classDef bad fill:#e78284,stroke:#d20f39,color:#232634
    class B,C gate
    class G good
    class R1,R2 bad
```

The panel turned the issue's check into a stronger one. The issue asked whether the source type itself is raw; the review reproduced the same `-Werror` failure through two shapes that predicate misses, so the gate asks the whole written type:

- **The source type itself** (`OpticsSpec<Box>`), the issue's case.
- **A member type behind a generic outer written bare** (`OpticsSpec<Outer.Holder>`): raw by JLS 4.8 even though `Holder` declares nothing of its own. A static nested type of a generic outer is not raw and stays accepted, pinned under `-Werror`.
- **A raw type argument** (`OpticsSpec<Box<List>>`): the generated file repeats it verbatim.

The predicate is `ProcessorUtils.firstRawIn`, **moved from `@GeneratePathBridge`** (#748), whose walk already covered arguments, wildcard bounds, arrays and the enclosing chain; `PathProcessor` now delegates, so the two processors that refuse raw shapes share one implementation. The diagnostic names the raw type it found and, where the source type itself is the raw one, shows the generic-spec form (`OpticsSpec<Box<U>>`). The bound hint on the type-variable refusal gained the same predicate: a hint naming a raw bound would steer straight into this refusal.

Per #740's settled policy, `constructorParameterType` stays unguarded: the raw source is what should not have been accepted, and its javadoc now records that the gate is what makes the unguarded read safe.

## What the change displaced

Two tests deliberately drove raw sources through the processor and pinned the old tolerance; both now pin the refusal. The `@InstanceOf` row was that route's only cover for the argument-count mismatch in `InstanceOfNarrowing.match`, so a new row covers the branch through the input that remains legal: a target reaching the source through a raw `extends` clause (`RawLeaf<Y> extends Node`), which pins nothing to `Y` exactly as before.

## Tests

- Refusals pinned verbatim with `hadErrorCount(1)`: the bare source (`@Wither`, and `@Wither` + `@ViaConstructor` proving one error at the declaration rather than one per member), the raw enclosing type, the raw type argument, and the raw-bound hint suppression.
- Acceptance rows under the consuming build's flags (`-Xlint:unchecked,rawtypes -Werror`, applied to the generated file in the same run): concrete `OpticsSpec<Box<String>>` with both strategies, generic `OpticsSpec<Box<U>>`, and static-nested `Registry.Tag`. The panel confirmed these pass pre-fix too; they are the ratchet the issue asked for, not regression cover.
- `SpecInterfaceAnalyser*`, `InstanceOfNarrowing*` and `ProcessorUtils*` hold their 100% line/branch/instruction pins.

## Docs

The [Compiler Errors](https://higher-kinded-j.github.io/latest/optics/compiler_errors.html) entry covers all three shapes and the raw-is-not-bare distinction; the type-variable sibling's fix line no longer suggests a shape this gate would refuse. Release note under 0.4.11-SNAPSHOT with the behaviour-change paragraph.

## Verification

`:hkj-processor:clean check` (coverage pins, ArchUnit rules), full-repo `assemble testClasses` under `-Werror`, `bookVerify`, heading check, spotless. Five-lens panel run after implementation; the raw-enclosing blocker (found independently by three lenses, probe-reproduced end to end) and every should-fix applied: the shared predicate, the stale `constructorParameterType` javadoc rewritten, the bound-hint guard, the nested-type rendering via `simpleTypeName`, and the release note's suppression claim corrected to "a file the spec author cannot edit".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Raw source types are now rejected early in optics specifications, including raw enclosing types and type arguments.
  * Compiler diagnostics now clearly identify the raw type and explain how to correct it.
  * Raw types are no longer suggested as fixes for generic type-variable errors.
  * Valid parameterized and static nested types continue to compile correctly under stricter compiler warnings.

* **Documentation**
  * Added guidance on raw generic types and updated release history notes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->