### PR TITLE
Lead with the verdict on the transformer error page

### DIFF
--- a/hkj-book/src/transformers/common_errors.md
+++ b/hkj-book/src/transformers/common_errors.md
@@ -1,25 +1,68 @@
 # Common Compiler Errors
 
-Transformer code is generic-heavy by nature: a typical signature like `Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Result>` packs three type parameters into two layers. When something goes wrong, the compiler messages can be hard to read. This page documents the errors developers hit most often, what they actually mean, and the fix.
+Transformer code is generic-heavy by nature: a typical signature like `Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Result>` packs three type parameters into two layers. When something goes wrong, the messages can be hard to read. Find your symptom in the table below and follow it to its section.
 
 ~~~admonish info title="What You'll Learn"
+- Which transformer mistakes javac catches, which the HKJ checker adds a message to, and which nothing catches
 - How to satisfy the missing-Monad constraint when constructing a transformer monad
 - How to unify error types across an `EitherT` chain
 - Why `StateT.mapT` takes an extra parameter that the other `mapT` methods do not
 - When to call `.value()` and when to leave a transformer alone
-- How to spot type-inference failures in `EitherT.fromEither` and similar factories
 ~~~
+
+~~~admonish tip title="Five of these six are javac errors"
+The compiler is mostly on your side here, and that is not an accident. A transformer stack encodes the error type inside the witness itself (`EitherTKind.Witness<F, L>`), so a step with the wrong `L` is a genuinely different type rather than an erased one. The Effect Path API pays for its lighter syntax with exactly that guarantee: compare [Effect §5](../effect/compiler_errors.md#5-the-error-type-is-silently-erased-across-a-chain), where the same mistake compiles.
+
+- **§1, §2, §3, §5 and §6 are javac errors.** The build stops, and the message is quoted in the section.
+- **§1, §3 and §5 also carry an HKJ checker companion**, which adds an actionable message beside javac's own. §2 and §6 javac catches on its own. See [Compile-Time Checks](../tooling/compile_checks.md).
+- **§4 compiles, and nothing reports it**, the checker included. `L` resolves to `Object` and stays there.
+~~~
+
+---
+
+## Find your message
+
+| The symptom | What it is | Caught by |
+|-------------|------------|-----------|
+| [`method eitherT cannot be applied`, expecting `Monad<F>`](#1-method-eithert-cannot-be-applied-to-given-types) | The outer monad was not passed to the factory | javac, plus `transformer-missing-monad` |
+| [`incompatible types`, with two `EitherTKind.Witness` shapes](#2-incompatible-types-error-type-mismatch-in-eithert-chain) | Two different error types `L` in one chain | javac |
+| [`mapT cannot be applied` on `StateT`](#3-method-mapt-cannot-be-applied-on-statet) | `StateT.mapT` needs a leading `Monad<G>` | javac, plus `state-t-mapt-arity` |
+| [`Either.right` silently gets `L = Object`](#4-the-phantom-l-on-eithertfromeither--eitherright) | Nothing constrains `L`, so javac defaults it | Nothing. Add the witness yourself |
+| [`cannot find symbol .value()` on a `Kind`](#5-cannot-find-symbol-value-on-a-kind) | `.value()` is on the concrete transformer, not on `Kind` | javac, plus `kind-value-narrow` |
+| [`For.from` not applicable, naming two stack types](#6-method-forfrom-is-not-applicable-with-the-wrong-monad) | Mixed transformer stacks in one comprehension | javac |
+
+Which line of defence answers depends on the mistake:
+
+```mermaid
+flowchart TD
+    C["Your transformer stack"]
+    J{"Does javac<br/>reject it?"}
+    N["Nothing says a word<br/>§4, L becomes Object"]
+    K{"Does an HKJ check<br/>run beside it?"}
+    KE["javac's error, plus an<br/>actionable HKJ message<br/>§1, §3, §5"]
+    JO["javac's error alone<br/>§2, §6"]
+
+    C --> J
+    J -->|no| N
+    J -->|yes| K
+    K -->|yes| KE
+    K -->|no| JO
+
+    classDef step fill:#8caaee,stroke:#1e66f5,color:#232634
+    classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
+    classDef caught fill:#a6d189,stroke:#40a02b,color:#232634
+    classDef missed fill:#e78284,stroke:#d20f39,color:#232634
+    class C step
+    class J,K decision
+    class KE,JO caught
+    class N missed
+```
 
 ---
 
 ## 1. "Method `eitherT` cannot be applied to given types"
 
-~~~admonish tip title="The HKJ checker catches this"
-Flagged at compile time by the `transformer-missing-monad` check
-(companion to javac's own error), naming the required outer `Monad<F>`
-(and `Monoid<W>` for `WriterTMonad`). See
-[Compile-Time Checks](../tooling/compile_checks.md).
-~~~
+**A javac error.** Every transformer monad needs a `Monad<F>` instance for the *outer* effect, and the factory cannot infer it from thin air.
 
 **The error:**
 
@@ -41,8 +84,6 @@ var eitherTMonad =
     Instances.eitherT();   // missing argument
 ```
 
-Every transformer monad needs a `Monad<F>` instance for the *outer* effect. The factory cannot infer it from thin air.
-
 **The fix:** pass the outer monad to the factory.
 
 <!-- verify -->
@@ -54,9 +95,15 @@ var eitherTMonad =
 
 The same rule applies to `OptionalTMonad`, `MaybeTMonad`, `ReaderTMonad`, `StateTMonad`, and `WriterTMonad`. `WriterTMonad` additionally requires a `Monoid<W>` for the output type.
 
+~~~admonish tip title="The HKJ checker catches this"
+The `transformer-missing-monad` check is the companion to javac's own error, and names the required outer `Monad<F>`, plus the `Monoid<W>` for `WriterTMonad`. See [Compile-Time Checks](../tooling/compile_checks.md).
+~~~
+
 ---
 
 ## 2. "Incompatible types: error type mismatch in EitherT chain"
+
+**A javac error.** Every step in an `EitherT` comprehension shares one error type `L`. Mixing a step that fails with `String` and one that fails with `DomainError` will not compile.
 
 **The error:**
 
@@ -79,18 +126,6 @@ EitherT<CompletableFutureKind.Witness, String, User> lookupUser(String id) {
 For.from(eitherTMonad, validatedET)
     .from(id -> lookupUser(id));   // String vs DomainError mismatch
 ```
-
-~~~admonish note title="This one really is a compile error (unlike Effect §5)"
-Contrast with [Effect §5](../effect/compiler_errors.md#5-the-error-type-is-silently-erased-across-a-chain),
-where the error type is *silently erased*. Here it is **not**: the
-transformer stack encodes `L` inside the witness itself
-(`EitherTKind.Witness<F, L>`), so a step with a different `L` is a
-genuinely different `Kind<…>` type and `For.from(...).from(...)`
-fails to type-check. The compiler does enforce this case; the section
-below is accurate as written.
-~~~
-
-Every step in an `EitherT` comprehension shares the same error type `L`. Mixing a step that fails with `String` and one that fails with `DomainError` will not compile.
 
 **The fix:** unify the error type, either by changing the function or by mapping at the boundary.
 
@@ -120,16 +155,17 @@ EitherT<CompletableFutureKind.Witness, DomainError, User> liftLookup(String id) 
 
 Option 1 is preferred for new code. Option 2 is useful when integrating with code you cannot change.
 
+~~~admonish note title="Why this one is caught, and the Path equivalent is not" collapsible=true
+Contrast with [Effect §5](../effect/compiler_errors.md#5-the-error-type-is-silently-erased-across-a-chain), where the error type is *silently erased*. Here it is not.
+
+The transformer stack encodes `L` inside the witness itself (`EitherTKind.Witness<F, L>`), so a step with a different `L` is a genuinely different `Kind<…>` type, and `For.from(...).from(...)` fails to type-check. The Path API's `Chainable<B>` carries no error type, which is what makes the same mistake compile there.
+~~~
+
 ---
 
 ## 3. "Method `mapT` cannot be applied" on `StateT`
 
-~~~admonish tip title="The HKJ checker catches this"
-Flagged at compile time by the `state-t-mapt-arity` check (companion to
-javac's own error), explaining that only `StateT.mapT` takes the
-leading `Monad<G>`. See
-[Compile-Time Checks](../tooling/compile_checks.md).
-~~~
+**A javac error.** `StateT.mapT` is the one `mapT` that takes a leading `Monad<G>`, because the state-threading function `S -> Kind<G, (S, A)>` has to close over the new monad.
 
 **The error:**
 
@@ -151,8 +187,6 @@ error: method mapT in record StateT<S,F,A> cannot be applied to given types;
 var optionalState = idState.mapT(idKind -> idToOptional.apply(idKind));   // missing first argument
 ```
 
-Most transformers' `mapT` takes a single function. `StateT.mapT` is the exception: because the state-threading function `S -> Kind<G, (S, A)>` must close over the new monad, the call requires an explicit `Monad<G>` instance as the first argument.
-
 **The fix:** pass the target monad alongside the function.
 
 <!-- verify -->
@@ -163,40 +197,29 @@ var optionalState = idState.mapT(optionalMonad, idKind -> idToOptional.apply(idK
 
 `EitherT.mapT`, `OptionalT.mapT`, `MaybeT.mapT`, `ReaderT.mapT`, and `WriterT.mapT` do not take this extra argument. Only `StateT` does.
 
+~~~admonish tip title="The HKJ checker catches this"
+The `state-t-mapt-arity` check is the companion to javac's own error, and explains that only `StateT.mapT` takes the leading `Monad<G>`. See [Compile-Time Checks](../tooling/compile_checks.md).
+~~~
+
 ---
 
 ## 4. The phantom `L` on `EitherT.fromEither` / `Either.right`
 
-~~~admonish warning title="No longer a compile error on the supported toolchain"
-Older write-ups described:
-
-```
-error: method fromEither ... cannot be applied to given types;
-  reason: cannot infer type-variable(s) F, L, R
-```
-
-On the supported compiler this **does not happen**. It is the same
-phantom-type-parameter situation as
-[Effect §1](../effect/compiler_errors.md#1-the-phantom-error-type-e-on-pathright):
-`Either.right(value)` has no Left, so when nothing constrains `L`
-modern `javac` resolves it to `java.lang.Object` and the code
-**compiles** rather than erroring. The mistake is silent, not loud.
-~~~
+**This compiles, and nothing reports it.** `Either.right(value)` has no Left, so when nothing constrains `L`, javac resolves it to `java.lang.Object` and says nothing.
 
 **The trigger:**
 
 <!-- verify -->
 ```java
-// L bound to DomainError from the typed variable -- fine:
+// L bound to DomainError by the typed variable: fine
 EitherT<CompletableFutureKind.Witness, DomainError, ValidatedOrder> step =
     EitherT.fromEither(futureMonad, Either.right(validated));
 
-// nothing constrains L -> L = Object, compiles silently:
+// nothing constrains L, so L = Object, and it compiles
 var untypedStep = EitherT.fromEither(futureMonad, Either.right(validated));
 ```
 
-**The fix:** pin `L` with an explicit type witness on the `Either` so
-`Object` never leaks in:
+**The fix:** pin `L` with an explicit type witness on the `Either`, so `Object` never leaks in:
 
 <!-- verify -->
 ```java
@@ -205,24 +228,24 @@ EitherT.fromEither(futureMonad, Either.<DomainError, ValidatedOrder>right(valida
 
 The witness costs nothing at runtime and keeps the error type honest.
 
-~~~admonish note title="Not caught by the HKJ checker"
-This is the excluded inference family (same as
-[Effect §1](../effect/compiler_errors.md#1-the-phantom-error-type-e-on-pathright)):
-modern `javac` silently resolves `L`, so there is no error for the
-checker to annotate. The witness is the fix. See
-[Compile-Time Checks](../tooling/compile_checks.md) for what the
-checker does and does not cover.
+~~~admonish note title="Why it is silent, and what older write-ups said" collapsible=true
+Older write-ups described an error here:
+
+```
+error: method fromEither ... cannot be applied to given types;
+  reason: cannot infer type-variable(s) F, L, R
+```
+
+On the supported compiler this does not happen. It is the same phantom-type-parameter situation as [Effect §1](../effect/compiler_errors.md#1-the-phantom-error-type-e-on-pathright): modern `javac` resolves `L` to `java.lang.Object` and the code compiles rather than erroring. The mistake is silent, not loud.
+
+The HKJ checker does not cover it either. This is the excluded inference family: javac raises nothing, so there is no error for a companion check to annotate, and an unconstrained `L` is not reliably distinguishable from code that means `Either<Object, …>`. The witness is the fix. See [Compile-Time Checks](../tooling/compile_checks.md) for what the checker does and does not cover.
 ~~~
 
 ---
 
 ## 5. "Cannot find symbol `.value()`" on a `Kind`
 
-~~~admonish tip title="The HKJ checker catches this"
-Flagged at compile time by the `kind-value-narrow` check (companion to
-javac's own error), pointing to the concrete-transformer narrow. See
-[Compile-Time Checks](../tooling/compile_checks.md).
-~~~
+**A javac error.** `.value()` is defined on the concrete `EitherT<F, L, R>`, and equivalently on `OptionalT`, `MaybeT`, `ReaderT`, `StateT` and `WriterT`. It is not part of the `Kind` interface, so a `Kind` value has to be narrowed back to the concrete transformer first.
 
 **The error:**
 
@@ -243,8 +266,6 @@ Kind<EitherTKind.Witness<CompletableFutureKind.Witness, DomainError>, Result> wo
 
 var result = workflow.value();   // Kind has no value() method
 ```
-
-`.value()` is defined on the concrete `EitherT<F, L, R>` (and equivalently on `OptionalT`, `MaybeT`, `ReaderT`, `StateT`, `WriterT`). It is not part of the `Kind` interface. When you have a `Kind` value, you must narrow it back to the concrete transformer first.
 
 **The fix:** call the matching narrow helper before extracting the underlying value.
 
@@ -268,9 +289,15 @@ EitherT<CompletableFutureKind.Witness, DomainError, Result> workflow =
 var result = workflow.value();
 ```
 
+~~~admonish tip title="The HKJ checker catches this"
+The `kind-value-narrow` check is the companion to javac's own error, and points at the concrete-transformer narrow. See [Compile-Time Checks](../tooling/compile_checks.md).
+~~~
+
 ---
 
 ## 6. "Method `For.from` is not applicable" with the wrong monad
+
+**A javac error.** `For.from(monad, source)` requires the source's witness type to match the monad's. Passing an `EitherTMonad` and an `OptionalT` mixes two different transformer stacks.
 
 **The error:**
 
@@ -291,8 +318,6 @@ For.from(eitherTMonad, OptionalT.fromKind(future))    // mismatched witness type
     .yield(user -> user);
 ```
 
-`For.from(monad, source)` requires the source's witness type to match the monad's witness type. Passing an `EitherTMonad` and an `OptionalT` mixes two different transformer stacks.
-
 **The fix:** make sure the monad you pass to `For.from` matches the witness of every step.
 
 <!-- verify -->
@@ -311,28 +336,24 @@ For.from(optionalTMonad, OptionalT.fromKind(future))
     .yield(user -> user.id());
 ```
 
-If you genuinely need to combine two effect layers (typed errors *and* absence in the same workflow), you are in stacking territory. See [Tutorial 03: Stacking Transformers](../tutorials/transformers/transformers_journey.md) and [Stack Archetypes](archetypes.md).
+If you genuinely need to combine two effect layers, typed errors *and* absence in the same workflow, you are in stacking territory. See [Tutorial 03: Stacking Transformers](../tutorials/transformers/transformers_journey.md) and [Stack Archetypes](archetypes.md).
 
 ---
 
-## Quick Diagnostic Table
-
-| Symptom | Likely cause | Fix |
-|---------|-------------|-----|
-| "method `eitherT` cannot be applied", expects `Monad<F>` | Forgot to pass the outer monad | `Instances.eitherT(futureMonad)` |
-| "incompatible types" with two `EitherTKind.Witness` shapes | Different error types `L` in the chain | Unify the error type or `mapLeft` at the boundary |
-| `mapT` "cannot be applied" on `StateT` | Missing `Monad<G>` first argument | `stateT.mapT(targetMonad, f)` |
-| "cannot infer type-variable" on `Either.right` / `EitherT.fromEither` | No `Left` value to infer `L` from | Add `Either.<E, A>right(...)` |
-| "cannot find symbol `.value()`" on a `Kind` | Need to narrow first | `EITHER_T.narrow(kind).value()` |
-| "For.from not applicable" with two stack types | Mixed transformer stacks | Use one consistent monad and lift accordingly |
-
----
+~~~admonish info title="Key Takeaways"
+* **The witness is what makes these errors loud.** A transformer stack carries `L` in the type, so a mismatched error type is a compile error rather than a runtime surprise.
+* **Every transformer factory wants the outer monad.** `Instances.eitherT(futureMonad)`, and a `Monoid<W>` as well for `WriterTMonad`.
+* **`StateT.mapT` is the one that takes a leading `Monad<G>`.** Every other transformer's `mapT` takes the function alone.
+* **`.value()` lives on the concrete transformer, not on `Kind`.** Narrow first, or declare the variable concrete and skip the round trip.
+* **Only §4 is silent.** An unconstrained `L` becomes `Object` with nothing to warn you, so pin it with `Either.<E, A>right(...)` at the source.
+~~~
 
 ~~~admonish tip title="See Also"
-- [Path or Transformer?](when_to_drop_to_transformers.md), the decision page that may save you from this chapter entirely
-- [Transformers at a Glance](transformers_at_a_glance.md), reference card for every transformer
-- [Effect Path Common Compiler Errors](../effect/compiler_errors.md), the equivalent for the Path API
-- [Migration Cookbook](migration_cookbook.md), side-by-side translations between styles
+- [Path or Transformer?](when_to_drop_to_transformers.md): the decision page that may save you from this chapter entirely
+- [Transformers at a Glance](transformers_at_a_glance.md): reference card for every transformer
+- [Effect Path Common Compiler Errors](../effect/compiler_errors.md): the equivalent for the Path API
+- [Compile-Time Checks](../tooling/compile_checks.md): the checks that add a message beside javac's own
+- [Migration Cookbook](migration_cookbook.md): side-by-side translations between styles
 ~~~
 
 ---


### PR DESCRIPTION
Follows [#819](https://github.com/higher-kinded-j/higher-kinded-j/pull/819), applying the same reference-page shape to the third error catalogue. The page was written as a linear document and used as a lookup table, with its diagnostic table at the bottom.

## A row that was wrong

The old diagnostic table offered this symptom for the phantom `L`:

> `"cannot infer type-variable"` on `Either.right` / `EitherT.fromEither`

§4 of the same page says that error **does not happen** on the supported toolchain: javac resolves `L` to `Object` and compiles silently. A reader scanning the table was being sent to look for a message javac never prints. The row now says what actually happens, `Either.right` silently gets `L = Object`.

## The severity axis

Not the optics catalogue's error / warning / note, and not the Effect page's either. Classified:

| | Sections | Caught by |
|---|---|---|
| javac error, with a checker companion | §1, §3, §5 | javac, plus `transformer-missing-monad` / `state-t-mapt-arity` / `kind-value-narrow` |
| javac error, javac alone | §2, §6 | javac |
| Compiles silently | §4 | Nothing, the checker included |

`compile_checks.md` has no check covering §2 or §6 (`witness-arity` is about unbounded witnesses, not mismatched ones), so the primer says javac catches those on its own rather than implying cover that does not exist.

**Why the compiler is mostly on your side here is the chapter's own argument for transformers**, and it was buried in a mid-section note. A transformer stack encodes `L` in the witness (`EitherTKind.Witness<F, L>`), so a step with the wrong error type is a genuinely different type rather than an erased one. That now leads the primer, set against the Path API's `Chainable<B>`, which carries no error type and lets [the same mistake compile](https://higher-kinded-j.github.io/effect/compiler_errors.html).

```mermaid
flowchart TD
    C["Your transformer stack"]
    J{"Does javac<br/>reject it?"}
    N["Nothing says a word<br/>§4, L becomes Object"]
    K{"Does an HKJ check<br/>run beside it?"}
    KE["javac's error, plus an<br/>actionable HKJ message<br/>§1, §3, §5"]
    JO["javac's error alone<br/>§2, §6"]

    C --> J
    J -->|no| N
    J -->|yes| K
    K -->|yes| KE
    K -->|no| JO

    classDef step fill:#8caaee,stroke:#1e66f5,color:#232634
    classDef decision fill:#e5c890,stroke:#df8e1d,color:#232634
    classDef caught fill:#a6d189,stroke:#40a02b,color:#232634
    classDef missed fill:#e78284,stroke:#d20f39,color:#232634
    class C step
    class J,K decision
    class KE,JO caught
    class N missed
```

## Structure

- The diagnostic table moves to the top as `## Find your message`, with symptom / what it is / caught by, each symptom linked to its section
- **Every section leads with a bolded verdict** ("A javac error", "This compiles, and nothing reports it"), then the quoted error, then the trigger, then the fix
- §4's "older write-ups described" framing now **follows** current behaviour instead of preceding it, and merges with the note saying the checker does not cover it either
- §2's contrast with the Path API moves into a collapsed `Why this one is caught, and the Path equivalent is not`
- Adds Key Takeaways; replaces the ` -- ` separator and the comma-separated See Also descriptions per `docs/STYLE-GUIDE.md`

## Verification

- `gradle :hkj-examples:bookVerify` passes. **All 15 verify markers unchanged**; the only code-fence changes are the mermaid block and one comment separator
- The book renders with the pinned toolchain with no errors
- Every anchor checked against the rendered HTML book-wide: **zero broken**, in-page, inbound, and the three cross-references out into the Effect page. No page deep-links into this one's anchors, which is what made renaming the table heading safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjqDGy1gWDqdnaZAP88Q7c
