### PR TITLE
Drop the last three issue links from the book

### DIFF
--- a/hkj-book/src/monads/try_monad.md
+++ b/hkj-book/src/monads/try_monad.md
@@ -166,7 +166,7 @@ String message = result2.foldFailureFirst(
 
 ~~~admonish warning title="`fold` is deprecated for removal in 0.5.0"
 
-The legacy `Try.fold(successMapper, failureMapper)` and `TryPath.fold(successMapper, failureMapper)` are success-first, which is inconsistent with the error-first ordering used by `Either`, `Validated`, `EitherF`, `EitherPath`, and `ValidationPath`. Both are `@Deprecated(forRemoval = true)` since 0.4.6 and are removed in 0.5.0. Use `foldFailureFirst(failureMapper, successMapper)` instead; the rename is intentional so that no call site can silently flip behaviour after an argument swap. The canonical name `fold` is planned to be reintroduced with the error-first argument order in 0.6.0. See [#452](https://github.com/higher-kinded-j/higher-kinded-j/issues/452).
+The legacy `Try.fold(successMapper, failureMapper)` and `TryPath.fold(successMapper, failureMapper)` are success-first, which is inconsistent with the error-first ordering used by `Either`, `Validated`, `EitherF`, `EitherPath`, and `ValidationPath`. Both are `@Deprecated(forRemoval = true)` since 0.4.6 and are removed in 0.5.0. Use `foldFailureFirst(failureMapper, successMapper)` instead; the rename is intentional so that no call site can silently flip behaviour after an argument swap. The canonical name `fold` is planned to be reintroduced with the error-first argument order in 0.6.0.
 ~~~
 
 ~~~admonish title="_recover(recoveryFunc)_"

--- a/hkj-book/src/optics/optics_spec_interfaces.md
+++ b/hkj-book/src/optics/optics_spec_interfaces.md
@@ -93,7 +93,7 @@ The generated prisms are primitives. Real JSON work wants field access, array tr
 Each is a prism composed with a hand-written `Affine` or `Traversal`, and the result types tell the story: `field` may miss (an `Affine`), `elements` may hit many (a `Traversal`).
 
 ~~~admonish warning title="Composed optics do not belong in the spec interface"
-A `default` method on a spec interface looks like the natural home for these, but it is not: the processor cannot read a method body during annotation processing, so there is nothing for the generated class to carry. The processor rejects one at the declaration ([#712](https://github.com/higher-kinded-j/higher-kinded-j/issues/712)), naming the two homes composition does have. Keep the spec interface to annotated abstract methods, and build everything else either in a `static` method on the interface or, as here, in a normal class; both call the generated statics.
+A `default` method on a spec interface looks like the natural home for these, but it is not: the processor cannot read a method body during annotation processing, so there is nothing for the generated class to carry. The processor rejects one at the declaration, naming the two homes composition does have. Keep the spec interface to annotated abstract methods, and build everything else either in a `static` method on the interface or, as here, in a normal class; both call the generated statics.
 ~~~
 
 ---

--- a/hkj-book/src/transformers/statet_transformer.md
+++ b/hkj-book/src/transformers/statet_transformer.md
@@ -200,7 +200,7 @@ var stateOnly = STATE_T.execStateT(computation, 10, optionalMonad);
 ```
 
 ~~~admonish note title="0.4.6 API Note"
-`evalStateT` and `execStateT` now take the `Monad<F>` as an explicit argument. The single-argument forms (`evalStateT(computation, 10)`, `execStateT(computation, 10)`) and the matching instance methods on `StateT` are deprecated for removal in 0.5.0, when the stored `monadF` record component is dropped so that two `StateT` values with the same state function compare equal regardless of the `Monad` instance they were built with. See the v0.4.6 entry in the [release history](../release-history.md) and [issue #445](https://github.com/higher-kinded-j/higher-kinded-j/issues/445).
+`evalStateT` and `execStateT` now take the `Monad<F>` as an explicit argument. The single-argument forms (`evalStateT(computation, 10)`, `execStateT(computation, 10)`) and the matching instance methods on `StateT` are deprecated for removal in 0.5.0, when the stored `monadF` record component is dropped so that two `StateT` values with the same state function compare equal regardless of the `Monad` instance they were built with. See the v0.4.6 entry in the [release history](../release-history.md).
 ~~~
 
 ---


### PR DESCRIPTION
Three book pages still linked a GitHub issue in prose. The book describes behaviour, not project state: an issue number points at a planning discussion that closes, moves or goes stale, while the page is read long after it. The release history is the one place a version-to-issue link earns its keep, and all three issues are already linked from there.

| Page | Was | Now |
|---|---|---|
| Try monad, the `fold` deprecation note | "…reintroduced with the error-first argument order in 0.6.0. See [#452]." | The sentence ends at 0.6.0; the versions that remove and reintroduce `fold` are unchanged. |
| Optics spec interfaces, the composed-optics warning | "The processor rejects one at the declaration ([#712]), naming the two homes…" | "The processor rejects one at the declaration, naming the two homes…" |
| StateT, the 0.4.6 API note | "See the v0.4.6 entry in the [release history] and [issue #445]." | "See the v0.4.6 entry in the [release history]." |

Nothing a reader acts on is lost: each sentence keeps its versions, its behaviour and its pointer to the release history.

The rule behind this is stated in `docs/STYLE-GUIDE.md` by #829, which also removed the two remaining links (to #702 and #703) from the mapping pages. With both merged, no issue or pull-request link remains anywhere in the book or the skills outside the release history.
