### PR TITLE
Render diagnostic type names structurally, keeping type-use annotations out (#759)

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -32,6 +32,8 @@ _In development. Release notes will be added here as changes land on `main`._
 
   _Behaviour change, moving a javac failure to the declaration:_ the shape previously generated a file naming the type raw throughout, which failed the consuming build under `-Xlint:rawtypes -Werror` in a file the spec author cannot edit; the spec now hears about it at its own declaration.
 
+- **Diagnostics render a type without its type-use annotations** ([#759](https://github.com/higher-kinded-j/higher-kinded-j/issues/759)): a type named in a compile-time message is now built from its element and resolved arguments rather than the mirror's string form, so a component declared `@Nullable Set<?>` is reported as `Set<?>`, the same rendering as the corrected declaration suggested beside it. A message no longer reads as advice to drop a nullness contract it never meant to touch.
+
 ### [v0.4.10](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.10) (30 August 2026)
 
 This release gives the mapper a stock vocabulary and takes every generating annotation through a generics pass: each one now emits source the consuming build compiles under `-Werror`, or explains at the declaration what it needs instead. The book gains a **Mapping at the Boundary** chapter with a law-checked capstone, and the house style it introduced now runs through the Optics and Resilience chapters.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -475,6 +475,9 @@ public class FocusProcessor extends AbstractProcessor {
                 .map(
                     resolved ->
                         resolved == null ? "Object" : ProcessorUtils.simpleTypeName(resolved));
-    return element.getSimpleName() + "<" + arguments.collect(Collectors.joining(", ")) + ">";
+    return ProcessorUtils.declaredHead(declaredType)
+        + "<"
+        + arguments.collect(Collectors.joining(", "))
+        + ">";
   }
 }

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/GeneratorRegistry.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/GeneratorRegistry.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
 
 /**
  * Resolves which {@link TraversableGenerator} handles a container type.
@@ -106,7 +107,7 @@ public final class GeneratorRegistry {
         "Multiple TraversableGenerator SPI providers with equal priority ("
             + other.priority()
             + ") support type "
-            + type
+            + ProcessorUtils.simpleTypeName(type)
             + ": "
             + matched.getClass().getName()
             + " and "

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/MappingProcessor.java
@@ -4140,20 +4140,20 @@ public class MappingProcessor extends AbstractProcessor {
   private String methodSignature(TypeElement spec, ExecutableElement method) {
     StringJoiner params = new StringJoiner(", ", "(", ")");
     for (TypeMirror parameter : memberSignatureIn(spec, method).getParameterTypes()) {
-      params.add(simpleTypeName(parameter));
+      params.add(parameterTypeName(parameter));
     }
     return method.getSimpleName() + params.toString();
   }
 
   /**
    * The compact display name of a parameter type: the element's simple name for declared types, so
-   * packages, type arguments and type-use annotations never clutter the diagnostic; a type variable
-   * renders as its own name.
+   * packages, type arguments and type-use annotations never clutter the diagnostic; any other shape
+   * renders as the shared diagnostic name, which keeps annotations out the same way.
    */
-  private static String simpleTypeName(TypeMirror type) {
+  private static String parameterTypeName(TypeMirror type) {
     return type instanceof DeclaredType declared
         ? declared.asElement().getSimpleName().toString()
-        : type.toString();
+        : ProcessorUtils.simpleTypeName(type);
   }
 
   void writeFile(TypeElement spec, String packageName, TypeSpec impl) {

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -590,13 +590,78 @@ public final class ProcessorUtils {
       // structural arm would have to render bound by bound. Annotations are stripped, argument
       // lists and all.
       default ->
-          type.toString()
-              // The optional leading dot is javac's own: an annotated type prints as
-              // enclosing.@Anno Simple, with the dot kept even where the enclosing is empty.
-              .replaceAll("\\.?+@[\\w.]*+(?:\\([^)]*+\\))?+\\s*+", "")
+          stripAnnotations(type.toString())
               .replaceAll("\\b(?:[a-z][\\p{Alnum}_]*\\.)+", "")
               .replace(",", ", ");
     };
+  }
+
+  /**
+   * Strips annotation tokens from a type's string form, for the shapes that render through {@code
+   * toString()}.
+   *
+   * <p>A scan rather than a pattern, because an annotation argument may contain the very characters
+   * a pattern would stop at: a bracket or a quote inside a string ({@code @Marker(")")}) or a
+   * nested annotation ({@code @Outer(@Inner(1))}). The scan tracks parenthesis depth and string and
+   * character literals, escapes included. A dot directly before the annotation goes with it: javac
+   * prints an annotated type as {@code enclosing.@Anno Simple}, and keeps the dot even where the
+   * enclosing is empty.
+   *
+   * @param rendered the type's string form; must not be null
+   * @return the string with annotation tokens and their trailing spaces removed (non-null)
+   */
+  static String stripAnnotations(String rendered) {
+    StringBuilder out = new StringBuilder();
+    int i = 0;
+    while (i < rendered.length()) {
+      char c = rendered.charAt(i);
+      if (c == '@') {
+        if (!out.isEmpty() && out.charAt(out.length() - 1) == '.') {
+          out.setLength(out.length() - 1);
+        }
+        i = skipAnnotation(rendered, i);
+      } else {
+        out.append(c);
+        i++;
+      }
+    }
+    return out.toString();
+  }
+
+  /** Consumes one annotation token starting at the {@code '@'}, returning the next index. */
+  private static int skipAnnotation(String rendered, int at) {
+    int i = at + 1;
+    while (i < rendered.length()
+        && (Character.isLetterOrDigit(rendered.charAt(i))
+            || rendered.charAt(i) == '_'
+            || rendered.charAt(i) == '.')) {
+      i++;
+    }
+    if (i < rendered.length() && rendered.charAt(i) == '(') {
+      int depth = 0;
+      char quote = 0;
+      do {
+        char c = rendered.charAt(i);
+        if (quote != 0) {
+          if (c == '\\') {
+            i++;
+          } else if (c == quote) {
+            quote = 0;
+          }
+        } else if (c == '"' || c == '\'') {
+          quote = c;
+        } else if (c == '(') {
+          depth++;
+        } else if (c == ')') {
+          depth--;
+        }
+        i++;
+      } while (i < rendered.length() && depth > 0);
+    }
+    while (i < rendered.length() && rendered.charAt(i) == ' ') {
+      i++;
+    }
+    return i;
   }
 
   /** The declared type's name: enclosing chain, simple name, and resolved arguments. */

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/util/ProcessorUtils.java
@@ -562,12 +562,92 @@ public final class ProcessorUtils {
    * diagnostic that offers a corrected declaration needs both: a rendering that drops either one
    * suggests source that does not compile.
    *
+   * <p>A declared type, array, wildcard, type variable or primitive is built from its element,
+   * resolved arguments or kind rather than {@code toString()}, so a type-use annotation never
+   * enters: {@code @Nullable Set<?>} reads as {@code Set<?>}, the same way the corrected
+   * declaration beside it is rendered. The annotation is not what a diagnostic about the type is
+   * about, and a message that prints it in one half and drops it in the other reads as advice to
+   * remove it (#759). The remaining kinds, an unresolvable type or an intersection, render from
+   * {@code toString()} with annotations stripped. Generated source is the opposite decision: {@link
+   * #typeNameOf} keeps type-use annotations, because there the annotation is part of the source
+   * being emitted (#750).
+   *
    * @param type the type to render; must not be null
    * @return the rendered name (non-null)
    * @since 0.4.10
    */
   public static String simpleTypeName(TypeMirror type) {
-    return type.toString().replaceAll("\\b(?:[a-z][\\p{Alnum}_]*\\.)+", "").replace(",", ", ");
+    return switch (type.getKind()) {
+      case DECLARED -> declaredName((DeclaredType) type);
+      case ARRAY -> simpleTypeName(((ArrayType) type).getComponentType()) + "[]";
+      case WILDCARD -> wildcardName((WildcardType) type);
+      case TYPEVAR -> ((TypeVariable) type).asElement().getSimpleName().toString();
+      // The kind names the type on its own; toString would carry any type-use annotation.
+      case BOOLEAN, BYTE, SHORT, INT, LONG, CHAR, FLOAT, DOUBLE ->
+          type.getKind().name().toLowerCase(Locale.ROOT);
+      // The lossy pre-#759 renderer, for what remains: an unresolvable type, whose element walk
+      // loses the qualifier on a nested name that the string keeps, and an intersection, which a
+      // structural arm would have to render bound by bound. Annotations are stripped, argument
+      // lists and all.
+      default ->
+          type.toString()
+              // The optional leading dot is javac's own: an annotated type prints as
+              // enclosing.@Anno Simple, with the dot kept even where the enclosing is empty.
+              .replaceAll("\\.?+@[\\w.]*+(?:\\([^)]*+\\))?+\\s*+", "")
+              .replaceAll("\\b(?:[a-z][\\p{Alnum}_]*\\.)+", "")
+              .replace(",", ", ");
+    };
+  }
+
+  /** The declared type's name: enclosing chain, simple name, and resolved arguments. */
+  private static String declaredName(DeclaredType declared) {
+    String arguments =
+        declared.getTypeArguments().isEmpty()
+            ? ""
+            : declared.getTypeArguments().stream()
+                .map(ProcessorUtils::simpleTypeName)
+                .collect(Collectors.joining(", ", "<", ">"));
+    return declaredHead(declared) + arguments;
+  }
+
+  /**
+   * The declared type's name without its arguments: the enclosing chain and the simple name.
+   *
+   * <p>For a diagnostic that rebuilds the argument list itself, the way {@code @GenerateFocus}
+   * suggests a concrete alternative to a wildcard: the head has to keep the nesting the full
+   * rendering keeps, or the suggestion names a type that does not compile.
+   *
+   * @param declared the type whose head to render; must not be null
+   * @return the enclosing chain and simple name, without arguments (non-null)
+   * @since 0.4.11
+   */
+  public static String declaredHead(DeclaredType declared) {
+    String prefix = "";
+    if (declared.getEnclosingType().getKind() == TypeKind.DECLARED) {
+      // A member reached through an instance carries the enclosing type, arguments and all:
+      // Outer<String>.Holder, or Outer.Holder where the outer level is written raw.
+      prefix = simpleTypeName(declared.getEnclosingType()) + ".";
+    } else {
+      // A static or top-level nesting has a NoType enclosing type, but the enclosing classes
+      // still print: Registry.Tag, as the declaration site would write it.
+      for (Element outer = declared.asElement().getEnclosingElement();
+          outer instanceof TypeElement typeElement;
+          outer = typeElement.getEnclosingElement()) {
+        prefix = typeElement.getSimpleName() + "." + prefix;
+      }
+    }
+    return prefix + declared.asElement().getSimpleName();
+  }
+
+  /** The wildcard as written: bare, extends-bounded or super-bounded. */
+  private static String wildcardName(WildcardType wildcard) {
+    if (wildcard.getExtendsBound() != null) {
+      return "? extends " + simpleTypeName(wildcard.getExtendsBound());
+    }
+    if (wildcard.getSuperBound() != null) {
+      return "? super " + simpleTypeName(wildcard.getSuperBound());
+    }
+    return "?";
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusRecognisedContainerTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusRecognisedContainerTest.java
@@ -277,6 +277,47 @@ class FocusRecognisedContainerTest {
               "record component 'Holder.f' has a wildcard type argument in " + component + ".");
     }
 
+    @Test
+    @DisplayName("a type-use annotation stays out of the reported type name")
+    void aTypeUseAnnotationStaysOutOfTheReportedTypeName() {
+      // Both halves of the message must render the type the same way: naming '@Nully Set<?>' and
+      // then suggesting 'Set<Object>' reads as advice to drop the annotation (#759).
+      var annotation =
+          JavaFileObjects.forSourceString(
+              "com.example.Nully",
+              """
+              package com.example;
+
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+
+              @Target(ElementType.TYPE_USE)
+              public @interface Nully {}
+              """);
+      var holder =
+          JavaFileObjects.forSourceString(
+              "com.example.Holder",
+              """
+              package com.example;
+
+              import java.util.Set;
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Holder(@Nully Set<?> f) {}
+              """);
+
+      Compilation compilation =
+          javac().withProcessors(new FocusProcessor()).compile(annotation, holder);
+
+      assertThat(compilation)
+          .hadErrorContaining(
+              "record component 'Holder.f' has a wildcard type argument in Set<?>.");
+      assertThat(compilation)
+          .hadErrorContaining(
+              "Declare the component with concrete type arguments, such as Set<Object>,");
+    }
+
     @ParameterizedTest(name = "{0}")
     @ValueSource(strings = {"Set", "Collection"})
     @DisplayName("a raw container is reported against the declaration")

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
@@ -2,10 +2,12 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.optics.processing.util;
 
+import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import com.palantir.javapoet.TypeVariableName;
 import java.util.LinkedHashMap;
@@ -21,7 +23,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.ElementFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,6 +47,183 @@ class ProcessorUtilsTest {
   void capitalisePassesDegenerateInputsThrough() {
     assertThat(ProcessorUtils.capitalise(null)).isNull();
     assertThat(ProcessorUtils.capitalise("")).isEmpty();
+  }
+
+  /**
+   * Contract tests for {@link ProcessorUtils#simpleTypeName}, driven through a real compilation so
+   * the type mirrors are javac's own. The subject declares one probe method per shape; each
+   * method's single parameter type is rendered and captured under the method's name.
+   */
+  @Nested
+  @DisplayName("simpleTypeName")
+  class SimpleTypeName {
+
+    /** Renders each probe method's parameter type, keyed by method name. */
+    private static final class CapturingProcessor extends AbstractProcessor {
+      private final Map<String, String> rendered = new LinkedHashMap<>();
+      private final Map<String, TypeKind> kinds = new LinkedHashMap<>();
+
+      @Override
+      public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+      }
+
+      @Override
+      public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+      }
+
+      @Override
+      public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+        TypeElement subject = processingEnv.getElementUtils().getTypeElement("com.test.Named");
+        if (subject == null) {
+          return false;
+        }
+        for (ExecutableElement method : ElementFilter.methodsIn(subject.getEnclosedElements())) {
+          VariableElement parameter = method.getParameters().getFirst();
+          rendered.put(
+              method.getSimpleName().toString(), ProcessorUtils.simpleTypeName(parameter.asType()));
+          kinds.put(method.getSimpleName().toString(), parameter.asType().getKind());
+        }
+        for (TypeKind kind :
+            List.of(
+                TypeKind.BOOLEAN,
+                TypeKind.BYTE,
+                TypeKind.SHORT,
+                TypeKind.INT,
+                TypeKind.LONG,
+                TypeKind.CHAR,
+                TypeKind.FLOAT,
+                TypeKind.DOUBLE)) {
+          rendered.put(
+              "primitive:" + kind,
+              ProcessorUtils.simpleTypeName(processingEnv.getTypeUtils().getPrimitiveType(kind)));
+        }
+        if (!subject.getTypeParameters().isEmpty()) {
+          TypeVariable variable = (TypeVariable) subject.getTypeParameters().getFirst().asType();
+          rendered.put(
+              "intersectionBound", ProcessorUtils.simpleTypeName(variable.getUpperBound()));
+        }
+        return false;
+      }
+    }
+
+    @Test
+    @DisplayName("renders by element and arguments: annotations out, packages off, nesting kept")
+    void rendersByElementAndArguments() {
+      var subject =
+          JavaFileObjects.forSourceString(
+              "com.test.Named",
+              """
+              package com.test;
+
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Set;
+
+              @SuppressWarnings("rawtypes")
+              abstract class Named<T extends CharSequence & Runnable> {
+                  @Target(ElementType.TYPE_USE)
+                  @interface Nully {}
+
+                  @Target(ElementType.TYPE_USE)
+                  @interface Ranged { int from(); }
+
+                  static class Registry<X> {
+                      static class Tag {}
+                  }
+
+                  class Holder {}
+
+                  abstract void plain(List<String> p);
+                  abstract void spacedArguments(Map<String, Integer> p);
+                  abstract void annotatedTop(@Nully Set<?> p);
+                  abstract void annotatedArgument(List<@Nully String> p);
+                  abstract void wildcardExtends(List<? extends Number> p);
+                  abstract void wildcardSuper(List<? super Number> p);
+                  abstract void typeVariable(T p);
+                  abstract void primitive(int p);
+                  abstract void annotatedPrimitive(@Nully int p);
+                  abstract void annotatedWithArguments(@Ranged(from = 0) int p);
+                  abstract void primitiveArray(int[] p);
+                  abstract void annotatedArrayComponent(@Nully String[] p);
+                  abstract void staticNested(Registry.Tag p);
+                  abstract void innerOfGeneric(Named<String>.Holder p);
+                  abstract void rawSite(List p);
+              }
+              """);
+
+      CapturingProcessor processor = new CapturingProcessor();
+      javac().withProcessors(processor).compile(subject);
+
+      // The annotated rows pin #759; the rest characterise the rendering the old string form
+      // already produced, so a change to any of them is a message change across the module.
+      assertThat(processor.rendered)
+          .containsEntry("plain", "List<String>")
+          .containsEntry("spacedArguments", "Map<String, Integer>")
+          .containsEntry("annotatedTop", "Set<?>")
+          .containsEntry("annotatedArgument", "List<String>")
+          .containsEntry("wildcardExtends", "List<? extends Number>")
+          .containsEntry("wildcardSuper", "List<? super Number>")
+          .containsEntry("typeVariable", "T")
+          .containsEntry("primitive", "int")
+          .containsEntry("annotatedPrimitive", "int")
+          .containsEntry("annotatedWithArguments", "int")
+          .containsEntry("primitiveArray", "int[]")
+          .containsEntry("annotatedArrayComponent", "String[]")
+          .containsEntry("staticNested", "Named.Registry.Tag")
+          .containsEntry("innerOfGeneric", "Named<String>.Holder")
+          .containsEntry("rawSite", "List")
+          .containsEntry("primitive:BOOLEAN", "boolean")
+          .containsEntry("primitive:BYTE", "byte")
+          .containsEntry("primitive:SHORT", "short")
+          .containsEntry("primitive:INT", "int")
+          .containsEntry("primitive:LONG", "long")
+          .containsEntry("primitive:CHAR", "char")
+          .containsEntry("primitive:FLOAT", "float")
+          .containsEntry("primitive:DOUBLE", "double")
+          .containsEntry("intersectionBound", "Object&CharSequence&Runnable");
+    }
+
+    @Test
+    @DisplayName("renders an unresolvable type by the name it was written under")
+    void rendersAnUnresolvableType() {
+      var subject =
+          JavaFileObjects.forSourceString(
+              "com.test.Named",
+              """
+              package com.test;
+
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+
+              abstract class Named {
+                  @Target(ElementType.TYPE_USE)
+                  @interface Ranged { int from(); }
+
+                  abstract void unresolved(Missing p);
+                  abstract void unresolvedNested(Missing.Inner p);
+                  abstract void unresolvedArguments(Missing<String, Integer> p);
+                  abstract void annotatedUnresolved(@Ranged(from = 0) Missing p);
+              }
+              """);
+
+      CapturingProcessor processor = new CapturingProcessor();
+      // The round still runs on the failed compilation, and the mirrors really are ErrorTypes:
+      // the string form keeps the qualifier on a nested name that an element walk would lose, so
+      // these render through the fallback arm, annotations and their arguments stripped.
+      Compilation compilation = javac().withProcessors(processor).compile(subject);
+
+      assertThat(compilation).failed();
+      assertThat(processor.kinds).containsEntry("unresolved", TypeKind.ERROR);
+      assertThat(processor.rendered)
+          .containsEntry("unresolved", "Missing")
+          .containsEntry("unresolvedNested", "Missing.Inner")
+          .containsEntry("unresolvedArguments", "Missing<String, Integer>")
+          .containsEntry("annotatedUnresolved", "Missing");
+    }
   }
 
   /**

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/util/ProcessorUtilsTest.java
@@ -188,6 +188,23 @@ class ProcessorUtilsTest {
     }
 
     @Test
+    @DisplayName("the annotation scan survives quotes, escapes and nesting a pattern cannot")
+    void annotationScanSurvivesQuotesAndNesting() {
+      assertThat(ProcessorUtils.stripAnnotations("List<String>")).isEqualTo("List<String>");
+      assertThat(ProcessorUtils.stripAnnotations("@A X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations(".@a.b.A X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations("@A() X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations("@A(\")\") X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations("@A(')') X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations("@A(\"\\\"\") X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations("@Outer(@Inner(1)) X")).isEqualTo("X");
+      assertThat(ProcessorUtils.stripAnnotations("Pair<@A X, @B_1 Y>")).isEqualTo("Pair<X, Y>");
+      assertThat(ProcessorUtils.stripAnnotations("@A")).isEmpty();
+      assertThat(ProcessorUtils.stripAnnotations("@A(")).isEmpty();
+      assertThat(ProcessorUtils.stripAnnotations("@A(1)X")).isEqualTo("X");
+    }
+
+    @Test
     @DisplayName("renders an unresolvable type by the name it was written under")
     void rendersAnUnresolvableType() {
       var subject =
@@ -203,10 +220,14 @@ class ProcessorUtilsTest {
                   @Target(ElementType.TYPE_USE)
                   @interface Ranged { int from(); }
 
+                  @Target(ElementType.TYPE_USE)
+                  @interface Labelled { String value(); }
+
                   abstract void unresolved(Missing p);
                   abstract void unresolvedNested(Missing.Inner p);
                   abstract void unresolvedArguments(Missing<String, Integer> p);
                   abstract void annotatedUnresolved(@Ranged(from = 0) Missing p);
+                  abstract void quotedUnresolved(@Labelled(")") Missing p);
               }
               """);
 
@@ -222,7 +243,8 @@ class ProcessorUtilsTest {
           .containsEntry("unresolved", "Missing")
           .containsEntry("unresolvedNested", "Missing.Inner")
           .containsEntry("unresolvedArguments", "Missing<String, Integer>")
-          .containsEntry("annotatedUnresolved", "Missing");
+          .containsEntry("annotatedUnresolved", "Missing")
+          .containsEntry("quotedUnresolved", "Missing");
     }
   }
 


### PR DESCRIPTION
Closes #759.

A diagnostic that named a type rendered it from the mirror's string form, so a type-use annotation survived into the message: a component declared `@Nullable Set<?>` was reported as having "a wildcard type argument in `@Nullable Set<?>`" beside the suggestion "such as `Set<Object>`", which reads as advice to drop a nullness contract the diagnostic was never about.

## One rendering for both halves

`ProcessorUtils.simpleTypeName` now builds the name the way the suggestion beside it always was built: structurally, so an annotation never enters.

- A declared type renders its enclosing chain (recursively where the enclosing type is carried, `Outer<String>.Holder`, and from the enclosing elements where the nesting is static, `Registry.Tag`), its simple name, and its resolved arguments — the same text the old package-stripping produced for every annotation-free type, which is why all forty call sites' pinned messages pass unchanged.
- Wildcards render as written (`?`, `? extends Number`, `? super Number`), arrays by component, type variables by name, and primitives by their kind, since `@Min(1) int` carries the annotation in its string form too.
- An unresolvable type and an intersection keep the string fallback, with annotations stripped, argument lists and all, plus the leading dot javac's annotated-type printing leaves behind. The fallback is where an error type renders best: its element walk would lose the qualifier on a nested `Missing.Inner` that the string keeps.

The class of mismatch goes rather than the instance, in both directions:

- `concreteAlternative`'s "such as" suggestions now carry the enclosing chain through the shared `declaredHead`, so a nested container's suggestion names a type that compiles; and its renderings of bounds and resolved wildcards pass through the same method, so `Set<? extends @Nully CharSequence>` suggests a clean `CharSequence`.
- The equal-priority tie warning from #774 concatenated the `TypeMirror` directly, the one message that stripped neither annotations nor packages; it now renders through the same method (the sweep this issue's review deferred to here).
- `MappingProcessor` carried a private renderer *shadowing* the shared name, whose non-declared arm had the same leak its own javadoc denied; it is renamed `parameterTypeName` and that arm delegates.

Generated source remains the opposite, deliberate decision: `typeNameOf` keeps type-use annotations (#750), and `simpleTypeName`'s javadoc now says so, so the two are not "aligned" by a future hand.

## Tests

- A unit contract table in `ProcessorUtilsTest` (the file's capturing-processor pattern): annotated top-level, argument, primitive, argument-carrying annotation and array component; both wildcard bounds; static and instance nesting; all eight primitive kinds; an intersection bound; a raw site; a type variable. The annotated rows pin #759; the rest are marked as characterising the rendering the old string form already produced.
- Unresolvable types in their own row, with the ERROR kind and the failed compilation pinned as premises: `Missing`, nested `Missing.Inner` (the qualifier kept), `Missing<String, Integer>` (the argument spacing exercised for real), and `@Ranged(from = 0) Missing` stripped clean.
- The issue's exact reproduction pinned in `FocusRecognisedContainerTest`: `@Nully Set<?>` reported as "a wildcard type argument in `Set<?>`" with the suggestion "such as `Set<Object>`" — both halves the same rendering.
- `ProcessorUtils*`, `GeneratorRegistry*` and `MappingProcessor*` hold their 100% line/branch/instruction pins; every verbatim diagnostic pin in the module passes unchanged.

## Docs

Release note under 0.4.11-SNAPSHOT. `simpleTypeName`'s javadoc records what renders structurally, what falls back, and the deliberate contrast with `typeNameOf`.

## Verification

`:hkj-processor:clean check` (coverage pins, ArchUnit rules), full-repo `assemble testClasses` under `-Werror`, `bookVerify`, heading check, spotless. Five-lens panel run after implementation; no blockers, and every should-fix applied: primitives moved out of the string fallback (probed: `@Size(max=5) int` had garbled to `(max=5) int` under the first cut's regex), the error-type routing corrected to keep nested qualifiers, the tie-warning and `MappingProcessor` sweeps, the `declaredHead` extraction, and the fallback's no-op remnants now genuinely exercised by the multi-argument unresolved row.

## Follow-up surfaced, not taken here

Around fifteen further sites concatenate a `TypeMirror` or qualified name directly into a message (`SpecInterfaceAnalyser`, `MappingProcessor`, `ErrorEnvelopeProcessor`); several deliberately print pasteable fully-qualified names, so each wants a per-site decision rather than a blanket sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile-time diagnostics so reported types consistently omit type-use annotations.
  * Type names now accurately display resolved element and argument types, including wildcards, primitives, arrays, and nested types.
  * Conflict warnings and suggested alternatives now use clearer, more consistent type names.

* **Tests**
  * Added coverage for annotated, wildcard, primitive, intersection, nested, and unresolved types in diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->