### PR TITLE
@GenerateFocus: reject a declined container from the analysis that declined it (#758)

### DIFF
--- a/hkj-book/src/release-history.md
+++ b/hkj-book/src/release-history.md
@@ -40,6 +40,10 @@ _In development. Release notes will be added here as changes land on `main`._
 
   _Behaviour change, moving a runtime failure to the declaration:_ a focus that did not contain the container's element compiled in 0.4.10 and misbehaved at runtime, throwing where it narrowed and polluting the container where it widened; it is now refused. The generated shape changes for auto-detected methods over such a lens focus (a target-typed local in place of the cast), with the same behaviour.
 
+- **`@GenerateFocus` leaves a wildcard container alone when nothing would widen it** ([#758](https://github.com/higher-kinded-j/higher-kinded-j/issues/758)): a `ZERO_OR_MORE` container whose element is a generic navigable record, such as `Map<String, ? extends Box<String>>` under `generateNavigators = true`, gets no navigator whatever its arguments, so its wildcard is no longer reported and the component stays a plain `FocusPath`, as its concrete twin `Map<String, Box<String>>` already did. The check that refuses a raw or wildcard-carrying container now reads the same result the generated method is built from, so the two cannot disagree. See [Custom Containers](optics/focus_containers.md#supported-container-types).
+
+  _Behaviour change, in that one corner:_ the shape was refused in 0.4.10 although nothing widened it; it now compiles as written. Every container that was rejected because something did widen it is rejected still, with the same message.
+
 ### [v0.4.10](https://github.com/higher-kinded-j/higher-kinded-j/releases/tag/v0.4.10) (30 August 2026)
 
 This release gives the mapper a stock vocabulary and takes every generating annotation through a generics pass: each one now emits source the consuming build compiles under `-Werror`, or explains at the declaration what it needs instead. The book gains a **Mapping at the Boundary** chapter with a law-checked capstone, and the house style it introduced now runs through the Optics and Resilience chapters.

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/FocusProcessor.java
@@ -21,11 +21,8 @@ import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.annotations.GenerateFocus;
-import org.higherkindedj.optics.processing.spi.Cardinality;
 import org.higherkindedj.optics.processing.spi.TraversableGenerator;
 import org.higherkindedj.optics.processing.util.Diagnostics;
 import org.higherkindedj.optics.processing.util.ExcludeFromJacocoGeneratedReport;
@@ -216,7 +213,6 @@ public class FocusProcessor extends AbstractProcessor {
 
     // Generate FocusPath methods for each component
     for (RecordComponentElement component : components) {
-      reportUndenotableWidening(component, widenCollections, navigatorGenerator, analysis);
       MethodSpec method = null;
 
       // Try to create a navigator method if navigators are enabled
@@ -226,11 +222,20 @@ public class FocusProcessor extends AbstractProcessor {
                 component, recordElement, components, recordTypeName);
       }
 
-      // Fall back to standard FocusPath method if no navigator method was created
+      // Fall back to the static FocusPath method when no navigator took the field. The one
+      // analysis says what that method widens to, and a container it turned away is rejected from
+      // the same result, so the method's shape and the diagnostic cannot disagree. A field a
+      // navigator did take reaches its element through a container the navigator's guard already
+      // admitted, so there is nothing to report for it.
       if (method == null) {
+        WideningAnalysis.Widening widening =
+            analysis.analyse(
+                component, stepsIntoContainers(component, widenCollections, navigatorGenerator));
+        if (widening.declined() != null) {
+          reportUndenotableContainer(component, widening.declined());
+        }
         method =
-            createFocusPathMethod(
-                component, recordElement, components, recordTypeName, widenCollections, analysis);
+            createFocusPathMethod(component, recordElement, components, recordTypeName, widening);
       }
 
       focusClassBuilder.addMethod(method);
@@ -266,13 +271,9 @@ public class FocusProcessor extends AbstractProcessor {
       TypeElement recordElement,
       List<? extends RecordComponentElement> allComponents,
       TypeName recordTypeName,
-      boolean widenCollections,
-      WideningAnalysis analysis) {
+      WideningAnalysis.Widening widening) {
 
     String componentName = component.getSimpleName().toString();
-
-    // Detect path type widening based on field type and annotations
-    WideningAnalysis.Widening widening = analysis.analyse(component, widenCollections);
 
     ClassName pathClass = widening.tier().pathClass();
     TypeName innerTypeName = widening.focusType();
@@ -345,85 +346,28 @@ public class FocusProcessor extends AbstractProcessor {
   }
 
   /**
-   * Rejects a component whose container is raw or carries a wildcard type argument, where the
-   * widening it would otherwise receive names an optic instance and so cannot be written.
+   * The {@code widenCollections} the analysis reads for a component no navigator took: whether it
+   * steps into a {@code ZERO_OR_MORE} container, or meets one it will turn away.
    *
-   * <p>The walk mirrors the one {@link WideningAnalysis} makes, so it reaches the same containers
-   * and stops where that one stops. A layer the current settings do not widen ends it: a {@code
-   * ZERO_OR_MORE} SPI field is left a plain {@code FocusPath} unless collections are widened or a
-   * navigator takes it, and the analysis then neither widens it nor looks inside it, so neither
-   * that layer nor anything under it can be reported.
+   * <p>The record's {@code widenCollections} decides, with one addition: a container a navigator
+   * would have stepped into to reach the navigable element inside it, had its widening been
+   * writable. The navigator hands such a field back to the static method, which leaves the
+   * container alone just as it would have without the flag, so nothing the method emits changes,
+   * since neither case records a step for it. What the flag does is let the analysis meet the
+   * container and turn it away, so that the declaration is rejected rather than left silently
+   * un-navigated.
    *
-   * @param component the record component to inspect
-   * @param widenCollections whether ZERO_OR_MORE SPI types widen
+   * @param component the record component
+   * @param widenCollections whether the record widens ZERO_OR_MORE containers
    * @param navigatorGenerator the navigator generator, or null when navigators are off
-   * @param analysis the widening analysis whose walk this one mirrors
    */
-  private void reportUndenotableWidening(
+  private static boolean stepsIntoContainers(
       RecordComponentElement component,
       boolean widenCollections,
-      NavigatorClassGenerator navigatorGenerator,
-      WideningAnalysis analysis) {
-
-    // A navigator only ever reads the component's own type, and the walk reaches a nested
-    // container only when that type denotes its own arguments, so this answer belongs to the
-    // first layer alone.
-    boolean navigatorWidens =
-        navigatorGenerator != null && navigatorGenerator.widensUndenotableSpiContainer(component);
-
-    TypeMirror current = component.asType();
-    for (int depth = 0; depth < WideningAnalysis.MAX_NESTING_DEPTH; depth++) {
-      if (current.getKind() != TypeKind.DECLARED) {
-        return;
-      }
-      DeclaredType declaredType = (DeclaredType) current;
-      boolean recognised = analysis.recognisedContainer(current);
-
-      // Optional, Maybe and List widen through .some()/.each(), whose free type variable takes an
-      // undenotable argument without complaint. Every other container -- a generator's, and the
-      // Set and Collection that name a stock Each -- widens through an inferred optic instance,
-      // and is at risk.
-      TraversableGenerator generator = recognised ? null : analysis.findSpiGenerator(current, null);
-      if (!recognised && generator == null) {
-        return;
-      }
-      if (!widensHere(generator, widenCollections, navigatorWidens)) {
-        return;
-      }
-      boolean undenotable =
-          recognised
-              ? analysis.recognisedWidensUndenotably(declaredType)
-              : WideningAnalysis.widensUndenotably(generator, declaredType);
-      if (undenotable) {
-        reportUndenotableContainer(component, declaredType);
-        return;
-      }
-      int typeArgIndex = generator == null ? 0 : generator.getFocusTypeArgumentIndex();
-      current = analysis.typeArgumentAt(declaredType, typeArgIndex);
-      if (current == null) {
-        return;
-      }
-    }
-  }
-
-  /**
-   * Whether the analysis widens this layer, and so goes on to look inside it.
-   *
-   * <p>Optional and the collections always do, and so does a {@code ZERO_OR_ONE} generator. A
-   * {@code ZERO_OR_MORE} generator only does when collections are widened or a navigator takes the
-   * field; left alone it stays a plain {@code FocusPath}, and the type arguments of everything
-   * beneath it are never asked for an optic.
-   *
-   * @param generator the generator for this layer, or null when Optional or a collection widens it
-   * @param widenCollections whether ZERO_OR_MORE SPI types widen
-   * @param navigatorWidens whether a navigator widens the component's own type
-   */
-  private static boolean widensHere(
-      TraversableGenerator generator, boolean widenCollections, boolean navigatorWidens) {
-    return generator == null
-        || generator.getCardinality() == Cardinality.ZERO_OR_ONE
-        || widenCollections
-        || navigatorWidens;
+      NavigatorClassGenerator navigatorGenerator) {
+    return widenCollections
+        || (navigatorGenerator != null
+            && navigatorGenerator.widensUndenotableSpiContainer(component));
   }
 
   /**
@@ -432,7 +376,7 @@ public class FocusProcessor extends AbstractProcessor {
    */
   private void reportUndenotableContainer(
       RecordComponentElement component, DeclaredType declaredType) {
-    boolean raw = declaredType.getTypeArguments().isEmpty();
+    boolean raw = ProcessorUtils.isRaw(declaredType);
     String qualifiedComponent =
         component.getEnclosingElement().getSimpleName() + "." + component.getSimpleName();
     Diagnostics.error(

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/NavigatorClassGenerator.java
@@ -17,6 +17,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import org.higherkindedj.optics.Lens;
 import org.higherkindedj.optics.annotations.GenerateFocus;
+import org.higherkindedj.optics.processing.WideningAnalysis.SpiLookup;
 import org.higherkindedj.optics.processing.WideningAnalysis.Tier;
 import org.higherkindedj.optics.processing.WideningAnalysis.Widening;
 import org.higherkindedj.optics.processing.spi.Cardinality;
@@ -768,7 +769,11 @@ public class NavigatorClassGenerator {
     if (fieldType.getKind() != TypeKind.DECLARED || analysis.recognisedContainer(fieldType)) {
       return null;
     }
-    return spiNavigableUnder(fieldType, analysis.wideningGenerator(fieldType, null));
+    // A container the analysis turns away gets no navigator: the static method it would compose
+    // leaves the container itself in focus, so there is no element to navigate to.
+    return analysis.spiLookup(fieldType, null) instanceof SpiLookup.Admitted admitted
+        ? spiNavigableUnder(fieldType, admitted.generator())
+        : null;
   }
 
   /**
@@ -776,14 +781,9 @@ public class NavigatorClassGenerator {
    * or {@code null} when there is none.
    *
    * <p>Split from {@link #spiNavigable} so that {@link #widensUndenotableSpiContainer} can ask the
-   * same question of a generator the widening guard has already turned away.
+   * same question of a generator the lookup refused.
    */
   private SpiNavigable spiNavigableUnder(TypeMirror fieldType, TraversableGenerator generator) {
-    if (generator == null) {
-      // A Collection subtype such as ArrayList is widened by the interface walk rather than by a
-      // generator, so there is no focus type argument to read.
-      return null;
-    }
     List<? extends TypeMirror> typeArgs = ((DeclaredType) fieldType).getTypeArguments();
     int focusIdx = generator.getFocusTypeArgumentIndex();
     if (focusIdx >= typeArgs.size()) {
@@ -833,11 +833,13 @@ public class NavigatorClassGenerator {
   }
 
   /**
-   * Whether a navigator for {@code component} would widen through an SPI container whose type
+   * Whether a navigator for {@code component} would have stepped into an SPI container whose type
    * arguments leave the optic instance undenotable.
    *
-   * <p>Answered here because the navigator generator decides which fields get a navigator; the
-   * diagnostic is reported by {@code FocusProcessor}, which sees each component once.
+   * <p>Answered here because the navigator generator decides which fields get a navigator. Such a
+   * field is handed back to the static method, and {@code FocusProcessor} asks the analysis to step
+   * into the container on the navigator's behalf, so that it is met and turned away, and the
+   * declaration is rejected from the same result that method is built from.
    *
    * @param component the record component to inspect
    * @return true when only the type arguments stand between this component and a navigator
@@ -854,10 +856,13 @@ public class NavigatorClassGenerator {
         || analysis.recognisedContainer(fieldType)) {
       return false;
     }
-    TraversableGenerator generator = analysis.findSpiGenerator(fieldType, null);
-    return generator != null
-        && WideningAnalysis.widensUndenotably(generator, fieldType)
-        && spiNavigableUnder(fieldType, generator) != null;
+    if (!(analysis.spiLookup(fieldType, null) instanceof SpiLookup.Refused refused)) {
+      return false;
+    }
+    // The element must be one a navigator is offered for. A generic element gets none whatever
+    // the container's arguments, so that container is left alone as it would have been anyway.
+    SpiNavigable navigable = spiNavigableUnder(fieldType, refused.generator());
+    return navigable != null && !declaresTypeParameters(navigable.element());
   }
 
   /**

--- a/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WideningAnalysis.java
+++ b/hkj-processor/src/main/java/org/higherkindedj/optics/processing/WideningAnalysis.java
@@ -48,8 +48,10 @@ import org.higherkindedj.optics.processing.util.ProcessorUtils;
  *   <li>Every other container arrives through the SPI. A {@code ZERO_OR_ONE} generator always
  *       widens; a {@code ZERO_OR_MORE} one waits for {@code widenCollections}.
  *   <li>A widening that names an optic instance cannot be written for a raw or wildcard-carrying
- *       container, so that declaration is rejected (issue #718). {@code Set} and {@code Collection}
- *       fall under that rule; {@code List} deliberately does not, and keeps the no-argument {@code
+ *       container. The walk turns such a container away and the widening {@linkplain
+ *       Widening#declined() names it}, so that the declaration is rejected where it is written
+ *       rather than inside generated source (issue #718). {@code Set} and {@code Collection} fall
+ *       under that rule; {@code List} deliberately does not, and keeps the no-argument {@code
  *       .each()} whose free type variable takes either without complaint. Routing {@code List}
  *       through an instance too would drag {@code List<?>} and raw {@code List} into the rejection
  *       for no runtime gain, since that traversal is the one they already work with.
@@ -200,11 +202,19 @@ public final class WideningAnalysis {
   /**
    * What a component's declared type widens to.
    *
+   * <p>A walk that turns a container away stops there, so the steps still describe a method that
+   * can be written: the widening as far as it goes, with the declined container left in focus. The
+   * declaration is rejected from the same result, so what the method emits and what the diagnostic
+   * names cannot disagree.
+   *
    * @param tier the path type the widened method returns
    * @param focusType the type the widened path focuses on
    * @param steps the layers peeled to get there, empty when nothing widens
+   * @param declined the container the walk would have widened but turned away, because the optic
+   *     instance that widens it cannot be instantiated from the container's type arguments; null
+   *     when every layer reached was widened or left alone
    */
-  public record Widening(Tier tier, TypeName focusType, List<Step> steps) {}
+  public record Widening(Tier tier, TypeName focusType, List<Step> steps, DeclaredType declined) {}
 
   private final ProcessingEnvironment processingEnv;
   private final GeneratorRegistry generatorRegistry;
@@ -232,15 +242,27 @@ public final class WideningAnalysis {
   public Widening analyse(RecordComponentElement component, boolean widenCollections) {
     TypeMirror componentType = component.asType();
     List<Step> steps = new ArrayList<>();
-    collect(component, componentType, widenCollections, 0, steps);
+    DeclaredType declined = collect(component, componentType, widenCollections, 0, steps);
+    // A container turned away at the outermost layer leaves no step behind, so a @Nullable one
+    // still widens through .nullable(): the method that yields compiles, and the declaration is
+    // rejected all the same.
     if (steps.isEmpty() && NullableAnnotations.hasNullableAnnotation(component)) {
       steps.add(new Step(StepKind.NULLABLE, null, null, null));
     }
-    return new Widening(tier(steps), focusType(componentType, steps), List.copyOf(steps));
+    return new Widening(tier(steps), focusType(componentType, steps), List.copyOf(steps), declined);
   }
 
-  /** Peels the container layers off a type, appending one step for each. */
-  private void collect(
+  /**
+   * Peels the container layers off a type, appending one step for each.
+   *
+   * <p>Two kinds of container end the walk short of the leaf. A layer the current settings do not
+   * widen is left alone, and a layer whose widening cannot be written is turned away and handed
+   * back, so that the declaration can be rejected from the result the method is built from. Nothing
+   * beneath either is looked at, because nothing beneath either is ever asked for an optic.
+   *
+   * @return the container turned away, or null when every layer reached was widened or left alone
+   */
+  private DeclaredType collect(
       RecordComponentElement component,
       TypeMirror type,
       boolean widenCollections,
@@ -248,26 +270,24 @@ public final class WideningAnalysis {
       List<Step> steps) {
 
     if (depth >= MAX_NESTING_DEPTH || type.getKind() != TypeKind.DECLARED) {
-      return;
+      return null;
     }
     DeclaredType declaredType = (DeclaredType) type;
     TypeElement typeElement = (TypeElement) declaredType.asElement();
     String qualifiedName = typeElement.getQualifiedName().toString();
 
     if (OPTIONAL_TYPES.contains(qualifiedName)) {
-      descend(component, declaredType, StepKind.OPTIONAL, null, 0, widenCollections, depth, steps);
-      return;
+      return descend(
+          component, declaredType, StepKind.OPTIONAL, null, 0, widenCollections, depth, steps);
     }
     StepKind collectionStep = COLLECTION_TYPES.get(qualifiedName);
     if (collectionStep != null) {
       // A Set or a Collection names an Each whose type arguments come from the field type, so a
-      // raw or wildcard-carrying one has no widening that can be written; it is left alone here
-      // and its declaration rejected where it is written (issues #718, #725).
-      if (!namesOpticInstance(collectionStep)
-          || !ProcessorUtils.hasUndenotableTypeArguments(type)) {
-        descend(component, declaredType, collectionStep, null, 0, widenCollections, depth, steps);
-      }
-      return;
+      // raw or wildcard-carrying one has no widening that can be written (issues #718, #725).
+      return namesOpticInstance(collectionStep) && ProcessorUtils.hasUndenotableTypeArguments(type)
+          ? declaredType
+          : descend(
+              component, declaredType, collectionStep, null, 0, widenCollections, depth, steps);
     }
 
     // A Kind field is read from the component's own declaration, so only the outermost layer of a
@@ -276,45 +296,73 @@ public final class WideningAnalysis {
       Optional<KindFieldInfo> kindInfo = new KindFieldAnalyser(processingEnv).analyse(component);
       if (kindInfo.isPresent()) {
         steps.add(new Step(kindStep(kindInfo.get()), kindInfo.get(), null, null));
-        return;
+        return null;
       }
     }
+    return collectSpi(component, declaredType, widenCollections, depth, steps);
+  }
+
+  /**
+   * Widens a layer through the SPI generator that supports it, leaves it alone, or turns it away.
+   *
+   * <p>A container the walk never steps into is never asked for an optic, so it is left alone
+   * whether or not its widening could be written; only a container the walk would have stepped into
+   * is turned away.
+   *
+   * @return the container turned away, or null when it was widened or left alone
+   */
+  private DeclaredType collectSpi(
+      RecordComponentElement component,
+      DeclaredType declaredType,
+      boolean widenCollections,
+      int depth,
+      List<Step> steps) {
 
     // The component rides along at every layer, so an equal-priority conflict on a type reached
     // only inside a container is still reported against the declaration that reaches it.
-    TraversableGenerator generator = wideningGenerator(type, component);
-    if (generator == null) {
-      return;
-    }
-    if (generator.getCardinality() == Cardinality.ZERO_OR_ONE) {
-      descend(
-          component,
-          declaredType,
-          StepKind.SPI_ZERO_OR_ONE,
-          generator,
-          generator.getFocusTypeArgumentIndex(),
-          widenCollections,
-          depth,
-          steps);
-      return;
-    }
-    // A ZERO_OR_MORE container is left un-widened by default, for backwards compatibility: the
-    // method keeps the container itself in focus until widenCollections says otherwise.
-    if (widenCollections) {
-      descend(
-          component,
-          declaredType,
-          StepKind.SPI_ZERO_OR_MORE,
-          generator,
-          generator.getFocusTypeArgumentIndex(),
-          widenCollections,
-          depth,
-          steps);
-    }
+    return switch (spiLookup(declaredType, component)) {
+      case SpiLookup.None _ -> null;
+      case SpiLookup.Refused refused ->
+          stepsInto(refused.generator(), widenCollections) ? declaredType : null;
+      case SpiLookup.Admitted admitted ->
+          stepsInto(admitted.generator(), widenCollections)
+              ? descend(
+                  component,
+                  declaredType,
+                  spiStep(admitted.generator()),
+                  admitted.generator(),
+                  admitted.generator().getFocusTypeArgumentIndex(),
+                  widenCollections,
+                  depth,
+                  steps)
+              : null;
+    };
   }
 
-  /** Records one layer and continues into the type argument it unwraps to. */
-  private void descend(
+  /**
+   * Whether the walk steps into a container this generator widens.
+   *
+   * <p>A {@code ZERO_OR_ONE} container is always stepped into. A {@code ZERO_OR_MORE} one is left
+   * un-widened by default, for backwards compatibility: the method keeps the container itself in
+   * focus until {@code widenCollections} says otherwise.
+   */
+  private static boolean stepsInto(TraversableGenerator generator, boolean widenCollections) {
+    return generator.getCardinality() == Cardinality.ZERO_OR_ONE || widenCollections;
+  }
+
+  /** The step a generator's cardinality calls for. */
+  private static StepKind spiStep(TraversableGenerator generator) {
+    return generator.getCardinality() == Cardinality.ZERO_OR_ONE
+        ? StepKind.SPI_ZERO_OR_ONE
+        : StepKind.SPI_ZERO_OR_MORE;
+  }
+
+  /**
+   * Records one layer and continues into the type argument it unwraps to.
+   *
+   * @return what the walk beneath this layer turned away, or null
+   */
+  private DeclaredType descend(
       RecordComponentElement component,
       DeclaredType declaredType,
       StepKind kind,
@@ -326,9 +374,9 @@ public final class WideningAnalysis {
 
     TypeMirror innerType = typeArgumentAt(declaredType, typeArgumentIndex);
     steps.add(new Step(kind, null, generator, innerType));
-    if (innerType != null) {
-      collect(component, innerType, widenCollections, depth + 1, steps);
-    }
+    return innerType == null
+        ? null
+        : collect(component, innerType, widenCollections, depth + 1, steps);
   }
 
   /** The step a Kind field's cardinality semantics call for. */
@@ -500,27 +548,6 @@ public final class WideningAnalysis {
     return OPTIONAL_TYPES.contains(qualifiedName) || COLLECTION_TYPES.containsKey(qualifiedName);
   }
 
-  /**
-   * Whether the widening a {@linkplain #recognisedContainer recognised container} would receive
-   * cannot be written, because it names an {@code Each} the container's own type arguments give
-   * javac no way to instantiate.
-   *
-   * <p>{@code Optional}, {@code Maybe} and {@code List} widen through a no-argument call whose free
-   * type variable takes a raw or wildcard-carrying container without complaint, so only {@code Set}
-   * and {@code Collection} answer true here.
-   *
-   * @param type a declared type
-   * @return true when the container is a {@code Set} or a {@code Collection} that is raw or carries
-   *     a wildcard type argument
-   * @since 0.4.10
-   */
-  public boolean recognisedWidensUndenotably(TypeMirror type) {
-    StepKind step = COLLECTION_TYPES.get(qualifiedNameOf(type));
-    return step != null
-        && namesOpticInstance(step)
-        && ProcessorUtils.hasUndenotableTypeArguments(type);
-  }
-
   /** The qualified name of a declared type's element. */
   private static String qualifiedNameOf(TypeMirror type) {
     return ((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName().toString();
@@ -534,7 +561,7 @@ public final class WideningAnalysis {
    * @return the resolved argument, or null when the container is raw or the wildcard resolves to no
    *     type at all
    */
-  public TypeMirror typeArgumentAt(DeclaredType declaredType, int index) {
+  private static TypeMirror typeArgumentAt(DeclaredType declaredType, int index) {
     List<? extends TypeMirror> args = declaredType.getTypeArguments();
     if (index >= args.size()) {
       return null;
@@ -543,54 +570,58 @@ public final class WideningAnalysis {
   }
 
   /**
-   * Finds the highest-priority SPI generator that supports the given type, from the {@link
-   * GeneratorRegistry} every generator-choosing site reads.
+   * What the SPI has to say about a container.
    *
-   * <p>Reached directly only by the diagnostic walks, which exist to report the container {@link
-   * #wideningGenerator} turned away. Every widening site reads its generator from that guard.
-   *
-   * @param type the type to check
-   * @param component the record component to report an equal-priority conflict against, or null
-   * @return the matched generator, or null if none supports the type
+   * <p>Classified once, here, so that no site ever holds a bare generator for a container whose
+   * widening cannot be written. Each site chooses what to do with a refused one: the walk turns it
+   * away and {@linkplain Widening#declined() records it}, the navigator declines to step into it,
+   * and the navigator's turned-away check asks what it would have reached.
    */
-  public TraversableGenerator findSpiGenerator(TypeMirror type, Element component) {
-    return generatorRegistry.generatorFor(type, component);
+  public sealed interface SpiLookup {
+
+    /** No generator on the annotation processor path supports the type. */
+    record None() implements SpiLookup {}
+
+    /**
+     * A generator supports the type, but the widening it would emit cannot be written.
+     *
+     * <p>A generator that names an optic instance — {@code .some(Affines.eitherRight())}, {@code
+     * .each(EachInstances.mapValuesEach())} — has that instance's type arguments inferred from the
+     * field type, which a raw or wildcard-carrying container gives javac no way to do. A generator
+     * with no optic expression widens through {@code .nullable()} or {@code .each()} instead, whose
+     * free type variable takes either without complaint, and is admitted.
+     *
+     * <p>Such a container is left un-widened, and its declaration is rejected where it is written
+     * rather than inside generated source (issue #718).
+     *
+     * @param generator the generator that supports the type
+     */
+    record Refused(TraversableGenerator generator) implements SpiLookup {}
+
+    /**
+     * A generator supports the type and its widening can be written.
+     *
+     * @param generator the generator to widen with
+     */
+    record Admitted(TraversableGenerator generator) implements SpiLookup {}
   }
 
   /**
-   * The generator that widens {@code type}, or null when none matches or the widening it would emit
-   * cannot be written.
+   * Classifies what the SPI has to say about {@code type}, reading the highest-priority generator
+   * from the {@link GeneratorRegistry} every generator-choosing site reads.
    *
-   * <p>Every widening site reads its generator from here, so the tier, the navigator class and the
-   * composition call cannot disagree about which containers widen.
-   *
-   * @param type the type to widen
+   * @param type the type to look up
    * @param component the record component to report an equal-priority conflict against, or null
-   * @return the generator to widen with, or null
+   * @return none, a refused generator, or an admitted one
    */
-  public TraversableGenerator wideningGenerator(TypeMirror type, Element component) {
-    TraversableGenerator matched = findSpiGenerator(type, component);
-    return matched != null && widensUndenotably(matched, type) ? null : matched;
-  }
-
-  /**
-   * Whether {@code generator} cannot write the widening it would emit for {@code type}.
-   *
-   * <p>A generator that names an optic instance — {@code .some(Affines.eitherRight())}, {@code
-   * .each(EachInstances.mapValuesEach())} — has that instance's type arguments inferred from the
-   * field type, which a raw or wildcard-carrying container gives javac no way to do. A generator
-   * with no optic expression widens through {@code .nullable()} or {@code .each()} instead, whose
-   * free type variable takes either without complaint.
-   *
-   * <p>Such a container is left un-widened, and its declaration is rejected where it is written
-   * rather than inside generated source (issue #718).
-   *
-   * @param generator the generator that would widen the type
-   * @param type the container type
-   * @return true when the widening cannot be written
-   */
-  public static boolean widensUndenotably(TraversableGenerator generator, TypeMirror type) {
-    return !generator.generateOpticExpression().isEmpty()
-        && ProcessorUtils.hasUndenotableTypeArguments(type);
+  public SpiLookup spiLookup(TypeMirror type, Element component) {
+    TraversableGenerator generator = generatorRegistry.generatorFor(type, component);
+    if (generator == null) {
+      return new SpiLookup.None();
+    }
+    boolean writable =
+        generator.generateOpticExpression().isEmpty()
+            || !ProcessorUtils.hasUndenotableTypeArguments(type);
+    return writable ? new SpiLookup.Admitted(generator) : new SpiLookup.Refused(generator);
   }
 }

--- a/hkj-processor/src/test/java/org/higherkindedj/architecture/ProcessorArchitectureRules.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/architecture/ProcessorArchitectureRules.java
@@ -4,6 +4,7 @@ package org.higherkindedj.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -15,7 +16,9 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.processing.AbstractProcessor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -38,12 +41,18 @@ class ProcessorArchitectureRules {
 
   private static final String BASE_PACKAGE = "org.higherkindedj";
 
-  /** The SPI generator lookup that every widening site must reach through the guard. */
-  private static final String SPI_LOOKUP = "findSpiGenerator";
+  /** The lookup arm that carries a generator whose widening cannot be written. */
+  private static final String REFUSED_LOOKUP =
+      "org.higherkindedj.optics.processing.WideningAnalysis$SpiLookup$Refused";
 
-  /** The methods that may reach the lookup directly: the guard itself, and the diagnostic walk. */
-  private static final Set<String> SPI_LOOKUP_CALLERS =
-      Set.of("wideningGenerator", "reportUndenotableWidening", "widensUndenotableSpiContainer");
+  /**
+   * The methods that may read a refused generator, both to ask what it would have done rather than
+   * to widen with it: the analysis's walk reads its cardinality, to tell a container it would have
+   * stepped into from one it leaves alone, and the navigator's turned-away check reads its focus
+   * argument, to say what the navigator would have reached.
+   */
+  private static final Set<String> REFUSED_GENERATOR_READERS =
+      Set.of("collectSpi", "widensUndenotableSpiContainer");
 
   private static JavaClasses classes;
 
@@ -215,23 +224,45 @@ class ProcessorArchitectureRules {
   }
 
   /**
-   * Every widening site must read its SPI generator through the guard.
+   * A refused generator widens nothing.
    *
    * <p>A generator widens by handing the path an optic instance whose type arguments javac infers
    * from the field type, which a raw or wildcard-carrying container gives it no way to do (#718).
-   * {@code wideningGenerator} is the one place such a container is turned away, so a site that
-   * looks a generator up itself would widen it anyway and emit source that cannot compile. The
-   * diagnostic walk is exempt: it exists to report the container the guard turned away.
+   * The SPI lookup classifies such a container as refused instead of handing out the bare
+   * generator, so no site widens it by accident; what is left to guard is a site reaching into the
+   * refused arm for the generator anyway. The two that may read it ask what the generator would
+   * have done, never what it would emit.
    */
   @Test
-  @DisplayName("SPI generator lookups should go through the widening guard")
-  void spi_generator_lookups_should_go_through_the_widening_guard() {
+  @DisplayName("A refused generator should widen nothing")
+  void a_refused_generator_should_widen_nothing() {
     classes()
         .that()
         .resideInAPackage("..processing..")
-        .should(lookUpSpiGeneratorsOnlyFrom(SPI_LOOKUP_CALLERS))
+        .should(readRefusedGeneratorsOnlyFrom(REFUSED_GENERATOR_READERS))
         .allowEmptyShould(true)
         .check(classes);
+  }
+
+  /**
+   * The refused-generator rule sees the readers it exempts.
+   *
+   * <p>That rule is keyed on a nested type's name and an accessor's, so renaming either would let
+   * it pass with nothing to check. The two readers it allows are known, and it must find exactly
+   * them.
+   */
+  @Test
+  @DisplayName("The refused-generator rule should see its readers")
+  void the_refused_generator_rule_should_see_its_readers() {
+    Set<String> readers =
+        StreamSupport.stream(classes.spliterator(), false)
+            .flatMap(ProcessorArchitectureRules::callsAndReferencesFrom)
+            .filter(access -> access.getTarget().getOwner().getName().equals(REFUSED_LOOKUP))
+            .filter(access -> access.getTarget().getName().equals("generator"))
+            .map(access -> access.getOrigin().getName())
+            .collect(Collectors.toSet());
+
+    assertThat(readers).isEqualTo(REFUSED_GENERATOR_READERS);
   }
 
   /**
@@ -258,10 +289,10 @@ class ProcessorArchitectureRules {
   /**
    * The registry answers only the route lookups.
    *
-   * <p>The widening guard (#718) keys on {@code findSpiGenerator}, which is now a delegate, so a
-   * site could otherwise read a generator straight from {@code GeneratorRegistry.generatorFor} and
-   * skip {@code wideningGenerator}'s turn-away of raw and wildcard-carrying containers. The
-   * delegate and the two non-widening route sites are the only permitted readers.
+   * <p>The Focus route's lookup classifies what it finds (#718), so a site reading a generator
+   * straight from {@code GeneratorRegistry.generatorFor} would hold a bare one for a raw or
+   * wildcard-carrying container and could widen it into source that cannot compile. That lookup and
+   * the two non-widening route sites are the only permitted readers.
    */
   @Test
   @DisplayName("Registry reads should stay behind the route lookups")
@@ -305,26 +336,25 @@ class ProcessorArchitectureRules {
    * @param allowed the names of the methods that may call the lookup
    * @return the arch condition
    */
-  private static ArchCondition<JavaClass> lookUpSpiGeneratorsOnlyFrom(Set<String> allowed) {
-    return new ArchCondition<>("look SPI generators up only from " + allowed) {
+  private static ArchCondition<JavaClass> readRefusedGeneratorsOnlyFrom(Set<String> allowed) {
+    return new ArchCondition<>("read a refused generator only from " + allowed) {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
-        javaClass.getMethodCallsFromSelf().stream()
-            .filter(call -> call.getTarget().getName().equals(SPI_LOOKUP))
-            .filter(call -> !allowed.contains(call.getOrigin().getName()))
+        callsAndReferencesFrom(javaClass)
+            .filter(access -> access.getTarget().getOwner().getName().equals(REFUSED_LOOKUP))
+            .filter(access -> access.getTarget().getName().equals("generator"))
+            .filter(access -> !allowed.contains(access.getOrigin().getName()))
             .forEach(
-                call ->
+                access ->
                     events.add(
                         SimpleConditionEvent.violated(
                             javaClass,
                             String.format(
-                                "%s.%s calls %s directly. Read the generator from"
-                                    + " wideningGenerator instead, so that a raw or"
-                                    + " wildcard-carrying container is turned away rather than"
-                                    + " widened into source that cannot compile.",
-                                javaClass.getSimpleName(),
-                                call.getOrigin().getName(),
-                                SPI_LOOKUP))));
+                                "%s.%s reads the generator of a refused SPI lookup. Its widening"
+                                    + " cannot be written, so match the admitted arm instead;"
+                                    + " a refused generator is read only to say what it would"
+                                    + " have done, never to widen with.",
+                                javaClass.getSimpleName(), access.getOrigin().getName()))));
       }
     };
   }
@@ -339,7 +369,7 @@ class ProcessorArchitectureRules {
 
   /** The methods that may read a choice from the registry: the delegate and the two route sites. */
   private static final Set<String> REGISTRY_READERS =
-      Set.of("findSpiGenerator", "generateTraversalsFile", "createTraversalMethod");
+      Set.of("spiLookup", "generateTraversalsFile", "createTraversalMethod");
 
   /** Method calls and method references from {@code javaClass}, which decide targets alike. */
   private static Stream<JavaAccess<?>> callsAndReferencesFrom(JavaClass javaClass) {
@@ -391,9 +421,9 @@ class ProcessorArchitectureRules {
                             javaClass,
                             String.format(
                                 "%s.%s reads a generator straight from the registry. Go through"
-                                    + " wideningGenerator or the route's one lookup, so that a"
-                                    + " raw or wildcard-carrying container is turned away rather"
-                                    + " than widened into source that cannot compile.",
+                                    + " the route's one lookup, so that a raw or"
+                                    + " wildcard-carrying container is turned away rather than"
+                                    + " widened into source that cannot compile.",
                                 javaClass.getSimpleName(), access.getOrigin().getName()))));
       }
     };

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorSpiEnhancementsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/FocusProcessorSpiEnhancementsTest.java
@@ -29,6 +29,8 @@ import org.higherkindedj.optics.processing.util.ProcessorUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for the SPI widening enhancements:
@@ -621,6 +623,37 @@ public class FocusProcessorSpiEnhancementsTest {
               "Map<String, ? extends Leaf> values");
 
       assertThat(compilation).succeeded();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"Map<String, Box<String>>", "Map<String, ? extends Box<String>>"})
+    @DisplayName("should leave a container alone whose navigable element is generic")
+    void shouldLeaveContainerOfGenericNavigableElementAlone(String component) {
+      // A generic element gets no navigator, so the container is never stepped into to reach it
+      // and stays a plain FocusPath; a wildcard it carries is then never asked for an optic, any
+      // more than its concrete twin's arguments are.
+      JavaFileObject box =
+          JavaFileObjects.forSourceString(
+              "com.example.Box",
+              """
+              package com.example;
+
+              import org.higherkindedj.optics.annotations.GenerateFocus;
+
+              @GenerateFocus
+              public record Box<T>(T value) {}
+              """);
+
+      Compilation compilation =
+          javac()
+              .withProcessors(new FocusProcessor())
+              .compile(holder("generateNavigators = true", component + " boxes"), box);
+
+      assertThat(compilation).succeeded();
+      assertGeneratedCodeContains(
+          compilation,
+          "com.example.HolderFocus",
+          "public static FocusPath<Holder, " + component + "> boxes()");
     }
 
     @Test

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedFocusSourceCompilesTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedFocusSourceCompilesTest.java
@@ -32,7 +32,9 @@ import org.junit.jupiter.params.provider.MethodSource;
  * having to predict the mechanism first.
  *
  * <p>Rejecting everything would satisfy that on its own, so the corpus below pins the other half:
- * every record in it compiles today, and a guard that grows too eager fails on it.
+ * every record in it compiles today, and a guard that grows too eager fails on it. A third corpus
+ * pins what neither sweep can see: a container the analysis turns away must reach the declaration
+ * as a diagnostic, because a missing error is not one the shape sweep can locate.
  */
 @DisplayName("Generated Focus source always compiles")
 class GeneratedFocusSourceCompilesTest {
@@ -235,6 +237,82 @@ class GeneratedFocusSourceCompilesTest {
         .isEmpty();
   }
 
+  /**
+   * A component the analysis turns away, the settings it is read under, and the container it names.
+   *
+   * <p>Each entry pins that the container turned away reaches the declaration, named as written,
+   * and that nothing else goes wrong: the method built from the same result still compiles.
+   */
+  private record Rejected(String component, String setting, String container) {}
+
+  private static final List<Rejected> REJECTED =
+      List.of(
+          // A Set or a Collection names its own Each, so a wildcard or raw one has none to write.
+          new Rejected("Set<?> f", "", "Set<?>"),
+          new Rejected("Collection<? extends Leaf> f", "", "Collection<? extends Leaf>"),
+          new Rejected("Set f", "", "Set"),
+          // A ZERO_OR_ONE generator always widens, so its container is met under every setting.
+          new Rejected("Either<String, ? extends Leaf> f", "", "Either<String, ? extends Leaf>"),
+          new Rejected("Try<?> f", "generateNavigators = true", "Try<?>"),
+          new Rejected("Either f", "", "Either"),
+          // A ZERO_OR_MORE generator's container is met once something steps into it: the
+          // record's own flag, or a navigator reaching for the navigable element inside.
+          new Rejected(
+              "Map<String, ? extends Leaf> f",
+              "widenCollections = true",
+              "Map<String, ? extends Leaf>"),
+          new Rejected(
+              "Map<String, ? extends Leaf> f",
+              "generateNavigators = true",
+              "Map<String, ? extends Leaf>"),
+          new Rejected("Map f", "widenCollections = true", "Map"),
+          // The walk carries on beneath a layer it widened, and names the first it turns away.
+          new Rejected(
+              "Optional<Either<String, ? extends Leaf>> f", "", "Either<String, ? extends Leaf>"),
+          new Rejected("List<Set<?>> f", "", "Set<?>"),
+          new Rejected(
+              "Either<String, Map<String, ?>> f", "widenCollections = true", "Map<String, ?>"),
+          new Rejected("Optional<Optional<Either<String, ?>>> f", "", "Either<String, ?>"),
+          // A @Nullable component turned away at its outermost layer still widens through
+          // .nullable(), and is rejected all the same.
+          new Rejected("@Nullable Set<?> f", "", "Set<?>"));
+
+  static Stream<Arguments> rejected() {
+    return REJECTED.stream()
+        .map(
+            entry ->
+                Arguments.of(
+                    entry.component()
+                        + " / "
+                        + (entry.setting().isEmpty() ? "defaults" : entry.setting()),
+                    entry));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("rejected")
+  @DisplayName("should reject at the declaration every container the analysis turns away")
+  void shouldRejectWhatTheAnalysisTurnsAway(String label, Rejected entry) {
+    Compilation compilation =
+        javac()
+            .withProcessors(new FocusProcessor())
+            .compile(holder(new Shape(label, List.of()), entry.setting(), entry.component()), LEAF);
+
+    String expected =
+        entry.container().contains("<")
+            ? "record component 'Holder.f' has a wildcard type argument in "
+                + entry.container()
+                + "."
+            : "record component 'Holder.f' has a raw " + entry.container() + ".";
+    assertThat(errorsFrom(compilation, "Holder.java"))
+        .as(
+            "%s: the analysis turns %s away, so the declaration must say so",
+            label, entry.container())
+        .anySatisfy(error -> assertThat(error).contains(expected));
+    assertThat(errorsFrom(compilation, GENERATED_OUTPUT))
+        .as("%s: the method built from the declined widening must still compile", label)
+        .isEmpty();
+  }
+
   /** A record carrying one component per type in the shape, read under the given settings. */
   private static JavaFileObject holder(Shape shape, String setting) {
     return holder(
@@ -258,6 +336,7 @@ class GeneratedFocusSourceCompilesTest {
         import org.higherkindedj.hkt.trymonad.Try;
         import org.higherkindedj.hkt.validated.Validated;
         import org.higherkindedj.optics.annotations.GenerateFocus;
+        import org.jspecify.annotations.Nullable;
         import java.util.Collection;
         import java.util.List;
         import java.util.Map;

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/WideningAnalysisDeclinedTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/WideningAnalysisDeclinedTest.java
@@ -1,0 +1,193 @@
+// Copyright (c) 2025 - 2026 Magnus Smith
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+package org.higherkindedj.optics.processing;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.JavaFileObject;
+import org.higherkindedj.optics.processing.WideningAnalysis.Step;
+import org.higherkindedj.optics.processing.WideningAnalysis.StepKind;
+import org.higherkindedj.optics.processing.WideningAnalysis.Tier;
+import org.higherkindedj.optics.processing.WideningAnalysis.Widening;
+import org.higherkindedj.optics.processing.spi.TraversableGenerator;
+import org.higherkindedj.optics.processing.util.ProcessorUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The analysis names the container it turns away, and its steps stop where that container was met.
+ *
+ * <p>Read straight off the analysis rather than through the diagnostic, so that the contract the
+ * processor reports from is pinned on its own: which layer is declined under which setting, what
+ * the layers before it still widen through, and that a {@code @Nullable} component turned away at
+ * its outermost layer keeps the {@code .nullable()} widening.
+ */
+@DisplayName("Widening analysis: declined containers")
+class WideningAnalysisDeclinedTest {
+
+  /** One component per way a container can be met, turned away, or left alone. */
+  private static final JavaFileObject HOLDER =
+      JavaFileObjects.forSourceString(
+          "com.example.Holder",
+          """
+          package com.example;
+
+          import java.util.List;
+          import java.util.Map;
+          import java.util.Optional;
+          import java.util.Set;
+          import org.higherkindedj.hkt.either.Either;
+          import org.jspecify.annotations.Nullable;
+
+          @SuppressWarnings("rawtypes")
+          public record Holder(
+              Either<String, ?> either,
+              Map<String, ?> map,
+              Set<?> set,
+              Set raw,
+              Optional<Either<String, ?>> nested,
+              Map<String, Either<String, ?>> beneath,
+              List<String> list,
+              @Nullable Set<?> nullable) {}
+          """);
+
+  /** What the analysis says of each Holder component, by name, with collections left alone. */
+  private static Map<String, Widening> leftAlone;
+
+  /** The same, with collections stepped into. */
+  private static Map<String, Widening> steppedInto;
+
+  @BeforeAll
+  static void analyseUnderBothSettings() {
+    leftAlone = analyse(false);
+    steppedInto = analyse(true);
+  }
+
+  /** Runs the analysis over Holder's components under one setting. */
+  private static Map<String, Widening> analyse(boolean widenCollections) {
+    Map<String, Widening> widenings = new LinkedHashMap<>();
+
+    final class Probe extends AbstractProcessor {
+      @Override
+      public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+      }
+
+      @Override
+      public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+      }
+
+      @Override
+      public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+          return false;
+        }
+        TypeElement holder = processingEnv.getElementUtils().getTypeElement("com.example.Holder");
+        List<TraversableGenerator> generators = new ArrayList<>();
+        ServiceLoader.load(TraversableGenerator.class, getClass().getClassLoader())
+            .forEach(generators::add);
+        WideningAnalysis analysis = new WideningAnalysis(processingEnv, generators);
+        for (RecordComponentElement component : holder.getRecordComponents()) {
+          widenings.put(
+              component.getSimpleName().toString(), analysis.analyse(component, widenCollections));
+        }
+        return false;
+      }
+    }
+
+    Compilation compilation = javac().withProcessors(new Probe()).compile(HOLDER);
+    assertThat(compilation).succeeded();
+    return Map.copyOf(widenings);
+  }
+
+  /** The declined container as the diagnostic would name it, or null. */
+  private static String declined(Widening widening) {
+    return widening.declined() == null ? null : ProcessorUtils.simpleTypeName(widening.declined());
+  }
+
+  private static List<StepKind> kinds(Widening widening) {
+    return widening.steps().stream().map(Step::kind).toList();
+  }
+
+  @Test
+  @DisplayName("names the container it turned away")
+  void namesTheContainerItTurnedAway() {
+    assertThat(declined(leftAlone.get("either"))).isEqualTo("Either<String, ?>");
+    assertThat(declined(leftAlone.get("set"))).isEqualTo("Set<?>");
+    assertThat(declined(leftAlone.get("raw"))).isEqualTo("Set");
+    assertThat(declined(leftAlone.get("nested"))).isEqualTo("Either<String, ?>");
+  }
+
+  @Test
+  @DisplayName("turns nothing away that it widened or left alone")
+  void turnsNothingAwayThatItWidenedOrLeftAlone() {
+    assertThat(declined(leftAlone.get("list"))).isNull();
+    // A ZERO_OR_MORE container is not stepped into by default, so neither it nor the container
+    // beneath it is ever asked for an optic.
+    assertThat(declined(leftAlone.get("map"))).isNull();
+    assertThat(declined(leftAlone.get("beneath"))).isNull();
+  }
+
+  @Test
+  @DisplayName("turns a ZERO_OR_MORE container away once widenCollections steps into it")
+  void turnsAZeroOrMoreContainerAwayOnceWidenCollectionsStepsIntoIt() {
+    assertThat(declined(steppedInto.get("map"))).isEqualTo("Map<String, ?>");
+    assertThat(declined(steppedInto.get("beneath"))).isEqualTo("Either<String, ?>");
+    assertThat(kinds(steppedInto.get("beneath"))).containsExactly(StepKind.SPI_ZERO_OR_MORE);
+  }
+
+  @Test
+  @DisplayName("builds the same method whether a container is turned away or left alone")
+  void buildsTheSameMethodWhetherAContainerIsTurnedAwayOrLeftAlone() {
+    // Neither records a step for the container, so the method built from either result is the
+    // same; only declined tells them apart. The processor relies on this when it steps into a
+    // container on a navigator's behalf that the navigator itself had to hand back.
+    Widening turnedAway = steppedInto.get("map");
+    Widening untouched = leftAlone.get("map");
+
+    assertThat(turnedAway.tier()).isEqualTo(untouched.tier());
+    assertThat(turnedAway.focusType()).isEqualTo(untouched.focusType());
+    assertThat(turnedAway.steps()).isEqualTo(untouched.steps());
+    assertThat(untouched.declined()).isNull();
+  }
+
+  @Test
+  @DisplayName("stops its steps where the container was met")
+  void stopsItsStepsWhereTheContainerWasMet() {
+    Widening nested = leftAlone.get("nested");
+    assertThat(kinds(nested)).containsExactly(StepKind.OPTIONAL);
+    assertThat(nested.tier()).isEqualTo(Tier.AFFINE);
+    assertThat(nested.focusType().toString()).endsWith("Either<java.lang.String, ?>");
+
+    Widening either = leftAlone.get("either");
+    assertThat(kinds(either)).isEmpty();
+    assertThat(either.tier()).isEqualTo(Tier.FOCUS);
+  }
+
+  @Test
+  @DisplayName("keeps the nullable() widening of a @Nullable component it turned away")
+  void keepsTheNullableWideningOfANullableComponentItTurnedAway() {
+    Widening nullable = leftAlone.get("nullable");
+
+    assertThat(declined(nullable)).isEqualTo("Set<?>");
+    assertThat(kinds(nullable)).containsExactly(StepKind.NULLABLE);
+    assertThat(nullable.tier()).isEqualTo(Tier.AFFINE);
+  }
+}


### PR DESCRIPTION
Closes #758.

`@GenerateFocus` had one analysis of what a component widens to and a second, hand-written walk that re-derived where that analysis stops, so that a raw or wildcard-carrying container could be rejected at its declaration. The two agreed by care alone. This takes the issue's second option: the analysis records the container it turns away, and the processor reports from the same result the generated method is built from.

```mermaid
flowchart LR
    subgraph before["before"]
        direction TB
        D1["record component"] --> A1["WideningAnalysis.collect()"]
        D1 --> W1["FocusProcessor.reportUndenotableWidening()"]
        A1 --> E1["static method"]
        W1 --> R1["diagnostic"]
        A1 -.->|"must agree"| W1
    end
    subgraph after["after"]
        direction TB
        D2["record component"] --> A2["WideningAnalysis.collect()"]
        A2 --> WD["Widening(tier, focusType, steps, declined)"]
        WD --> E2["static method"]
        WD --> R2["diagnostic"]
    end

    classDef one fill:#a6d189,stroke:#40a02b,color:#232634
    classDef two fill:#e5c890,stroke:#df8e1d,color:#232634
    class A1,E1,A2,WD,E2,R2 one
    class W1,R1 two
```

## What changed

- **`WideningAnalysis.Widening` carries `declined`**, the `DeclaredType` the walk turned away, or null. `collect()` returns it; the SPI layer moves into `collectSpi()`, which tells "no generator supports this" from "the generator cannot write this widening". The cardinality check comes first, so a `ZERO_OR_MORE` container nothing steps into is left alone rather than declined, and nothing beneath it is looked at. A declined walk stops where it met the container, so the steps still describe a method that compiles: the widening as far as it goes.
- **`FocusProcessor` reports from that result.** The mirrored walk, `widensHere`, and the `recognised ? … : …` choice of undenotability question are gone. The static-method branch analyses once, reports `declined` if set, and builds the method from the same `Widening`. A field a navigator took reaches its element through a container the navigator's guard already admitted, so it has nothing to report.
- **The navigator's turned-away signal honours its own contract.** `widensUndenotableSpiContainer` documents itself as "true when only the type arguments stand between this component and a navigator", but did not ask whether the element was generic, which `navigatorTarget` does. Measured before the change: `Map<String, ? extends Box<String>>` under `generateNavigators = true` was rejected while `Map<String, Box<String>>` compiled as a plain `FocusPath`. The wildcard twin now compiles the same way. This is the one behaviour change, and it is listed in the release history. One asymmetry remains and is deliberate: the concrete twin gets the existing note explaining that a generic target gets no navigator, while the wildcard twin is silent, because that note's advice (`widenCollections = true`) would lead it straight to a rejection.
- **The SPI lookup is classified once.** `WideningAnalysis.spiLookup` answers `None`, `Refused(generator)` or `Admitted(generator)`, so no site ever holds a bare generator for a container whose widening cannot be written. The walk switches on it, the navigator steps into `Admitted` only, and the navigator's turned-away check matches `Refused`. `findSpiGenerator`, `wideningGenerator` and the public `widensUndenotably` are gone, which removes the second application of the guard the review panel spotted.
- **The ArchUnit rule now guards what matters.** "SPI lookups go through the guard" (an allow-list of callers) becomes "a refused generator widens nothing": only the walk and the navigator's turned-away check may read `Refused.generator()`, and both read it to ask what the generator would have done, never to widen. A companion test pins that the rule sees exactly those two readers, so a rename cannot make it pass vacuously. The registry rule's reader list follows the lookup's new name.
- `recognisedWidensUndenotably` is removed and `typeArgumentAt` made private.

## The `@Nullable` interaction

A declined container is a separate component of `Widening`, not a step, so `analyse()`'s rule that `NULLABLE` is appended only when no step was taken is untouched: `@Nullable Set<?>` still widens through `.nullable()` to an `AffinePath<Holder, Set<?>>` that compiles, and the declaration is rejected all the same. Pinned in `WideningAnalysisDeclinedTest` and in the rejected corpus.

## Tests

- `GeneratedFocusSourceCompilesTest` gains the guard the issue asks for: a rejected-shape corpus beside the still-compiles one, each entry asserting the container the analysis turns away is named at the declaration and that nothing comes back from generated output.
- `WideningAnalysisDeclinedTest` reads `Widening.declined()` straight off the analysis through a probe processor: which layer is declined under which setting, that the steps stop where it was met, and the `@Nullable` tier.
- `FocusProcessorSpiEnhancementsTest` pins the generic-element corner for both the concrete and the wildcard container.

`gradle :hkj-processor:check` is green: tests, ArchUnit rules, spotless and the JaCoCo gates, with `WideningAnalysis`, `NavigatorClassGenerator` and `FocusProcessor` at 100% line, branch and instruction coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCF71VE6S9uGidw5jtjyog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Generic navigable containers now compile successfully when navigation does not descend into their generic elements.
  - Container handling now consistently preserves plain `FocusPath` behavior for equivalent concrete and wildcard forms.
  - Containers that cannot be safely widened continue to be rejected with clear diagnostics.
  - Nullable components retain their expected behavior when widening is declined.

- **Documentation**
  - Updated the release history with details of the improved container and navigator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->