### PR TITLE
Assert an Invalid's located FieldErrors as rendered lines (#691)

### DIFF
--- a/.claude/skills/hkj-test/SKILL.md
+++ b/.claude/skills/hkj-test/SKILL.md
@@ -95,7 +95,7 @@ assertThatEither(result).isRight().hasRightSatisfying(v ->
     assertThat(v).isPositive().isLessThan(100));
 ```
 
-`MaybeAssert` mirrors the shape with `isJust()` / `isNothing()`. `TryAssert` uses `isSuccess()` / `isFailure()`, plus `hasExceptionOfType(...)` and `hasExceptionSatisfying(...)`. `ValidatedAssert` uses `isValid()` / `isInvalid()`, plus `hasValueOfType` / `hasErrorOfType`.
+`MaybeAssert` mirrors the shape with `isJust()` / `isNothing()`. `TryAssert` uses `isSuccess()` / `isFailure()`, plus `hasExceptionOfType(...)` and `hasExceptionSatisfying(...)`. `ValidatedAssert` uses `isValid()` / `isInvalid()`, plus `hasValueOfType` / `hasErrorOfType`, and `hasFieldErrors(...)` for a located accumulation.
 
 ### NonEmptyList
 
@@ -135,17 +135,27 @@ Also `hasLeftSatisfying(...)` / `hasRightSatisfying(...)`.
 
 ### Validation accumulation (FieldError)
 
-There is **no** dedicated "accumulated validation" assertion; `ValidatedAssert` is unchanged. Assert accumulation by taking the `NonEmptyList<FieldError>` off the `Invalid` and asserting on the located errors:
+`hasFieldErrors` on `ValidatedAssert` asserts the whole accumulation at once: each `FieldError` rendered as `"path: message"`, compared in declaration order, which is the accumulation contract. It is the assertion for a codec parse, a mapping `parse`/`patch`, a fallible merge or an assembly companion:
+
+<!-- verify -->
+```java
+Validated<NonEmptyList<FieldError>, Customer> parsed = mapping.parse(dto);
+
+assertThatValidated(parsed)
+    .isInvalid()
+    .hasFieldErrors("customer.email: not an email address", "customer.age: must be positive");
+```
+
+It applies to the located-error channel only: the `Invalid` must carry an `Iterable` of `FieldError`, which `NonEmptyList<FieldError>` is. On any other error type it fails saying so - use `hasError` / `hasErrorSatisfying` there.
+
+To take a single error apart - its segments, or a message matched loosely - `assertThatFieldError` is the per-error assertion:
 
 <!-- verify -->
 ```java
 import static org.higherkindedj.hkt.assertions.FieldErrorAssert.assertThatFieldError;
 import static org.higherkindedj.hkt.assertions.NonEmptyListAssert.assertThatNonEmptyList;
 
-Validated<NonEmptyList<FieldError>, Customer> result = mapping.parse(dto);
-
-assertThatValidated(result).isInvalid();
-NonEmptyList<FieldError> errors = result.getError();
+NonEmptyList<FieldError> errors = mapping.parse(dto).getError();
 
 assertThatNonEmptyList(errors).hasSize(2);
 assertThatFieldError(errors.head()).hasPath("customer.email").hasMessageContaining("not an email");
@@ -417,7 +427,7 @@ Both modules are now in scope; no further imports are required.
 - **Forgetting the `unwrap` function on transformer asserts.** The transformer entry-points take *two* arguments: the Kind itself and an unwrapper of type `Function<Kind<F, X>, Optional<X>>`. For the common Optional-as-outer-monad case, the unwrapper is just `OPTIONAL::narrow`.
 - **Asserting on a Right value when the Either might be Left** (or any other state-mismatch). The assertions throw with a clear message; do not pre-call `.getRight()` outside the assertion chain.
 - **Using `ValidatedAssert.assertThatValidated(v, "description")` then trying `.as(...)` again.** The two-arg factory already calls `as(description)`. Subsequent `.as(...)` calls overwrite it.
-- **Looking for an "accumulated errors" assertion on `ValidatedAssert`.** There isn't one, and it is not an omission. Assert `isInvalid()`, take the `NonEmptyList<FieldError>` via `getError()`, then use `assertThatNonEmptyList` for the shape and `assertThatFieldError` (`hasPath` / `hasSegments` / `isUnlabelled`) for each located error.
+- **Hand-rolling `result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.of())` to assert an accumulation.** That is `hasFieldErrors(...)`. Drop to `getError()` plus `assertThatNonEmptyList` / `assertThatFieldError` only when you need one error's segments or a loose message match.
 - **Confusing a `Left` with a defect on `VResultPath`.** A typed domain failure is `isLeft()`; a thrown exception is `hasDefect()`. They are different channels.
 - **Passing duplicate fixtures to `assertLensLaws` / `assertAffineLaws`.** `a1` and `a2` must differ from each other and from the current focus, otherwise the set-set law is untestable. The harness fails fast with that message rather than silently passing.
 

--- a/hkj-book/src/glossary/optics.md
+++ b/hkj-book/src/glossary/optics.md
@@ -136,7 +136,7 @@ FieldError bare    = FieldError.of("not a postcode");   // unlocated leaf
 FieldError located = bare.at("zip").at("address");      // pathString() == "address.zip"
 ```
 
-**Located automatically:** `Validated.fields()` and the `parseIfPresent` edits prepend the field label onto each error's path, so a leaf validator creates unlocated `FieldError.of(...)`s and the assembly attaches the location. `hkj-test` ships `assertThatFieldError`.
+**Located automatically:** `Validated.fields()` and the `parseIfPresent` edits prepend the field label onto each error's path, so a leaf validator creates unlocated `FieldError.of(...)`s and the assembly attaches the location. `hkj-test` asserts the whole accumulation with `assertThatValidated(result).hasFieldErrors(...)`, and a single error's path with `assertThatFieldError`.
 
 **Related:** [Open-Arity Assembly](../monads/validated_assembly.md), [NonEmptyList](data-effects.md#nonemptylist), [Validated Assembly](#validated-assembly), [ValidatedPrism](#validatedprism)
 

--- a/hkj-book/src/monads/validated_assembly.md
+++ b/hkj-book/src/monads/validated_assembly.md
@@ -123,7 +123,7 @@ A component whose type is itself annotated accepts its sub-companion's result di
 | Steps where later ones depend on earlier results | `flatMap` / `via` (short-circuiting, by design) |
 
 ~~~admonish tip title="Testing located errors"
-`hkj-test` ships `assertThatFieldError` alongside `assertThatValidated`:
+`hkj-test` asserts a whole accumulation as rendered `"path: message"` lines with `assertThatValidated(result).hasFieldErrors(...)`, and takes a single error apart with `assertThatFieldError`:
 
 ```java
 {{#include ../../../hkj-examples/src/test/java/org/higherkindedj/example/book/monads/assembly/ValidatedAssemblyBookTest.java:field_error}}

--- a/hkj-book/src/tooling/test_assertions.md
+++ b/hkj-book/src/tooling/test_assertions.md
@@ -97,6 +97,22 @@ assertThatValidated(form)
     .hasErrorSatisfying(errors -> errors.size() == 2, "two errors collected");
 ```
 
+When the error channel is the located one - `NonEmptyList<FieldError>`, what every codec parse,
+mapping `parse`/`patch`, fallible merge and assembly companion returns - `hasFieldErrors` asserts
+the whole accumulation as rendered `"path: message"` lines, in declaration order:
+
+<!-- verify -->
+```java
+assertThatValidated(parsed)
+    .isInvalid()
+    .hasFieldErrors(
+        "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
+        "placedOn: not an ISO-8601 date (expected e.g. 2026-07-28)");
+```
+
+Order is asserted because declaration order *is* the accumulation contract. A reworded message
+fails as a one-line diff against the full rendered list.
+
 ### `LazyAssert`
 
 `Lazy` carries its own evaluation lifecycle, so the assertions track it explicitly:
@@ -345,7 +361,7 @@ void personMappingIsLawful() {
 }
 ```
 
-For asserting on the located failures themselves, `assertThatFieldError` pairs with `assertThatValidated`: it matches a `FieldError`'s path (`hasPath("address.zip")`) and message (`hasMessage`, `hasMessageContaining`) alongside the usual `Validated` assertions.
+For asserting on the located failures themselves, `assertThatValidated(...).hasFieldErrors(...)` takes the whole accumulation as rendered lines; `assertThatFieldError` takes one error apart, matching its path (`hasPath("address.zip")`) and message (`hasMessage`, `hasMessageContaining`).
 
 ~~~admonish tip title="See Also"
 - [Manual Gradle and Maven Setup](manual_setup.md) - Adding hkj-test to projects that do not use the HKJ build plugin

--- a/hkj-core/src/test/java/org/higherkindedj/hkt/validated/ValidatedAssemblyTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/hkt/validated/ValidatedAssemblyTest.java
@@ -44,10 +44,6 @@ class ValidatedAssemblyTest {
     return result.fold(nel -> nel.map(FieldError::pathString).toJavaList(), _ -> List.<String>of());
   }
 
-  private static List<String> rendered(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.<String>of());
-  }
-
   @Nested
   @DisplayName("accumulate(): generic error payload, and() chains")
   class Accumulate {
@@ -1183,7 +1179,7 @@ class ValidatedAssemblyTest {
               .field("email", badF("not an address"))
               .apply((a1, a2) -> a1 + a2);
 
-      assertThat(rendered(result)).containsExactly("just wrong", "email: not an address");
+      assertThatValidated(result).hasFieldErrors("just wrong", "email: not an address");
     }
 
     @Test
@@ -1203,8 +1199,7 @@ class ValidatedAssemblyTest {
               .field("address", address)
               .apply(Customer::new);
 
-      assertThatValidated(customer).isInvalid();
-      assertThat(rendered(customer)).containsExactly("address.zip: not a postcode");
+      assertThatValidated(customer).isInvalid().hasFieldErrors("address.zip: not a postcode");
     }
 
     @Test

--- a/hkj-core/src/test/java/org/higherkindedj/optics/validated/StandardCodecsTest.java
+++ b/hkj-core/src/test/java/org/higherkindedj/optics/validated/StandardCodecsTest.java
@@ -23,8 +23,6 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
-import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
-import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,10 +36,6 @@ import org.junit.jupiter.api.Test;
 @DisplayName("StandardCodecs - the stock ValidatedPrism vocabulary")
 class StandardCodecsTest {
 
-  private static List<String> errors(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.of());
-  }
-
   @Nested
   @DisplayName("identifiers")
   class Identifiers {
@@ -53,8 +47,8 @@ class StandardCodecsTest {
           StandardCodecs.uuid(), "123e4567-e89b-12d3-a456-426614174000", "not-a-uuid");
       assertThatValidated(StandardCodecs.uuid().parse("123E4567-E89B-12D3-A456-426614174000"))
           .isInvalid();
-      assertThat(errors(StandardCodecs.uuid().parse("nope")))
-          .containsExactly("not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)");
+      assertThatValidated(StandardCodecs.uuid().parse("nope"))
+          .hasFieldErrors("not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)");
       assertThat(StandardCodecs.uuid().build(new UUID(0L, 42L)))
           .isEqualTo("00000000-0000-0000-0000-00000000002a");
     }
@@ -64,8 +58,8 @@ class StandardCodecsTest {
     void uriCodec() {
       assertValidatedPrismLaws(
           StandardCodecs.uri(), "https://example.org/orders/42", "ht tp://broken");
-      assertThat(errors(StandardCodecs.uri().parse("ht tp://broken")))
-          .containsExactly("not a URI (expected e.g. https://example.org/orders/42)");
+      assertThatValidated(StandardCodecs.uri().parse("ht tp://broken"))
+          .hasFieldErrors("not a URI (expected e.g. https://example.org/orders/42)");
       assertThat(StandardCodecs.uri().build(URI.create("mailto:ada@example.org")))
           .isEqualTo("mailto:ada@example.org");
     }
@@ -95,8 +89,8 @@ class StandardCodecsTest {
     @DisplayName("localDate: ISO-8601 by default")
     void localDateIso() {
       assertValidatedPrismLaws(StandardCodecs.localDate(), "2026-07-28", "28/07/2026");
-      assertThat(errors(StandardCodecs.localDate().parse("2026-7-28")))
-          .containsExactly("not an ISO-8601 date (expected e.g. 2026-07-28)");
+      assertThatValidated(StandardCodecs.localDate().parse("2026-7-28"))
+          .hasFieldErrors("not an ISO-8601 date (expected e.g. 2026-07-28)");
       assertThat(StandardCodecs.localDate().build(LocalDate.of(2026, 7, 28)))
           .isEqualTo("2026-07-28");
     }
@@ -106,8 +100,8 @@ class StandardCodecsTest {
     void localDateCustomFormat() {
       var codec = StandardCodecs.localDate(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
       assertValidatedPrismLaws(codec, "28/07/2026", "2026-07-28");
-      assertThat(errors(codec.parse("2026-07-28")))
-          .containsExactly("not a date (expected e.g. 28/07/2026)");
+      assertThatValidated(codec.parse("2026-07-28"))
+          .hasFieldErrors("not a date (expected e.g. 28/07/2026)");
     }
 
     @Test
@@ -135,8 +129,8 @@ class StandardCodecsTest {
     void instantCodec() {
       assertValidatedPrismLaws(StandardCodecs.instant(), "2026-07-28T12:34:56Z", "not-an-instant");
       assertThatValidated(StandardCodecs.instant().parse("2026-07-28T13:34:56+01:00")).isInvalid();
-      assertThat(errors(StandardCodecs.instant().parse("nope")))
-          .containsExactly("not an ISO-8601 instant (expected e.g. 2026-07-28T12:34:56Z)");
+      assertThatValidated(StandardCodecs.instant().parse("nope"))
+          .hasFieldErrors("not an ISO-8601 instant (expected e.g. 2026-07-28T12:34:56Z)");
     }
 
     @Test
@@ -186,8 +180,8 @@ class StandardCodecsTest {
           StandardCodecs.offsetDateTime(), "2026-07-28T12:00:00+01:00", "2026-07-28T12:00+01:00");
       assertValidatedPrismLaws(
           StandardCodecs.offsetDateTime(), "2026-07-28T12:34:56.5Z", "2026-07-28T12:34:56.50Z");
-      assertThat(errors(StandardCodecs.offsetDateTime().parse("nope")))
-          .containsExactly(
+      assertThatValidated(StandardCodecs.offsetDateTime().parse("nope"))
+          .hasFieldErrors(
               "not an ISO-8601 date-time with offset (expected e.g. 2026-07-28T12:34:56+01:00)");
       assertThat(
               StandardCodecs.offsetDateTime()
@@ -201,8 +195,8 @@ class StandardCodecsTest {
       var codec =
           StandardCodecs.offsetDateTime(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"));
       assertValidatedPrismLaws(codec, "2026-07-28T12:34:56+01:00", "nope");
-      assertThat(errors(codec.parse("nope")))
-          .containsExactly("not a date-time (expected e.g. 2026-07-28T12:34:56+01:00)");
+      assertThatValidated(codec.parse("nope"))
+          .hasFieldErrors("not a date-time (expected e.g. 2026-07-28T12:34:56+01:00)");
       assertThatNullPointerException()
           .isThrownBy(() -> StandardCodecs.offsetDateTime(null))
           .withMessage("formatter must not be null");
@@ -226,8 +220,8 @@ class StandardCodecsTest {
     @DisplayName("enumByName: exact names parse; the message lists the permitted constants")
     void enumCodec() {
       assertValidatedPrismLaws(StandardCodecs.enumByName(OrderStatus.class), "PAID", "paid");
-      assertThat(errors(StandardCodecs.enumByName(OrderStatus.class).parse("SHIPPED")))
-          .containsExactly("unknown OrderStatus (expected one of NEW, PAID, CANCELLED)");
+      assertThatValidated(StandardCodecs.enumByName(OrderStatus.class).parse("SHIPPED"))
+          .hasFieldErrors("unknown OrderStatus (expected one of NEW, PAID, CANCELLED)");
       assertThat(StandardCodecs.enumByName(OrderStatus.class).build(OrderStatus.CANCELLED))
           .isEqualTo("CANCELLED");
     }
@@ -265,8 +259,8 @@ class StandardCodecsTest {
     void bigDecimalCodec() {
       assertValidatedPrismLaws(StandardCodecs.bigDecimal(), "123.45", "1E+3");
       assertValidatedPrismLaws(StandardCodecs.bigDecimal(), "0.010", "abc");
-      assertThat(errors(StandardCodecs.bigDecimal().parse("1E+3")))
-          .containsExactly("not a number in plain notation (expected e.g. 123.45)");
+      assertThatValidated(StandardCodecs.bigDecimal().parse("1E+3"))
+          .hasFieldErrors("not a number in plain notation (expected e.g. 123.45)");
       assertThat(StandardCodecs.bigDecimal().build(new BigDecimal("0.010"))).isEqualTo("0.010");
     }
 
@@ -285,16 +279,16 @@ class StandardCodecsTest {
     void intCodec() {
       assertValidatedPrismLaws(StandardCodecs.intFromString(), "42", "007");
       assertValidatedPrismLaws(StandardCodecs.intFromString(), "-7", "+7");
-      assertThat(errors(StandardCodecs.intFromString().parse("nope")))
-          .containsExactly("not a 32-bit integer (expected e.g. 42)");
+      assertThatValidated(StandardCodecs.intFromString().parse("nope"))
+          .hasFieldErrors("not a 32-bit integer (expected e.g. 42)");
     }
 
     @Test
     @DisplayName("longFromString: as intFromString with a wider range")
     void longCodec() {
       assertValidatedPrismLaws(StandardCodecs.longFromString(), "9223372036854775807", "0x10");
-      assertThat(errors(StandardCodecs.longFromString().parse("nope")))
-          .containsExactly("not a 64-bit integer (expected e.g. 42)");
+      assertThatValidated(StandardCodecs.longFromString().parse("nope"))
+          .hasFieldErrors("not a 64-bit integer (expected e.g. 42)");
     }
 
     @Test
@@ -302,8 +296,8 @@ class StandardCodecsTest {
     void doubleCodec() {
       assertValidatedPrismLaws(StandardCodecs.doubleFromString(), "3.14", "1e3");
       assertValidatedPrismLaws(StandardCodecs.doubleFromString(), "NaN", "nan");
-      assertThat(errors(StandardCodecs.doubleFromString().parse("1e3")))
-          .containsExactly("not a double in canonical form (expected e.g. 3.14)");
+      assertThatValidated(StandardCodecs.doubleFromString().parse("1e3"))
+          .hasFieldErrors("not a double in canonical form (expected e.g. 3.14)");
     }
 
     @Test
@@ -311,8 +305,8 @@ class StandardCodecsTest {
     void booleanCodec() {
       assertValidatedPrismLaws(StandardCodecs.booleanStrict(), "true", "TRUE");
       assertValidatedPrismLaws(StandardCodecs.booleanStrict(), "false", "no");
-      assertThat(errors(StandardCodecs.booleanStrict().parse("TRUE")))
-          .containsExactly("not a boolean (expected true or false)");
+      assertThatValidated(StandardCodecs.booleanStrict().parse("TRUE"))
+          .hasFieldErrors("not a boolean (expected true or false)");
     }
   }
 
@@ -324,8 +318,8 @@ class StandardCodecsTest {
     @DisplayName("currency: ISO 4217 codes, uppercase as the standard defines them")
     void currencyCodec() {
       assertValidatedPrismLaws(StandardCodecs.currency(), "GBP", "gbp");
-      assertThat(errors(StandardCodecs.currency().parse("notacurrency")))
-          .containsExactly("not an ISO 4217 currency code (expected e.g. GBP)");
+      assertThatValidated(StandardCodecs.currency().parse("notacurrency"))
+          .hasFieldErrors("not an ISO 4217 currency code (expected e.g. GBP)");
       assertThat(StandardCodecs.currency().build(Currency.getInstance("EUR"))).isEqualTo("EUR");
     }
 
@@ -333,8 +327,8 @@ class StandardCodecsTest {
     @DisplayName("locale: BCP 47 tags in canonical case; case-folded tags are rejections")
     void localeCodec() {
       assertValidatedPrismLaws(StandardCodecs.locale(), "en-GB", "en-gb");
-      assertThat(errors(StandardCodecs.locale().parse("not a tag!")))
-          .containsExactly("not a BCP 47 language tag (expected e.g. en-GB)");
+      assertThatValidated(StandardCodecs.locale().parse("not a tag!"))
+          .hasFieldErrors("not a BCP 47 language tag (expected e.g. en-GB)");
       assertThat(StandardCodecs.locale().build(Locale.forLanguageTag("en-GB"))).isEqualTo("en-GB");
     }
   }
@@ -353,9 +347,9 @@ class StandardCodecsTest {
               .field("id", StandardCodecs.uuid().parse("123e4567-e89b-12d3-a456-426614174000"))
               .apply((date, total, id) -> List.of(date, total, id));
 
-      assertThatValidated(result).isInvalid();
-      assertThat(errors(result))
-          .containsExactly(
+      assertThatValidated(result)
+          .isInvalid()
+          .hasFieldErrors(
               "placedOn: not an ISO-8601 date (expected e.g. 2026-07-28)",
               "total: not a number in plain notation (expected e.g. 123.45)");
     }

--- a/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/book/BookSnippetVerificationTest.java
@@ -60,7 +60,7 @@ class BookSnippetVerificationTest {
    * compiled source directly and is a stronger guarantee than compiling a copy of it. Lower the
    * floor deliberately then, and say so in the commit message.
    */
-  private static final int MINIMUM_VERIFIED_SNIPPETS = 2439;
+  private static final int MINIMUM_VERIFIED_SNIPPETS = 2441;
 
   /**
    * How many of those snippets must quote a diagnostic, under {@code verify:rejects} or {@code

--- a/hkj-examples/src/test/java/org/higherkindedj/example/basic/validated/GeneratedAssemblyTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/basic/validated/GeneratedAssemblyTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.FieldErrorAssert.assertThatFieldError;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
-import java.util.List;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
@@ -19,10 +18,6 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("@GenerateAssembly end-to-end")
 class GeneratedAssemblyTest {
-
-  private static List<String> rendered(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.<String>of());
-  }
 
   @Test
   @DisplayName("All components valid: assemble() invokes the canonical constructor")
@@ -47,8 +42,9 @@ class GeneratedAssemblyTest {
             .age(Validated.invalidNel(FieldError.of("not a number")))
             .assemble();
 
-    assertThatValidated(user).isInvalid();
-    assertThat(rendered(user)).containsExactly("name: must not be blank", "age: not a number");
+    assertThatValidated(user)
+        .isInvalid()
+        .hasFieldErrors("name: must not be blank", "age: not a number");
   }
 
   @Test

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/StandardCodecsBookTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/StandardCodecsBookTest.java
@@ -7,7 +7,6 @@ import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidat
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
@@ -38,9 +37,9 @@ class StandardCodecsBookTest {
     Validated<NonEmptyList<FieldError>, Order> parsed =
         OrderMappingImpl.INSTANCE.parse(new OrderDto("NOPE", "28/07/2026", "SHIPPED", "1E+3"));
 
-    assertThatValidated(parsed).isInvalid();
-    assertThat(rendered(parsed))
-        .containsExactly(
+    assertThatValidated(parsed)
+        .isInvalid()
+        .hasFieldErrors(
             "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
             "placedOn: not an ISO-8601 date (expected e.g. 2026-07-28)",
             "status: unknown OrderStatus (expected one of NEW, PAID, CANCELLED)",
@@ -90,9 +89,5 @@ class StandardCodecsBookTest {
             AssetMappingImpl.INSTANCE.parse(
                 new AssetDto(upper.toLowerCase(java.util.Locale.ROOT), "rack")))
         .isInvalid();
-  }
-
-  private static List<String> rendered(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.of());
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/WideMappingLawsTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/WideMappingLawsTest.java
@@ -5,7 +5,6 @@ package org.higherkindedj.example.book.mapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
-import java.util.List;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
@@ -62,9 +61,9 @@ class WideMappingLawsTest {
     Validated<NonEmptyList<FieldError>, WideAccount> parsed =
         WideAccountMappingImpl.INSTANCE.parse(wire);
 
-    assertThatValidated(parsed).isInvalid();
-    assertThat(rendered(parsed))
-        .containsExactly(
+    assertThatValidated(parsed)
+        .isInvalid()
+        .hasFieldErrors(
             "f1: must not be null", "f17: must not be null", "email: not an email address");
     // ANCHOR_END: wide_laws
   }
@@ -85,9 +84,5 @@ class WideMappingLawsTest {
     return new WideAccountDto(
         "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14",
         "v15", "v16", "v17", "v18", "v19", email);
-  }
-
-  private static List<String> rendered(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.of());
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/capstone/BoundaryCapstoneBookLawsTest.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/example/book/mapping/capstone/BoundaryCapstoneBookLawsTest.java
@@ -49,9 +49,9 @@ class BoundaryCapstoneBookLawsTest {
 
     Validated<NonEmptyList<FieldError>, Order> parsed = OrderMappingImpl.INSTANCE.parse(hostile);
 
-    assertThatValidated(parsed).isInvalid();
-    assertThat(rendered(parsed))
-        .containsExactly(
+    assertThatValidated(parsed)
+        .isInvalid()
+        .hasFieldErrors(
             "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
             "customer.email: not an email address",
             "lines.1.price: not a number in plain notation (expected e.g. 123.45)",
@@ -119,9 +119,5 @@ class BoundaryCapstoneBookLawsTest {
     bean.setName(name);
     bean.setEmail(email);
     return bean;
-  }
-
-  private static List<String> rendered(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.of());
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial12_AccumulatingAssembly.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/coretypes/Tutorial12_AccumulatingAssembly.java
@@ -93,11 +93,6 @@ public class Tutorial12_AccumulatingAssembly {
     }
   }
 
-  /** Renders each error as {@code "path: message"} so ordering and location are easy to assert. */
-  private static List<String> errorStrings(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.<String>of());
-  }
-
   // ═════════════════════════════════════════════════════════════════════════
   // Exercise 1: A first assembly
   // ═════════════════════════════════════════════════════════════════════════
@@ -161,8 +156,7 @@ public class Tutorial12_AccumulatingAssembly {
     Validated<NonEmptyList<FieldError>, User> result = answerRequired();
     List<String> expected = answerRequired();
 
-    assertThatValidated(result).isInvalid();
-    assertThat(errorStrings(result)).isEqualTo(expected);
+    assertThatValidated(result).isInvalid().hasFieldErrors(expected.toArray(String[]::new));
     assertThat(expected).hasSize(2);
   }
 
@@ -235,8 +229,7 @@ public class Tutorial12_AccumulatingAssembly {
 
     Validated<NonEmptyList<FieldError>, Customer> result = answerRequired();
 
-    assertThatValidated(result).isInvalid();
-    assertThat(errorStrings(result)).containsExactly("address.zip: not a postcode");
+    assertThatValidated(result).isInvalid().hasFieldErrors("address.zip: not a postcode");
   }
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -319,8 +312,7 @@ public class Tutorial12_AccumulatingAssembly {
 
     Validated<NonEmptyList<FieldError>, Pair> corrected = answerRequired();
 
-    assertThatValidated(corrected).isInvalid();
-    assertThat(errorStrings(corrected)).containsExactly("email: not an address");
+    assertThatValidated(corrected).isInvalid().hasFieldErrors("email: not an address");
   }
 
   /*

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial24_MultiEdit.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial24_MultiEdit.java
@@ -5,7 +5,6 @@ package org.higherkindedj.tutorial.optics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
-import java.util.List;
 import org.higherkindedj.hkt.Update;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
@@ -98,10 +97,6 @@ public class Tutorial24_MultiEdit {
     } catch (NumberFormatException e) {
       return Validated.invalidNel(FieldError.of("must be a whole number"));
     }
-  }
-
-  private static List<String> errorStrings(Validated<NonEmptyList<FieldError>, ?> validated) {
-    return validated.getError().toJavaList().stream().map(FieldError::toString).toList();
   }
 
   @Nested
@@ -235,9 +230,9 @@ public class Tutorial24_MultiEdit {
       // TODO: accumulate BOTH located fallible edits and apply.
       Validated<NonEmptyList<FieldError>, Profile> patched = answerRequired();
 
-      assertThatValidated(patched).isInvalid();
-      assertThat(errorStrings(patched))
-          .containsExactly("email: not an email address", "age: must be a whole number");
+      assertThatValidated(patched)
+          .isInvalid()
+          .hasFieldErrors("email: not an email address", "age: must be a whole number");
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial25_ValidatedPrism.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial25_ValidatedPrism.java
@@ -5,7 +5,6 @@ package org.higherkindedj.tutorial.optics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
-import java.util.List;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
@@ -169,9 +168,9 @@ public class Tutorial25_ValidatedPrism {
       // (label "percent") so both failures surface together.
       Validated<NonEmptyList<FieldError>, Discount> result = answerRequired();
 
-      assertThatValidated(result).isInvalid();
-      assertThat(result.getError().toJavaList().stream().map(FieldError::toString).toList())
-          .isEqualTo(List.of("name: blank", "percent: must be between 0 and 100"));
+      assertThatValidated(result)
+          .isInvalid()
+          .hasFieldErrors("name: blank", "percent: must be between 0 and 100");
     }
   }
 

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial26_RecordMapping.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/optics/Tutorial26_RecordMapping.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 import org.higherkindedj.example.tutorials.mapping.Booking;
 import org.higherkindedj.example.tutorials.mapping.BookingDto;
@@ -131,13 +130,11 @@ public class Tutorial26_RecordMapping {
     /**
      * Exercise 3: the payoff.
      *
-     * <p>Task: parse this three-defect wire and collect the rendered errors: a bad id, a bad email
-     * inside the <em>nested</em> guest, and a bad date. All three must surface at once, in
-     * declaration order, each located.
+     * <p>Task: parse this three-defect wire: a bad id, a bad email inside the <em>nested</em>
+     * guest, and a bad date. All three must surface at once, in declaration order, each located.
      *
      * <pre>
-     *   // Hint 1: parse it, then render with
-     *   //         {@code parsed.getError().map(FieldError::toString).toJavaList()}.
+     *   // Hint 1: parse it; {@code hasFieldErrors} renders each error as "path: message".
      *   // Hint 2: the nested guest's failure locates as {@code guest.email}.
      * </pre>
      */
@@ -147,11 +144,12 @@ public class Tutorial26_RecordMapping {
       BookingDto hostile =
           new BookingDto("NOPE", new GuestDto("Ada Lovelace", "not-an-email"), "28/07/2026", 3);
 
-      // TODO: parse the hostile wire and render its errors as strings.
-      List<String> errors = answerRequired();
+      // TODO: parse the hostile wire.
+      Validated<NonEmptyList<FieldError>, Booking> parsed = answerRequired();
 
-      assertThat(errors)
-          .containsExactly(
+      assertThatValidated(parsed)
+          .isInvalid()
+          .hasFieldErrors(
               "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
               "guest.email: not an email address",
               "arrival: not an ISO-8601 date (expected e.g. 2026-07-28)");

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial12_AccumulatingAssembly_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/coretypes/Tutorial12_AccumulatingAssembly_Solution.java
@@ -42,10 +42,6 @@ public class Tutorial12_AccumulatingAssembly_Solution {
     }
   }
 
-  private static List<String> errorStrings(Validated<NonEmptyList<FieldError>, ?> result) {
-    return result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.<String>of());
-  }
-
   // ─── Exercise 1 ────────────────────────────────────────────────────────────
 
   /**
@@ -110,8 +106,7 @@ public class Tutorial12_AccumulatingAssembly_Solution {
             .apply(User::new);
     List<String> expected = List.of("name: must not be blank", "age: not a number");
 
-    assertThatValidated(result).isInvalid();
-    assertThat(errorStrings(result)).isEqualTo(expected);
+    assertThatValidated(result).isInvalid().hasFieldErrors(expected.toArray(String[]::new));
     assertThat(expected).hasSize(2);
   }
 
@@ -177,8 +172,7 @@ public class Tutorial12_AccumulatingAssembly_Solution {
             .field("address", address)
             .apply(Customer::new);
 
-    assertThatValidated(result).isInvalid();
-    assertThat(errorStrings(result)).containsExactly("address.zip: not a postcode");
+    assertThatValidated(result).isInvalid().hasFieldErrors("address.zip: not a postcode");
   }
 
   // ─── Exercise 5 ────────────────────────────────────────────────────────────
@@ -242,7 +236,6 @@ public class Tutorial12_AccumulatingAssembly_Solution {
             .field("email", parseEmail("oops"))
             .apply(Pair::new);
 
-    assertThatValidated(corrected).isInvalid();
-    assertThat(errorStrings(corrected)).containsExactly("email: not an address");
+    assertThatValidated(corrected).isInvalid().hasFieldErrors("email: not an address");
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial24_MultiEdit_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial24_MultiEdit_Solution.java
@@ -5,7 +5,6 @@ package org.higherkindedj.tutorial.solutions.optics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
-import java.util.List;
 import org.higherkindedj.hkt.Update;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
@@ -57,10 +56,6 @@ public class Tutorial24_MultiEdit_Solution {
     } catch (NumberFormatException e) {
       return Validated.invalidNel(FieldError.of("must be a whole number"));
     }
-  }
-
-  private static List<String> errorStrings(Validated<NonEmptyList<FieldError>, ?> validated) {
-    return validated.getError().toJavaList().stream().map(FieldError::toString).toList();
   }
 
   @Nested
@@ -162,9 +157,9 @@ public class Tutorial24_MultiEdit_Solution {
                   Edit.parseIfPresent(AGE, "not-a-number", Tutorial24_MultiEdit_Solution::parseAge))
               .apply(eve);
 
-      assertThatValidated(patched).isInvalid();
-      assertThat(errorStrings(patched))
-          .containsExactly("email: not an email address", "age: must be a whole number");
+      assertThatValidated(patched)
+          .isInvalid()
+          .hasFieldErrors("email: not an email address", "age: must be a whole number");
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial25_ValidatedPrism_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial25_ValidatedPrism_Solution.java
@@ -5,7 +5,6 @@ package org.higherkindedj.tutorial.solutions.optics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
-import java.util.List;
 import java.util.Optional;
 import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.validated.FieldError;
@@ -114,9 +113,9 @@ public class Tutorial25_ValidatedPrism_Solution {
               .field("percent", percent.parse("125%"))
               .apply(Discount::new);
 
-      assertThatValidated(result).isInvalid();
-      assertThat(result.getError().toJavaList().stream().map(FieldError::toString).toList())
-          .isEqualTo(List.of("name: blank", "percent: must be between 0 and 100"));
+      assertThatValidated(result)
+          .isInvalid()
+          .hasFieldErrors("name: blank", "percent: must be between 0 and 100");
     }
   }
 }

--- a/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial26_RecordMapping_Solution.java
+++ b/hkj-examples/src/test/java/org/higherkindedj/tutorial/solutions/optics/Tutorial26_RecordMapping_Solution.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 import org.higherkindedj.example.tutorials.mapping.Booking;
 import org.higherkindedj.example.tutorials.mapping.BookingDto;
@@ -89,10 +88,10 @@ public class Tutorial26_RecordMapping_Solution {
 
       Validated<NonEmptyList<FieldError>, Booking> parsed =
           BookingMappingImpl.INSTANCE.parse(hostile);
-      List<String> errors = parsed.getError().map(FieldError::toString).toJavaList();
 
-      assertThat(errors)
-          .containsExactly(
+      assertThatValidated(parsed)
+          .isInvalid()
+          .hasFieldErrors(
               "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
               "guest.email: not an email address",
               "arrival: not an ISO-8601 date (expected e.g. 2026-07-28)");

--- a/hkj-examples/src/test/resources/fixtures/tooling_test_assertions.java
+++ b/hkj-examples/src/test/resources/fixtures/tooling_test_assertions.java
@@ -37,9 +37,11 @@ import org.higherkindedj.hkt.instances.Instances;
 import org.higherkindedj.hkt.io.IO;
 import org.higherkindedj.hkt.lazy.Lazy;
 import org.higherkindedj.hkt.maybe.Maybe;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
 import org.higherkindedj.hkt.optional.OptionalKind;
 import org.higherkindedj.hkt.state.StateTuple;
 import org.higherkindedj.hkt.trymonad.Try;
+import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
 import org.higherkindedj.hkt.vstream.VStream;
 import org.higherkindedj.hkt.vtask.VTask;
@@ -107,6 +109,13 @@ class Fixture {
 
   static final Validated<List<String>, String> form =
       Validated.invalid(List.of("name required", "email invalid"));
+
+  static final Validated<NonEmptyList<FieldError>, Order> parsed =
+      Validated.invalid(
+          NonEmptyList.of(
+              FieldError.of("not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)")
+                  .at("id"),
+              FieldError.of("not an ISO-8601 date (expected e.g. 2026-07-28)").at("placedOn")));
 
   static final Lazy<Integer> failing =
       Lazy.defer(

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedMappingLawsTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/GeneratedMappingLawsTest.java
@@ -4,6 +4,7 @@ package org.higherkindedj.optics.processing;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.optics.processing.RuntimeCompilationHelper.invoke;
 
 import com.google.testing.compile.Compilation;
@@ -131,10 +132,7 @@ class GeneratedMappingLawsTest {
               .getDeclaredConstructor(String.class, int.class)
               .newInstance(null, 41);
       Validated<NonEmptyList<FieldError>, Object> parsed = asValidatedPrism(impl).parse(nullWire);
-      Assertions.assertThat(parsed.isInvalid()).isTrue();
-      Assertions.assertThat(
-              parsed.getError().toJavaList().stream().map(FieldError::toString).toList())
-          .containsExactly("name: must not be null");
+      assertThatValidated(parsed).isInvalid().hasFieldErrors("name: must not be null");
     } catch (ReflectiveOperationException e) {
       throw new AssertionError(e);
     }

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MappingProcessorTest.java
@@ -4,6 +4,7 @@ package org.higherkindedj.optics.processing;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.optics.processing.RuntimeCompilationHelper.invoke;
 
 import com.google.testing.compile.Compilation;
@@ -1290,10 +1291,9 @@ class MappingProcessorTest {
         @SuppressWarnings("unchecked")
         Validated<NonEmptyList<FieldError>, Object> parsed =
             (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", companyDto);
-        Assertions.assertThat(parsed.isInvalid()).isTrue();
-        Assertions.assertThat(
-                parsed.getError().toJavaList().stream().map(FieldError::toString).toList())
-            .containsExactly("customers.1.email: not an email address");
+        assertThatValidated(parsed)
+            .isInvalid()
+            .hasFieldErrors("customers.1.email: not an email address");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -2067,10 +2067,6 @@ class MappingProcessorTest {
       return (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "patch", domain, wire);
     }
 
-    private List<String> renderedErrors(Validated<NonEmptyList<FieldError>, Object> result) {
-      return result.getError().toJavaList().stream().map(FieldError::toString).toList();
-    }
-
     @Test
     @DisplayName("a leaf-carrying projection emits build + validated patch, no asLens, no parse")
     void leafProjectionEmitsBuildAndPatch() {
@@ -2166,9 +2162,9 @@ class MappingProcessorTest {
                 .newInstance("nope", null, 44);
 
         Validated<NonEmptyList<FieldError>, Object> patched = patch(impl, domain, wire);
-        Assertions.assertThat(patched.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(patched))
-            .containsExactly("email: not an email address", "notes: must not be null");
+        assertThatValidated(patched)
+            .isInvalid()
+            .hasFieldErrors("email: not an email address", "notes: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -2194,9 +2190,9 @@ class MappingProcessorTest {
                 .newInstance(null, null, 44);
 
         Validated<NonEmptyList<FieldError>, Object> patched = patch(impl, domain, wire);
-        Assertions.assertThat(patched.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(patched))
-            .containsExactly("email: must not be null", "notes: must not be null");
+        assertThatValidated(patched)
+            .isInvalid()
+            .hasFieldErrors("email: must not be null", "notes: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -2262,8 +2258,7 @@ class MappingProcessorTest {
                 wireClass
                     .getDeclaredConstructor(String.class, String.class)
                     .newInstance("nope", "new memo"));
-        Assertions.assertThat(bad.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(bad)).containsExactly("email: not an email address");
+        assertThatValidated(bad).isInvalid().hasFieldErrors("email: not an email address");
 
         // A valid wire writes the renamed component back to its domain source.
         Validated<NonEmptyList<FieldError>, Object> good =
@@ -2388,9 +2383,7 @@ class MappingProcessorTest {
                 .newInstance(wireAddress);
 
         Validated<NonEmptyList<FieldError>, Object> patched = patch(impl, domain, wire);
-        Assertions.assertThat(patched.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(patched))
-            .containsExactly("address.zip: must be 5 digits");
+        assertThatValidated(patched).isInvalid().hasFieldErrors("address.zip: must be 5 digits");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -2466,10 +2459,8 @@ class MappingProcessorTest {
                 .newInstance(List.of("good@example.com", "nope"));
 
         Validated<NonEmptyList<FieldError>, Object> patched = patch(impl, domain, wire);
-        Assertions.assertThat(patched.isInvalid()).isTrue();
         // "nope" at position 1: located by index, making this test's name literal.
-        Assertions.assertThat(renderedErrors(patched))
-            .containsExactly("emails.1: not an email address");
+        assertThatValidated(patched).isInvalid().hasFieldErrors("emails.1: not an email address");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -2566,8 +2557,7 @@ class MappingProcessorTest {
                 wireClass
                     .getDeclaredConstructor(java.util.Optional.class)
                     .newInstance(java.util.Optional.of("nope")));
-        Assertions.assertThat(bad.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(bad)).containsExactly("backup: not an email address");
+        assertThatValidated(bad).isInvalid().hasFieldErrors("backup: not an email address");
 
         Validated<NonEmptyList<FieldError>, Object> nullRead =
             patch(
@@ -2576,8 +2566,7 @@ class MappingProcessorTest {
                 wireClass
                     .getDeclaredConstructor(java.util.Optional.class)
                     .newInstance(new Object[] {null}));
-        Assertions.assertThat(nullRead.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(nullRead)).containsExactly("backup: must not be null");
+        assertThatValidated(nullRead).isInvalid().hasFieldErrors("backup: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -2649,11 +2638,9 @@ class MappingProcessorTest {
                 .newInstance(new LinkedHashMap<>(Map.of("work", "nope")));
 
         Validated<NonEmptyList<FieldError>, Object> patched = patch(impl, domain, wire);
-        Assertions.assertThat(patched.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(patched)).hasSize(1);
-        Assertions.assertThat(renderedErrors(patched).getFirst())
-            .startsWith("entries")
-            .contains("not an email address");
+        assertThatValidated(patched)
+            .isInvalid()
+            .hasFieldErrors("entries.work: not an email address");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -7765,10 +7752,6 @@ class MappingProcessorTest {
       return (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", wire);
     }
 
-    private List<String> renderedErrors(Validated<NonEmptyList<FieldError>, Object> result) {
-      return result.getError().toJavaList().stream().map(FieldError::toString).toList();
-    }
-
     @Test
     @DisplayName(
         "null components are located, accumulated invalids, never an NPE — the guard"
@@ -7786,9 +7769,9 @@ class MappingProcessorTest {
                 .newInstance(null, "not-an-email", 36);
 
         Validated<NonEmptyList<FieldError>, Object> parsed = parse(impl, wire);
-        Assertions.assertThat(parsed.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(parsed))
-            .containsExactly("name: must not be null", "email: not an email address");
+        assertThatValidated(parsed)
+            .isInvalid()
+            .hasFieldErrors("name: must not be null", "email: not an email address");
 
         // A null leaf read never reaches the leaf's prism (which would throw): guard first.
         Object nullLeafWire =
@@ -7796,8 +7779,7 @@ class MappingProcessorTest {
                 .loadClass("com.example.UserDto")
                 .getDeclaredConstructor(String.class, String.class, int.class)
                 .newInstance("Ada", null, 36);
-        Assertions.assertThat(renderedErrors(parse(impl, nullLeafWire)))
-            .containsExactly("email: must not be null");
+        assertThatValidated(parse(impl, nullLeafWire)).hasFieldErrors("email: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -7880,8 +7862,7 @@ class MappingProcessorTest {
                 .getDeclaredConstructor(String.class, result.loadClass("com.example.CustomerDto"))
                 .newInstance("7", innerNull);
 
-        Assertions.assertThat(renderedErrors(parse(impl, wire)))
-            .containsExactly("customer.name: must not be null");
+        assertThatValidated(parse(impl, wire)).hasFieldErrors("customer.name: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -7984,9 +7965,7 @@ class MappingProcessorTest {
         @SuppressWarnings("unchecked")
         Validated<NonEmptyList<FieldError>, Object> patched =
             (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "patch", domain, wire);
-        Assertions.assertThat(patched.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(patched))
-            .containsExactly("address.zip: must not be null");
+        assertThatValidated(patched).isInvalid().hasFieldErrors("address.zip: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -8051,8 +8030,7 @@ class MappingProcessorTest {
                 .loadClass("com.example.RosterDto")
                 .getDeclaredConstructor(String.class, List.class)
                 .newInstance("7", null);
-        Assertions.assertThat(renderedErrors(parse(impl, nullListWire)))
-            .containsExactly("emails: must not be null");
+        assertThatValidated(parse(impl, nullListWire)).hasFieldErrors("emails: must not be null");
 
         // A null ELEMENT is a located invalid at its index,
         // completing the doctrine inside containers.
@@ -8061,8 +8039,8 @@ class MappingProcessorTest {
                 .loadClass("com.example.RosterDto")
                 .getDeclaredConstructor(String.class, List.class)
                 .newInstance("7", Arrays.asList("a@b.c", null));
-        Assertions.assertThat(renderedErrors(parse(impl, nullElementWire)))
-            .containsExactly("emails.1: must not be null");
+        assertThatValidated(parse(impl, nullElementWire))
+            .hasFieldErrors("emails.1: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -8160,10 +8138,9 @@ class MappingProcessorTest {
         @SuppressWarnings("unchecked")
         Validated<NonEmptyList<FieldError>, Object> parsed =
             (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", pageDto);
-        Assertions.assertThat(parsed.isInvalid()).isTrue();
-        Assertions.assertThat(
-                parsed.getError().toJavaList().stream().map(FieldError::toString).toList())
-            .containsExactly("items.1.email: not an email address");
+        assertThatValidated(parsed)
+            .isInvalid()
+            .hasFieldErrors("items.1.email: not an email address");
 
         // The null doctrine composes with the substitution too: a null element is located.
         Object nullElementPage =
@@ -8174,9 +8151,7 @@ class MappingProcessorTest {
         @SuppressWarnings("unchecked")
         Validated<NonEmptyList<FieldError>, Object> nullParsed =
             (Validated<NonEmptyList<FieldError>, Object>) invoke(impl, "parse", nullElementPage);
-        Assertions.assertThat(
-                nullParsed.getError().toJavaList().stream().map(FieldError::toString).toList())
-            .containsExactly("items.1: must not be null");
+        assertThatValidated(nullParsed).hasFieldErrors("items.1: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -9552,9 +9527,7 @@ class MappingProcessorTest {
       Object invalid =
           dto.getDeclaredConstructor(String.class, String.class).newInstance("Ada", "nope");
       Validated<NonEmptyList<FieldError>, Object> parsed = parse(impl, invalid);
-      Assertions.assertThat(parsed.isInvalid()).isTrue();
-      Assertions.assertThat(parsed.getError().toJavaList().stream().map(FieldError::toString))
-          .containsExactly("email: not an email address");
+      assertThatValidated(parsed).isInvalid().hasFieldErrors("email: not an email address");
     }
 
     @Test
@@ -10544,9 +10517,7 @@ class MappingProcessorTest {
       withNull.add(null);
       Validated<NonEmptyList<FieldError>, Object> parsed =
           parse(impl, dtoCtor.newInstance("Blue", withNull, Map.of()));
-      Assertions.assertThat(parsed.isInvalid()).isTrue();
-      Assertions.assertThat(parsed.getError().toJavaList().stream().map(FieldError::toString))
-          .containsExactly("tags.1: must not be null");
+      assertThatValidated(parsed).isInvalid().hasFieldErrors("tags.1: must not be null");
 
       // and an absent one is still valid emptiness
       Assertions.assertThat(parse(impl, dtoCtor.newInstance("Blue", null, null)).isValid())

--- a/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MergeProcessorTest.java
+++ b/hkj-processor/src/test/java/org/higherkindedj/optics/processing/MergeProcessorTest.java
@@ -4,6 +4,7 @@ package org.higherkindedj.optics.processing;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 import static org.higherkindedj.optics.processing.RuntimeCompilationHelper.invoke;
 
 import com.google.testing.compile.Compilation;
@@ -305,10 +306,9 @@ class MergeProcessorTest {
         Validated<NonEmptyList<FieldError>, Object> merged =
             (Validated<NonEmptyList<FieldError>, Object>)
                 invoke(assembly, "assemble", user, wrapper);
-        Assertions.assertThat(merged.isInvalid()).isTrue();
-        Assertions.assertThat(
-                merged.getError().toJavaList().stream().map(FieldError::toString).toList())
-            .containsExactly("name: must not be null", "customer.email: must not be null");
+        assertThatValidated(merged)
+            .isInvalid()
+            .hasFieldErrors("name: must not be null", "customer.email: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }
@@ -1419,10 +1419,6 @@ class MergeProcessorTest {
           .newInstance("DE00", 5);
     }
 
-    private List<String> renderedErrors(Validated<NonEmptyList<FieldError>, Object> result) {
-      return result.getError().toJavaList().stream().map(FieldError::toString).toList();
-    }
-
     @Test
     @DisplayName(
         "null source components are located, accumulated invalids — the guard beats the" + " leaf")
@@ -1437,17 +1433,16 @@ class MergeProcessorTest {
         Validated<NonEmptyList<FieldError>, Object> merged =
             (Validated<NonEmptyList<FieldError>, Object>)
                 invoke(assembly, "assemble", user(result, null, "not-an-email"), account(result));
-        Assertions.assertThat(merged.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(merged))
-            .containsExactly("name: must not be null", "email: not an email address");
+        assertThatValidated(merged)
+            .isInvalid()
+            .hasFieldErrors("name: must not be null", "email: not an email address");
 
         // A null leaf read never reaches the leaf's prism (which would throw): guard first.
         @SuppressWarnings("unchecked")
         Validated<NonEmptyList<FieldError>, Object> nullLeaf =
             (Validated<NonEmptyList<FieldError>, Object>)
                 invoke(assembly, "assemble", user(result, "Ada", null), account(result));
-        Assertions.assertThat(nullLeaf.isInvalid()).isTrue();
-        Assertions.assertThat(renderedErrors(nullLeaf)).containsExactly("email: must not be null");
+        assertThatValidated(nullLeaf).isInvalid().hasFieldErrors("email: must not be null");
       } catch (ReflectiveOperationException e) {
         throw new AssertionError(e);
       }

--- a/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/ValidatedAssert.java
+++ b/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/ValidatedAssert.java
@@ -2,10 +2,13 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.assertions;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Invalid;
 import org.higherkindedj.hkt.validated.Valid;
 import org.higherkindedj.hkt.validated.Validated;
@@ -136,6 +139,36 @@ public class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<E, A>,
     return this;
   }
 
+  /**
+   * Asserts that the Validated is Invalid and its accumulated {@link FieldError}s render, in that
+   * order, as the given lines.
+   *
+   * <p>Each error is rendered by {@link FieldError#toString()}, i.e. {@code "path: message"}, or
+   * just the message for an unlabelled leaf error. Order is asserted because declaration order is
+   * the accumulation doctrine: {@code fields()} reports the errors in the order the fields were
+   * declared.
+   *
+   * <pre>{@code
+   * assertThatValidated(OrderMappingImpl.INSTANCE.parse(badDto))
+   *     .hasFieldErrors(
+   *         "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
+   *         "placedOn: not an ISO-8601 date (expected e.g. 2026-07-28)");
+   * }</pre>
+   *
+   * <p>Applies to the located-error channel only: the Invalid must carry an {@link Iterable} of
+   * {@code FieldError}, which is what {@code NonEmptyList<FieldError>} is. For any other error type
+   * use {@link #hasError(Object)} or {@link #hasErrorSatisfying(Predicate, String)}.
+   *
+   * @param expected the rendered errors, in accumulation order
+   */
+  public ValidatedAssert<E, A> hasFieldErrors(String... expected) {
+    isInvalid();
+    Assertions.assertThat(renderedFieldErrors())
+        .as("Validated FieldErrors")
+        .containsExactly(expected);
+    return this;
+  }
+
   /** Asserts that the Validated is Valid and the value is an instance of the expected class. */
   public ValidatedAssert<E, A> hasValueOfType(Class<?> expectedClass) {
     isValid();
@@ -178,5 +211,32 @@ public class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<E, A>,
   /** Direct accessor for the Invalid error. Caller must have verified the Validated is Invalid. */
   private E invalidError() {
     return ((Invalid<E, A>) actual).error();
+  }
+
+  /**
+   * Renders the accumulated located errors, failing if the Invalid does not carry {@link
+   * FieldError}s. Caller must have verified the Validated is Invalid.
+   */
+  private List<String> renderedFieldErrors() {
+    E error = invalidError();
+    if (!(error instanceof Iterable<?> located)) {
+      throw failure(
+          "Cannot render FieldErrors from an error of type <%s>: <%s>. hasFieldErrors() applies to"
+              + " the located-error channel (NonEmptyList<FieldError>); use hasError() or"
+              + " hasErrorSatisfying() for other error types.",
+          error.getClass().getSimpleName(), error);
+    }
+    List<String> rendered = new ArrayList<>();
+    for (Object element : located) {
+      if (element instanceof FieldError fieldError) {
+        rendered.add(fieldError.toString());
+      } else {
+        throw failure(
+            "Expected every accumulated error to be a FieldError but element %d was a <%s>: <%s>."
+                + " Accumulated errors: <%s>.",
+            rendered.size(), element.getClass().getSimpleName(), element, error);
+      }
+    }
+    return List.copyOf(rendered);
   }
 }

--- a/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/ValidatedAssert.java
+++ b/hkj-test/src/main/java/org/higherkindedj/hkt/assertions/ValidatedAssert.java
@@ -14,6 +14,7 @@ import org.higherkindedj.hkt.validated.Valid;
 import org.higherkindedj.hkt.validated.Validated;
 import org.higherkindedj.hkt.validated.ValidatedKind;
 import org.higherkindedj.hkt.validated.ValidatedKindHelper;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Fluent assertion utilities for {@link Validated} types. Provides a convenient API for testing
@@ -208,7 +209,10 @@ public class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<E, A>,
     return ((Valid<E, A>) actual).value();
   }
 
-  /** Direct accessor for the Invalid error. Caller must have verified the Validated is Invalid. */
+  /**
+   * Direct accessor for the Invalid error, never null: {@link Invalid} rejects a null error. Caller
+   * must have verified the Validated is Invalid.
+   */
   private E invalidError() {
     return ((Invalid<E, A>) actual).error();
   }
@@ -232,11 +236,20 @@ public class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<E, A>,
         rendered.add(fieldError.toString());
       } else {
         throw failure(
-            "Expected every accumulated error to be a FieldError but element %d was a <%s>: <%s>."
-                + " Accumulated errors: <%s>.",
-            rendered.size(), element.getClass().getSimpleName(), element, error);
+            "Expected every accumulated error to be a FieldError but element %d was <%s> (type"
+                + " <%s>). Accumulated errors: <%s>.",
+            rendered.size(), element, simpleTypeName(element), error);
       }
     }
     return List.copyOf(rendered);
+  }
+
+  /**
+   * The element's simple type name, or {@code "null"}. A {@code NonEmptyList} rejects null
+   * elements, but {@link #hasFieldErrors} accepts any {@link Iterable}, and a plain {@code
+   * Arrays.asList} can hold one.
+   */
+  private static String simpleTypeName(@Nullable Object element) {
+    return element == null ? "null" : element.getClass().getSimpleName();
   }
 }

--- a/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/ValidatedAssertContractTest.java
+++ b/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/ValidatedAssertContractTest.java
@@ -2,8 +2,14 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for license information.
 package org.higherkindedj.hkt.assertions;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
+
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +24,10 @@ class ValidatedAssertContractTest
   private static final Validated<String, Integer> INVALID_ERR = Validated.invalid("err");
   private static final Validated<String, Integer> INVALID_OTHER = Validated.invalid("other");
 
+  private static final Validated<NonEmptyList<FieldError>, Integer> LOCATED =
+      Validated.invalid(
+          NonEmptyList.of(FieldError.of("not a UUID").at("id"), FieldError.of("must be positive")));
+
   @Override
   protected Function<Validated<String, Integer>, ValidatedAssert<String, Integer>> entry() {
     return ValidatedAssert::assertThatValidated;
@@ -26,6 +36,46 @@ class ValidatedAssertContractTest
   @Test
   void described_factory_is_callable() {
     ValidatedAssert.assertThatValidated(VALID_42, "described").isValid();
+  }
+
+  @Test
+  void hasFieldErrors_renders_each_located_error_in_accumulation_order() {
+    assertThatValidated(LOCATED).hasFieldErrors("id: not a UUID", "must be positive");
+  }
+
+  @Test
+  void hasFieldErrors_rejects_a_different_rendering() {
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertThatValidated(LOCATED).hasFieldErrors("id: not a UUID"));
+  }
+
+  @Test
+  void hasFieldErrors_rejects_a_valid_subject() {
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertThatValidated(VALID_42).hasFieldErrors("anything"));
+  }
+
+  @Test
+  void hasFieldErrors_rejects_an_error_channel_that_is_not_a_collection() {
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertThatValidated(INVALID_ERR).hasFieldErrors("err"))
+        .withMessageContaining("hasFieldErrors() applies to the located-error channel");
+  }
+
+  @Test
+  void hasFieldErrors_rejects_a_collection_of_something_other_than_FieldError() {
+    Validated<List<String>, Integer> plainLines = Validated.invalid(List.of("e1"));
+
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertThatValidated(plainLines).hasFieldErrors("e1"))
+        .withMessageContaining("element 0 was a <String>");
+  }
+
+  @Test
+  void hasFieldErrors_accepts_an_empty_located_channel() {
+    Validated<List<FieldError>, Integer> none = Validated.invalid(List.of());
+
+    assertThatValidated(none).hasFieldErrors();
   }
 
   @Override

--- a/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/ValidatedAssertContractTest.java
+++ b/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/ValidatedAssertContractTest.java
@@ -5,6 +5,7 @@ package org.higherkindedj.hkt.assertions;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.higherkindedj.hkt.assertions.ValidatedAssert.assertThatValidated;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -68,7 +69,21 @@ class ValidatedAssertContractTest
 
     assertThatExceptionOfType(AssertionError.class)
         .isThrownBy(() -> assertThatValidated(plainLines).hasFieldErrors("e1"))
-        .withMessageContaining("element 0 was a <String>");
+        .withMessageContaining("element 0 was <e1> (type <String>)");
+  }
+
+  /**
+   * A {@code NonEmptyList} rejects null elements, but the assertion accepts any {@code Iterable},
+   * and {@code Arrays.asList} does not: the null must fail as an assertion, not an NPE.
+   */
+  @Test
+  void hasFieldErrors_rejects_a_null_among_the_located_errors() {
+    Validated<List<FieldError>, Integer> withNull =
+        Validated.invalid(Arrays.asList(FieldError.of("first"), null));
+
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertThatValidated(withNull).hasFieldErrors("first"))
+        .withMessageContaining("element 1 was <null> (type <null>)");
   }
 
   @Test

--- a/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/ValidatedAssertExample.java
+++ b/hkj-test/src/test/java/org/higherkindedj/hkt/assertions/ValidatedAssertExample.java
@@ -7,6 +7,8 @@ import static org.higherkindedj.hkt.validated.ValidatedKindHelper.VALIDATED;
 
 import java.util.List;
 import org.higherkindedj.hkt.Kind;
+import org.higherkindedj.hkt.nonemptylist.NonEmptyList;
+import org.higherkindedj.hkt.validated.FieldError;
 import org.higherkindedj.hkt.validated.Validated;
 import org.higherkindedj.hkt.validated.ValidatedKind;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +42,20 @@ class ValidatedAssertExample {
     assertThatValidated(result)
         .isInvalid()
         .hasErrorSatisfying(errors -> errors.size() == 2, "two errors collected");
+  }
+
+  @Test
+  @DisplayName("hasFieldErrors() asserts the located errors as rendered lines, in order")
+  void locatedErrors() {
+    Validated<NonEmptyList<FieldError>, Integer> result =
+        Validated.invalid(
+            NonEmptyList.of(
+                FieldError.of("not an address").at("email").at("customer"),
+                FieldError.of("must be positive").at("age").at("customer")));
+
+    assertThatValidated(result)
+        .isInvalid()
+        .hasFieldErrors("customer.email: not an address", "customer.age: must be positive");
   }
 
   @Test


### PR DESCRIPTION
Closes #691.

## The gap

Asserting "this parse failed with exactly these located errors" is the most common assertion against every accumulating surface — codec parses, mapping `parse`/`patch`, fallible merges, assembly companions — and hkj-test could not express it. `ValidatedAssert` is generic in `E` and stopped at `isInvalid()`; `FieldErrorAssert` handles one error. So tests hand-rolled the same fold:

```java
result.fold(nel -> nel.map(FieldError::toString).toJavaList(), _ -> List.of())
```

in **seventeen** files across hkj-core, hkj-examples and hkj-processor, book-included snippets among them — so the book taught the workaround too.

## What lands

`ValidatedAssert.hasFieldErrors(String...)`: asserts `Invalid`, then compares each accumulated `FieldError`'s rendering with `containsExactly`.

```java
assertThatValidated(OrderMappingImpl.INSTANCE.parse(badDto))
    .isInvalid()
    .hasFieldErrors(
        "id: not a UUID (expected e.g. 123e4567-e89b-12d3-a456-426614174000)",
        "placedOn: not an ISO-8601 date (expected e.g. 2026-07-28)");
```

Order is asserted by default: declaration order is the accumulation contract. A reworded message reads as a one-line diff against the full rendered list.

## Where it hangs

The issue left this open. A specialised subclass cannot chain — `AbstractAssert` fixes `SELF` to `ValidatedAssert<E, A>`, so `.isInvalid().hasFieldErrors(...)` would not compile — and widening `SELF` breaks a published signature. It is therefore a member that checks the channel at runtime, the shape `WriterAssert.hasEmptyLog` already uses.

```mermaid
flowchart TD
    A["hasFieldErrors(...)"] --> B{"Invalid?"}
    B -- no --> F1["fails: isInvalid()"]
    B -- yes --> C{"error is an Iterable?"}
    C -- no --> F2["fails, naming hasError()<br/>/ hasErrorSatisfying()"]
    C -- yes --> D{"every element<br/>a FieldError?"}
    D -- no --> F3["fails, naming the<br/>offending element"]
    D -- yes --> E["containsExactly on<br/>the rendered lines"]

    classDef ok fill:#a6da95,stroke:#8bd5ca,color:#1e2030
    classDef bad fill:#ed8796,stroke:#ee99a0,color:#1e2030
    class E ok
    class F1,F2,F3 bad
```

Accepting any `Iterable` rather than `NonEmptyList` specifically costs nothing and covers the `List<FieldError>` channel the Spring tests use.

## The sweep

Every hand-rolled fold is replaced, including the one case that asserted a *shape* rather than a rendering: the map-key projection's error is exactly `entries.work: not an email address`, so `hasSize(1)` plus `startsWith`/`contains` becomes one stronger assertion. Two tutorials shift their exercise from "render the errors" to "parse the wire", since the assertion now does the rendering.

One helper survives in `MappingProcessorTest`, where the structured `FieldError` values — not their rendering — are what the test compares.

## Docs

The test-assertions page, the hkj-test skill (whose Common Mistakes entry said this assertion did not exist *and was not an omission*), and the two other pages that named `assertThatFieldError` as the way to test located errors. Both new snippets are `<!-- verify -->` gated, so the floors move with them.

## Verification

- `gradle build` green, including hkj-test's 100% line + instruction gate and `:hkj-examples:bookVerify`.
- Six focused contract tests cover the match, the ordering mismatch, the Valid subject, both wrong-channel refusals and the empty located channel.

---

Rebased on `main` after #824. That PR added two more copies of the fold in `MappingProcessorTest`; both are swept here, so the claim that no hand-rolled copy remains still holds. The snippet floor resolves to 2441 (main's 2439 plus the two snippets this PR gates).

Note: the issue carries a `Target 0.4.10` label; 0.4.10 has shipped and the tree is on `0.4.11-SNAPSHOT`, so the label wants moving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fluent assertion for validating complete accumulated field-error results in declaration order, using `"path: message"` formatting.

- **Documentation**
  - Updated testing guidance, tutorials, examples, and glossary content to explain whole-accumulation assertions and single-error assertions.

- **Tests**
  - Expanded coverage for ordered field errors, invalid results, malformed error channels, and empty error collections.
  - Updated validation examples and verified snippet counts to use the new assertion style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->